### PR TITLE
[algorithms][get_turn_info] fix bug reported by Jeremy Murphy on the boost mailing list

### DIFF
--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -654,12 +654,13 @@ private :
     template
     <
         int Index,
-        typename Point,
+        typename Point1,
+        typename Point2,
         typename IntersectionInfo
     >
-    static inline bool set_tp(Point const& , Point const& , Point const& , int side_rk_r,
+    static inline bool set_tp(Point1 const& , Point1 const& , Point1 const& , int side_rk_r,
                 bool const handle_robustness,
-                Point const& , Point const& , int side_rk_s,
+                Point2 const& , Point2 const& , int side_rk_s,
                 TurnInfo& tp, IntersectionInfo const& intersection_info)
     {
         boost::ignore_unused_variable_warning(handle_robustness);


### PR DESCRIPTION
In `collinear_opposite` the `set_tp` method was assuming that all point types passed to it are the same; this
is not the case: there are two different point types; the problem appeared when using `point_xy` in `rtree` and running intersects queries; in this case `get_turn_info` was instantiated with two different point types, the one used by the user and the one used by the `rtree` to store boxes, which were different.
