### PR TITLE
Fix/centroid

### DIFF
--- a/include/boost/geometry/algorithms/centroid.hpp
+++ b/include/boost/geometry/algorithms/centroid.hpp
@@ -5,8 +5,8 @@
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 // Copyright (c) 2014 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2014.
-// Modifications copyright (c) 2014 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014, 2015.
+// Modifications copyright (c) 2014-2015 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -118,8 +118,8 @@ template
 <
     typename Indexed,
     typename Point,
-    std::size_t Dimension,
-    std::size_t DimensionCount
+    std::size_t Dimension = 0,
+    std::size_t DimensionCount = dimension<Indexed>::type::value
 >
 struct centroid_indexed_calculator
 {
@@ -139,8 +139,7 @@ struct centroid_indexed_calculator
 
         centroid_indexed_calculator
             <
-                Indexed, Point,
-                Dimension + 1, DimensionCount
+                Indexed, Point, Dimension + 1
             >::apply(indexed, centroid);
     }
 };
@@ -163,8 +162,7 @@ struct centroid_indexed
     {
         centroid_indexed_calculator
             <
-                Indexed, Point,
-                0, dimension<Indexed>::type::value
+                Indexed, Point
             >::apply(indexed, centroid);
     }
 };
@@ -253,10 +251,12 @@ struct centroid_range
             typename Strategy::state_type state;
             centroid_range_state<Closure>::apply(range, transformer,
                                                  strategy, state);
-            strategy.result(state, centroid);
-
-            // translate the result back
-            transformer.apply_reverse(centroid);
+            
+            if ( strategy.result(state, centroid) )
+            {
+                // translate the result back
+                transformer.apply_reverse(centroid);
+            }
         }
     }
 };
@@ -305,10 +305,12 @@ struct centroid_polygon
             
             typename Strategy::state_type state;
             centroid_polygon_state::apply(poly, transformer, strategy, state);
-            strategy.result(state, centroid);
-
-            // translate the result back
-            transformer.apply_reverse(centroid);
+            
+            if ( strategy.result(state, centroid) )
+            {
+                // translate the result back
+                transformer.apply_reverse(centroid);
+            }
         }
     }
 };
@@ -369,10 +371,12 @@ struct centroid_multi
         {
             Policy::apply(*it, transformer, strategy, state);
         }
-        Strategy::result(state, centroid);
 
-        // translate the result back
-        transformer.apply_reverse(centroid);
+        if ( strategy.result(state, centroid) )
+        {
+            // translate the result back
+            transformer.apply_reverse(centroid);
+        }
     }
 };
 

--- a/include/boost/geometry/algorithms/centroid.hpp
+++ b/include/boost/geometry/algorithms/centroid.hpp
@@ -43,8 +43,9 @@
 #include <boost/geometry/geometries/concepts/check.hpp>
 
 #include <boost/geometry/algorithms/assign.hpp>
-#include <boost/geometry/algorithms/detail/interior_iterator.hpp>
 #include <boost/geometry/algorithms/convert.hpp>
+#include <boost/geometry/algorithms/detail/interior_iterator.hpp>
+#include <boost/geometry/algorithms/detail/point_on_border.hpp>
 #include <boost/geometry/algorithms/not_implemented.hpp>
 #include <boost/geometry/strategies/centroid.hpp>
 #include <boost/geometry/strategies/concepts/centroid_concept.hpp>
@@ -240,7 +241,7 @@ template <closure_selector Closure>
 struct centroid_range
 {
     template<typename Range, typename Point, typename Strategy>
-    static inline void apply(Range const& range, Point& centroid,
+    static inline bool apply(Range const& range, Point& centroid,
                              Strategy const& strategy)
     {
         if (range_ok(range, centroid))
@@ -256,8 +257,11 @@ struct centroid_range
             {
                 // translate the result back
                 transformer.apply_reverse(centroid);
+                return true;
             }
         }
+
+        return false;
     }
 };
 
