### PR TITLE
[geometry] Fix the order of Boost.Variant includes.

### DIFF
--- a/include/boost/geometry/algorithms/append.hpp
+++ b/include/boost/geometry/algorithms/append.hpp
@@ -22,6 +22,8 @@
 
 
 #include <boost/range.hpp>
+
+#include <boost/variant/variant_fwd.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/apply_visitor.hpp>
 

--- a/include/boost/geometry/algorithms/area.hpp
+++ b/include/boost/geometry/algorithms/area.hpp
@@ -18,9 +18,10 @@
 #include <boost/mpl/if.hpp>
 #include <boost/range/functions.hpp>
 #include <boost/range/metafunctions.hpp>
+
+#include <boost/variant/variant_fwd.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/variant_fwd.hpp>
 
 #include <boost/geometry/core/closure.hpp>
 #include <boost/geometry/core/exterior_ring.hpp>

--- a/include/boost/geometry/algorithms/assign.hpp
+++ b/include/boost/geometry/algorithms/assign.hpp
@@ -26,6 +26,10 @@
 #include <boost/numeric/conversion/cast.hpp>
 #include <boost/type_traits.hpp>
 
+#include <boost/variant/variant_fwd.hpp>
+#include <boost/variant/static_visitor.hpp>
+#include <boost/variant/apply_visitor.hpp>
+
 #include <boost/geometry/algorithms/detail/assign_box_corners.hpp>
 #include <boost/geometry/algorithms/detail/assign_indexed_point.hpp>
 #include <boost/geometry/algorithms/detail/assign_values.hpp>
@@ -40,8 +44,6 @@
 #include <boost/geometry/geometries/concepts/check.hpp>
 
 #include <boost/geometry/util/for_each_coordinate.hpp>
-
-#include <boost/variant/variant_fwd.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/algorithms/buffer.hpp
+++ b/include/boost/geometry/algorithms/buffer.hpp
@@ -17,9 +17,10 @@
 #include <cstddef>
 
 #include <boost/numeric/conversion/cast.hpp>
+
+#include <boost/variant/variant_fwd.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/variant_fwd.hpp>
 
 #include <boost/geometry/algorithms/clear.hpp>
 #include <boost/geometry/algorithms/envelope.hpp>

--- a/include/boost/geometry/algorithms/centroid.hpp
+++ b/include/boost/geometry/algorithms/centroid.hpp
@@ -24,9 +24,10 @@
 #include <cstddef>
 
 #include <boost/range.hpp>
+
+#include <boost/variant/variant_fwd.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/variant_fwd.hpp>
 
 #include <boost/geometry/core/closure.hpp>
 #include <boost/geometry/core/cs.hpp>

--- a/include/boost/geometry/algorithms/clear.hpp
+++ b/include/boost/geometry/algorithms/clear.hpp
@@ -16,9 +16,10 @@
 
 
 #include <boost/type_traits/remove_const.hpp>
-#include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/static_visitor.hpp>
+
 #include <boost/variant/variant_fwd.hpp>
+#include <boost/variant/static_visitor.hpp>
+#include <boost/variant/apply_visitor.hpp>
 
 #include <boost/geometry/algorithms/not_implemented.hpp>
 #include <boost/geometry/core/access.hpp>

--- a/include/boost/geometry/algorithms/convert.hpp
+++ b/include/boost/geometry/algorithms/convert.hpp
@@ -22,9 +22,10 @@
 #include <boost/range.hpp>
 #include <boost/type_traits/is_array.hpp>
 #include <boost/type_traits/remove_reference.hpp>
+
+#include <boost/variant/variant_fwd.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/variant_fwd.hpp>
 
 #include <boost/geometry/arithmetic/arithmetic.hpp>
 #include <boost/geometry/algorithms/not_implemented.hpp>

--- a/include/boost/geometry/algorithms/convex_hull.hpp
+++ b/include/boost/geometry/algorithms/convex_hull.hpp
@@ -20,9 +20,10 @@
 #define BOOST_GEOMETRY_ALGORITHMS_CONVEX_HULL_HPP
 
 #include <boost/array.hpp>
+
+#include <boost/variant/variant_fwd.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/variant_fwd.hpp>
 
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/point_order.hpp>

--- a/include/boost/geometry/algorithms/correct.hpp
+++ b/include/boost/geometry/algorithms/correct.hpp
@@ -23,9 +23,10 @@
 #include <boost/mpl/assert.hpp>
 #include <boost/range.hpp>
 #include <boost/type_traits/remove_reference.hpp>
+
+#include <boost/variant/variant_fwd.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/variant_fwd.hpp>
 
 #include <boost/geometry/algorithms/detail/interior_iterator.hpp>
 

--- a/include/boost/geometry/algorithms/covered_by.hpp
+++ b/include/boost/geometry/algorithms/covered_by.hpp
@@ -22,9 +22,9 @@
 
 #include <cstddef>
 
+#include <boost/variant/variant_fwd.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/variant_fwd.hpp>
 
 #include <boost/geometry/algorithms/not_implemented.hpp>
 #include <boost/geometry/algorithms/within.hpp>

