### PR TITLE
Feature/support for one point geometries

### DIFF
--- a/include/boost/geometry/iterators/detail/segment_iterator/range_segment_iterator.hpp
+++ b/include/boost/geometry/iterators/detail/segment_iterator/range_segment_iterator.hpp
@@ -104,7 +104,7 @@ struct range_segment_iterator
 
     // default constructor
     range_segment_iterator()
-        : m_it(), m_has_less_than_two_elements()
+        : m_it(), m_has_less_than_two_elements(false)
     {}
 
     // for begin

--- a/include/boost/geometry/iterators/detail/segment_iterator/range_segment_iterator.hpp
+++ b/include/boost/geometry/iterators/detail/segment_iterator/range_segment_iterator.hpp
@@ -91,7 +91,7 @@ struct range_iterator_end<Range, open>
 
 
 template <typename Range, typename Value, typename Reference = Value>
-class range_segment_iterator
+struct range_segment_iterator
     : public boost::iterator_facade
         <
             range_segment_iterator<Range, Value, Reference>,
@@ -100,16 +100,6 @@ class range_segment_iterator
             Reference
         >
 {
-private:
-    static bool has_less_than_two_elements(Range const& r)
-    {
-        iterator_type first = range_iterator_begin<Range>::apply(r);
-        iterator_type last = range_iterator_end<Range>::apply(r);
-
-        return first == last || ++first == last;
-    }
-
-public:
     typedef typename range_iterator_type<Range>::type iterator_type;
 
     // default constructor
@@ -120,15 +110,15 @@ public:
     // for begin
     range_segment_iterator(Range& r)
         : m_it(range_iterator_begin<Range>::apply(r))
-        , m_has_less_than_two_elements(has_less_than_two_elements(r))
+        , m_has_less_than_two_elements(boost::size(r) < 2u)
     {}
 
     // for end
     range_segment_iterator(Range& r, bool)
         : m_it(range_iterator_end<Range>::apply(r))
-        , m_has_less_than_two_elements(has_less_than_two_elements(r))
+        , m_has_less_than_two_elements(boost::size(r) < 2u)
     {
-        if (!m_has_less_than_two_elements)
+        if (! m_has_less_than_two_elements)
         {
             // the range consists of at least two items
             --m_it;

--- a/include/boost/geometry/iterators/detail/segment_iterator/range_segment_iterator.hpp
+++ b/include/boost/geometry/iterators/detail/segment_iterator/range_segment_iterator.hpp
@@ -100,23 +100,40 @@ class range_segment_iterator
             Reference
         >
 {
+private:
+    static bool has_less_than_two_elements(Range const& r)
+    {
+        iterator_type first = range_iterator_begin<Range>::apply(r);
+        iterator_type last = range_iterator_end<Range>::apply(r);
+
+        return first == last || ++first == last;
+    }
+
 public:
     typedef typename range_iterator_type<Range>::type iterator_type;
 
     // default constructor
     range_segment_iterator()
-        : m_it()
+        : m_it(), m_has_less_than_two_elements()
     {}
 
     // for begin
     range_segment_iterator(Range& r)
         : m_it(range_iterator_begin<Range>::apply(r))
+        , m_has_less_than_two_elements(has_less_than_two_elements(r))
     {}
 
     // for end
     range_segment_iterator(Range& r, bool)
-        : m_it(--range_iterator_end<Range>::apply(r))
-    {}
+        : m_it(range_iterator_end<Range>::apply(r))
+        , m_has_less_than_two_elements(has_less_than_two_elements(r))
+    {
+        if (!m_has_less_than_two_elements)
+        {
+            // the range consists of at least two items
+            --m_it;
+        }
+    }
 
     template
     <
@@ -151,6 +168,11 @@ private:
 
     inline Reference dereference() const
     {
+        if (m_has_less_than_two_elements)
+        {
+            return Reference(*m_it, *m_it);
+        }
+
         iterator_type next(m_it);
         ++next;
         return Reference(*m_it, *next);
@@ -184,6 +206,7 @@ private:
 
 private:
     iterator_type m_it;
+    bool m_has_less_than_two_elements;
 };
 
 

--- a/test/algorithms/distance/distance_linear_areal.cpp
+++ b/test/algorithms/distance/distance_linear_areal.cpp
@@ -65,6 +65,10 @@ void test_distance_segment_polygon(Strategy const& strategy)
     tester::apply("segment(-1 20,-1 -20)",
                   "polygon((-10 -10,10 -10,10 10,-10 10,-10 -10))",
                   0, 0, strategy);
+
+    tester::apply("segment(0 0,1 1)",
+                  "polygon((2 2))",
+                  sqrt(2.0), 2, strategy);
 }
 
 //===========================================================================
@@ -93,6 +97,14 @@ void test_distance_linestring_polygon(Strategy const& strategy)
     tester::apply("linestring(-1 20,1 20,1 -20)",
                   "polygon((-10 -10,10 -10,10 10,-10 10,-10 -10))",
                   0, 0, strategy, true);
+
+    tester::apply("linestring(-2 1)",
+                  "polygon((0 0,10 0,10 10,0 10,0 0))",
+                  2, 4, strategy, true);
+
+    tester::apply("linestring(-5 1,-2 1)",
+                  "polygon((0 0))",
+                  sqrt(5.0), 5, strategy, true);
 }
 
 //===========================================================================
@@ -139,6 +151,14 @@ void test_distance_multilinestring_polygon(Strategy const& strategy)
     tester::apply("multilinestring((-1 20,1 20,1 30),(-1 20,1 20,1 -20))",
                   "polygon((-10 -10,10 -10,10 10,-10 10,-10 -10))",
                   0, 0, strategy, true);
+
+    tester::apply("multilinestring((-100 -100,-90 -90),(1 20))",
+                  "polygon((-10 -10,10 -10,10 10,-10 10,-10 -10))",
+                  10, 100, strategy, true);
+
+    tester::apply("multilinestring((-100 -100,-90 -90),(-1 20,1 20,1 30))",
+                  "polygon((-110 -110))",
+                  sqrt(200.0), 200, strategy, true);
 }
 
 //===========================================================================

--- a/test/algorithms/distance/distance_linear_linear.cpp
+++ b/test/algorithms/distance/distance_linear_linear.cpp
@@ -79,6 +79,10 @@ void test_distance_segment_linestring(Strategy const& strategy)
     tester::apply("segment(1 1,2 2)",
                   "linestring(3 3,3 3)",
                   sqrt(2.0), 2, strategy);
+
+    tester::apply("segment(1 1,2 2)",
+                  "linestring(3 3)",
+                  sqrt(2.0), 2, strategy);
 }
 
 //===========================================================================
