### PR TITLE
Add support for writing geometries to WKB

### DIFF
--- a/extensions/test/gis/io/wkb/read_wkb.cpp
+++ b/extensions/test/gis/io/wkb/read_wkb.cpp
@@ -11,16 +11,23 @@
 #include <string>
 #include <vector>
 
+#include <iostream>
+
 #include <boost/test/included/test_exec_monitor.hpp>
 #include <boost/test/included/unit_test.hpp>
 #include <boost/test/floating_point_comparison.hpp>
 #include <boost/cstdint.hpp>
+#include <boost/geometry/strategies/strategies.hpp>
 
 #include <boost/geometry/algorithms/equals.hpp>
 #include <boost/geometry/geometries/geometries.hpp>
 #include <boost/geometry/io/wkt/read.hpp>
 #include <boost/geometry/extensions/gis/io/wkb/read_wkb.hpp>
 #include <boost/geometry/extensions/gis/io/wkb/utility.hpp>
+
+#include <boost/geometry/io/wkt/wkt.hpp>
+#include <boost/geometry/io/wkt/write.hpp>
+#include <boost/assign/list_of.hpp>
 
 namespace bg = boost::geometry;
 
@@ -38,7 +45,7 @@ void test_geometry_wrong_wkb(std::string const& wkbhex, std::string const& wkt)
 }
 
 template <typename Geometry, bool IsEqual>
-void test_geometry_equals(std::string const& wkbhex, std::string const& wkt)
+void test_geometry_equals_old(std::string const& wkbhex, std::string const& wkt)
 {
     byte_vector wkb;
     BOOST_CHECK( bg::hex2wkb(wkbhex, std::back_inserter(wkb)) );
@@ -47,7 +54,26 @@ void test_geometry_equals(std::string const& wkbhex, std::string const& wkt)
 
     Geometry g_expected;
     bg::read_wkt(wkt, g_expected);
+
     BOOST_CHECK( bg::equals(g_wkb, g_expected) == IsEqual );
+}
+
+template <typename Geometry, bool IsEqual>
+void test_geometry_equals(Geometry const& g_expected, std::string const& wkbhex)
+{
+    byte_vector wkb;
+    BOOST_CHECK( bg::hex2wkb(wkbhex, std::back_inserter(wkb)));
+        
+    Geometry g_wkb;
+    bg::read_wkb(wkb.begin(), wkb.end(), g_wkb);
+
+    BOOST_CHECK( bg::equals(g_wkb, g_expected) == IsEqual );
+
+    if(bg::equals(g_wkb, g_expected) != IsEqual)
+    {
+        std::cout << "EXPECTED: " << bg::wkt(g_expected) << std::endl;
+        std::cout << "ACTUAL  : " << bg::wkt(g_wkb) << std::endl;
+    }
 }
 
 //template <typename P, bool Result>
