### PR TITLE
[doc][algorithms] add documentation for the comparable_distance free function that takes a strategy

### DIFF
--- a/include/boost/geometry/algorithms/detail/comparable_distance/interface.hpp
+++ b/include/boost/geometry/algorithms/detail/comparable_distance/interface.hpp
@@ -27,7 +27,24 @@ namespace boost { namespace geometry
 {
 
 
-// MK::need to add qbk documentation
+/*!
+\brief \brief_calc2{comparable distance measurement} \brief_strategy
+\ingroup distance
+\details The free function comparable_distance does not necessarily calculate the distance,
+    but it calculates a distance measure such that two distances are comparable to each other.
+    For example: for the Cartesian coordinate system, Pythagoras is used but the square root
+    is not taken, which makes it faster and the results of two point pairs can still be
+    compared to each other.
+\tparam Geometry1 first geometry type
+\tparam Geometry2 second geometry type
+\tparam Strategy \tparam_strategy{Distance}
+\param geometry1 \param_geometry
+\param geometry2 \param_geometry
+\param strategy \param_strategy{distance}
+\return \return_calc{comparable distance}
+
+\qbk{distinguish,with strategy}
+ */
 template <typename Geometry1, typename Geometry2, typename Strategy>
 inline typename strategy::distance::services::return_type
                 <


### PR DESCRIPTION
The problem with the currently created page is that the function definition is too long (due to the very long description for the return type). Any ideas how to fix this?
