### PR TITLE
[algorithms] Replace A and B BOOST_VARIANT_ENUM_PARAMS parameters with T...

### DIFF
--- a/include/boost/geometry/algorithms/assign.hpp
+++ b/include/boost/geometry/algorithms/assign.hpp
@@ -319,8 +319,8 @@ struct assign<Geometry1, variant<BOOST_VARIANT_ENUM_PARAMS(T)> >
 };
     
     
-template <BOOST_VARIANT_ENUM_PARAMS(typename A), BOOST_VARIANT_ENUM_PARAMS(typename B)>
-struct assign<variant<BOOST_VARIANT_ENUM_PARAMS(A)>, variant<BOOST_VARIANT_ENUM_PARAMS(B)> >
+template <BOOST_VARIANT_ENUM_PARAMS(typename T1), BOOST_VARIANT_ENUM_PARAMS(typename T2)>
+struct assign<variant<BOOST_VARIANT_ENUM_PARAMS(T1)>, variant<BOOST_VARIANT_ENUM_PARAMS(T2)> >
 {
     struct visitor: static_visitor<void>
     {
@@ -339,8 +339,8 @@ struct assign<variant<BOOST_VARIANT_ENUM_PARAMS(A)>, variant<BOOST_VARIANT_ENUM_
     };
         
     static inline void
-    apply(variant<BOOST_VARIANT_ENUM_PARAMS(A)>& geometry1,
-          variant<BOOST_VARIANT_ENUM_PARAMS(B)> const& geometry2)
+    apply(variant<BOOST_VARIANT_ENUM_PARAMS(T1)>& geometry1,
+          variant<BOOST_VARIANT_ENUM_PARAMS(T2)> const& geometry2)
     {
         return apply_visitor(visitor(), geometry1, geometry2);
     }

--- a/include/boost/geometry/algorithms/crosses.hpp
+++ b/include/boost/geometry/algorithms/crosses.hpp
@@ -144,8 +144,8 @@ namespace resolve_variant
     };
     
     
