### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/include/boost/geometry/algorithms/detail/overlay/assign_parents.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/assign_parents.hpp
@@ -247,7 +247,7 @@ inline void assign_parents(Geometry1 const& geometry1,
                 //    a dramatic improvement (factor 5 for star_comb testcase)
                 ring_identifier id_of_positive = vector[index_positive].id;
                 ring_info_type& outer = ring_map[id_of_positive];
-                std::size_t index = 0;
+                index = 0;
                 for (vector_iterator_type it = boost::begin(vector);
                     it != boost::end(vector); ++it, ++index)
                 {

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -354,9 +354,6 @@ struct touch : public base_turn_handler
             else
             {
                 // Pk at other side than Qi/Pk
-                int const side_qk_q = side.qk_wrt_q1();
-                bool const q_turns_left = side_qk_q == 1;
-
                 ti.operations[0].operation = q_turns_left
                             ? operation_intersection
                             : operation_union;
@@ -481,8 +478,6 @@ struct equal : public base_turn_handler
         // If they turn to same side (not opposite sides)
         if (! opposite(side_pk_p, side_qk_p))
         {
-            int const side_pk_q2 = side.pk_wrt_q2();
-
             // If pk is left of q2 or collinear: p: union, q: intersection
             ui_else_iu(side_pk_q2 != -1, ti);
         }

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
@@ -612,7 +612,6 @@ struct get_turn_info_for_endpoint
         // If they turn to same side (not opposite sides)
         if ( ! base_turn_handler::opposite(side_pk_p, side_qk_p) )
         {
-            int const side_pk_q2 = side.pk_wrt_q2();
             // If pk is left of q2 or collinear: p: union, q: intersection
             if ( side_pk_q2 != -1 )
             {

--- a/include/boost/geometry/algorithms/detail/relate/areal_areal.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/areal_areal.hpp
@@ -117,7 +117,7 @@ public:
 
                 // TODO: O(N)
                 // Optimize!
-                int pig = detail::within::point_in_geometry(range::front(range_ref), m_other_areal);
+                pig = detail::within::point_in_geometry(range::front(range_ref), m_other_areal);
 
                 // hole outside
                 if ( pig < 0 )
@@ -153,7 +153,7 @@ public:
 
                 // TODO: O(N)
                 // Optimize!
-                int pig = detail::within::point_in_geometry(range::front(range_ref), m_other_areal);
+                pig = detail::within::point_in_geometry(range::front(range_ref), m_other_areal);
 
                 // hole inside
                 if ( pig > 0 )

--- a/include/boost/geometry/extensions/algorithms/detail/overlay/dissolver.hpp
+++ b/include/boost/geometry/extensions/algorithms/detail/overlay/dissolver.hpp
@@ -554,7 +554,7 @@ struct dissolver_generic
 
             // Re-initialize the list
             index_vector.clear();
-            int index = 0;
+            index = 0;
             for(typename boost::range_iterator<helper_vector_type const>::type
                 it = boost::begin(helper_vector);
                 it != boost::end(helper_vector);

--- a/include/boost/geometry/extensions/gis/projections/impl/pj_ell_set.hpp
+++ b/include/boost/geometry/extensions/gis/projections/impl/pj_ell_set.hpp
@@ -57,7 +57,6 @@ static const double RV6 = .04243827160493827160; /* 55/1296 */
 /* initialize geographic shape parameters */
 inline void pj_ell_set(std::vector<pvalue>& parameters, double &a, double &es)
 {
-    int i = 0;
     double b = 0.0;
     double e = 0.0;
     std::string name;
@@ -127,7 +126,7 @@ inline void pj_ell_set(std::vector<pvalue>& parameters, double &a, double &es)
         } else if (pj_param(parameters, "bR_h").i) { /* sphere--harmonic mean */
             a = 2. * a * b / (a + b);
             es = 0.;
-        } else if ((i = pj_param(parameters, "tR_lat_a").i) || /* sphere--arith. */
+        } else if ((int i = pj_param(parameters, "tR_lat_a").i) || /* sphere--arith. */
             pj_param(parameters, "tR_lat_g").i) { /* or geom. mean at latitude */
             double tmp;
 


### PR DESCRIPTION
This removes unused variables and redundant re-declarations to silence
warnings about variable shadowing. Tested on MSVC 14 CTP2.
