### PR TITLE
Fix ‘closure’ is not a member of ‘boost::geometry’.

### DIFF
--- a/include/boost/geometry/algorithms/num_points.hpp
+++ b/include/boost/geometry/algorithms/num_points.hpp
@@ -30,6 +30,7 @@
 #include <boost/variant/apply_visitor.hpp>
 #include <boost/variant/variant_fwd.hpp>
 
+#include <boost/geometry/core/closure.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/tag_cast.hpp>
 #include <boost/geometry/core/tags.hpp>


### PR DESCRIPTION
Building examples uncovers following missing include in num_points.hpp:

../../boost/geometry/algorithms/num_points.hpp:68:16: error: ‘closure’ is not a member of ‘boost::geometry’

Adding an include of core/closure.hpp fixes this.
