### PR TITLE
[overlay] quick fix for boost trac ticket #10019

### DIFF
--- a/include/boost/geometry/algorithms/detail/overlay/intersection_insert.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/intersection_insert.hpp
@@ -393,14 +393,13 @@ template
 <
     typename Linestring, typename Box,
     typename GeometryOut,
-    overlay_type OverlayType,
     bool Reverse1, bool Reverse2, bool ReverseOut
 >
 struct intersection_insert
     <
         Linestring, Box,
         GeometryOut,
-        OverlayType,
+        overlay_intersection,
         Reverse1, Reverse2, ReverseOut,
         linestring_tag, box_tag, linestring_tag,
         false, true, false


### PR DESCRIPTION
the specialization of intersection_insert for linestring/box computes the intersection, but pretends as if it works for difference as well;

quick fix: further specialize this specialization of intersection insert so that it works only for overlay_intersection;
problem and quick fix related to boost trac ticket #10019;
