### PR TITLE
Fix route costs in graph_route_example

### DIFF
--- a/example/07_a_graph_route_example.cpp
+++ b/example/07_a_graph_route_example.cpp
@@ -31,12 +31,8 @@
 // For output:
 #include <boost/geometry/io/svg/svg_mapper.hpp>
 
-// Yes, this example currently uses an extension:
-
 // For distance-calculations over the Earth:
 //#include <boost/geometry/extensions/gis/geographic/strategies/andoyer.hpp>
-// Yes, this example currently uses some extensions:
-
 
 // Read an ASCII file containing WKT's, fill a vector of tuples
 // The tuples consist of at least <0> a geometry and <1> an identifying string
@@ -90,6 +86,9 @@ namespace boost
     BOOST_INSTALL_PROPERTY(edge, bg_property);
 }
 
+// To calculate distance, declare and construct a strategy with average earth radius
+boost::geometry::strategy::distance::haversine<double> const haversine(6372795.0);
+
 // Define properties for vertex
 template <typename Point>
 struct bg_vertex_property
@@ -99,8 +98,8 @@ struct bg_vertex_property
         boost::geometry::assign_zero(location);
     }
     bg_vertex_property(Point const& loc)
+        : location(loc)
     {
-        location = loc;
     }
 
     Point location;
@@ -112,8 +111,8 @@ struct bg_edge_property
 {
     bg_edge_property(Linestring const& line)
         : m_line(line)
+        , m_length(boost::geometry::length(line, haversine))
     {
-        m_length = boost::geometry::length(line);
     }
 
     inline operator double() const
@@ -304,9 +303,6 @@ int main()
     double const km = 1000.0;
     std::cout << "distances, all in KM" << std::endl
         << std::fixed << std::setprecision(0);
-
-    // To calculate distance, declare and construct a strategy with average earth radius
-    boost::geometry::strategy::distance::haversine<double> haversine(6372795.0);
 
     // Main functionality: calculate shortest routes from/to all cities
 

--- a/example/07_b_graph_route_example.cpp
+++ b/example/07_b_graph_route_example.cpp
@@ -34,8 +34,6 @@
 // For output:
 #include <boost/geometry/io/svg/svg_mapper.hpp>
 
-// Yes, this example currently uses an extension:
-
 // For distance-calculations over the Earth:
 //#include <boost/geometry/extensions/gis/geographic/strategies/andoyer.hpp>
 
@@ -82,7 +80,8 @@ void read_wkt(std::string const& filename, std::vector<Tuple>& tuples, Box& box)
     }
 }
 
-
+// To calculate distance, declare and construct a strategy with average earth radius
+boost::geometry::strategy::distance::haversine<double> const haversine(6372795.0);
 
 // Define properties for vertex
 template <typename Point>
@@ -93,8 +92,8 @@ struct bg_vertex_property
         boost::geometry::assign_zero(location);
     }
     bg_vertex_property(Point const& loc)
+        : location(loc)
     {
-        location = loc;
     }
 
     Point location;
@@ -106,8 +105,8 @@ struct bg_edge_property
 {
     bg_edge_property(Linestring const& line)
         : m_line(line)
+        , length(boost::geometry::length(line, haversine))
     {
-        length = boost::geometry::length(line);
     }
 
     inline Linestring const& line() const
@@ -291,9 +290,6 @@ int main()
     double const km = 1000.0;
     std::cout << "distances, all in KM" << std::endl
         << std::fixed << std::setprecision(0);
-
-    // To calculate distance, declare and construct a strategy with average earth radius
-    boost::geometry::strategy::distance::haversine<double> haversine(6372795.0);
 
     // Main functionality: calculate shortest routes from/to all cities
 


### PR DESCRIPTION
For some reason, the graph_route examples have evolved into a broken state.

Basically, road length is taken without considering the earth radius.
Which leads to the following output:

distances, all in KM
Boston          - Chicago         -> through the air: 1370 , over the road: 0  
Boston          - Houston         -> through the air: 2568 , over the road: 0  
Boston          - Los Angeles     -> through the air: 4192 , over the road: 0  
Boston          - Miami           -> through the air: 2025 , over the road: 0  
Boston          - New York        -> through the air: 303  , over the road: 0  
Boston          - Phoenix         -> through the air: 3694 , over the road: 0  
Boston          - Washington DC   -> through the air: 641  , over the road: 0  
Chicago         - Boston          -> through the air: 1370 , over the road: 0  
Chicago         - Houston         -> through the air: 1496 , over the road: 0  
Chicago         - Los Angeles     -> through the air: 2822 , over the road: 0  
Chicago         - Miami           -> through the air: 1912 , over the road: 0  
Chicago         - New York        -> through the air: 1147 , over the road: 0  
Chicago         - Phoenix         -> through the air: 2333 , over the road: 0  
Chicago         - Washington DC   -> through the air: 960  , over the road: 0   

cost is mostly between 0 and 1, and later gets divided by 1000.

The bug is rather obvious: You need to use the haversine strategy
for linestring length as well, so that the distance though air
and over the road have same units.

With this commit applied, the output looks like this now:

distances, all in KM
Boston          - Chicago         -> through the air: 1370 , over the road: 1572
Boston          - Houston         -> through the air: 2568 , over the road: 2931
Boston          - Los Angeles     -> through the air: 4192 , over the road: 4811
Boston          - Miami           -> through the air: 2025 , over the road: 2875
Boston          - New York        -> through the air: 303  , over the road: 330 
Boston          - Phoenix         -> through the air: 3694 , over the road: 4327
Boston          - Washington DC   -> through the air: 641  , over the road: 704 
Chicago         - Boston          -> through the air: 1370 , over the road: 1572
Chicago         - Houston         -> through the air: 1496 , over the road: 2049
Chicago         - Los Angeles     -> through the air: 2822 , over the road: 3263
Chicago         - Miami           -> through the air: 1912 , over the road: 2253
Chicago         - New York        -> through the air: 1147 , over the road: 1252
Chicago         - Phoenix         -> through the air: 2333 , over the road: 2971
Chicago         - Washington DC   -> through the air: 960  , over the road: 1101