@@ -294,8 +298,8 @@ struct centroid_polygon_state
 struct centroid_polygon
 {
     template<typename Polygon, typename Point, typename Strategy>
-    static inline void apply(Polygon const& poly, Point& centroid,
-            Strategy const& strategy)
+    static inline bool apply(Polygon const& poly, Point& centroid,
+                             Strategy const& strategy)
     {
         if (range_ok(exterior_ring(poly), centroid))
         {
@@ -310,8 +314,11 @@ struct centroid_polygon
             {
                 // translate the result back
                 transformer.apply_reverse(centroid);
+                return true;
             }
         }
+
+        return false;
     }
 };
 
@@ -346,7 +353,7 @@ template <typename Policy>
 struct centroid_multi
 {
     template <typename Multi, typename Point, typename Strategy>
-    static inline void apply(Multi const& multi,
+    static inline bool apply(Multi const& multi,
                              Point& centroid,
                              Strategy const& strategy)
     {
@@ -376,6 +383,25 @@ struct centroid_multi
         {
             // translate the result back
             transformer.apply_reverse(centroid);
+            return true;
+        }
+        
+        return false;
+    }
+};
+
+
+template <typename Algorithm>
+struct centroid_linear_areal
+{
+    template <typename Geometry, typename Point, typename Strategy>
+    static inline void apply(Geometry const& geom,
+                             Point& centroid,
+                             Strategy const& strategy)
+    {
+        if ( ! Algorithm::apply(geom, centroid, strategy) )
+        {
+            geometry::point_on_border(centroid, geom);
         }
     }
 };
@@ -414,32 +440,47 @@ struct centroid<Segment, segment_tag>
 
 template <typename Ring>
 struct centroid<Ring, ring_tag>
-    : detail::centroid::centroid_range<geometry::closure<Ring>::value>
+    : detail::centroid::centroid_linear_areal
+        <
+            detail::centroid::centroid_range<geometry::closure<Ring>::value>
+        >
 {};
 
 template <typename Linestring>
 struct centroid<Linestring, linestring_tag>
-    : detail::centroid::centroid_range<closed>
+    : detail::centroid::centroid_linear_areal
+        <
+            detail::centroid::centroid_range<closed>
+        >
 {};
 
 template <typename Polygon>
 struct centroid<Polygon, polygon_tag>
-    : detail::centroid::centroid_polygon
+    : detail::centroid::centroid_linear_areal
+        <
+            detail::centroid::centroid_polygon
+        >
 {};
 
 template <typename MultiLinestring>
 struct centroid<MultiLinestring, multi_linestring_tag>
-    : detail::centroid::centroid_multi
+    : detail::centroid::centroid_linear_areal
         <
-            detail::centroid::centroid_range_state<closed>
+            detail::centroid::centroid_multi
+            <
+                detail::centroid::centroid_range_state<closed>
+            >
         >
 {};
 
 template <typename MultiPolygon>
 struct centroid<MultiPolygon, multi_polygon_tag>
-    : detail::centroid::centroid_multi
+    : detail::centroid::centroid_linear_areal
         <
-            detail::centroid::centroid_polygon_state
+            detail::centroid::centroid_multi
+            <
+                detail::centroid::centroid_polygon_state
+            >
         >
 {};
 

--- a/include/boost/geometry/strategies/cartesian/centroid_average.hpp
+++ b/include/boost/geometry/strategies/cartesian/centroid_average.hpp
@@ -4,6 +4,11 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
+// This file was modified by Oracle on 2015.
+// Modifications copyright (c) 2015 Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -14,6 +19,8 @@
 #ifndef BOOST_GEOMETRY_STRATEGIES_CARTESIAN_CENTROID_AVERAGE_HPP
 #define BOOST_GEOMETRY_STRATEGIES_CARTESIAN_CENTROID_AVERAGE_HPP
 
+
+#include <cstddef>
 
 #include <boost/geometry/algorithms/assign.hpp>
 #include <boost/geometry/arithmetic/arithmetic.hpp>
@@ -46,7 +53,7 @@ private :
     class sum
     {
         friend class average;
-        int count;
+        std::size_t count;
         PointCentroid centroid;
 
     public :
@@ -68,10 +75,15 @@ public :
         state.count++;
     }
 
-    static inline void result(sum const& state, PointCentroid& centroid)
+    static inline bool result(sum const& state, PointCentroid& centroid)
     {
         centroid = state.centroid;
-        divide_value(centroid, state.count);
+        if ( state.count > 0 )
+        {
+            divide_value(centroid, state.count);
+            return true;
+        }
+        return false;
     }
 
 };

