### PR TITLE
[algorithms][buffer] fix header for inclusion of disjoint

### DIFF
--- a/include/boost/geometry/algorithms/detail/buffer/turn_in_piece_visitor.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/turn_in_piece_visitor.hpp
@@ -14,7 +14,7 @@
 #include <boost/geometry/arithmetic/dot_product.hpp>
 #include <boost/geometry/algorithms/equals.hpp>
 #include <boost/geometry/algorithms/expand.hpp>
-#include <boost/geometry/algorithms/detail/disjoint/box_box.hpp>
+#include <boost/geometry/algorithms/detail/disjoint/point_box.hpp>
 #include <boost/geometry/algorithms/detail/overlay/segment_identifier.hpp>
 #include <boost/geometry/algorithms/detail/overlay/get_turn_info.hpp>
 #include <boost/geometry/strategies/buffer.hpp>
@@ -42,7 +42,11 @@ struct turn_ovelaps_box
     template <typename Box, typename Turn>
     static inline bool apply(Box const& box, Turn const& turn)
     {
-        return ! geometry::disjoint(box, turn.robust_point);
+        return ! dispatch::disjoint
+            <
+                typename Turn::robust_point_type,
+                Box
+            >::apply(turn.robust_point, box);
     }
 };
 


### PR DESCRIPTION
It is the point-box and not the box-box version that is needed; also the call to disjoint is not done via the free function but rather using the disjoint dispatch struct
