### PR TITLE
Algorithms/Turns missing include

### DIFF
--- a/include/boost/geometry/algorithms/detail/turns/debug_turn.hpp
+++ b/include/boost/geometry/algorithms/detail/turns/debug_turn.hpp
@@ -14,8 +14,10 @@
 #include <iostream>
 #include <string>
 
-#include <boost/geometry/io/wkt/write.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+
+#include <boost/geometry/io/wkt/write.hpp>
+#include <boost/geometry/algorithms/detail/overlay/debug_turn_info.hpp>
 #endif // BOOST_GEOMETRY_DEBUG_TURNS
 
 


### PR DESCRIPTION
add missing include that causes compilation error in unit tests when `-DBOOST_GEOMETRY_TEST_DEBUG` is defined, and re-arrange order of includes
