### PR TITLE
[doc][release notes] update release notes for boost 1.58 (bugfixes)

### DIFF
--- a/doc/release_notes.qbk
+++ b/doc/release_notes.qbk
@@ -26,6 +26,8 @@
 [*Bugfixes]
 
 * Bug in multipoint/polygon multipoint/multipolygon distance computation (wrong detection of points inside the areal geometry)
+* Bug in flatten_iterator's assignment operator causing an access violation 
+* Bug in Cartesian segment-segment intersection strategy when one segment degenerates to a point and is collinear to the other non-degenerate segment
 
 [/=================]
 [heading Boost 1.57]


### PR DESCRIPTION
Add recent bugfixes:
- in `flatten_iterator` (access violation)
- in Cartesian segment-segment intersection strategy

To be merged after PR #175 is reviewed and merged.