--- a/include/boost/geometry/algorithms/crosses.hpp
+++ b/include/boost/geometry/algorithms/crosses.hpp
@@ -21,7 +21,10 @@
 #define BOOST_GEOMETRY_ALGORITHMS_CROSSES_HPP
 
 #include <cstddef>
+
 #include <boost/variant/variant_fwd.hpp>
+#include <boost/variant/static_visitor.hpp>
+#include <boost/variant/apply_visitor.hpp>
 
 #include <boost/geometry/core/access.hpp>
 

--- a/include/boost/geometry/algorithms/detail/disjoint/interface.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/interface.hpp
@@ -23,9 +23,9 @@
 
 #include <cstddef>
 
+#include <boost/variant/variant_fwd.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/variant_fwd.hpp>
 
 #include <boost/geometry/geometries/concepts/check.hpp>
 

--- a/include/boost/geometry/algorithms/detail/is_simple/interface.hpp
+++ b/include/boost/geometry/algorithms/detail/is_simple/interface.hpp
@@ -10,9 +10,9 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_IS_SIMPLE_INTERFACE_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_IS_SIMPLE_INTERFACE_HPP
 
+#include <boost/variant/variant_fwd.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/variant_fwd.hpp>
 
 #include <boost/geometry/geometries/concepts/check.hpp>
 

--- a/include/boost/geometry/algorithms/detail/is_valid/interface.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/interface.hpp
@@ -10,9 +10,9 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_IS_VALID_INTERFACE_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_IS_VALID_INTERFACE_HPP
 
+#include <boost/variant/variant_fwd.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/variant_fwd.hpp>
 
 #include <boost/geometry/geometries/concepts/check.hpp>
 

--- a/include/boost/geometry/algorithms/envelope.hpp
+++ b/include/boost/geometry/algorithms/envelope.hpp
@@ -18,9 +18,10 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 #include <boost/range.hpp>
+
+#include <boost/variant/variant_fwd.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/variant_fwd.hpp>
 
 #include <boost/geometry/algorithms/assign.hpp>
 #include <boost/geometry/algorithms/expand.hpp>

--- a/include/boost/geometry/algorithms/equals.hpp
+++ b/include/boost/geometry/algorithms/equals.hpp
@@ -26,6 +26,10 @@
 
 #include <boost/range.hpp>
 
+#include <boost/variant/variant_fwd.hpp>
+#include <boost/variant/static_visitor.hpp>
+#include <boost/variant/apply_visitor.hpp>
+
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/geometry_id.hpp>
@@ -50,8 +54,6 @@
 
 #include <boost/geometry/views/detail/indexed_point_view.hpp>
 
-#include <boost/variant/static_visitor.hpp>
-#include <boost/variant/apply_visitor.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/algorithms/expand.hpp
+++ b/include/boost/geometry/algorithms/expand.hpp
@@ -20,6 +20,10 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <boost/variant/variant_fwd.hpp>
+#include <boost/variant/static_visitor.hpp>
+#include <boost/variant/apply_visitor.hpp>
+
 #include <boost/geometry/algorithms/not_implemented.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/geometries/concepts/check.hpp>
@@ -28,9 +32,6 @@
 
 #include <boost/geometry/strategies/compare.hpp>
 #include <boost/geometry/policies/compare.hpp>
