### PR TITLE
New feature: below minimum size algorithm and exception

### DIFF
--- a/include/boost/geometry/algorithms/detail/throw_below_minimum_size.hpp
+++ b/include/boost/geometry/algorithms/detail/throw_below_minimum_size.hpp
@@ -1,0 +1,48 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2015, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+#ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_THROW_BELOW_MINIMUM_SIZE_HPP
+#define BOOST_GEOMETRY_ALGORITHMS_DETAIL_THROW_BELOW_MINIMUM_SIZE_HPP
+
+#include <boost/geometry/core/exception.hpp>
+#include <boost/geometry/algorithms/is_below_minimum_size.hpp>
+
+#if defined(BOOST_GEOMETRY_BELOW_MINIMUM_SIZE_NO_THROW)
+#include <boost/core/ignore_unused.hpp>
+#endif
+
+namespace boost { namespace geometry
+{
+
+#ifndef DOXYGEN_NO_DETAIL
+namespace detail
+{
+
+template <typename Geometry>
+inline void throw_below_minimum_size(Geometry const& geometry)
+{
+#if ! defined(BOOST_GEOMETRY_BELOW_MINIMUM_SIZE_NO_THROW)
+    if (geometry::is_below_minimum_size(geometry))
+    {
+        throw below_minimum_size_exception();
+    }
+#else
+    boost::ignore_unused(geometry);
+#endif
+}
+
+} // namespace detail
+#endif // DOXYGEN_NO_DETAIL
+
+
+}} // namespace boost::geometry
+
+
+#endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_THROW_BELOW_MINIMUM_SIZE_HPP
+

