### PR TITLE
Examples of buffer strategies

### DIFF
--- a/doc/src/examples/strategies/buffer_join_miter.cpp
+++ b/doc/src/examples/strategies/buffer_join_miter.cpp
@@ -18,7 +18,6 @@
 int main()
 {
     typedef boost::geometry::model::d2::point_xy<double> point;
-    typedef boost::geometry::model::linestring<point> linestring;
     typedef boost::geometry::model::polygon<point> polygon;
 
     // Declare the join_miter strategy

--- a/doc/src/examples/strategies/buffer_join_round.cpp
+++ b/doc/src/examples/strategies/buffer_join_round.cpp
@@ -18,7 +18,6 @@
 int main()
 {
     typedef boost::geometry::model::d2::point_xy<double> point;
-    typedef boost::geometry::model::linestring<point> linestring;
     typedef boost::geometry::model::polygon<point> polygon;
 
     // Declare the join_round strategy with 72 points for a full circle


### PR DESCRIPTION
Remove unused local types in examples of remove unused local types in examples of buffer strategy `join_round` and buffer strategy `join_miter`