@@ -163,6 +167,14 @@ void test_distance_segment_multilinestring(Strategy const& strategy)
     tester::apply("segment(1 1,2 2)",
                   "multilinestring((2.5 0,4 0,5 0),(3 3,3 3))",
                    sqrt(2.0), 2, strategy);
+
+    tester::apply("segment(1 1,2 2)",
+                  "multilinestring((2.5 0),(3 3,3 3))",
+                   sqrt(2.0), 2, strategy);
+
+    tester::apply("segment(1 1,2 2)",
+                  "multilinestring((2.5 0,4 0,5 0),(3 3))",
+                   sqrt(2.0), 2, strategy);
 }
 
 //===========================================================================
@@ -190,6 +202,14 @@ void test_distance_linestring_multilinestring(Strategy const& strategy)
 
     tester::apply("linestring(1 1,2 2)",
                   "multilinestring((2.5 0,4 0,5 0),(3 3,3 3))",
+                   sqrt(2.0), 2, strategy);
+
+    tester::apply("linestring(2 2)",
+                  "multilinestring((2.5 0,4 0,5 0),(3 3,3 3))",
+                   sqrt(2.0), 2, strategy);
+
+    tester::apply("linestring(1 1,2 2)",
+                  "multilinestring((2.5 0,4 0,5 0),(3 3))",
                    sqrt(2.0), 2, strategy);
 
     tester::apply("linestring(1 1,2 2,3 3,4 4,5 5,6 6,7 7,8 8,9 9)",
@@ -223,6 +243,10 @@ void test_distance_multilinestring_multilinestring(Strategy const& strategy)
     tester::apply("multilinestring((0 0,0 1,1 1),(10 0,11 1,12 2))",
                   "multilinestring((0.5 0.5,0.75 0.75),(11.1 0,11.1 0.9))",
                   sqrt(0.02), 0.02, strategy);
+
+    tester::apply("multilinestring((0 0),(1 1))",
+                  "multilinestring((2 2),(3 3))",
+                  sqrt(2.0), 2, strategy);
 }
 
 //===========================================================================