--- a/include/boost/geometry/algorithms/is_below_minimum_size.hpp
+++ b/include/boost/geometry/algorithms/is_below_minimum_size.hpp
@@ -1,0 +1,257 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2015, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+#ifndef BOOST_GEOMETRY_ALGORITHMS_IS_BELOW_MINIMUM_SIZE_HPP
+#define BOOST_GEOMETRY_ALGORITHMS_IS_BELOW_MINIMUM_SIZE_HPP
+
+#include <cstddef>
+
+#include <boost/range.hpp>
+
+#include <boost/variant/apply_visitor.hpp>
+#include <boost/variant/static_visitor.hpp>
+#include <boost/variant/variant_fwd.hpp>
+
+#include <boost/geometry/core/closure.hpp>
+#include <boost/geometry/core/exterior_ring.hpp>
+#include <boost/geometry/core/interior_rings.hpp>
+#include <boost/geometry/core/tag.hpp>
+#include <boost/geometry/core/tags.hpp>
+
+#include <boost/geometry/algorithms/not_implemented.hpp>
+
+#include <boost/geometry/algorithms/detail/check_iterator_range.hpp>
+
+#include <boost/geometry/geometries/concepts/check.hpp>
+
+
+namespace boost { namespace geometry
+{
+
+// Silence warning C4127: conditional expression is constant
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4127)
+#endif
+
+
+#ifndef DOXYGEN_NO_DETAIL
+namespace detail { namespace is_below_minimum_size
+{
+
+struct always_not_below
+{
+    template <typename Geometry>
+    static inline bool apply(Geometry const&)
+    {
+        return true;
+    }
+};
+
+template <std::size_t MinimumSize>
+struct range_not_below_minimum_size
+{
+    template <typename Range>
+    static inline bool apply(Range const& range)
+    {
+        return boost::size(range) >= MinimumSize;
+    }
+};
+
+class polygon_not_below_minimum_size
+{
+private:
+
+    template <typename Polygon>
+    struct predicate
+    {
+        typedef range_not_below_minimum_size
+            <
+                core_detail::closure::minimum_ring_size
+                    <
+                        closure<Polygon>::value
+                    >::value
+            > type;
+    };
+
+    template <typename Predicate, typename InteriorRings>
+    static inline bool
+    apply_to_interior_rings(InteriorRings const& interior_rings)
+    {
+        return check_iterator_range
+            <
+                Predicate, true // allow for no interior rings
+            >::apply(boost::begin(interior_rings), boost::end(interior_rings));
+    }
+
+public:
+    template <typename Polygon>
+    static inline bool apply(Polygon const& polygon)
+    {
+        typedef typename predicate<Polygon>::type predicate_type;
+        return predicate_type::apply(exterior_ring(polygon))
+            && apply_to_interior_rings
+                <
+                    predicate_type
+                >(interior_rings(polygon));
+    }
+};
+
+template <typename Predicate, bool AllowEmptyMultiGeometry>
+struct multigeometry_not_below_minimum_size
+{
+    template <typename MultiGeometry>
+    static inline bool apply(MultiGeometry const& multi_geometry)
+    {
+        return check_iterator_range
+            <
+                Predicate,
+                AllowEmptyMultiGeometry
+            >::apply(boost::begin(multi_geometry),
+                     boost::end(multi_geometry));
+    }
+};
+
+}} // namespace detail::is_below_minimum_size
+#endif // DOXYGEN_NO_DETAIL
+
+
+#ifndef DOXYGEN_NO_DISPATCH
+namespace dispatch
+{
+
+template <typename Geometry, typename Tag = typename tag<Geometry>::type>
+struct is_not_below_minimum_size: not_implemented<Tag>
+{};
+
+template <typename Geometry>
+struct is_not_below_minimum_size<Geometry, point_tag>
+    : detail::is_below_minimum_size::always_not_below
+{};
+
+template <typename Geometry>
+struct is_not_below_minimum_size<Geometry, box_tag>
+    : detail::is_below_minimum_size::always_not_below
+{};
+
+template <typename Geometry>
+struct is_not_below_minimum_size<Geometry, segment_tag>
+    : detail::is_below_minimum_size::always_not_below
+{};
+
+template <typename Geometry>
+struct is_not_below_minimum_size<Geometry, linestring_tag>
+    : detail::is_below_minimum_size::range_not_below_minimum_size<2>
+{};
+
+template <typename Geometry>
+struct is_not_below_minimum_size<Geometry, ring_tag>
+    : detail::is_below_minimum_size::range_not_below_minimum_size
+        <
+            core_detail::closure::minimum_ring_size
+                <
+                    closure<Geometry>::value
+                >::value
+        >
+{};
+
+template <typename Geometry>
+struct is_not_below_minimum_size<Geometry, polygon_tag>
+    : detail::is_below_minimum_size::polygon_not_below_minimum_size
+{};
+
+template <typename Geometry>
+struct is_not_below_minimum_size<Geometry, multi_point_tag>
+    : detail::is_below_minimum_size::range_not_below_minimum_size<1>
+{};
+
+template <typename Geometry>
+struct is_not_below_minimum_size<Geometry, multi_linestring_tag>
+    : detail::is_below_minimum_size::multigeometry_not_below_minimum_size
+        <
+            detail::is_below_minimum_size::range_not_below_minimum_size<2>,
+            false
+        >
+{};
+
+template <typename Geometry>
+struct is_not_below_minimum_size<Geometry, multi_polygon_tag>
+    : detail::is_below_minimum_size::multigeometry_not_below_minimum_size
+        <
+            detail::is_below_minimum_size::polygon_not_below_minimum_size,
+            false
+        >
+{};
+
+} // namespace dispatch
+#endif // DOXYGEN_NO_DISPATCH
+
+
+namespace resolve_variant
+{
+
+template <typename Geometry>
+struct is_below_minimum_size
+{
+    static inline bool apply(Geometry const& geometry)
+    {
+        concept::check<Geometry const>();
+
+        return !dispatch::is_not_below_minimum_size<Geometry>::apply(geometry);
+    }
+};
+
+template <BOOST_VARIANT_ENUM_PARAMS(typename T)>
+struct is_below_minimum_size<boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)> >
+{
+    struct visitor: boost::static_visitor<bool>
+    {
+        template <typename Geometry>
+        inline bool operator()(Geometry const& geometry) const
+        {
+            return is_below_minimum_size<Geometry>::apply(geometry);
+        }
+    };
+
+    static inline bool
+    apply(boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)> const& geometry)
+    {
+        return boost::apply_visitor(visitor(), geometry);
+    }
+};
+
+} // namespace resolve_variant
+
+
+/*!
+\brief \brief_calc{checks whether a geometry's number of points is
+below the minimum acceptable size}
+\ingroup is_below_minimum_size
+\details \details_calc{is_below_minimum_size}.
+\tparam Geometry \tparam_geometry
+\param geometry \param_geometry
+\return \return_calc{true if the geometry has less than the minimum
+acceptable number of points}
+
+\qbk{[include reference/algorithms/is_below_minimum_size.qbk]}
+*/
+template <typename Geometry>
+inline bool is_below_minimum_size(Geometry const& geometry)
+{
+    return resolve_variant::is_below_minimum_size<Geometry>::apply(geometry);
+}
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+}} // namespace boost::geometry
+
+
+#endif // BOOST_GEOMETRY_ALGORITHMS_IS_BELOW_MINIMUM_SIZE_HPP

