### PR TITLE
[policies][robustness] properly initialize m_approximation in default segment_ratio constructor

### DIFF
--- a/include/boost/geometry/policies/robustness/segment_ratio.hpp
+++ b/include/boost/geometry/policies/robustness/segment_ratio.hpp
@@ -109,6 +109,7 @@ public :
     inline segment_ratio()
         : m_numerator(0)
         , m_denominator(1)
+        , m_approximation(0)
     {}
 
     inline segment_ratio(const Type& nominator, const Type& denominator)


### PR DESCRIPTION
m_approximation is not initialized by the default constructor.

Among other things, this creates a problem when comparing the default constructed segment ratio with another segment ratio. In the comparison the approximation is initially used, and since the approximation is not initialized, the result of the comparison is not predictable (can vary from run to run of the same algorithm).