@@ -64,45 +90,190 @@ void test_geometry_equals(std::string const& wkbhex, std::string const& wkt)
 
 int test_main(int, char* [])
 {
-    typedef bg::model::point<double, 2, bg::cs::cartesian> point_type;
-    typedef bg::model::linestring<point_type> linestring_type;
+    {
+        typedef bg::model::point<double, 2, bg::cs::cartesian> point_type;
+        typedef bg::model::point<double, 3, bg::cs::cartesian> point3d_type;
 
-    //
-    // POINT
-    //
+        //
+        // POINT
+        //
 
-    test_geometry_equals<point_type, true>(
-        "01010000005839B4C876BEF33F83C0CAA145B61640", "POINT (1.234 5.678)");
+        test_geometry_equals_old<point_type, true>(
+            "01010000005839B4C876BEF33F83C0CAA145B61640", "POINT (1.234 5.678)");
 
-    // XYZ - POINT(1.234 5.678 99) - Z coordinate ignored
-    test_geometry_equals<point_type, true>(
-        "01010000805839B4C876BEF33F83C0CAA145B616400000000000C05840", "POINT(1.234 5.678)");
+        test_geometry_equals_old<point3d_type, true>(
+            "01E90300005839B4C876BEF33F83C0CAA145B616404F401361C3332240", "POINT(1.234 5.678 9.1011)");
 
-    // SRID=32632;POINT(1.234 5.678) - PostGIS EWKT
-    test_geometry_equals<point_type, false>(
-        "0101000020787F00005839B4C876BEF33F83C0CAA145B61640", "POINT (1.234 5.678)");
+        //     // XYZ - POINT(1.234 5.678 99) - Z coordinate ignored
+        //     test_geometry_equals<point_type, true>(
+        //         "01010000805839B4C876BEF33F83C0CAA145B616400000000000C05840", "POINT(1.234 5.678)");
+        // 
+        //     // SRID=32632;POINT(1.234 5.678) - PostGIS EWKT
+        //     test_geometry_equals<point_type, false>(
+        //         "0101000020787F00005839B4C876BEF33F83C0CAA145B61640", "POINT (1.234 5.678)");
+        // 
+        //     // SRID=4326;POINT(1.234 5.678 99) - PostGIS EWKT
+        //     test_geometry_equals<point_type, false>(
+        //         "01010000A0E61000005839B4C876BEF33F83C0CAA145B616400000000000C05840", "POINT(1.234 5.678)");
+        // 
+        //     // POINTM(1.234 5.678 99) - XYM with M compound ignored
+        //     test_geometry_equals<point_type, true>(
+        //         "01010000405839B4C876BEF33F83C0CAA145B616400000000000C05840", "POINT (1.234 5.678)");
+        // 
+        //     // SRID=32632;POINTM(1.234 5.678 99)
+        //     test_geometry_equals<point_type, false>(
+        //         "0101000060787F00005839B4C876BEF33F83C0CAA145B616400000000000C05840", "POINT (1.234 5.678)");
+        // 
+        //     // POINT(1.234 5.678 15 79) - XYZM - Z and M compounds ignored
+        //     test_geometry_equals<point_type, true>(
+        //         "01010000C05839B4C876BEF33F83C0CAA145B616400000000000002E400000000000C05340",
+        //         "POINT (1.234 5.678)");
+        // 
+        //     // SRID=4326;POINT(1.234 5.678 15 79) - XYZM + SRID
+        //     test_geometry_equals<point_type, false>(
+        //         "01010000E0E61000005839B4C876BEF33F83C0CAA145B616400000000000002E400000000000C05340",
+        //         "POINT (1.234 5.678)");
 
-    // SRID=4326;POINT(1.234 5.678 99) - PostGIS EWKT
-    test_geometry_equals<point_type, false>(
-        "01010000A0E61000005839B4C876BEF33F83C0CAA145B616400000000000C05840", "POINT(1.234 5.678)");
+    }
 
-    // POINTM(1.234 5.678 99) - XYM with M compound ignored
-    test_geometry_equals<point_type, true>(
-        "01010000405839B4C876BEF33F83C0CAA145B616400000000000C05840", "POINT (1.234 5.678)");
+    {
+        typedef bg::model::point<double, 2, bg::cs::cartesian> point_type;
+        typedef bg::model::point<double, 3, bg::cs::cartesian> point3d_type;
 
-    // SRID=32632;POINTM(1.234 5.678 99)
-    test_geometry_equals<point_type, false>(
-        "0101000060787F00005839B4C876BEF33F83C0CAA145B616400000000000C05840", "POINT (1.234 5.678)");
+        typedef bg::model::linestring<point_type> linestring_type;
+        typedef bg::model::linestring<point3d_type> linestring3d_type;
 
-    // POINT(1.234 5.678 15 79) - XYZM - Z and M compounds ignored
-    test_geometry_equals<point_type, true>(
-        "01010000C05839B4C876BEF33F83C0CAA145B616400000000000002E400000000000C05340",
-        "POINT (1.234 5.678)");
+        typedef bg::model::polygon<point_type> polygon_type;
+        typedef bg::model::polygon<point3d_type> polygon3d_type;
 
-    // SRID=4326;POINT(1.234 5.678 15 79) - XYZM + SRID
-    test_geometry_equals<point_type, false>(
-        "01010000E0E61000005839B4C876BEF33F83C0CAA145B616400000000000002E400000000000C05340",
-        "POINT (1.234 5.678)");
+        //
+        // POINT
+        //
+
+        {
+            point_type point(1.0, 2.0);
+
+            test_geometry_equals<point_type, true>
+                (
+                point, 
+                "0101000000000000000000F03F0000000000000040"
+                );
+        }
+
+        {
+            point3d_type point(1.0, 2.0, 3.0);
+
+            test_geometry_equals<point3d_type, true>
+                (
+                point, 
+                "01E9030000000000000000F03F00000000000000400000000000000840"
+                );
+        }
+
+        //
+        // LINESTRING
+        //
+
+        {
+            linestring_type linestring;
+
+            bg::append(linestring, 
+                boost::assign::list_of
+                (point_type(1.0, 2.0))
+                (point_type(2.0, 3.0))
+                (point_type(4.0, 5.0))
+                );
+
+            test_geometry_equals<linestring_type, true>
+                (
+                linestring, 
+                "010200000003000000000000000000F03F00000000000000400000000000000040000000000000084000000000000010400000000000001440"
+                );
+        }
+
+// 		{
+// 			linestring3d_type linestring;
+// 
+// 			bg::append(linestring, 
+// 				boost::assign::list_of
+// 				(point3d_type(1.0, 2.0, 3.0))
+// 				(point3d_type(2.0, 3.0, 4.0))
+// 				(point3d_type(4.0, 5.0, 6.0))
+// 				);
+// 
+// 			test_geometry_equals<linestring3d_type, true>
+// 				(
+// 				linestring, 
+// 				"01EA03000003000000000000000000F03F00000000000000400000000000000840000000000000004000000000000008400000000000001040000000000000104000000000000014400000000000001840"
+// 				);
+// 		}
+
+        //
+        // POLYGON
+        //
+
+        {
+            polygon_type polygon;
+
+            bg::append(polygon, 
+                boost::assign::list_of
+                (point_type(50.0, 50.0))
+                (point_type(50.0, 100.0))
+                (point_type(100.0, 100.0))
+                (point_type(100.0, 50.0))
+                (point_type(50.0, 50.0))
+                );
+
+            test_geometry_equals<polygon_type, true>
+                (
+                polygon, 
+                "010300000001000000050000000000000000004940000000000000494000000000000049400000000000005940000000000000594000000000000059400000000000005940000000000000494000000000000049400000000000004940"
+                );
+        }
+
+// 		{
+// 			polygon3d_type polygon;
+// 
+// 			bg::append(polygon, boost::assign::list_of(point3d_type(50.0, 50.0, 5.0))(point3d_type(50.0, 100.0, 10.0))(point3d_type(100.0, 100.0, 5.0))(point3d_type(100.0, 50.0, 10.0))(point3d_type(50.0, 50.0, 5.0)));
+// 
+// 			test_geometry_equals<polygon3d_type, true>
+// 				(
+// 				polygon, 
+// 				"01EB0300000100000005000000000000000000494000000000000049400000000000001440000000000000494000000000000059400000000000002440000000000000594000000000000059400000000000001440000000000000594000000000000049400000000000002440000000000000494000000000000049400000000000001440"
+// 				);
+// 		}
+
+        {
+            polygon_type polygon;
+
+            bg::append(polygon, 
+                boost::assign::list_of
+                (point_type(35, 10))
+                (point_type(45, 45))
+                (point_type(15, 40))
+                (point_type(10, 20))
+                (point_type(35, 10))
+                );
+            
+            // Create an interior ring (append does not do this automatically)
+            boost::geometry::interior_rings(polygon).resize(1);
+            
+            bg::append(polygon, 
+                boost::assign::list_of
+                (point_type(20, 30))
+                (point_type(35, 35))
+                (point_type(30, 20))
+                (point_type(20, 30))
+                , 0);
+            
+            test_geometry_equals<polygon_type, true>
+                (
+                polygon, 
+                "0103000000020000000500000000000000008041400000000000002440000000000080464000000000008046400000000000002E40000000000000444000000000000024400000000000003440000000000080414000000000000024400400000000000000000034400000000000003E40000000000080414000000000008041400000000000003E40000000000000344000000000000034400000000000003E40"
+                );
+        }
+
+    }
 
     return 0;
 }