--- a/include/boost/geometry/core/exception.hpp
+++ b/include/boost/geometry/core/exception.hpp
@@ -1,8 +1,13 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
-// Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
-// Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
+// Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
+// Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
+
+// This file was modified by Oracle on 2015.
+// Modifications copyright (c) 2015, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
@@ -51,6 +56,33 @@ public:
     virtual char const* what() const throw()
     {
         return "Boost.Geometry Empty-Input exception";
+    }
+};
+
+/*!
+\brief Below Minimum Size Exception
+\ingroup core
+\details The below_minimum_size_exception is thrown if free functions,
+    e.g. distance, are called with geometries whose number of points
+    is below the minimum acceptable threshold size, e.g. a linestring
+    with one point or less, a polygon with two or less points, an
+    empty multi-geometry, etc.
+\qbk{
+[heading See also]
+\* [link geometry.reference.algorithms.area the area function]
+\* [link geometry.reference.algorithms.distance the distance function]
+\* [link geometry.reference.algorithms.length the length function]
+}
+ */
+class below_minimum_size_exception : public geometry::exception
+{
+public:
+
+    inline below_minimum_size_exception() {}
+
+    virtual char const* what() const throw()
+    {
+        return "Boost.Geometry Below-Minimum-Size exception";
     }
 };
 

--- a/test/algorithms/Jamfile.v2
+++ b/test/algorithms/Jamfile.v2
@@ -28,6 +28,7 @@ test-suite boost-geometry-algorithms
     [ run envelope.cpp : : : <toolset>msvc:<cxxflags>/bigobj ]
     [ run expand.cpp ]
     [ run for_each.cpp ]
+    [ run is_below_minimum_size.cpp ]
     [ run is_simple.cpp : : : <toolset>msvc:<cxxflags>/bigobj ]
     [ run is_valid.cpp : : : <toolset>msvc:<cxxflags>/bigobj ]
     [ run length.cpp ]