--- a/test/algorithms/distance/distance_pointlike_areal.cpp
+++ b/test/algorithms/distance/distance_pointlike_areal.cpp
@@ -63,6 +63,15 @@ void test_distance_point_polygon(Strategy const& strategy)
                   "polygon((-10 -10,10 -10,10 10,-10 10,-10 -10),\
                    (-5 -5,-5 5,5 5,5 -5,-5 -5))",
                   5, 25, strategy);
+
+    // polygons with single-point rings
+    tester::apply("point(0 0)",
+                  "polygon((-5 5))",
+                  sqrt(50.0), 50, strategy);
+
+    tester::apply("point(0 0)",
+                  "polygon((-10 -10,10 -10,10 10,-10 10,-10 -10),(-5 5))",
+                  0, 0, strategy);
 }
 
 //===========================================================================
@@ -87,6 +96,11 @@ void test_distance_point_ring(Strategy const& strategy)
     tester::apply("point(0 0)",
                   "polygon((-10 -10,10 -10,10 10,-10 10,-10 -10))",
                   0, 0, strategy);
+
+    // single-point rings
+    tester::apply("point(0 0)",
+                  "polygon((-10 -10))",
+                  sqrt(200.0), 200, strategy);
 }
 
 //===========================================================================
@@ -177,6 +191,11 @@ void test_distance_multipoint_ring(Strategy const& strategy)
     tester::apply("multipoint(0 0,5 5,4 4)",
                   "polygon((-10 -10,10 -10,10 10,-10 10,-10 -10))",
                   0, 0, strategy);
+
+    // single-point ring
+    tester::apply("multipoint(0 0,5 5,4 4)",
+                  "polygon((10 10))",
+                  sqrt(50.0), 50, strategy);
 }
 
 //===========================================================================

--- a/test/algorithms/distance/distance_pointlike_linear.cpp
+++ b/test/algorithms/distance/distance_pointlike_linear.cpp
@@ -62,12 +62,14 @@ void test_distance_point_linestring(Strategy const& strategy)
 #endif
     typedef test_distance_of_geometries<point_type, linestring_type> tester;
 
-    tester::apply("point(0 0)", "linestring(2 0)", 2, 4, strategy);
     tester::apply("point(0 0)", "linestring(2 0,3 0)", 2, 4, strategy);
     tester::apply("point(2.5 3)", "linestring(2 0,3 0)", 3, 9, strategy);
     tester::apply("point(2 0)", "linestring(2 0,3 0)", 0, 0, strategy);
     tester::apply("point(3 0)", "linestring(2 0,3 0)", 0, 0, strategy);
     tester::apply("point(2.5 0)", "linestring(2 0,3 0)", 0, 0, strategy);
+
+    // linestring with a single point
+    tester::apply("point(0 0)", "linestring(2 0)", 2, 4, strategy);
 }
 
 //===========================================================================
