### PR TITLE
[algorithms][is_valid] declare debug_complement_graph as inline

### DIFF
--- a/include/boost/geometry/algorithms/detail/is_valid/debug_complement_graph.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/debug_complement_graph.hpp
@@ -56,8 +56,8 @@ debug_print_complement_graph(OutputStream& os,
 }
 #else
 template <typename OutputStream, typename TurnPoint>
-void debug_print_complement_graph(OutputStream&,
-                                  complement_graph<TurnPoint> const&)
+inline void debug_print_complement_graph(OutputStream&,
+                                         complement_graph<TurnPoint> const&)
 {
 }
 #endif


### PR DESCRIPTION
Should fix clang-darwin-{asan,asan11,tot,tot11} errors in develop regression matrix.
