### PR TITLE
Fix/closing iterator for empty ranges

### DIFF
--- a/include/boost/geometry/iterators/closing_iterator.hpp
+++ b/include/boost/geometry/iterators/closing_iterator.hpp
@@ -57,7 +57,7 @@ struct closing_iterator
         , m_iterator(boost::end(range))
         , m_end(boost::end(range))
         , m_size(boost::size(range))
-        , m_index(m_size + 1)
+        , m_index((m_size == 0) ? 0 : m_size + 1)
     {}
 
     /// Default constructor

--- a/test/iterators/closing_iterator.cpp
+++ b/test/iterators/closing_iterator.cpp
@@ -28,6 +28,27 @@
 
 
 // The closing iterator should also work on normal std:: containers
+void test_empty_non_geometry()
+{
+    std::vector<int> v;
+
+    typedef bg::closing_iterator
+        <
+            std::vector<int> const
+        > closing_iterator;
+
+
+    closing_iterator it(v);
+    closing_iterator end(v, true);
+
+    std::ostringstream out;
+    for (; it != end; ++it)
+    {
+        out << *it;
+    }
+    BOOST_CHECK_EQUAL(out.str(), "");
+}
+
 void test_non_geometry()
 {
     std::vector<int> v;
@@ -106,6 +127,7 @@ void test_geometry(std::string const& wkt)
 template <typename P>
 void test_all()
 {
+    test_empty_non_geometry();
     test_non_geometry();
     test_geometry<bg::model::ring<P> >("POLYGON((1 1,1 4,4 4,4 1))");
 }


### PR DESCRIPTION
This PR fixes a bug in the `closing_iterator` when it is applied to an empty range

The `closing_iterator` was not working for empty ranges as it was trying to append the first range item of an empty range to the end of the range.

The proposed fix changes the index of the last item in the closing iterator's range to be 0 instead of 1 when the range is empty.