--- a/extensions/test/gis/io/wkb/write_wkb.cpp
+++ b/extensions/test/gis/io/wkb/write_wkb.cpp
@@ -1,0 +1,195 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+// Unit Test
+
+// Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <iterator>
+#include <string>
+#include <vector>
+
+#include <iostream>
+
+#include <boost/test/included/test_exec_monitor.hpp>
+#include <boost/test/included/unit_test.hpp>
+#include <boost/test/floating_point_comparison.hpp>
+#include <boost/cstdint.hpp>
+#include <boost/geometry/strategies/strategies.hpp>
+
+#include <boost/geometry/algorithms/equals.hpp>
+#include <boost/geometry/geometries/geometries.hpp>
+#include <boost/geometry/io/wkt/read.hpp>
+#include <boost/geometry/extensions/gis/io/wkb/write_wkb.hpp>
+#include <boost/geometry/extensions/gis/io/wkb/utility.hpp>
+
+#include <boost/geometry/io/wkt/wkt.hpp>
+
+#include <boost/range/algorithm_ext/push_back.hpp>
+#include <boost/assign/list_of.hpp>
+
+namespace bg = boost::geometry;
+
+namespace { // anonymous
+
+template <typename Geometry, bool IsEqual>
+void test_geometry_equals(Geometry const& geometry, std::string const& wkbhex)
+{
+    std::string wkb_out;
+    bg::write_wkb(geometry, std::back_inserter(wkb_out));
+
+    std::string hex_out;
+    BOOST_CHECK( bg::wkb2hex(wkb_out.begin(), wkb_out.end(), hex_out) );
+
+    BOOST_CHECK_EQUAL( wkbhex, hex_out);
+}
+
+} // namespace anonymous
+
+int test_main(int, char* [])
+{
+    typedef bg::model::point<double, 2, bg::cs::cartesian> point_type;
+    typedef bg::model::point<double, 3, bg::cs::cartesian> point3d_type;
+    typedef bg::model::linestring<point_type> linestring_type;
+    typedef bg::model::linestring<point3d_type> linestring3d_type;
+    typedef bg::model::polygon<point_type> polygon_type;
+    typedef bg::model::polygon<point3d_type> polygon3d_type;
+
+    //
+    // POINT
+    //
+
+    {
+        point_type point(1.0, 2.0);
+
+        test_geometry_equals<point_type, true>
+            (
+            point,
+            "0101000000000000000000F03F0000000000000040"
+            );
+    }
+
+    {
+        point3d_type point(1.0, 2.0, 3.0);
+
+        test_geometry_equals<point3d_type, true>
+            (
+            point,
+            "01E9030000000000000000F03F00000000000000400000000000000840"
+            );
+    }
+
+    //
+    // LINESTRING
+    //
+
+    {
+        linestring_type linestring;
+
+        bg::append(linestring, 
+            boost::assign::list_of
+            (point_type(1.0, 2.0))
+            (point_type(2.0, 3.0))
+            (point_type(4.0, 5.0))
+            );
+
+        test_geometry_equals<linestring_type, true>
+            (
+            linestring,
+            "010200000003000000000000000000F03F00000000000000400000000000000040000000000000084000000000000010400000000000001440"
+            );
+    }
+
+    {
+        linestring3d_type linestring;
+
+        bg::append(linestring, 
+            boost::assign::list_of
+            (point3d_type(1.0, 2.0, 3.0))
+            (point3d_type(2.0, 3.0, 4.0))
+            (point3d_type(4.0, 5.0, 6.0))
+            );
+
+        test_geometry_equals<linestring3d_type, true>
+            (
+            linestring,
+            "01EA03000003000000000000000000F03F00000000000000400000000000000840000000000000004000000000000008400000000000001040000000000000104000000000000014400000000000001840"
+            );
+    }
+
+    //
+    // POLYGON
+    //
+
+    {
+        polygon_type polygon;
+
+        bg::append(polygon, 
+            boost::assign::list_of
+            (point_type(50.0, 50.0))
+            (point_type(50.0, 100.0))
+            (point_type(100.0, 100.0))
+            (point_type(100.0, 50.0))
+            (point_type(50.0, 50.0))
+            );
+
+        test_geometry_equals<polygon_type, true>
+            (
+            polygon,
+            "010300000001000000050000000000000000004940000000000000494000000000000049400000000000005940000000000000594000000000000059400000000000005940000000000000494000000000000049400000000000004940"
+            );
+    }
+
+    {
+        polygon3d_type polygon;
+
+        bg::append(polygon, 
+            boost::assign::list_of
+            (point3d_type(50.0, 50.0, 5.0))
+            (point3d_type(50.0, 100.0, 10.0))
+            (point3d_type(100.0, 100.0, 5.0))
+            (point3d_type(100.0, 50.0, 10.0))
+            (point3d_type(50.0, 50.0, 5.0))
+            );
+
+        test_geometry_equals<polygon3d_type, true>
+            (
+            polygon,
+            "01EB0300000100000005000000000000000000494000000000000049400000000000001440000000000000494000000000000059400000000000002440000000000000594000000000000059400000000000001440000000000000594000000000000049400000000000002440000000000000494000000000000049400000000000001440"
+            );
+    }
+
+    {
+        polygon_type polygon;
+
+        bg::append(polygon, 
+            boost::assign::list_of
+            (point_type(35, 10))
+            (point_type(45, 45))
+            (point_type(15, 40))
+            (point_type(10, 20))
+            (point_type(35, 10))
+            );
+
+        // Create an interior ring (append does not do this automatically)
+        boost::geometry::interior_rings(polygon).resize(1);
+
+        bg::append(polygon, 
+            boost::assign::list_of
+            (point_type(20, 30))
+            (point_type(35, 35))
+            (point_type(30, 20))
+            (point_type(20, 30))
+            , 0);
+
+        test_geometry_equals<polygon_type, true>
+            (
+            polygon,
+            "0103000000020000000500000000000000008041400000000000002440000000000080464000000000008046400000000000002E40000000000000444000000000000024400000000000003440000000000080414000000000000024400400000000000000000034400000000000003E40000000000080414000000000008041400000000000003E40000000000000344000000000000034400000000000003E40"
+            );
+    }
+
+    return 0;
+}

