### PR TITLE
Fix/is simple closed linestrings

### DIFF
--- a/doc/release_notes.qbk
+++ b/doc/release_notes.qbk
@@ -54,6 +54,7 @@
 * Bug in buffers for joins with a imited number of points
 * Bug in buffers for joins with large buffer distances
 * Bug in closing iterator not working properly when the input range is empty
+* Bug in is_simple, not handling properly closed simple linestrings within multilinestrings
 
 [/=================]
 [heading Boost 1.57]

--- a/include/boost/geometry/algorithms/detail/is_simple/linear.hpp
+++ b/include/boost/geometry/algorithms/detail/is_simple/linear.hpp
@@ -93,6 +93,19 @@ private:
                   || geometry::equals(point, range::back(linestring)) );
         }
 
+        template <typename Point, typename Linestring>
+        static inline bool is_closing_point_of(Point const& point,
+                                               Linestring const& linestring)
+        {
+            BOOST_ASSERT( boost::size(linestring) > 1 );
+            return
+                geometry::equals(range::front(linestring),
+                                 range::back(linestring))
+                &&
+                geometry::equals(range::front(linestring), point)
+                ;
+        }
+
         template <typename Linestring1, typename Linestring2>
         static inline bool have_same_boundary_points(Linestring1 const& ls1,
                                                      Linestring2 const& ls2)
@@ -129,6 +142,13 @@ private:
             linestring const& ls2 =
                 range::at(m_multilinestring,
                           turn.operations[1].seg_id.multi_index);
+
+            if (turn.operations[0].seg_id.multi_index
+                == turn.operations[1].seg_id.multi_index)
+            {
+                BOOST_ASSERT(is_closing_point_of(turn.point, ls1));
+                return true;
+            }
 
             return
                 is_boundary_point_of(turn.point, ls1)

--- a/test/algorithms/is_simple.cpp
+++ b/test/algorithms/is_simple.cpp
@@ -161,6 +161,7 @@ BOOST_AUTO_TEST_CASE( test_is_simple_linestring )
     // simple closed linestrings
     test_simple(from_wkt<G>("LINESTRING(0 0,1 0,1 1,0 0)"), true);
     test_simple(from_wkt<G>("LINESTRING(0 0,1 0,1 1,0 1,0 0)"), true);
+    test_simple(from_wkt<G>("LINESTRING(0 0,10 0,10 10,0 10,0 0)"), true);
 
     // non-simple linestrings
     test_simple(from_wkt<G>("LINESTRING(0 0,1 0,0 0)"), false);
@@ -173,6 +174,7 @@ BOOST_AUTO_TEST_CASE( test_is_simple_linestring )
     test_simple(from_wkt<G>("LINESTRING(0 0,3 0,5 0,4 0,2 0)"), false);
     test_simple(from_wkt<G>("LINESTRING(0 0,3 0,2 0,5 0)"), false);
     test_simple(from_wkt<G>("LINESTRING(0 0,2 0,2 2,1 0,0 0)"), false);
+    test_simple(from_wkt<G>("LINESTRING(0 0,0 10,5 10,0 0,10 10,10 5,10 0,0 0)"), false);
 }
 
 BOOST_AUTO_TEST_CASE( test_is_simple_multilinestring )
@@ -208,6 +210,7 @@ BOOST_AUTO_TEST_CASE( test_is_simple_multilinestring )
                 true);
     test_simple(from_wkt<G>("MULTILINESTRING((0 0,1 0),(0 0,0 1),(0 0,-1 0),(0 0,0 -1))"),
                 true);
+    test_simple(from_wkt<G>("MULTILINESTRING((0 0,10 0,10 10,0 10,0 0))"), true);
 
     // non-simple multilinestrings
     test_simple(from_wkt<G>("MULTILINESTRING((0 0,2 2),(0 0,2 2))"), false);
@@ -246,6 +249,7 @@ BOOST_AUTO_TEST_CASE( test_is_simple_multilinestring )
                 false);
     test_simple(from_wkt<G>("MULTILINESTRING((0 0,1 0,1 1,0 1,0 0),(-1 -1,-1 0,0 0,0 -1,-1 -1))"),
                 false);
+    test_simple(from_wkt<G>("MULTILINESTRING((0 0,0 10,5 10,0 0,10 10,10 5,10 0,0 0))"), false);
 }
 
 BOOST_AUTO_TEST_CASE( test_is_simple_areal )


### PR DESCRIPTION
`bg::is_simple` was handling incorrectly simple closed linestrings within multilinestrings. For example the geometry with WKT `MULTILINESTRING((0 0,10 0,10 10,0 10,0 0))` was failing.

The reason is that the linestring was accepted as a valid linestring, and then for verifying the validity of the multi-linestring, the self-turns of the multi-linestring were computed; the closing point of the linestring was reported as a turn which was wrongly considered as an unacceptable turn.

In this PR such turns are checked explicitly and reported as acceptable.