-    template <BOOST_VARIANT_ENUM_PARAMS(typename A), BOOST_VARIANT_ENUM_PARAMS(typename B)>
-    struct crosses<variant<BOOST_VARIANT_ENUM_PARAMS(A)>, variant<BOOST_VARIANT_ENUM_PARAMS(B)> >
+    template <BOOST_VARIANT_ENUM_PARAMS(typename T1), BOOST_VARIANT_ENUM_PARAMS(typename T2)>
+    struct crosses<variant<BOOST_VARIANT_ENUM_PARAMS(T1)>, variant<BOOST_VARIANT_ENUM_PARAMS(T2)> >
     {
         struct visitor: static_visitor<bool>
         {
@@ -165,8 +165,8 @@ namespace resolve_variant
         
         static inline bool
         apply(
-              const variant<BOOST_VARIANT_ENUM_PARAMS(A)>& geometry1,
-              const variant<BOOST_VARIANT_ENUM_PARAMS(B)>& geometry2)
+              const variant<BOOST_VARIANT_ENUM_PARAMS(T1)>& geometry1,
+              const variant<BOOST_VARIANT_ENUM_PARAMS(T2)>& geometry2)
         {
             return apply_visitor(visitor(), geometry1, geometry2);
         }

--- a/include/boost/geometry/algorithms/detail/comparable_distance/interface.hpp
+++ b/include/boost/geometry/algorithms/detail/comparable_distance/interface.hpp
@@ -232,13 +232,13 @@ struct comparable_distance
 
 template
 <
-    BOOST_VARIANT_ENUM_PARAMS(typename A),
-    BOOST_VARIANT_ENUM_PARAMS(typename B)
+    BOOST_VARIANT_ENUM_PARAMS(typename T1),
+    BOOST_VARIANT_ENUM_PARAMS(typename T2)
 >
 struct comparable_distance
     <
-        boost::variant<BOOST_VARIANT_ENUM_PARAMS(A)>,
-        boost::variant<BOOST_VARIANT_ENUM_PARAMS(B)>
+        boost::variant<BOOST_VARIANT_ENUM_PARAMS(T1)>,
+        boost::variant<BOOST_VARIANT_ENUM_PARAMS(T2)>
     >
 {
     template <typename Strategy>
@@ -246,8 +246,8 @@ struct comparable_distance
         <
             typename comparable_distance_result
                 <
-                    boost::variant<BOOST_VARIANT_ENUM_PARAMS(A)>,
-                    boost::variant<BOOST_VARIANT_ENUM_PARAMS(B)>,
+                    boost::variant<BOOST_VARIANT_ENUM_PARAMS(T1)>,
+                    boost::variant<BOOST_VARIANT_ENUM_PARAMS(T2)>,
                     Strategy
                 >::type
         >
@@ -279,12 +279,12 @@ struct comparable_distance
     template <typename Strategy>
     static inline typename comparable_distance_result
         <
-            boost::variant<BOOST_VARIANT_ENUM_PARAMS(A)>,
-            boost::variant<BOOST_VARIANT_ENUM_PARAMS(B)>,
+            boost::variant<BOOST_VARIANT_ENUM_PARAMS(T1)>,
+            boost::variant<BOOST_VARIANT_ENUM_PARAMS(T2)>,
             Strategy
         >::type
-    apply(boost::variant<BOOST_VARIANT_ENUM_PARAMS(A)> const& geometry1,
-          boost::variant<BOOST_VARIANT_ENUM_PARAMS(B)> const& geometry2,
+    apply(boost::variant<BOOST_VARIANT_ENUM_PARAMS(T1)> const& geometry1,
+          boost::variant<BOOST_VARIANT_ENUM_PARAMS(T2)> const& geometry2,
           Strategy const& strategy)
     {
         return apply_visitor(visitor<Strategy>(strategy), geometry1, geometry2);

--- a/include/boost/geometry/algorithms/detail/distance/interface.hpp
+++ b/include/boost/geometry/algorithms/detail/distance/interface.hpp
@@ -260,13 +260,13 @@ struct distance<Geometry1, variant<BOOST_VARIANT_ENUM_PARAMS(T)> >
 
 template
 <
-    BOOST_VARIANT_ENUM_PARAMS(typename A),
-    BOOST_VARIANT_ENUM_PARAMS(typename B)
+    BOOST_VARIANT_ENUM_PARAMS(typename T1),
+    BOOST_VARIANT_ENUM_PARAMS(typename T2)
 >
 struct distance
     <
-        boost::variant<BOOST_VARIANT_ENUM_PARAMS(A)>,
-        boost::variant<BOOST_VARIANT_ENUM_PARAMS(B)>
+        boost::variant<BOOST_VARIANT_ENUM_PARAMS(T1)>,
+        boost::variant<BOOST_VARIANT_ENUM_PARAMS(T2)>
     >
 {
     template <typename Strategy>
@@ -274,8 +274,8 @@ struct distance
         <
             typename distance_result
                 <
-                    boost::variant<BOOST_VARIANT_ENUM_PARAMS(A)>,
-                    boost::variant<BOOST_VARIANT_ENUM_PARAMS(B)>,
+                    boost::variant<BOOST_VARIANT_ENUM_PARAMS(T1)>,
+                    boost::variant<BOOST_VARIANT_ENUM_PARAMS(T2)>,
                     Strategy
                 >::type
         >
@@ -304,12 +304,12 @@ struct distance
     template <typename Strategy>
     static inline typename distance_result
         <
-            boost::variant<BOOST_VARIANT_ENUM_PARAMS(A)>,
-            boost::variant<BOOST_VARIANT_ENUM_PARAMS(B)>,
+            boost::variant<BOOST_VARIANT_ENUM_PARAMS(T1)>,
+            boost::variant<BOOST_VARIANT_ENUM_PARAMS(T2)>,
             Strategy
         >::type
-    apply(boost::variant<BOOST_VARIANT_ENUM_PARAMS(A)> const& geometry1,
-          boost::variant<BOOST_VARIANT_ENUM_PARAMS(B)> const& geometry2,
+    apply(boost::variant<BOOST_VARIANT_ENUM_PARAMS(T1)> const& geometry1,
+          boost::variant<BOOST_VARIANT_ENUM_PARAMS(T2)> const& geometry2,
           Strategy const& strategy)
     {
         return apply_visitor(visitor<Strategy>(strategy), geometry1, geometry2);

--- a/include/boost/geometry/algorithms/detail/intersection/interface.hpp
+++ b/include/boost/geometry/algorithms/detail/intersection/interface.hpp
@@ -223,8 +223,8 @@ struct intersection<Geometry1, variant<BOOST_VARIANT_ENUM_PARAMS(T)> >
 };
 
 
-template <BOOST_VARIANT_ENUM_PARAMS(typename A), BOOST_VARIANT_ENUM_PARAMS(typename B)>
-struct intersection<variant<BOOST_VARIANT_ENUM_PARAMS(A)>, variant<BOOST_VARIANT_ENUM_PARAMS(B)> >
+template <BOOST_VARIANT_ENUM_PARAMS(typename T1), BOOST_VARIANT_ENUM_PARAMS(typename T2)>
+struct intersection<variant<BOOST_VARIANT_ENUM_PARAMS(T1)>, variant<BOOST_VARIANT_ENUM_PARAMS(T2)> >
 {
     template <typename GeometryOut>
     struct visitor: static_visitor<bool>
@@ -255,8 +255,8 @@ struct intersection<variant<BOOST_VARIANT_ENUM_PARAMS(A)>, variant<BOOST_VARIANT
     template <typename GeometryOut>
     static inline bool
     apply(
-          const variant<BOOST_VARIANT_ENUM_PARAMS(A)>& geometry1,
-          const variant<BOOST_VARIANT_ENUM_PARAMS(B)>& geometry2,
+          const variant<BOOST_VARIANT_ENUM_PARAMS(T1)>& geometry1,
+          const variant<BOOST_VARIANT_ENUM_PARAMS(T2)>& geometry2,
           GeometryOut& geometry_out)
     {
         return apply_visitor(visitor<GeometryOut>(geometry_out), geometry1, geometry2);


### PR DESCRIPTION
This PR is an attempt to fix two tickets:
https://svn.boost.org/trac/boost/ticket/10467
https://svn.boost.org/trac/boost/ticket/10863

It replaces `A` and `B` parameters of `BOOST_VARIANT_ENUM_PARAMS(xxx)` with `T1` and `T2` respectively, which should play well with `B0` macro definition from `termios.h`. Replacement names was choosen because such names are already used in the library.

An alternative would be to use `T` and `U`, which seems to be the most commonly used template parameters names around Boost, e.g. `U0` is used in Fusion, Iostreams, TypeErasure. Shorter names means shorter symbols which is good for the compiler.
