### PR TITLE
[test][util] guard use of boost::long_long_type inside a

### DIFF
--- a/test/util/math_sqrt.cpp
+++ b/test/util/math_sqrt.cpp
@@ -17,6 +17,7 @@
 
 #include <boost/test/included/unit_test.hpp>
 
+#include <boost/config.hpp>
 #include <boost/type_traits/is_fundamental.hpp>
 
 #include "number_types.hpp"


### PR DESCRIPTION
BOOST_HAS_LONG_LONG block