--- a/include/boost/geometry/strategies/cartesian/centroid_bashein_detmer.hpp
+++ b/include/boost/geometry/strategies/cartesian/centroid_bashein_detmer.hpp
@@ -4,6 +4,11 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
+// This file was modified by Oracle on 2015.
+// Modifications copyright (c) 2015 Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -14,6 +19,8 @@
 #ifndef BOOST_GEOMETRY_STRATEGIES_CARTESIAN_CENTROID_BASHEIN_DETMER_HPP
 #define BOOST_GEOMETRY_STRATEGIES_CARTESIAN_CENTROID_BASHEIN_DETMER_HPP
 
+
+#include <cstddef>
 
 #include <boost/mpl/if.hpp>
 #include <boost/numeric/conversion/cast.hpp>
@@ -143,7 +150,7 @@ private :
     class sums
     {
         friend class bashein_detmer;
-        int count;
+        std::size_t count;
         calculation_type sum_a2;
         calculation_type sum_x;
         calculation_type sum_y;

--- a/test/algorithms/centroid.cpp
+++ b/test/algorithms/centroid.cpp
@@ -5,8 +5,8 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2014.
-// Modifications copyright (c) 2014 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014, 2015.
+// Modifications copyright (c) 2014-2015 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -29,6 +29,17 @@
 BOOST_GEOMETRY_REGISTER_C_ARRAY_CS(cs::cartesian)
 BOOST_GEOMETRY_REGISTER_BOOST_TUPLE_CS(cs::cartesian)
 
+template <typename Geometry>
+void test_invalid(std::string const& wkt)
+{
+    Geometry geom;
+    typename bg::point_type<Geometry>::type pt, pt2;
+    bg::read_wkt(wkt, geom);
+    bg::assign_zero(pt);
+    pt2 = pt;
+    bg::centroid(geom, pt);
+    BOOST_CHECK(bg::equals(pt, pt2));
+}
 
 template <typename Polygon>
 void test_polygon()
@@ -47,6 +58,11 @@ void test_polygon()
 
     test_centroid<Polygon>("POLYGON((0 0,0 10,10 10,10 0,0 0))", 5.0, 5.0);
     test_centroid<Polygon>("POLYGON((-10 0,0 0,0 -10,-10 -10,-10 0))", -5.0, -5.0);
+
+    // invalid, self-intersecting polygon (area = 0)
+    //test_centroid<Polygon>("POLYGON((1 1,4 -2,4 2,10 0,1 0,10 1,1 1))", 5.5, 0.0);
+    test_invalid<Polygon>("POLYGON((1 1,4 -2,4 2,10 0,1 0,10 1,1 1))");
+    test_invalid<Polygon>("POLYGON((1 1,1 1,1 1,1 1))");
 }
 
 
@@ -59,6 +75,10 @@ void test_2d()
 
     test_centroid<bg::model::linestring<P> >("LINESTRING(1 1,10 1,1 0,10 0,4 -2,1 1)",
                                              5.41385255923004, 0.13507358481085);
+
+    // degenerated linestring (length = 0)
+    //test_centroid<bg::model::linestring<P> >("LINESTRING(1 1, 1 1)", 1.0, 1.0);
+    test_invalid<bg::model::linestring<P> >("LINESTRING(1 1, 1 1)");
 
     test_centroid<bg::model::segment<P> >("LINESTRING(1 1, 3 3)", 2.0, 2.0);
 

--- a/test/algorithms/centroid.cpp
+++ b/test/algorithms/centroid.cpp
@@ -29,18 +29,6 @@
 BOOST_GEOMETRY_REGISTER_C_ARRAY_CS(cs::cartesian)
 BOOST_GEOMETRY_REGISTER_BOOST_TUPLE_CS(cs::cartesian)
 
