### PR TITLE
[recalculate] add missing include for boost typeof

### DIFF
--- a/include/boost/geometry/algorithms/detail/recalculate.hpp
+++ b/include/boost/geometry/algorithms/detail/recalculate.hpp
@@ -22,6 +22,7 @@
 #include <boost/numeric/conversion/bounds.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 #include <boost/type_traits.hpp>
+#include <boost/typeof/typeof.hpp>
 
 #include <boost/geometry/arithmetic/arithmetic.hpp>
 #include <boost/geometry/algorithms/append.hpp>


### PR DESCRIPTION
needed because of BOOST_AUTO_TPL