@@ -111,6 +113,27 @@ void test_distance_point_multilinestring(Strategy const& strategy)
     tester::apply("POINT(0 0)",
                   "MULTILINESTRING((10 10,10 0),(20 20,20 20))",
                   10, 100, strategy);
+
+    // multilinestrings containing an empty linestring
+    tester::apply("POINT(0 0)",
+                  "MULTILINESTRING((),(10 0),(20 20,20 20))",
+                  10, 100, strategy);
+    tester::apply("POINT(0 0)",
+                  "MULTILINESTRING((),(10 0),(),(20 20,20 20))",
+                  10, 100, strategy);
+
+    // multilinestrings containing a linestring with a single point
+    tester::apply("POINT(0 0)",
+                  "MULTILINESTRING((10 0),(20 20,20 20))",
+                  10, 100, strategy);
+    tester::apply("POINT(0 0)",
+                  "MULTILINESTRING((20 20,20 20),(10 0))",
+                  10, 100, strategy);
+
+    // multilinestring with a single-point linestring and empty linestrings
+    tester::apply("POINT(0 0)",
+                  "MULTILINESTRING((),(20 20,20 20),(),(10 0))",
+                  10, 100, strategy);
 }
 
 //===========================================================================
@@ -139,6 +162,11 @@ void test_distance_linestring_multipoint(Strategy const& strategy)
     tester::apply("linestring(3 3,4 4,100 100)",
                   "multipoint(0 0,1 0,0 1,1 1)",
                   sqrt(8.0), 8, strategy);
+
+    // linestring with a single point
+    tester::apply("linestring(1 8)",
+                  "multipoint(0 0,3 0,4 -7,10 100)",
+                  sqrt(65.0), 65, strategy);
 }
 
 //===========================================================================
@@ -166,6 +194,27 @@ void test_distance_multipoint_multilinestring(Strategy const& strategy)
                   0, 0, strategy);
     tester::apply("multipoint(0 0,1 0,0 1,1 1)",
                   "multilinestring((3 3,4 4),(4 4,5 5))",
+                  sqrt(8.0), 8, strategy);
+
+    // multilinestring with empty linestring
+    tester::apply("multipoint(0 0,1 0,0 1,1 1)",
+                  "multilinestring((),(3 3,4 4),(4 4,5 5))",
+                  sqrt(8.0), 8, strategy);
+    tester::apply("multipoint(0 0,1 0,0 1,1 1)",
+                  "multilinestring((3 3,4 4),(),(4 4,5 5))",
+                  sqrt(8.0), 8, strategy);
+
+    // multilinestrings with a single-point linestrings
+    tester::apply("multipoint(0 0,1 0,0 1,1 1)",
+                  "multilinestring((3 3),(4 4,5 5))",
+                  sqrt(8.0), 8, strategy);
+    tester::apply("multipoint(0 0,1 0,0 1,1 1)",
+                  "multilinestring((4 4,5 5),(3 3))",
+                  sqrt(8.0), 8, strategy);
+
+    // multilinestring with a single-point linestring and empty linestring
+    tester::apply("multipoint(0 0,1 0,0 1,1 1)",
+                  "multilinestring((4 4,5 5),(),(3 3))",
                   sqrt(8.0), 8, strategy);
 }
 


### PR DESCRIPTION
In this PR I modify the `range_segment_iterator` class to support ranges with less than two elements.
With this modification of the `range_segment_iterator` class, the `segment_iterator` can support (invalid) geometries that contain ranges with less than two points.

A consequence of this PR is that `bg::distance` can now compute the distance for (invalid) geometries that contain ranges of less than two points (e.g., one-point linestrings, non-empty closed rings with less than four points, non-empty open rings with less than three points, non-empty multilinestrings that contain one-point linestrings (or even empty linestrings), one-point polygons, etc.)

The unit tests in this PR rely on the fix proposed in PR #196, so PR #196 should be merged first.