### PR TITLE
[strategies][agnostic] fix bug in Graham-Andrew strategy:

### DIFF
--- a/include/boost/geometry/strategies/agnostic/hull_graham_andrew.hpp
+++ b/include/boost/geometry/strategies/agnostic/hull_graham_andrew.hpp
@@ -323,7 +323,7 @@ private:
         while (output_size >= 3)
         {
             rev_iterator rit = output.rbegin();
-            point_type const& last = *rit++;
+            point_type const last = *rit++;
             point_type const& last2 = *rit++;
 
             if (Factor * side::apply(*rit, last, last2) <= 0)


### PR DESCRIPTION
last is used again after two calls to pop_back() which can invalidate
the reference;
patch: make last a true point rather than a reference
bug reported/patch suggested by David Zhao

(re-opening PR #70)
