### PR TITLE
Moving from boost.timer old to new API

### DIFF
--- a/test/algorithms/buffer/multi_point_buffer.cpp
+++ b/test/algorithms/buffer/multi_point_buffer.cpp
@@ -174,7 +174,7 @@ void test_growth(int n, int distance_count)
 {
     srand(int(time(NULL)));
     //std::cout << typeid(bg::coordinate_type<P>::type).name() << std::endl;
-    boost::timer t;
+    boost::timer::cpu_timer t;
 
     namespace buf = bg::strategy::buffer;
     typedef bg::model::polygon<P> polygon;
@@ -203,7 +203,8 @@ void test_growth(int n, int distance_count)
         }
         previous_area = area;
     }
-    std::cout << "n=" << n << " time=" << t.elapsed() << std::endl;
+    
+    std::cout << "n=" << n << " time=" << t.format(3, "%t") << std::endl;
 }
 
 int test_main(int, char* [])

--- a/test/robustness/convex_hull/random_multi_points.cpp
+++ b/test/robustness/convex_hull/random_multi_points.cpp
@@ -18,7 +18,7 @@
 #include <boost/random/uniform_int.hpp>
 #include <boost/random/uniform_real.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <boost/timer.hpp>
+#include <boost/timer/timer.hpp>
 
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/geometries.hpp>
@@ -136,7 +136,7 @@ void test_random_multi_points(MultiPoint& result, int& index,
 template <typename T>
 void test_all(int seed, int count, int field_size, int pcount, settings_type const& settings)
 {
-    boost::timer t;
+    boost::timer::cpu_timer t;
 
     typedef boost::minstd_rand base_generator_type;
 
@@ -160,7 +160,7 @@ void test_all(int seed, int count, int field_size, int pcount, settings_type con
     std::cout
         << "points: " << index
         << " type: " << typeid(T).name()
-        << " time: " << t.elapsed()  << std::endl;
+        << " time: " << t.format(3, "%t")  << std::endl;
 }
 
 int main(int argc, char** argv)

--- a/test/robustness/overlay/areal_areal/interior_triangles.cpp
+++ b/test/robustness/overlay/areal_areal/interior_triangles.cpp
@@ -24,7 +24,7 @@
 #include <boost/random/uniform_int.hpp>
 #include <boost/random/uniform_real.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <boost/timer.hpp>
+#include <boost/timer/timer.hpp>
 
 template <typename Polygon>
 inline void make_polygon(Polygon& polygon, int count_x, int count_y, int index, int offset)
@@ -73,7 +73,7 @@ void test_star_comb(int count_x, int count_y, int offset, p_q_settings const& se
 template <typename T, bool Clockwise, bool Closed>
 void test_all(int count, int count_x, int count_y, int offset, p_q_settings const& settings)
 {
-    boost::timer t;
+    boost::timer::cpu_timer t;
 
     typedef bg::model::polygon
         <
@@ -87,7 +87,7 @@ void test_all(int count, int count_x, int count_y, int offset, p_q_settings cons
     }
     std::cout
         << " type: " << string_from_type<T>::name()
-        << " time: " << t.elapsed()  << std::endl;
+        << " time: " << t.format(3, "%t")  << std::endl;
 }
 
 int main(int argc, char** argv)

--- a/test/robustness/overlay/areal_areal/intersection_pies.cpp
+++ b/test/robustness/overlay/areal_areal/intersection_pies.cpp
@@ -14,7 +14,7 @@
 #include <test_overlay_p_q.hpp>
 
 #include <boost/program_options.hpp>
-#include <boost/timer.hpp>
+#include <boost/timer/timer.hpp>
 
 template <typename Polygon>
 inline void make_pie(Polygon& polygon,
@@ -133,7 +133,7 @@ template <typename T, bool Clockwise, bool Closed>
 void test_pie(int total_segment_count, T factor_p, T factor_q,
             bool multi, bool single_selftangent, p_q_settings const& settings)
 {
-    boost::timer t;
+    boost::timer::cpu_timer t;
     typedef bg::model::d2::point_xy<T> point_type;
     typedef bg::model::polygon<point_type, Clockwise, Closed> polygon;
     typedef bg::model::multi_polygon<polygon> multi_polygon;
@@ -224,7 +224,7 @@ void test_pie(int total_segment_count, T factor_p, T factor_q,
         }
     }
     std::cout
-        << "Time: " << t.elapsed()  << std::endl
+        << "Time: " << t.format(3, "%t")  << std::endl
         << "Good: " << good_count << std::endl
         << "Bad: " << bad_count << std::endl;
 }

--- a/test/robustness/overlay/areal_areal/intersection_stars.cpp
+++ b/test/robustness/overlay/areal_areal/intersection_stars.cpp
@@ -16,7 +16,7 @@
 #include <test_overlay_p_q.hpp>
 
 #include <boost/program_options.hpp>
-#include <boost/timer.hpp>
+#include <boost/timer/timer.hpp>
 
 template <typename Polygon>
 inline void make_star(Polygon& polygon,
@@ -64,7 +64,7 @@ inline void make_star(Polygon& polygon,
 template <typename T, typename CalculationType>
 void test_star(int count, int min_points, int max_points, T rotation, p_q_settings const& settings)
 {
-    boost::timer t;
+    boost::timer::cpu_timer t;
     typedef bg::model::d2::point_xy<T> point_type;
     typedef bg::model::polygon<point_type> polygon;
 
@@ -97,7 +97,7 @@ void test_star(int count, int min_points, int max_points, T rotation, p_q_settin
     std::cout
         << "polygons: " << n
         << " type: " << string_from_type<T>::name()
-        << " time: " << t.elapsed()  << std::endl;
+        << " time: " << t.format(3, "%t")  << std::endl;
 }
 
 template <typename T, typename CalculationType>

--- a/test/robustness/overlay/areal_areal/intersects.cpp
+++ b/test/robustness/overlay/areal_areal/intersects.cpp
@@ -24,7 +24,7 @@
 #include <boost/random/uniform_int.hpp>
 #include <boost/random/uniform_real.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <boost/timer.hpp>
+#include <boost/timer/timer.hpp>
 
 
 template <typename MultiPolygon>
@@ -81,7 +81,7 @@ void test_intersects(int count_x, int count_y, int width_x, p_q_settings const& 
 template <typename T, bool Clockwise, bool Closed>
 void test_all(int count, int count_x, int count_y, int width_x, p_q_settings const& settings)
 {
-    boost::timer t;
+    boost::timer::cpu_timer t;
 
     typedef bg::model::polygon
         <
@@ -99,7 +99,7 @@ void test_all(int count, int count_x, int count_y, int width_x, p_q_settings con
     }
     std::cout
         << " type: " << string_from_type<T>::name()
-        << " time: " << t.elapsed()  << std::endl;
+        << " time: " << t.format(3, "%t")  << std::endl;
 }
 
 int main(int argc, char** argv)

--- a/test/robustness/overlay/areal_areal/random_ellipses_stars.cpp
+++ b/test/robustness/overlay/areal_areal/random_ellipses_stars.cpp
@@ -14,7 +14,7 @@
 #include <test_overlay_p_q.hpp>
 
 #include <boost/program_options.hpp>
-#include <boost/timer.hpp>
+#include <boost/timer/timer.hpp>
 #include <boost/random/linear_congruential.hpp>
 #include <boost/random/uniform_int.hpp>
 #include <boost/random/uniform_real.hpp>
@@ -103,7 +103,7 @@ void test_star_ellipse(int seed, int index, star_params const& par_p,
 template <typename T, bool Clockwise, bool Closed>
 void test_type(int seed, int count, p_q_settings const& settings)
 {
-    boost::timer t;
+    boost::timer::cpu_timer t;
 
     typedef boost::minstd_rand base_generator_type;
 
@@ -162,7 +162,7 @@ void test_type(int seed, int count, p_q_settings const& settings)
     }
     std::cout
         << "type: " << string_from_type<T>::name()
-        << " time: " << t.elapsed()  << std::endl;
+        << " time: " << t.format(3, "%t")  << std::endl;
 }
 
 template <bool Clockwise, bool Closed>

--- a/test/robustness/overlay/areal_areal/recursive_polygons.cpp
+++ b/test/robustness/overlay/areal_areal/recursive_polygons.cpp
@@ -17,7 +17,7 @@
 #include <boost/random/uniform_int.hpp>
 #include <boost/random/uniform_real.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <boost/timer.hpp>
+#include <boost/timer/timer.hpp>
 
 
 template <typename Polygon, typename Generator>
@@ -110,7 +110,7 @@ bool test_recursive_boxes(MultiPolygon& result, int& index,
 template <typename T, bool Clockwise, bool Closed>
 void test_all(int seed, int count, int field_size, int level, bool triangular, p_q_settings const& settings)
 {
-    boost::timer t;
+    boost::timer::cpu_timer t;
 
     typedef boost::minstd_rand base_generator_type;
 
@@ -136,7 +136,7 @@ void test_all(int seed, int count, int field_size, int level, bool triangular, p
     std::cout
         << "polygons: " << index
         << " type: " << string_from_type<T>::name()
-        << " time: " << t.elapsed()  << std::endl;
+        << " time: " << t.format(3, "%t")  << std::endl;
 }
 
 int main(int argc, char** argv)

--- a/test/robustness/overlay/areal_areal/star_comb.cpp
+++ b/test/robustness/overlay/areal_areal/star_comb.cpp
@@ -20,7 +20,7 @@
 #include <boost/random/uniform_int.hpp>
 #include <boost/random/uniform_real.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <boost/timer.hpp>
+#include <boost/timer/timer.hpp>
 
 #include <star_comb.hpp>
 
@@ -53,7 +53,7 @@ void test_star_comb(int star_point_count, int comb_comb_count, double factor1, d
 template <typename T, bool Clockwise, bool Closed>
 void test_all(int count, int star_point_count, int comb_comb_count, double factor1, double factor2, bool do_union, p_q_settings const& settings)
 {
-    boost::timer t;
+    boost::timer::cpu_timer t;
 
     typedef bg::model::polygon
         <
@@ -66,7 +66,7 @@ void test_all(int count, int star_point_count, int comb_comb_count, double facto
     }
     std::cout
         << " type: " << string_from_type<T>::name()
-        << " time: " << t.elapsed()  << std::endl;
+        << " time: " << t.format(3, "%t")  << std::endl;
 }
 
 int main(int argc, char** argv)

--- a/test/robustness/overlay/areal_areal/star_comb.hpp
+++ b/test/robustness/overlay/areal_areal/star_comb.hpp
@@ -13,7 +13,7 @@
 #include <string>
 #include <vector>
 
-#include <boost/timer.hpp>
+#include <boost/timer/timer.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/math/constants/constants.hpp>
 

--- a/test/robustness/overlay/areal_areal/ticket_9081.cpp
+++ b/test/robustness/overlay/areal_areal/ticket_9081.cpp
@@ -23,7 +23,7 @@
  #include <boost/geometry/multi/geometries/multi_polygon.hpp>
 
 #include <boost/foreach.hpp>
-#include <boost/timer.hpp>
+#include <boost/timer/timer.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/geometry/io/svg/svg_mapper.hpp>
 #include <fstream>
@@ -91,7 +91,7 @@ int main()
     {
 
 
-    boost::timer t;
+    boost::timer::cpu_timer t;
     std::vector<multi_polygon> poly_list;
 
     for(int i=0;i<num_orig;i++)
@@ -219,7 +219,7 @@ int main()
         }
     }
 
-    std::cout << "FINISHED " << t.elapsed() << std::endl;
+    std::cout << "FINISHED " << t.format(3, "%t") << std::endl;
 
     }
     catch(std::exception const& e)

--- a/test/robustness/overlay/buffer/recursive_polygons_buffer.cpp
+++ b/test/robustness/overlay/buffer/recursive_polygons_buffer.cpp
@@ -21,7 +21,7 @@
 #include <boost/random/uniform_int.hpp>
 #include <boost/random/uniform_real.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <boost/timer.hpp>
+#include <boost/timer/timer.hpp>
 
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/geometries.hpp>
@@ -240,7 +240,7 @@ bool test_buffer(MultiPolygon& result, int& index,
 template <typename T, bool Clockwise, bool Closed, typename Settings>
 void test_all(int seed, int count, int level, Settings const& settings)
 {
-    boost::timer t;
+    boost::timer::cpu_timer t;
 
     typedef boost::minstd_rand base_generator_type;
 
@@ -266,7 +266,7 @@ void test_all(int seed, int count, int level, Settings const& settings)
     std::cout
         << "geometries: " << index
         << " type: " << typeid(T).name()
-        << " time: " << t.elapsed()  << std::endl;
+        << " time: " << t.format(3, "%t")  << std::endl;
 }
 
 int main(int argc, char** argv)

--- a/test/robustness/overlay/linear_areal/recursive_polygons_linear_areal.cpp
+++ b/test/robustness/overlay/linear_areal/recursive_polygons_linear_areal.cpp
@@ -21,7 +21,7 @@
 #include <boost/random/uniform_int.hpp>
 #include <boost/random/uniform_real.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <boost/timer.hpp>
+#include <boost/timer/timer.hpp>
 
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/geometries.hpp>
@@ -396,7 +396,7 @@ bool test_linear_areal(MultiPolygon& result, int& index,
 template <typename T, bool Clockwise, bool Closed>
 void test_all(int seed, int count, int level, common_settings const& settings)
 {
-    boost::timer t;
+    boost::timer::cpu_timer t;
 
     typedef boost::minstd_rand base_generator_type;
 
@@ -422,7 +422,7 @@ void test_all(int seed, int count, int level, common_settings const& settings)
     std::cout
         << "geometries: " << index
         << " type: " << typeid(T).name()
-        << " time: " << t.elapsed()  << std::endl;
+        << " time: " << t.format(3, "%t")  << std::endl;
 }
 
 int main(int argc, char** argv)

--- a/test/strategies/pythagoras.cpp
+++ b/test/strategies/pythagoras.cpp
@@ -19,7 +19,7 @@
 #  pragma warning( disable : 4101 )
 #endif
 
-#include <boost/timer.hpp>
+#include <boost/timer/timer.hpp>
 
 #include <boost/concept/requires.hpp>
 #include <boost/concept_check.hpp>
@@ -296,7 +296,7 @@ void test_all_3d()
 template <typename P, typename Strategy>
 void time_compare_s(int const n)
 {
-    boost::timer t;
+    boost::timer::cpu_timer t;
     P p1, p2;
     bg::assign_values(p1, 1, 1);
     bg::assign_values(p2, 2, 2);
@@ -310,7 +310,8 @@ void time_compare_s(int const n)
             s += strategy.apply(p1, p2);
         }
     }
-    std::cout << "s: " << s << " t: " << t.elapsed() << std::endl;
+    
+    std::cout << "s: " << s << " t: " << t.format(3, "%t") << std::endl;
 }
 
 template <typename P>

--- a/test/strategies/pythagoras_point_box.cpp
+++ b/test/strategies/pythagoras_point_box.cpp
@@ -28,7 +28,7 @@
 #endif
 
 #include <boost/core/ignore_unused.hpp>
-#include <boost/timer.hpp>
+#include <boost/timer/timer.hpp>
 
 #include <boost/concept/requires.hpp>
 #include <boost/concept_check.hpp>
@@ -397,7 +397,7 @@ void time_compare_s(int const n)
 {
     typedef bg::model::box<P> box_type;
 
-    boost::timer t;
+    boost::timer::cpu_timer t;
     P p;
     box_type b;
     bg::assign_values(b, 0, 0, 1, 1);
@@ -415,7 +415,8 @@ void time_compare_s(int const n)
             s += strategy.apply(p, b);
         }
     }
-    std::cout << "s: " << s << " t: " << t.elapsed() << std::endl;
+    
+    std::cout << "s: " << s << " t: " << t.format(3, "%t") << std::endl;
 }
 
 template <typename P>


### PR DESCRIPTION
Please find here the PR for fixing the issues you have in geometry, due to the changes in boost.test.
http://article.gmane.org/gmane.comp.lib.boost.devel/256800
