### PR TITLE
[test][buffer] remove used local typedef

### DIFF
--- a/test/algorithms/buffer/test_buffer.hpp
+++ b/test/algorithms/buffer/test_buffer.hpp
@@ -340,8 +340,6 @@ void test_buffer(std::string const& caseid, Geometry const& geometry,
         : ""
         ;
 
-    typedef typename bg::point_type<GeometryOut>::type output_point_type;
-
     if (distance_right < -998)
     {
         distance_right = distance_left;


### PR DESCRIPTION
Remove local typedef, producing an unused-local-typedef warning with g++ 4.8
