### PR TITLE
Fix warnings about narrowing conversions on 64-bit systems with 32-bit int

### DIFF
--- a/include/boost/geometry/algorithms/convert.hpp
+++ b/include/boost/geometry/algorithms/convert.hpp
@@ -160,7 +160,7 @@ struct range_to_range
         // point for open output.
         view_type view(rview);
 
-        int n = boost::size(view);
+        boost::range_size<Range1>::type n = boost::size(view);
         if (geometry::closure<Range2>::value == geometry::open)
         {
             n--;

--- a/include/boost/geometry/algorithms/detail/extreme_points.hpp
+++ b/include/boost/geometry/algorithms/detail/extreme_points.hpp
@@ -280,7 +280,7 @@ struct extreme_points_on_ring
     template <typename Iterator>
     static inline bool right_turn(Ring const& ring, Iterator it)
     {
-        int const index = std::distance(boost::begin(ring), it);
+        std::iterator_traits<Iterator>::difference_type const index = std::distance(boost::begin(ring), it);
         geometry::ever_circling_range_iterator<Ring const> left(ring);
         geometry::ever_circling_range_iterator<Ring const> right(ring);
         left += index;
@@ -328,7 +328,7 @@ struct extreme_points_on_ring
             return false;
         }
 
-        int const index = std::distance(boost::begin(ring), max_it);
+        std::iterator_traits<range_iterator>::difference_type const index = std::distance(boost::begin(ring), max_it);
 //std::cout << "Extreme point lies at " << index << " having " << geometry::wkt(*max_it) << std::endl;
 
         geometry::ever_circling_range_iterator<Ring const> left(ring);

--- a/include/boost/geometry/views/detail/points_view.hpp
+++ b/include/boost/geometry/views/detail/points_view.hpp
@@ -105,7 +105,7 @@ class points_view
         }
 
         Point const* m_points;
-        int m_index;
+        difference_type m_index;
     };
 
 public :


### PR DESCRIPTION
I have fixed some warnings appearing on (at least) MSVC12 64-bit, since int was used as difference type / size type, hence compiler warned about narrowing conversion (possible loss of data C4244).

Everything builds fine and tests pass on MSVC12 64-bit.

Still, there are lots of C4267 warnings about conversion from 'size_t' to 'int'
