### PR TITLE
Fixes for range segment iterators

### DIFF
--- a/include/boost/geometry/iterators/detail/segment_iterator/range_segment_iterator.hpp
+++ b/include/boost/geometry/iterators/detail/segment_iterator/range_segment_iterator.hpp
@@ -91,7 +91,7 @@ struct range_iterator_end<Range, open>
 
 
 template <typename Range, typename Value, typename Reference = Value>
-struct range_segment_iterator
+class range_segment_iterator
     : public boost::iterator_facade
         <
             range_segment_iterator<Range, Value, Reference>,
@@ -100,6 +100,12 @@ struct range_segment_iterator
             Reference
         >
 {
+    static inline bool has_less_than_two_elements(Range const& r)
+    {
+        return boost::size(r) < ((closure<Range>::value == open) ? 1u : 2u);
+    }
+
+public:
     typedef typename range_iterator_type<Range>::type iterator_type;
 
     // default constructor
@@ -110,13 +116,13 @@ struct range_segment_iterator
     // for begin
     range_segment_iterator(Range& r)
         : m_it(range_iterator_begin<Range>::apply(r))
-        , m_has_less_than_two_elements(boost::size(r) < 2u)
+        , m_has_less_than_two_elements(has_less_than_two_elements(r))
     {}
 
     // for end
     range_segment_iterator(Range& r, bool)
         : m_it(range_iterator_end<Range>::apply(r))
-        , m_has_less_than_two_elements(boost::size(r) < 2u)
+        , m_has_less_than_two_elements(has_less_than_two_elements(r))
     {
         if (! m_has_less_than_two_elements)
         {


### PR DESCRIPTION
This PR is about two fixes:
* Declare the `range_segment_iterator` as a class so as to match the friend declaration inside it (to avoid relevant warning)
* Fix bug in initialization of the `m_has_less_than_two_elements` boolean member variable for open ranges. When the range is open (e.g., when the range is a open ring, or one of the rings of an open polygon), the actual size of the range is increased by one (due to the closing iterator). So whether the actual (equivalent closed) range has less than 2 elements amounts to asking whether the original range is empty (has less then 1 element).