--- a/test/algorithms/is_below_minimum_size.cpp
+++ b/test/algorithms/is_below_minimum_size.cpp
@@ -1,0 +1,171 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+// Unit Test
+
+// Copyright (c) 2015, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+#include <iostream>
+
+#include <boost/variant.hpp>
+
+#include <geometry_test_common.hpp>
+
+#include <boost/geometry/algorithms/is_below_minimum_size.hpp>
+#include <boost/geometry/algorithms/detail/throw_below_minimum_size.hpp>
+#include <boost/geometry/geometries/geometries.hpp>
+
+#include <boost/geometry/io/wkt/wkt.hpp>
+
+template <std::size_t D, typename T = double>
+struct box_dD
+{
+    typedef boost::geometry::model::box
+        <
+            boost::geometry::model::point<T, D, boost::geometry::cs::cartesian>
+        > type;
+};
+
+template <typename Geometry>
+inline void test_one(Geometry const& geometry, bool expected)
+{
+    bool detected = bg::is_below_minimum_size(geometry);
+    BOOST_CHECK_EQUAL(expected, detected);
+}
+
+template <typename Geometry>
+inline void test_one(std::string const& wkt, bool expected)
+{
+    Geometry geometry;
+    bg::read_wkt(wkt, geometry);
+    test_one<Geometry>(geometry, expected);
+}
+
+
+template <typename Geometry>
+inline void test_throw_exception(Geometry const& geometry)
+{
+    bg::detail::throw_below_minimum_size(geometry);
+}
+
+template <typename Geometry>
+inline void test_catch_exception(Geometry const& geometry)
+{
+    try
+    {
+        test_throw_exception(geometry);
+    }
+    catch (bg::below_minimum_size_exception const&)
+    {
+    }
+}
+
+
+
+int test_main(int, char* [])
+{
+    typedef bg::model::point<double,2,bg::cs::cartesian> point;
+    typedef bg::model::linestring<point> linestring;
+    typedef bg::model::segment<point> segment;
+    typedef bg::model::box<point> box;
+    typedef bg::model::ring<point> ring;
+    typedef bg::model::polygon<point> polygon;
+    typedef bg::model::multi_point<point> multi_point;
+    typedef bg::model::multi_linestring<linestring> multi_linestring;
+    typedef bg::model::multi_polygon<polygon> multi_polygon;
+
+    // open geometries
+    typedef bg::model::ring<point, true, false> open_ring;
+    typedef bg::model::polygon<point, true, false> open_polygon;
+    typedef bg::model::multi_polygon<open_polygon> open_multi_polygon;
+
+    test_one<point>("POINT(0 0)", false);
+    test_one<linestring>("LINESTRING()", true);
+    test_one<linestring>("LINESTRING(0 0)", true);
+    test_one<linestring>("LINESTRING(0 0,0 0)", false);
+    test_one<linestring>("LINESTRING(0 0,1 1)", false);
+    test_one<segment>("LINESTRING(0 0,1 1)", false);
+    test_one<box>("POLYGON((0 0,10 10))", false);
+    test_one<box_dD<3>::type>("BOX(0 0 0,1 1 1)", false);
+    test_one<box_dD<4>::type>("BOX(0 0 0 0,1 1 1 1)", false);
+    test_one<box_dD<5>::type>("BOX(0 0 0 0 0,1 1 1 1 1)", false);
+    test_one<ring>("POLYGON(())", true);
+    test_one<ring>("POLYGON((0 0))", true);
+    test_one<ring>("POLYGON((0 0,1 1))", true);
+    test_one<ring>("POLYGON((0 0,1 1,0 1))", true);
+    test_one<ring>("POLYGON((0 0,1 1,0 1,0 0))", false);
+    test_one<polygon>("POLYGON(())", true);
+    test_one<polygon>("POLYGON((0 0))", true);
+    test_one<polygon>("POLYGON((0 0,10 10))", true);
+    test_one<polygon>("POLYGON((0 0,10 10,0 10))", true);
+    test_one<polygon>("POLYGON((0 0,10 10,0 10,0 0))", false);
+    test_one<polygon>("POLYGON((),(4 4,6 4,6 6,4 6,4 4))", true);
+    test_one<polygon>("POLYGON((0 0),(4 4,6 4,6 6,4 6,4 4))", true);
+    test_one<polygon>("POLYGON((0 0,0 10),(4 4,6 4,6 6,4 6,4 4))", true);
+    test_one<polygon>("POLYGON((0 0,0 10,10 10),(4 4,6 4,6 6,4 6,4 4))", true);
+    test_one<polygon>("POLYGON((0 0,0 10,10 10,10 0),(4 4,6 4,6 6,4 6,4 4))", false);
+    test_one<polygon>("POLYGON((0 0,0 10,10 10,10 0,0 0),(4 4,6 4,6 6,4 6,4 4))", false);
+    test_one<polygon>("POLYGON((0 0,0 10,10 10,10 0,0 0),())", true);
+    test_one<polygon>("POLYGON((0 0,0 10,10 10,10 0,0 0),(4 4))", true);
+    test_one<polygon>("POLYGON((0 0,0 10,10 10,10 0,0 0),(4 4,6 4))", true);
+    test_one<polygon>("POLYGON((0 0,0 10,10 10,10 0,0 0),(4 4,6 4,6 6))", true);
+    test_one<polygon>("POLYGON((0 0,0 10,10 10,10 0,0 0),(4 4,6 4,6 6,4 6))", false);
+    test_one<multi_point>("MULTIPOINT()", true);
+    test_one<multi_point>("MULTIPOINT(0 0)", false);
+    test_one<multi_point>("MULTIPOINT(0 0,1 1)", false);
+    test_one<multi_linestring>("MULTILINESTRING()", true);
+    test_one<multi_linestring>("MULTILINESTRING((0 0),(2 2,3 3,4 4))", true);
+    test_one<multi_linestring>("MULTILINESTRING((0 0,1 1),(2 2))", true);
+    test_one<multi_linestring>("MULTILINESTRING((0 0,1 1),())", true);
+    test_one<multi_linestring>("MULTILINESTRING((0 0),())", true);
+    test_one<multi_linestring>("MULTILINESTRING((0 0,1 1),(2 2,3 3,4 4))", false);
+    test_one<multi_polygon>("MULTIPOLYGON()", true);
+    test_one<multi_polygon>("MULTIPOLYGON(((0 0,0 10,0 0)),((0 10,1 10,1 9,0 10)))", true);
+    test_one<multi_polygon>("MULTIPOLYGON(((0 0,0 10,10 10,10 0,0 0)),((0 10,1 10,1 9)))", true);
+    test_one<multi_polygon>("MULTIPOLYGON(((0 0,0 10,10 10,10 0,0 0)),((0 10,1 10,1 9,0 10)))", false);
+
+    // test open geometries
+    test_one<open_ring>("POLYGON(())", true);
+    test_one<open_ring>("POLYGON((0 0))", true);
+    test_one<open_ring>("POLYGON((0 0,1 1))", true);
+    test_one<open_ring>("POLYGON((0 0,1 1,0 1))", false);
+    test_one<open_ring>("POLYGON((0 0,1 1,0 1,0 0))", false);
+    test_one<open_polygon>("POLYGON((0 0,10 10))", true);
+    test_one<open_polygon>("POLYGON((0 0,10 10,0 10))", false);
+    test_one<open_polygon>("POLYGON((0 0,10 10,0 10),(1 1))", true);
+    test_one<open_multi_polygon>("MULTIPOLYGON(((0 0,0 10)),((0 10,1 10,1 9)))", true);
+    test_one<open_multi_polygon>("MULTIPOLYGON(((0 0,0 10,10 10,10 0)),((0 10,1 10)))", true);
+    test_one<open_multi_polygon>("MULTIPOLYGON(((0 0,0 10,10 10,10 0)),((0 10,1 10,1 9)))", false);
+    test_one<open_multi_polygon>("MULTIPOLYGON(((0 0,0 10,10 10,10 0,0 0)),((0 10,1 10,1 9,0 10)))", false);
+
+    // test variant geometry
+    typedef boost::variant
+        <
+            multi_point, multi_linestring, open_polygon
+        > variant_type;
+
+    variant_type v;
+    multi_point mp;
+    multi_linestring mls;
+    open_polygon open_poly;
+    bg::read_wkt("MULTIPOINT(0 0)", mp);
+    bg::read_wkt("MULTILINESTRING((0 0,1 1),(2 2))", mls);
+    bg::read_wkt("POLYGON((0 0,20 20,20 0),(5 4,8 4,8 5))", open_poly);
+    v = mp;
+    test_one(v, false);
+    v = mls;
+    test_one(v, true);
+    v = open_poly;
+    test_one(v, false);
+
+    // test catching the exception
+    test_throw_exception(mp);
+    test_catch_exception(mls);
+    test_throw_exception(open_poly);
+
+    return 0;
+}
+


### PR DESCRIPTION
In this PR I propose a new algorithm `is_below_minimum_size` which tests whether the size of a geometry is below the minimum acceptable size so that the geometry can be considered as valid. More specifically:
* For points, segments and boxes the algorithm always returns false.
* For linestrings the algorithm returns true is the linestrings has less than 2 points.
* For rings and polygons the algorithm returns true is the ring or the polygon's rings have less than 3 or 4 points, depending on whether the ring or polygon is open or closed, respectively.
* For multi-points the algorithm returns true is the multi-point has size 0.
* For multi-linestrings and multi-polygons the algorithm returns true if at least one of the contained geometries has less than the minimum acceptable number of points.

Besides this new algorithm this PR introduces
* a new exception called `below_minimum_size` that is to be thrown when a geometry's size is below the minimum acceptable one (in the sense described below)
* a new free function (in `algorithms/detail`) called `throw_below_minimum_size` that takes as input a geometry and throws the `below_minimum_size` exception if the result of the `is_below_minimum_size` for this geometry is false.

The motivation for this PR is to replace the `empty_geometry_exception` in the distance code, and possibly in other algorithms.