### PR TITLE
[geometry][test] Fix concept check failures.

### DIFF
--- a/include/boost/geometry/arithmetic/arithmetic.hpp
+++ b/include/boost/geometry/arithmetic/arithmetic.hpp
@@ -139,7 +139,7 @@ inline void add_value(Point& p, typename detail::param<Point>::type value)
 template <typename Point1, typename Point2>
 inline void add_point(Point1& p1, Point2 const& p2)
 {
-    BOOST_CONCEPT_ASSERT( (concept::Point<Point2>) );
+    BOOST_CONCEPT_ASSERT( (concept::Point<Point1>) );
     BOOST_CONCEPT_ASSERT( (concept::ConstPoint<Point2>) );
 
     for_each_coordinate(p1, detail::point_operation<Point2, std::plus>(p2));
@@ -171,7 +171,7 @@ inline void subtract_value(Point& p, typename detail::param<Point>::type value)
 template <typename Point1, typename Point2>
 inline void subtract_point(Point1& p1, Point2 const& p2)
 {
-    BOOST_CONCEPT_ASSERT( (concept::Point<Point2>) );
+    BOOST_CONCEPT_ASSERT( (concept::Point<Point1>) );
     BOOST_CONCEPT_ASSERT( (concept::ConstPoint<Point2>) );
 
     for_each_coordinate(p1, detail::point_operation<Point2, std::minus>(p2));
@@ -204,7 +204,7 @@ inline void multiply_value(Point& p, typename detail::param<Point>::type value)
 template <typename Point1, typename Point2>
 inline void multiply_point(Point1& p1, Point2 const& p2)
 {
-    BOOST_CONCEPT_ASSERT( (concept::Point<Point2>) );
+    BOOST_CONCEPT_ASSERT( (concept::Point<Point1>) );
     BOOST_CONCEPT_ASSERT( (concept::ConstPoint<Point2>) );
 
     for_each_coordinate(p1, detail::point_operation<Point2, std::multiplies>(p2));
@@ -236,7 +236,7 @@ inline void divide_value(Point& p, typename detail::param<Point>::type value)
 template <typename Point1, typename Point2>
 inline void divide_point(Point1& p1, Point2 const& p2)
 {
-    BOOST_CONCEPT_ASSERT( (concept::Point<Point2>) );
+    BOOST_CONCEPT_ASSERT( (concept::Point<Point1>) );
     BOOST_CONCEPT_ASSERT( (concept::ConstPoint<Point2>) );
 
     for_each_coordinate(p1, detail::point_operation<Point2, std::divides>(p2));
@@ -268,7 +268,7 @@ inline void assign_value(Point& p, typename detail::param<Point>::type value)
 template <typename Point1, typename Point2>
 inline void assign_point(Point1& p1, const Point2& p2)
 {
-    BOOST_CONCEPT_ASSERT( (concept::Point<Point2>) );
+    BOOST_CONCEPT_ASSERT( (concept::Point<Point1>) );
     BOOST_CONCEPT_ASSERT( (concept::ConstPoint<Point2>) );
 
     for_each_coordinate(p1, detail::point_assignment<Point2>(p2));

--- a/test/arithmetic/arithmetic.cpp
+++ b/test/arithmetic/arithmetic.cpp
@@ -29,7 +29,7 @@ BOOST_GEOMETRY_REGISTER_C_ARRAY_CS(cs::cartesian)
 BOOST_GEOMETRY_REGISTER_BOOST_TUPLE_CS(cs::cartesian)
 
 
-template <typename P>
+template <typename P, typename P2>
 void test_addition()
 {
     P p1;
@@ -39,15 +39,14 @@ void test_addition()
     BOOST_CHECK(bg::get<1>(p1) == 12);
     BOOST_CHECK(bg::get<2>(p1) == 13);
 
-    P p2;
-    bg::assign_values(p2, 4, 5, 6);
+    P2 p2(4, 5, 6);
     bg::add_point(p1, p2);
     BOOST_CHECK(bg::get<0>(p1) == 15);
     BOOST_CHECK(bg::get<1>(p1) == 17);
     BOOST_CHECK(bg::get<2>(p1) == 19);
 }
 
-template <typename P>
+template <typename P, typename P2>
 void test_subtraction()
 {
     P p1;
@@ -57,15 +56,14 @@ void test_subtraction()
     BOOST_CHECK(bg::get<1>(p1) == -8);
     BOOST_CHECK(bg::get<2>(p1) == -7);
 
-    P p2;
-    bg::assign_values(p2, 4, 6, 8);
+    P2 p2(4, 6, 8);
     bg::subtract_point(p1, p2);
     BOOST_CHECK(bg::get<0>(p1) == -13);
     BOOST_CHECK(bg::get<1>(p1) == -14);
     BOOST_CHECK(bg::get<2>(p1) == -15);
 }
 
-template <typename P>
+template <typename P, typename P2>
 void test_multiplication()
 {
     P p1;
@@ -75,15 +73,14 @@ void test_multiplication()
     BOOST_CHECK(bg::get<1>(p1) == 10);
     BOOST_CHECK(bg::get<2>(p1) == 15);
 
-    P p2;
-    bg::assign_values(p2, 4, 5, 6);
+    P2 p2(4, 5, 6);
     bg::multiply_point(p1, p2);
     BOOST_CHECK(bg::get<0>(p1) == 20);
     BOOST_CHECK(bg::get<1>(p1) == 50);
     BOOST_CHECK(bg::get<2>(p1) == 90);
 }
 
-template <typename P>
+template <typename P, typename P2>
 void test_division()
 {
     P p1;
@@ -93,40 +90,41 @@ void test_division()
     BOOST_CHECK(bg::get<1>(p1) == 20);
     BOOST_CHECK(bg::get<2>(p1) == 30);
 
-    P p2;
-    bg::assign_values(p2, 2, 4, 6);
+    P2 p2(2, 4, 6);
     bg::divide_point(p1, p2);
     BOOST_CHECK(bg::get<0>(p1) == 5);
     BOOST_CHECK(bg::get<1>(p1) == 5);
     BOOST_CHECK(bg::get<2>(p1) == 5);
 }
 
-template <typename P>
+template <typename P, typename P2>
 void test_assign()
 {
     P p1;
-    P p2;
+    P2 p2(12, 34, 56);
     bg::assign_values(p1, 12, 34, 56);
-    bg::assign_point(p2, p1);
-    BOOST_CHECK(bg::get<0>(p2) == 12);
-    BOOST_CHECK(bg::get<1>(p2) == 34);
-    BOOST_CHECK(bg::get<2>(p2) == 56);
+    bg::assign_point(p1, p2);
+    BOOST_CHECK(bg::get<0>(p1) == 12);
+    BOOST_CHECK(bg::get<1>(p1) == 34);
+    BOOST_CHECK(bg::get<2>(p1) == 56);
 
-    bg::assign_value(p2, 78);
-    BOOST_CHECK(bg::get<0>(p2) == 78);
-    BOOST_CHECK(bg::get<1>(p2) == 78);
-    BOOST_CHECK(bg::get<2>(p2) == 78);
+    bg::assign_value(p1, 78);
+    BOOST_CHECK(bg::get<0>(p1) == 78);
+    BOOST_CHECK(bg::get<1>(p1) == 78);
+    BOOST_CHECK(bg::get<2>(p1) == 78);
 }
 
 
 template <typename P>
 void test_all()
 {
-    test_addition<P>();
-    test_subtraction<P>();
-    test_multiplication<P>();
-    test_division<P>();
-    test_assign<P>();
+    typedef test::test_const_point P2;
+
+    test_addition<P, P2>();
+    test_subtraction<P, P2>();
+    test_multiplication<P, P2>();
+    test_division<P, P2>();
+    test_assign<P, P2>();
 }
 
 

--- a/test/test_common/test_point.hpp
+++ b/test/test_common/test_point.hpp
@@ -17,6 +17,7 @@
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/tag.hpp>
+#include <boost/geometry/geometries/register/point.hpp>
 
 // NOTE: since Boost 1.51 the Point type may always be a pointer.
 // Therefore the traits class don't need to add a pointer.
@@ -32,8 +33,19 @@ struct test_point
     float c1, c2, c3;
 };
 
+struct test_const_point
+{
+    test_const_point()
+      : c1(0.0), c2(0.0), c3(0.0) { }
+
+    test_const_point(float c1, float c2, float c3)
+      : c1(c1), c2(c2), c3(c3) { }
+
+    const float c1, c2, c3;
+};
 
 } // namespace test
+
 
 
 namespace boost { namespace geometry { namespace traits {
@@ -90,5 +102,10 @@ template<> struct access<test::test_point, 2>
 };
 
 }}} // namespace bg::traits
+
+BOOST_GEOMETRY_REGISTER_POINT_3D_CONST(test::test_const_point,
+                                       float,
+                                       boost::geometry::cs::cartesian,
+                                       c1, c2, c3);
 
 #endif // GEOMETRY_TEST_TEST_COMMON_TEST_POINT_HPP


### PR DESCRIPTION
The functions in arithmetic.hpp would check the concepts Point and ConstPoint
on Point2, instead of checking Point on Point1 and ConstPoint on Point2.

This would cause concept check failures when attempting to operate from
a ConstPoint.

(boost-trac: #10077)
