### PR TITLE
Fix get_turn_info

### DIFF
--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -1019,7 +1019,7 @@ struct get_turn_info
                 else
                 {
                     // Swap p/q
-                    side_calculator<Point1, Point2> swapped_side_calc(qi, qj, qk, pi, pj, pk);
+                    side_calculator<Point2, Point1> swapped_side_calc(qi, qj, qk, pi, pj, pk);
                     policy::template apply<1>(qi, qj, qk, pi, pj, pk,
                                 tp, result.template get<0>(), result.template get<1>(),
                                 swapped_side_calc);


### PR DESCRIPTION
Fix template parameter order in side_calculator call (would fail with
different point types).