--- a/include/boost/geometry/extensions/gis/io/wkb/detail/ogc.hpp
+++ b/include/boost/geometry/extensions/gis/io/wkb/detail/ogc.hpp
@@ -62,7 +62,7 @@ struct byte_order_type
     };
 };
 
-struct geometry_type
+struct geometry_type_ogc
 {
     enum enum_t
     {
@@ -78,9 +78,131 @@ struct geometry_type
     };
 };
 
-}} // namespace detail::endian
+struct geometry_type_ewkt
+{
+    enum enum_t
+    {
+        point      = 1,
+        linestring = 2,
+        polygon    = 3,
+
+        // TODO: Not implemented
+        //multipoint = 4,
+        //multilinestring = 5,
+        //multipolygon = 6,
+        //collection = 7
+
+
+        pointz      = 1001,
+        linestringz = 1002,
+        polygonz    = 1003
+    };
+};
+
+struct ogc_policy
+{
+};
+
+struct ewkt_policy
+{
+};
+
+template
+<
+    typename Geometry, 
+    typename CheckPolicy = ogc_policy, 
+    typename Tag = typename tag<Geometry>::type
+>
+struct geometry_type : not_implemented<Tag>
+{
+};
+
+template <typename Geometry, typename CheckPolicy>
+struct geometry_type<Geometry, CheckPolicy, point_tag>
+{
+    static bool check(boost::uint32_t value) 
+    { 
+        return value == get_impl<dimension<Geometry>::value>(); 
+    }
+
+    static boost::uint32_t get() 
+    { 
+        return get_impl<dimension<Geometry>::value>(); 
+    }
+
+private:
+
+    template <int dimension>
+    static boost::uint32_t get_impl() 
+    {
+        return geometry_type_ogc::point;
+    }
+
+    template <>
+    static boost::uint32_t get_impl<3>()
+    {
+        return 1000 + geometry_type_ogc::point;
+    }
+};
+
+template <typename Geometry, typename CheckPolicy>
+struct geometry_type<Geometry, CheckPolicy, linestring_tag>
+{
+    static bool check(boost::uint32_t value) 
+    { 
+        return value == get_impl<dimension<Geometry>::value>(); 
+    }
+
+    static boost::uint32_t get() 
+    { 
+        return get_impl<dimension<Geometry>::value>(); 
+    }
+
+private:
+
+    template <int dimension>
+    static boost::uint32_t get_impl() 
+    {
+        return geometry_type_ogc::linestring;
+    }
+
+    template <>
+    static boost::uint32_t get_impl<3>()
+    {
+        return 1000 + geometry_type_ogc::linestring;
+    }
+};
+
+template <typename Geometry, typename CheckPolicy>
+struct geometry_type<Geometry, CheckPolicy, polygon_tag>
+{
+    static bool check(boost::uint32_t value) 
+    { 
+        return value == get_impl<dimension<Geometry>::value>(); 
+    }
+
+    static boost::uint32_t get() 
+    { 
+        return get_impl<dimension<Geometry>::value>(); 
+    }
+
+private:
+
+    template <int dimension>
+    static boost::uint32_t get_impl() 
+    {
+        return geometry_type_ogc::polygon;
+    }
+
+    template <>
+    static boost::uint32_t get_impl<3>()
+    {
+        return 1000 + geometry_type_ogc::polygon;
+    }
+};
+
+}} // namespace detail::wkb
 #endif // DOXYGEN_NO_IMPL
 
 }} // namespace boost::geometry
