### PR TITLE
check_result_type is missing inline qualifier

### DIFF
--- a/include/boost/geometry/algorithms/detail/within/point_in_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/within/point_in_geometry.hpp
@@ -37,13 +37,13 @@ namespace boost { namespace geometry {
 #ifndef DOXYGEN_NO_DETAIL
 namespace detail { namespace within {
 
-int check_result_type(int result)
+inline int check_result_type(int result)
 {
     return result;
 }
 
 template <typename T>
-void check_result_type(T result)
+inline void check_result_type(T result)
 {
     BOOST_ASSERT(false);
 }


### PR DESCRIPTION
Function check_result_type is missing inline qualifier.
