### PR TITLE
[algorithms][overlay] remove usused include

### DIFF
--- a/include/boost/geometry/algorithms/detail/overlay/linear_linear.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/linear_linear.hpp
@@ -24,7 +24,6 @@
 #include <boost/geometry/algorithms/detail/turns/compare_turns.hpp>
 #include <boost/geometry/algorithms/detail/turns/filter_continue_turns.hpp>
 #include <boost/geometry/algorithms/detail/turns/remove_duplicate_turns.hpp>
-#include <boost/geometry/algorithms/detail/turns/print_turns.hpp>
 
 #include <boost/geometry/algorithms/detail/overlay/overlay_type.hpp>
 #include <boost/geometry/algorithms/detail/overlay/follow_linear_linear.hpp>


### PR DESCRIPTION
BTW, this include creates an dependence with <iostream>, which should certainly be avoided.

It also happens that the modified file is not used anywhere else but in algortihm tests, so it can very well be moved in there.