-
 #endif // BOOST_GEOMETRY_IO_WKB_DETAIL_OGC_HPP

--- a/include/boost/geometry/extensions/gis/io/wkb/detail/writer.hpp
+++ b/include/boost/geometry/extensions/gis/io/wkb/detail/writer.hpp
@@ -1,0 +1,205 @@
+#ifndef BOOST_GEOMETRY_IO_WKB_DETAIL_WRITER_HPP
+#define BOOST_GEOMETRY_IO_WKB_DETAIL_WRITER_HPP
+
+#include <cassert>
+#include <cstddef>
+#include <algorithm>
+#include <iterator>
+#include <limits>
+
+#include <boost/concept_check.hpp>
+#include <boost/cstdint.hpp>
+#include <boost/type_traits/is_integral.hpp>
+#include <boost/type_traits/is_same.hpp>
+#include <boost/static_assert.hpp>
+
+#include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/coordinate_dimension.hpp>
+#include <boost/geometry/core/coordinate_type.hpp>
+#include <boost/geometry/core/exterior_ring.hpp>
+#include <boost/geometry/core/interior_rings.hpp>
+#include <boost/geometry/extensions/gis/io/wkb/detail/endian.hpp>
+#include <boost/geometry/extensions/gis/io/wkb/detail/ogc.hpp>
+
+#include <boost/range.hpp>
+#include <boost/range/algorithm/for_each.hpp>
+
+namespace boost { namespace geometry
+{
+
+#ifndef DOXYGEN_NO_DETAIL
+namespace detail { namespace wkb
+{
+
+    template <typename T>
+    struct value_writer
+    {
+        typedef T value_type;
+
+        template <typename OutputIterator>
+        static bool write(const T& value, OutputIterator& iter, byte_order_type::enum_t byte_order)
+        {
+            endian::endian_value<T> parsed_value(value);
+
+// 				if (byte_order_type::xdr == byte_order)
+// 				{
+// 					parsed_value.template store<endian::big_endian_tag>(iter);
+// 				}
+// 				else if (byte_order_type::ndr == byte_order)
+// 				{
+// 					parsed_value.template store<endian::little_endian_tag>(iter);
+// 				}
+// 				else
+// 				{
+                parsed_value.template store<endian::native_endian_tag>(iter);
+// 				}
+
+            return true;
+        }
+    };
+
+    template <typename P, int I, int N>
+    struct writer_assigner
+    {
+        template <typename OutputIterator>
+        static void run(const P& point, OutputIterator& iter, byte_order_type::enum_t byte_order)
+        {
+            typedef typename coordinate_type<P>::type coordinate_type;
+
+            value_writer<double>::write(boost::geometry::get<I>(point), iter, byte_order);
+
+            writer_assigner<P, I+1, N>::run(point, iter, byte_order);
+        }
+    };
+
+    template <typename P, int N>
+    struct writer_assigner<P, N, N>
+    {
+        template <typename OutputIterator>
+        static void run(const P& point, OutputIterator& iter, byte_order_type::enum_t byte_order)
+        {
+            // terminate
+            boost::ignore_unused_variable_warning(point);
+            boost::ignore_unused_variable_warning(iter);
+            boost::ignore_unused_variable_warning(byte_order);
+        }
+    };
+
+    template <typename P>
+    struct point_writer
+    {
+        template <typename OutputIterator>
+        static bool write(const P& point, OutputIterator& iter,
+            byte_order_type::enum_t byte_order)
+        {
+            // write endian type
+            value_writer<uint8_t>::write(byte_order, iter, byte_order);
+
+            // write geometry type
+            uint32_t type = geometry_type<P>::get();
+            value_writer<uint32_t>::write(type, iter, byte_order);
+
+            // write point's x, y, z
+            writer_assigner<P, 0, dimension<P>::value>::run(point, iter, byte_order);
+
+            return true;
+        }
+    };
+
+    template <typename L>
+    struct linestring_writer
+    {
+        template <typename OutputIterator>
+        static bool write(const L& linestring, OutputIterator& iter,
+            byte_order_type::enum_t byte_order)
+        {
+            // write endian type
+            value_writer<uint8_t>::write(byte_order, iter, byte_order);
+
+            // write geometry type
+            uint32_t type = geometry_type<L>::get();
+            value_writer<uint32_t>::write(type, iter, byte_order);
+
+            // write num points
+            uint32_t num_points = boost::size(linestring);
+            value_writer<uint32_t>::write(num_points, iter, byte_order);
+
+            typedef typename point_type<L>::type point_type;
+
+            for(boost::range_iterator<const L>::type point_iter = boost::begin(linestring);
+                point_iter != boost::end(linestring);
+                ++point_iter)
+            {
+                // write point's x, y, z
+                writer_assigner<point_type, 0, dimension<point_type>::value>::run(*point_iter, iter, byte_order);
+            }
+
+            return true;
+        }
+    };
+
+    template <typename P>
+    struct polygon_writer
+    {
+        template <typename OutputIterator>
+        static bool write(const P& polygon, OutputIterator& iter,
+            byte_order_type::enum_t byte_order)
+        {
+            // write endian type
+            value_writer<uint8_t>::write(byte_order, iter, byte_order);
+
+            // write geometry type
+            uint32_t type = geometry_type<P>::get();
+            value_writer<uint32_t>::write(type, iter, byte_order);
+
+            // write num rings
+            uint32_t num_rings = 1 + boost::geometry::num_interior_rings(polygon);
+            value_writer<uint32_t>::write(num_rings, iter, byte_order);
+
+            typedef typename point_type<P>::type point_type;
+
+            // write exterior ring
+            typedef typename boost::geometry::ring_type<const P>::type ring_type;
+            ring_type exterior_ring = boost::geometry::exterior_ring(polygon);
+
+            uint32_t num_exterior_ring_points = boost::geometry::num_points(exterior_ring);
+            value_writer<uint32_t>::write(num_exterior_ring_points, iter, byte_order);
+
+            for(boost::range_iterator<const ring_type>::type point_iter = boost::begin(exterior_ring); 
+                point_iter != boost::end(exterior_ring);
+                ++point_iter)
+            {
+                // write point's x, y, z
+                writer_assigner<point_type, 0, dimension<point_type>::value>::run(*point_iter, iter, byte_order);
+            }
+
+            // write interor rings
+            typedef typename boost::geometry::interior_type<const P>::type interior_rings_type;
+
+            interior_rings_type interior_rings = boost::geometry::interior_rings(polygon);
+
+            for(boost::range_iterator<const interior_rings_type>::type interior_ring_iter = boost::begin(interior_rings); 
+                interior_ring_iter != boost::end(interior_rings);
+                ++interior_ring_iter)
+            {
+                uint32_t num_interior_ring_points = boost::geometry::num_points(*interior_ring_iter);
+                value_writer<uint32_t>::write(num_interior_ring_points, iter, byte_order);
+
+                for(boost::range_iterator<const ring_type>::type point_iter = boost::begin(*interior_ring_iter); 
+                    point_iter != boost::end(*interior_ring_iter); 
+                    ++point_iter)
+                {
+                    // write point's x, y, z
+                    writer_assigner<point_type, 0, dimension<point_type>::value>::run(*point_iter, iter, byte_order);
+                }
+            }
+
+            return true;
+        }
+    };
+
+}} // namespace detail::wkb
+#endif // DOXYGEN_NO_IMPL
+
+}} // namespace boost::geometry
+#endif // BOOST_GEOMETRY_IO_WKB_DETAIL_WRITER_HPP

