### PR TITLE
[doc][min/max corner] fix geometry include

### DIFF
--- a/doc/reference/core/min_max_corner.qbk
+++ b/doc/reference/core/min_max_corner.qbk
@@ -13,7 +13,7 @@
 [heading Header]
 Either
 
-`#include <boost/geometry/geometry.hpp>`
+`#include <boost/geometry.hpp>`
 
 Or
 


### PR DESCRIPTION
Replace hard-coded include of `boost/geometry/geometry.hpp` by `boost/geometry.hpp`
