### PR TITLE
Examples

### DIFF
--- a/doc/src/examples/algorithms/area.cpp
+++ b/doc/src/examples/algorithms/area.cpp
@@ -15,7 +15,6 @@
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/polygon.hpp>
-#include <boost/geometry/io/wkt/wkt.hpp>
 
 namespace bg = boost::geometry; /*< Convenient namespace alias >*/
 

--- a/doc/src/examples/algorithms/area_with_strategy.cpp
+++ b/doc/src/examples/algorithms/area_with_strategy.cpp
@@ -15,7 +15,6 @@
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/polygon.hpp>
-#include <boost/geometry/io/wkt/wkt.hpp>
 
 namespace bg = boost::geometry; /*< Convenient namespace alias >*/
 

--- a/doc/src/examples/algorithms/centroid.cpp
+++ b/doc/src/examples/algorithms/centroid.cpp
@@ -16,8 +16,6 @@
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/polygon.hpp>
-
-#include <boost/geometry/io/wkt/wkt.hpp>
 /*<-*/ #include "create_svg_two.hpp" /*->*/
 
 int main()

--- a/doc/src/examples/algorithms/difference.cpp
+++ b/doc/src/examples/algorithms/difference.cpp
@@ -16,7 +16,6 @@
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/polygon.hpp>
-#include <boost/geometry/io/wkt/wkt.hpp>
 
 #include <boost/foreach.hpp>
 /*<-*/ #include "create_svg_overlay.hpp" /*->*/

--- a/doc/src/examples/algorithms/difference_inserter.cpp
+++ b/doc/src/examples/algorithms/difference_inserter.cpp
@@ -16,7 +16,6 @@
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/polygon.hpp>
-#include <boost/geometry/io/wkt/wkt.hpp>
 
 #include <boost/foreach.hpp>
 /*<-*/ #include "create_svg_overlay.hpp" /*->*/

--- a/doc/src/examples/algorithms/distance.cpp
+++ b/doc/src/examples/algorithms/distance.cpp
@@ -20,8 +20,6 @@
 #include <boost/geometry/geometries/multi_point.hpp>
 #include <boost/geometry/geometries/multi_polygon.hpp>
 
-#include <boost/geometry/io/wkt/wkt.hpp>
-
 #include <boost/foreach.hpp>
 
 int main()

--- a/doc/src/examples/algorithms/envelope.cpp
+++ b/doc/src/examples/algorithms/envelope.cpp
@@ -16,8 +16,6 @@
 #include <boost/geometry/geometries/box.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/polygon.hpp>
-#include <boost/geometry/io/wkt/wkt.hpp>
-
 /*<-*/ #include "create_svg_two.hpp" /*->*/
 
 int main()

--- a/doc/src/examples/algorithms/for_each_point.cpp
+++ b/doc/src/examples/algorithms/for_each_point.cpp
@@ -15,7 +15,6 @@
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/polygon.hpp>
-#include <boost/geometry/io/wkt/wkt.hpp>
 
 
 

--- a/doc/src/examples/algorithms/for_each_point_const.cpp
+++ b/doc/src/examples/algorithms/for_each_point_const.cpp
@@ -15,7 +15,6 @@
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/polygon.hpp>
-#include <boost/geometry/io/wkt/wkt.hpp>
 
 
 template <typename Point>

--- a/doc/src/examples/algorithms/intersection_ls_ls_point.cpp
+++ b/doc/src/examples/algorithms/intersection_ls_ls_point.cpp
@@ -14,7 +14,6 @@
 #include <deque>
 
 #include <boost/geometry.hpp>
-#include <boost/geometry/io/wkt/wkt.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/register/linestring.hpp>
 

--- a/doc/src/examples/algorithms/intersection_poly_poly.cpp
+++ b/doc/src/examples/algorithms/intersection_poly_poly.cpp
@@ -16,7 +16,6 @@
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/polygon.hpp>
-#include <boost/geometry/io/wkt/wkt.hpp>
 
 #include <boost/foreach.hpp>
 /*<-*/ #include "create_svg_overlay.hpp" /*->*/

--- a/doc/src/examples/algorithms/intersection_segment.cpp
+++ b/doc/src/examples/algorithms/intersection_segment.cpp
@@ -14,7 +14,6 @@
 
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
-#include <boost/geometry/io/wkt/wkt.hpp>
 
 #include <boost/foreach.hpp>
 