--- a/include/boost/geometry/extensions/gis/io/wkb/write_wkb.hpp
+++ b/include/boost/geometry/extensions/gis/io/wkb/write_wkb.hpp
@@ -1,0 +1,120 @@
+#ifndef BOOST_GEOMETRY_IO_WKB_WRITE_WKB_HPP
+#define BOOST_GEOMETRY_IO_WKB_WRITE_WKB_HPP
+
+#include <iterator>
+
+#include <boost/type_traits/is_convertible.hpp>
+#include <boost/static_assert.hpp>
+
+#include <boost/geometry/core/tags.hpp>
+#include <boost/geometry/extensions/gis/io/wkb/detail/writer.hpp>
+
+namespace boost { namespace geometry
+{
+
+#ifndef DOXYGEN_NO_DISPATCH
+namespace dispatch
+{
+
+template <typename Tag, typename G>
+struct write_wkb 
+{
+};
+
+template <typename G>
+struct write_wkb<point_tag, G>
+{
+    template <typename OutputIterator>
+    static inline bool write(const G& geometry, OutputIterator& iter, 
+                       detail::wkb::byte_order_type::enum_t byte_order)
+    {
+        return detail::wkb::point_writer<G>::write(geometry, iter, byte_order);
+    }
+};
+
+template <typename G>
+struct write_wkb<linestring_tag, G>
+{
+    template <typename OutputIterator>
+    static inline bool write(const G& geometry, OutputIterator& iter, 
+                       detail::wkb::byte_order_type::enum_t byte_order)
+    {
+        return detail::wkb::linestring_writer<G>::write(geometry, iter, byte_order);
+    }
+};
+
+template <typename G>
+struct write_wkb<polygon_tag, G>
+{
+    template <typename OutputIterator>
+    static inline bool write(const G& geometry, OutputIterator& iter, 
+                       detail::wkb::byte_order_type::enum_t byte_order)
+    {
+        return detail::wkb::polygon_writer<G>::write(geometry, iter, byte_order);
+    }
+};
+
+} // namespace dispatch
+#endif // DOXYGEN_NO_DISPATCH
+
+template <typename G, typename OutputIterator>
+inline bool write_wkb(const G& geometry, OutputIterator& iter)
+{
+    // The WKB is written to an OutputIterator.
+    BOOST_STATIC_ASSERT((
+        boost::is_convertible
+        <
+        typename std::iterator_traits<OutputIterator>::iterator_category,
+        const std::output_iterator_tag&
+        >::value));
+
+// Will write in the native byte order
+#ifdef BOOST_BIG_ENDIAN
+        detail::wkb::byte_order_type::enum_t byte_order =  detail::wkb::byte_order_type::xdr;
+#else
+        detail::wkb::byte_order_type::enum_t byte_order =  detail::wkb::byte_order_type::ndr;
+#endif
+
+    if
+        (!dispatch::write_wkb
+        <
+        typename tag<G>::type,
+        G
+        >::write(geometry, iter, byte_order))
+    {
+        return false;
+    }
+
+    return true;
+}
+
+// 	template <typename G, typename OutputIterator>
+// 	inline bool write_wkb(G& geometry, OutputIterator iter, 
+// 		detail::wkb::byte_order_type::enum_t source_byte_order, 
+// 		detail::wkb::byte_order_type::enum_t target_byte_order)
+// 	{
+// 		// The WKB is written to an OutputIterator.
+// 		BOOST_STATIC_ASSERT((
+// 			boost::is_convertible
+// 			<
+// 			typename std::iterator_traits<OutputIterator>::iterator_category,
+// 			const std::output_iterator_tag&
+// 			>::value));
+// 
+// 		if
+// 			(
+// 			!dispatch::write_wkb
+// 			<
+// 			typename tag<G>::type,
+// 			G
+// 			>::write(geometry, iter, byte_order)
+// 			)
+// 		{
+// 			return false;
+// 		}
+// 
+// 		return true;
+// 	}
+
+}} // namespace boost::geometry
+#endif // BOOST_GEOMETRY_IO_WKB_WRITE_WKB_HPP


### PR DESCRIPTION
This patchset adds support for writing to the WKB format from geometries. There are a couple of fixes to support geometry adaptions there as well, and I had to modify the geometry_type to support different dimensions and formats.

This implementation is generic enough to be able to support CIRCULARSTRING, implemented on top of this implentation locally, so it should be sufficiently user-extendable for some use cases.

Current limitations: 
* endian conversion is not supported (yet)
* there might be some use of C++11 in there, which I will remove when the direction of this PR
* no support for multi-geometries (yet)
* there might be traces of CIRCULARSTRING left.

I am prepared to do more work to get this patch into Boost.Geometry proper, as it is a hassle to maintain this out-of-tree. :)