-
-#include <boost/variant/static_visitor.hpp>
-#include <boost/variant/apply_visitor.hpp>
 
 
 namespace boost { namespace geometry

--- a/include/boost/geometry/algorithms/length.hpp
+++ b/include/boost/geometry/algorithms/length.hpp
@@ -34,9 +34,9 @@
 #include <boost/mpl/transform.hpp>
 #include <boost/type_traits.hpp>
 
-#include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/static_visitor.hpp>
 #include <boost/variant/variant_fwd.hpp>
+#include <boost/variant/static_visitor.hpp>
+#include <boost/variant/apply_visitor.hpp>
 
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/closure.hpp>

--- a/include/boost/geometry/algorithms/num_geometries.hpp
+++ b/include/boost/geometry/algorithms/num_geometries.hpp
@@ -23,9 +23,10 @@
 #include <cstddef>
 
 #include <boost/range.hpp>
+
+#include <boost/variant/variant_fwd.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/variant_fwd.hpp>
 
 #include <boost/geometry/algorithms/not_implemented.hpp>
 

--- a/include/boost/geometry/algorithms/num_interior_rings.hpp
+++ b/include/boost/geometry/algorithms/num_interior_rings.hpp
@@ -24,9 +24,9 @@
 
 #include <boost/range.hpp>
 
+#include <boost/variant/variant_fwd.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/variant_fwd.hpp>
 
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tags.hpp>

--- a/include/boost/geometry/algorithms/num_points.hpp
+++ b/include/boost/geometry/algorithms/num_points.hpp
@@ -26,9 +26,9 @@
 
 #include <boost/range.hpp>
 
+#include <boost/variant/variant_fwd.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/variant_fwd.hpp>
 
 #include <boost/geometry/core/closure.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>

--- a/include/boost/geometry/algorithms/num_segments.hpp
+++ b/include/boost/geometry/algorithms/num_segments.hpp
@@ -17,9 +17,9 @@
 
 #include <boost/range.hpp>
 
+#include <boost/variant/variant_fwd.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/variant_fwd.hpp>
 
 #include <boost/geometry/core/closure.hpp>
 #include <boost/geometry/core/tag.hpp>

--- a/include/boost/geometry/algorithms/perimeter.hpp
+++ b/include/boost/geometry/algorithms/perimeter.hpp
@@ -20,9 +20,10 @@
 #define BOOST_GEOMETRY_ALGORITHMS_PERIMETER_HPP
 
 #include <boost/range/metafunctions.hpp>
+
+#include <boost/variant/variant_fwd.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/variant_fwd.hpp>
 
 #include <boost/geometry/algorithms/length.hpp>
 #include <boost/geometry/algorithms/detail/calculate_null.hpp>

--- a/include/boost/geometry/algorithms/remove_spikes.hpp
+++ b/include/boost/geometry/algorithms/remove_spikes.hpp
@@ -16,9 +16,10 @@
 
 #include <boost/range.hpp>
 #include <boost/type_traits/remove_reference.hpp>
+
+#include <boost/variant/variant_fwd.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/variant_fwd.hpp>
 
 #include <boost/geometry/core/closure.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>

--- a/include/boost/geometry/algorithms/reverse.hpp
+++ b/include/boost/geometry/algorithms/reverse.hpp
@@ -19,9 +19,10 @@
 
 #include <boost/range.hpp>
 #include <boost/type_traits/remove_reference.hpp>
+
+#include <boost/variant/variant_fwd.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/variant_fwd.hpp>
 
 #include <boost/geometry/algorithms/detail/interior_iterator.hpp>
 #include <boost/geometry/algorithms/detail/multi_modify.hpp>

--- a/include/boost/geometry/algorithms/simplify.hpp
+++ b/include/boost/geometry/algorithms/simplify.hpp
@@ -18,9 +18,10 @@
 
 #include <boost/core/ignore_unused.hpp>
 #include <boost/range.hpp>
+
+#include <boost/variant/variant_fwd.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/variant_fwd.hpp>
 
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/closure.hpp>

--- a/include/boost/geometry/algorithms/touches.hpp
+++ b/include/boost/geometry/algorithms/touches.hpp
@@ -23,6 +23,10 @@
 
 #include <deque>
 
+#include <boost/variant/variant_fwd.hpp>
+#include <boost/variant/static_visitor.hpp>
+#include <boost/variant/apply_visitor.hpp>
+
 #include <boost/geometry/geometries/concepts/check.hpp>
 #include <boost/geometry/algorithms/detail/for_each_range.hpp>
 #include <boost/geometry/algorithms/detail/overlay/overlay.hpp>
@@ -32,9 +36,6 @@
 #include <boost/geometry/algorithms/num_geometries.hpp>
 #include <boost/geometry/algorithms/detail/sub_range.hpp>
 #include <boost/geometry/policies/robustness/no_rescale_policy.hpp>
-#include <boost/variant/static_visitor.hpp>
-#include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/variant_fwd.hpp>
 
 #include <boost/geometry/algorithms/detail/relate/relate.hpp>
 

--- a/include/boost/geometry/algorithms/transform.hpp
+++ b/include/boost/geometry/algorithms/transform.hpp
@@ -20,9 +20,10 @@
 
 #include <boost/range.hpp>
 #include <boost/type_traits/remove_reference.hpp>
+
+#include <boost/variant/variant_fwd.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/variant_fwd.hpp>
 
 #include <boost/geometry/algorithms/assign.hpp>
 #include <boost/geometry/algorithms/clear.hpp>

--- a/include/boost/geometry/algorithms/within.hpp
+++ b/include/boost/geometry/algorithms/within.hpp
@@ -24,9 +24,10 @@
 
 #include <boost/concept_check.hpp>
 #include <boost/range.hpp>
+
+#include <boost/variant/variant_fwd.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/variant_fwd.hpp>
 
 #include <boost/geometry/algorithms/make.hpp>
 #include <boost/geometry/algorithms/not_implemented.hpp>

--- a/include/boost/geometry/io/wkt/write.hpp
+++ b/include/boost/geometry/io/wkt/write.hpp
@@ -20,9 +20,10 @@
 
 #include <boost/array.hpp>
 #include <boost/range.hpp>
+
+#include <boost/variant/variant_fwd.hpp>
 #include <boost/variant/apply_visitor.hpp>
 #include <boost/variant/static_visitor.hpp>
-#include <boost/variant/variant_fwd.hpp>
 
 #include <boost/geometry/algorithms/detail/interior_iterator.hpp>
 #include <boost/geometry/algorithms/assign.hpp>


### PR DESCRIPTION
This PR fixes the errors related to Boost.Variant variadic templates support.

variant_fwd.hpp must be included before other Boost.Variant headers because it contains config used in other parts of this library.