--- a/doc/src/examples/algorithms/intersects_linestring.cpp
+++ b/doc/src/examples/algorithms/intersects_linestring.cpp
@@ -15,7 +15,6 @@
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/linestring.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
-#include <boost/geometry/io/wkt/wkt.hpp>
 
 int main()
 {

--- a/doc/src/examples/algorithms/intersects_segment.cpp
+++ b/doc/src/examples/algorithms/intersects_segment.cpp
@@ -15,7 +15,6 @@
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/linestring.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
-#include <boost/geometry/io/wkt/wkt.hpp>
 
 int main()
 {

--- a/doc/src/examples/algorithms/length.cpp
+++ b/doc/src/examples/algorithms/length.cpp
@@ -14,7 +14,6 @@
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/linestring.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
-#include <boost/geometry/io/wkt/wkt.hpp>
 
 
 int main()

--- a/doc/src/examples/algorithms/num_geometries.cpp
+++ b/doc/src/examples/algorithms/num_geometries.cpp
@@ -16,7 +16,6 @@
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/polygon.hpp>
 #include <boost/geometry/geometries/multi_polygon.hpp>
-#include <boost/geometry/io/wkt/wkt.hpp>
 
 
 int main()

--- a/doc/src/examples/algorithms/num_interior_rings.cpp
+++ b/doc/src/examples/algorithms/num_interior_rings.cpp
@@ -16,7 +16,6 @@
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/polygon.hpp>
 #include <boost/geometry/geometries/multi_polygon.hpp>
-#include <boost/geometry/io/wkt/wkt.hpp>
 
 
 int main()

--- a/doc/src/examples/algorithms/num_points.cpp
+++ b/doc/src/examples/algorithms/num_points.cpp
@@ -16,7 +16,6 @@
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/polygon.hpp>
 #include <boost/geometry/geometries/multi_polygon.hpp>
-#include <boost/geometry/io/wkt/wkt.hpp>
 
 
 int main()

--- a/doc/src/examples/algorithms/simplify_insert_with_strategy.cpp
+++ b/doc/src/examples/algorithms/simplify_insert_with_strategy.cpp
@@ -15,7 +15,6 @@
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/linestring.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
-#include <boost/geometry/io/wkt/wkt.hpp>
 
 int main()
 {

--- a/doc/src/examples/algorithms/sym_difference.cpp
+++ b/doc/src/examples/algorithms/sym_difference.cpp
@@ -16,7 +16,6 @@
 #include <boost/geometry/geometries/polygon.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/multi_polygon.hpp>
-#include <boost/geometry/io/wkt/wkt.hpp>
 
 #include <boost/foreach.hpp>
 /*<-*/ #include "create_svg_overlay.hpp" /*->*/

--- a/doc/src/examples/algorithms/union.cpp
+++ b/doc/src/examples/algorithms/union.cpp
@@ -16,7 +16,6 @@
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/polygon.hpp>
-#include <boost/geometry/io/wkt/wkt.hpp>
 
 #include <boost/foreach.hpp>
 /*<-*/ #include "create_svg_overlay.hpp" /*->*/

--- a/doc/src/examples/algorithms/within.cpp
+++ b/doc/src/examples/algorithms/within.cpp
@@ -16,8 +16,6 @@
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/polygon.hpp>
-
-#include <boost/geometry/io/wkt/wkt.hpp>
 /*<-*/ #include "create_svg_two.hpp" /*->*/
 
 int main()

--- a/doc/src/examples/geometries/register/multi_point.cpp
+++ b/doc/src/examples/geometries/register/multi_point.cpp
@@ -14,7 +14,6 @@
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/adapted/boost_tuple.hpp>
 #include <boost/geometry/geometries/register/multi_point.hpp>
-#include <boost/geometry/io/wkt/wkt.hpp>
 
 typedef boost::tuple<float, float> point_type;
 

--- a/doc/src/examples/geometries/register/multi_point_templated.cpp
+++ b/doc/src/examples/geometries/register/multi_point_templated.cpp
@@ -14,7 +14,6 @@
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/adapted/boost_tuple.hpp>
 #include <boost/geometry/geometries/register/multi_point.hpp>
-#include <boost/geometry/io/wkt/wkt.hpp>
 
 
 BOOST_GEOMETRY_REGISTER_MULTI_POINT_TEMPLATED(std::deque)


### PR DESCRIPTION
Remove inclusion of `boost/geometry/io/wkt/wkt.hpp`; it is included by `boost/geometry.hpp`