-template <typename Geometry>
-void test_invalid(std::string const& wkt)
-{
-    Geometry geom;
-    typename bg::point_type<Geometry>::type pt, pt2;
-    bg::read_wkt(wkt, geom);
-    bg::assign_zero(pt);
-    pt2 = pt;
-    bg::centroid(geom, pt);
-    BOOST_CHECK(bg::equals(pt, pt2));
-}
-
 template <typename Polygon>
 void test_polygon()
 {
@@ -60,9 +48,14 @@ void test_polygon()
     test_centroid<Polygon>("POLYGON((-10 0,0 0,0 -10,-10 -10,-10 0))", -5.0, -5.0);
 
     // invalid, self-intersecting polygon (area = 0)
-    //test_centroid<Polygon>("POLYGON((1 1,4 -2,4 2,10 0,1 0,10 1,1 1))", 5.5, 0.0);
-    test_invalid<Polygon>("POLYGON((1 1,4 -2,4 2,10 0,1 0,10 1,1 1))");
-    test_invalid<Polygon>("POLYGON((1 1,1 1,1 1,1 1))");
+    test_centroid<Polygon>("POLYGON((1 1,4 -2,4 2,10 0,1 0,10 1,1 1))", 1.0, 1.0);
+    // invalid, degenerated
+    test_centroid<Polygon>("POLYGON((1 1,1 1,1 1,1 1))", 1.0, 1.0);
+    test_centroid<Polygon>("POLYGON((1 1))", 1.0, 1.0);
+
+    // should (1.5 1) be returned?
+    // if yes, then all other Polygons degenerated to Linestrings should be handled
+    test_centroid<Polygon>("POLYGON((1 1,2 1,1 1,1 1))", 1.0, 1.0);
 }
 
 
@@ -77,8 +70,8 @@ void test_2d()
                                              5.41385255923004, 0.13507358481085);
 
     // degenerated linestring (length = 0)
-    //test_centroid<bg::model::linestring<P> >("LINESTRING(1 1, 1 1)", 1.0, 1.0);
-    test_invalid<bg::model::linestring<P> >("LINESTRING(1 1, 1 1)");
+    test_centroid<bg::model::linestring<P> >("LINESTRING(1 1, 1 1)", 1.0, 1.0);
+    test_centroid<bg::model::linestring<P> >("LINESTRING(1 1)", 1.0, 1.0);
 
     test_centroid<bg::model::segment<P> >("LINESTRING(1 1, 3 3)", 2.0, 2.0);
 

--- a/test/algorithms/multi_centroid.cpp
+++ b/test/algorithms/multi_centroid.cpp
@@ -55,6 +55,11 @@ void test_2d(bool is_integer = false)
             "MULTILINESTRING((0 0,0 2),(1 0,1 2))",
             0.5, 1.0);
 
+        // degenerated
+        test_centroid<bg::model::multi_linestring<bg::model::linestring<P> > >(
+            "MULTILINESTRING((1 1,1 1))",
+            1.0, 1.0);
+
 
         test_centroid<bg::model::multi_polygon<bg::model::polygon<P> > >(
             "MULTIPOLYGON(((1 1,1 3,3 3,3 1,1 1)),((4 1,4 3,8 3,8 1,4 1)))",
@@ -65,6 +70,14 @@ void test_2d(bool is_integer = false)
             ",3.7 1.6,3.4 2,4.1 3,5.3 2.6,5.4 1.2,4.9 0.8,2.9 0.7,2 1.3)),"
             "((10 10,10 12,12 12,12 10,10 10)))",
             7.338463104108615, 6.0606722055552407);
+
+        // degenerated
+        test_centroid<bg::model::multi_polygon<bg::model::polygon<P> > >(
+            "MULTIPOLYGON(((1 1,1 1,1 1,1 1,1 1)))",
+            1.0, 1.0);
+        test_centroid<bg::model::multi_polygon<bg::model::polygon<P> > >(
+            "MULTIPOLYGON(((1 1)))",
+            1.0, 1.0);
     }
 
 


### PR DESCRIPTION
Various improvements for centroid():
- more deterministic result for invalid geometries, this "fixes" the issue introduced by https://github.com/boostorg/geometry/pull/155, the modification (translation) of a result even if it wasn't correctly calculated,
- check for `count == 0` in average strategy and returning `false` in this case, this also makes it CentroidStrategyConcept-conformant,
- replacement of `int` with `std::size_t` for counters (should really be `range_size<>::type` but still safer than `int`),
- use of default template parameters to improve readability.



