### PR TITLE
Fix/warnings

### DIFF
--- a/include/boost/geometry/algorithms/centroid.hpp
+++ b/include/boost/geometry/algorithms/centroid.hpp
@@ -335,6 +335,7 @@ struct centroid_multi_point_state
                              Strategy const& strategy,
                              typename Strategy::state_type& state)
     {
+        boost::ignore_unused(strategy);
         strategy.apply(static_cast<Point const&>(transformer.apply(point)),
                        state);
     }

--- a/include/boost/geometry/algorithms/detail/buffer/turn_in_original_visitor.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/turn_in_original_visitor.hpp
@@ -9,6 +9,9 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_BUFFER_TURN_IN_ORIGINAL_VISITOR
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_BUFFER_TURN_IN_ORIGINAL_VISITOR
 
+
+#include <boost/core/ignore_unused.hpp>
+
 #include <boost/geometry/algorithms/expand.hpp>
 #include <boost/geometry/algorithms/detail/disjoint/point_box.hpp>
 #include <boost/geometry/strategies/agnostic/point_in_poly_winding.hpp>
@@ -81,6 +84,8 @@ template
 inline bool point_in_range(Strategy& strategy, State& state,
         Point const& point, Iterator begin, Iterator end)
 {
+    boost::ignore_unused(strategy);
+
     Iterator it = begin;
     for (Iterator previous = it++; it != end; ++previous, ++it)
     {

--- a/include/boost/geometry/algorithms/detail/equals/collect_vectors.hpp
+++ b/include/boost/geometry/algorithms/detail/equals/collect_vectors.hpp
@@ -17,7 +17,6 @@
 
 
 #include <boost/numeric/conversion/cast.hpp>
-#include <boost/range.hpp>
 
 #include <boost/geometry/algorithms/detail/interior_iterator.hpp>
 
@@ -28,7 +27,7 @@
 #include <boost/geometry/geometries/concepts/check.hpp>
 
 #include <boost/geometry/util/math.hpp>
-
+#include <boost/geometry/util/range.hpp>
 
 
 namespace boost { namespace geometry
@@ -159,7 +158,7 @@ struct range_collect_vectors
         if ( collected_count > 1 )
         {
             typedef typename boost::range_iterator<Collection>::type c_iterator;
-            c_iterator first = collection.begin() + c_old_size;
+            c_iterator first = range::pos(collection, c_old_size);
 
             if ( first->same_direction(collection.back()) )
             {

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -2,6 +2,11 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2015.
+// Modifications copyright (c) 2015 Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -11,6 +16,8 @@
 
 
 #include <boost/assert.hpp>
+#include <boost/core/ignore_unused.hpp>
+
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/strategies/intersection.hpp>
 
@@ -104,17 +111,19 @@ struct base_turn_handler
     template <typename TurnInfo, typename IntersectionInfo>
     static inline void assign_point(TurnInfo& ti,
                 method_type method,
-                IntersectionInfo const& info, int index)
+                IntersectionInfo const& info, unsigned int index)
     {
         ti.method = method;
-        BOOST_ASSERT(index >= 0 && unsigned(index) < info.count); // TODO  remove this
+
+        BOOST_ASSERT(index < info.count);
+
         geometry::convert(info.intersections[index], ti.point);
         ti.operations[0].fraction = info.fractions[index].robust_ra;
         ti.operations[1].fraction = info.fractions[index].robust_rb;
     }
 
     template <typename IntersectionInfo>
-    static inline int non_opposite_to_index(IntersectionInfo const& info)
+    static inline unsigned int non_opposite_to_index(IntersectionInfo const& info)
     {
         return info.fractions[0].robust_rb < info.fractions[1].robust_rb
             ? 1 : 0;
@@ -132,7 +141,7 @@ struct touch_interior : public base_turn_handler
     // Index: 0, P is the interior, Q is touching and vice versa
     template
     <
-        int Index,
+        unsigned int Index,
         typename Point1,
         typename Point2,
         typename IntersectionInfo,
@@ -155,8 +164,9 @@ struct touch_interior : public base_turn_handler
         // 2) Important is: if q_k goes to LEFT, RIGHT, COLLINEAR
         //    and, if LEFT/COLL, if it is lying LEFT or RIGHT w.r.t. q_i
 
-        static int const index_p = Index;
-        static int const index_q = 1 - Index;
+        BOOST_STATIC_ASSERT(Index <= 1);
+        static unsigned int const index_p = Index;
+        static unsigned int const index_q = 1 - Index;
 
         int const side_qi_p = dir_info.sides.template get<index_q, 0>();
         int const side_qk_p = side.qk_wrt_p1();
@@ -166,7 +176,7 @@ struct touch_interior : public base_turn_handler
             // Q crosses P from left->right or from right->left (test "ML1")
             // Union: folow P (left->right) or Q (right->left)
             // Intersection: other turn
-            int index = side_qk_p == -1 ? index_p : index_q;
+            unsigned int index = side_qk_p == -1 ? index_p : index_q;
             ti.operations[index].operation = operation_union;
             ti.operations[1 - index].operation = operation_intersection;
             return;
@@ -193,7 +203,7 @@ struct touch_interior : public base_turn_handler
             // or Q turns right on the right side of P (test "MR2")
             // Union: take left turn (Q if Q turns left, P if Q turns right)
             // Intersection: other turn
-            int index = side_qk_q == 1 ? index_q : index_p;
+            unsigned int index = side_qk_q == 1 ? index_q : index_p;
             ti.operations[index].operation = operation_union;
             ti.operations[1 - index].operation = operation_intersection;
         }
@@ -215,10 +225,10 @@ struct touch_interior : public base_turn_handler
                 // Opposite direction, which is never travelled.
                 // If Q turns left, P continues for intersection
                 // If Q turns right, P continues for union
-                ti.operations[Index].operation = side_qk_q == 1
+                ti.operations[index_p].operation = side_qk_q == 1
                     ? operation_intersection
                     : operation_union;
-                ti.operations[1 - Index].operation = operation_blocked;
+                ti.operations[index_q].operation = operation_blocked;
             }
         }
         else
@@ -516,7 +526,7 @@ struct equal_opposite : public base_turn_handler
         if (AssignPolicy::include_opposite)
         {
             tp.method = method_equal;
-            for (int i = 0; i < 2; i++)
+            for (unsigned int i = 0; i < 2; i++)
             {
                 tp.operations[i].operation = operation_opposite;
             }
@@ -653,7 +663,7 @@ private :
 
     template
     <
-        int Index,
+        unsigned int Index,
         typename Point1,
         typename Point2,
         typename IntersectionInfo
@@ -663,8 +673,9 @@ private :
                 Point2 const& , Point2 const& , int side_rk_s,
                 TurnInfo& tp, IntersectionInfo const& intersection_info)
     {
-        boost::ignore_unused_variable_warning(handle_robustness);
-        boost::ignore_unused_variable_warning(side_rk_s);
+        BOOST_STATIC_ASSERT(Index <= 1);
+
+        boost::ignore_unused(handle_robustness, side_rk_s);
 
         operation_type blocked = operation_blocked;
         switch(side_rk_r)
@@ -788,7 +799,7 @@ public:
             if ((dir_info.arrival[1] == -1 && dir_info.arrival[0] == 0)
                 || (dir_info.arrival[0] == -1 && dir_info.arrival[1] == 0))
             {
-                for (int i = 0; i < 2; i++)
+                for (unsigned int i = 0; i < 2; i++)
                 {
                     tp.operations[i].operation = operation_opposite;
                 }
@@ -833,7 +844,7 @@ struct crosses : public base_turn_handler
         // Intersection: take Q
         // Otherwise: vice versa
         int const side_qi_p1 = dir_info.sides.template get<1, 0>();
-        int const index = side_qi_p1 == 1 ? 0 : 1;
+        unsigned int const index = side_qi_p1 == 1 ? 0 : 1;
         ti.operations[index].operation = operation_union;
         ti.operations[1 - index].operation = operation_intersection;
     }

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
@@ -290,7 +290,7 @@ struct get_turn_info_for_endpoint
                                        linear_intersections::ip_info const& ip_info,
                                        TurnInfo const& tp_model,
                                        IntersectionInfo const& inters,
-                                       int ip_index,
+                                       unsigned int ip_index,
                                        OutputIterator out)
     {
 #ifdef BOOST_GEOMETRY_DEBUG_GET_TURNS_LINEAR_LINEAR
@@ -396,7 +396,7 @@ struct get_turn_info_for_endpoint
                                        RobustPoint2 const& ri2, RobustPoint2 const& rj2, RobustPoint2 const& rk2,
                                        bool first1, bool last1, bool first2, bool last2,
                                        bool ip_i2, bool ip_j2, TurnInfo const& tp_model,
-                                       IntersectionInfo const& inters, int ip_index,
+                                       IntersectionInfo const& inters, unsigned int ip_index,
                                        operation_type & op1, operation_type & op2)
     {
         boost::ignore_unused_variable_warning(i2);
@@ -535,7 +535,7 @@ struct get_turn_info_for_endpoint
               typename OutputIterator>
     static inline void assign(Point1 const& pi, Point2 const& qi,
                               IntersectionResult const& result,
-                              int ip_index,
+                              unsigned int ip_index,
                               method_type method,
                               operation_type op0, operation_type op1,
                               turn_position pos0, turn_position pos1,

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -843,7 +843,7 @@ struct get_turn_info_linear_areal
             
             // equals<> or collinear<> will assign the second point,
             // we'd like to assign the first one
-            int ip_index = ip_count > 1 ? 1 : 0;
+            unsigned int ip_index = ip_count > 1 ? 1 : 0;
             base_turn_handler::assign_point(tp, tp.method, inters.i_info(), ip_index);
 
             AssignPolicy::apply(tp, pi, qi, inters.i_info(), inters.d_info());

--- a/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
@@ -559,7 +559,8 @@ struct get_turns_cs
                 RobustPolicy const& robust_policy,
                 Turns& turns,
                 InterruptPolicy& interrupt_policy,
-                int multi_index = -1, int ring_index = -1)
+                signed_index_type multi_index = -1,
+                signed_index_type ring_index = -1)
     {
         if ( boost::size(range) <= 1)
         {
@@ -572,7 +573,8 @@ struct get_turns_cs
         cview_type cview(range);
         view_type view(cview);
 
-        typename boost::range_size<view_type>::type segments_count1 = boost::size(view) - 1;
+        typedef typename boost::range_size<view_type>::type size_type;
+        size_type segments_count1 = boost::size(view) - 1;
 
         iterator_type it = boost::begin(view);
 
@@ -585,7 +587,7 @@ struct get_turns_cs
 
         //char previous_side[2] = {0, 0};
 
-        int index = 0;
+        signed_index_type index = 0;
 
         for (iterator_type prev = it++;
             it != boost::end(view);
@@ -624,7 +626,7 @@ struct get_turns_cs
                         bp[0], bp[1], bp[2], bp[3],
                         // NOTE: some dummy values could be passed below since this would be called only for Polygons and Boxes
                         index == 0,
-                        unsigned(index) == segments_count1,
+                        size_type(index) == segments_count1,
                         robust_policy,
                         turns, interrupt_policy);
                 // Future performance enhancement:
@@ -729,7 +731,7 @@ struct get_turns_polygon_cs
             int source_id2, Box const& box,
             RobustPolicy const& robust_policy,
             Turns& turns, InterruptPolicy& interrupt_policy,
-            int multi_index = -1)
+            signed_index_type multi_index = -1)
     {
         typedef typename geometry::ring_type<Polygon>::type ring_type;
 
@@ -747,7 +749,7 @@ struct get_turns_polygon_cs
                 turns, interrupt_policy,
                 multi_index, -1);
 
-        int i = 0;
+        signed_index_type i = 0;
 
         typename interior_return_type<Polygon const>::type
             rings = interior_rings(polygon);
@@ -786,7 +788,7 @@ struct get_turns_multi_polygon_cs
                 Multi const
             >::type iterator_type;
 
-        int i = 0;
+        signed_index_type i = 0;
         for (iterator_type it = boost::begin(multi);
              it != boost::end(multi);
              ++it, ++i)

--- a/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
@@ -299,8 +299,8 @@ public :
                     if (InterruptPolicy::enabled)
                     {
                         if (interrupt_policy.apply(
-                            std::make_pair(boost::begin(turns) + size_before,
-                                boost::end(turns))))
+                                std::make_pair(range::pos(turns, size_before),
+                                               boost::end(turns))))
                         {
                             return false;
                         }

--- a/include/boost/geometry/algorithms/detail/partition.hpp
+++ b/include/boost/geometry/algorithms/detail/partition.hpp
@@ -494,7 +494,7 @@ public :
 struct visit_no_policy
 {
     template <typename Box>
-    static inline void apply(Box const&, int )
+    static inline void apply(Box const&, std::size_t )
     {}
 };
 

--- a/include/boost/geometry/algorithms/detail/relate/follow_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/follow_helpers.hpp
@@ -98,9 +98,9 @@ struct for_each_disjoint_geometry_if<OpId, Geometry, Tag, true>
         std::vector<bool> detected_intersections(count, false);
         for ( TurnIt it = first ; it != last ; ++it )
         {
-            int multi_index = it->operations[OpId].seg_id.multi_index;
+            signed_index_type multi_index = it->operations[OpId].seg_id.multi_index;
             BOOST_ASSERT(multi_index >= 0);
-            std::size_t index = static_cast<std::size_t>(multi_index);
+            std::size_t const index = static_cast<std::size_t>(multi_index);
             BOOST_ASSERT(index < count);
             detected_intersections[index] = true;
         }
@@ -116,8 +116,8 @@ struct for_each_disjoint_geometry_if<OpId, Geometry, Tag, true>
             if ( *it == false )
             {
                 found = true;
-                bool cont = pred(range::at(geometry,
-                                           std::distance(detected_intersections.begin(), it)));
+                std::size_t const index = std::size_t(std::distance(detected_intersections.begin(), it));
+                bool cont = pred(range::at(geometry, index));
                 if ( !cont )
                     break;
             }

--- a/include/boost/geometry/algorithms/detail/relate/linear_areal.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/linear_areal.hpp
@@ -321,7 +321,7 @@ struct linear_areal
                     // if there was some previous ring
                     if ( prev_seg_id_ptr != NULL )
                     {
-                        int const next_ring_index = prev_seg_id_ptr->ring_index + 1;
+                        signed_index_type const next_ring_index = prev_seg_id_ptr->ring_index + 1;
                         BOOST_ASSERT(next_ring_index >= 0);
                         
                         // if one of the last rings of previous single geometry was ommited
@@ -392,7 +392,7 @@ struct linear_areal
             // if there was some previous ring
             if ( prev_seg_id_ptr != NULL )
             {
-                int const next_ring_index = prev_seg_id_ptr->ring_index + 1;
+                signed_index_type const next_ring_index = prev_seg_id_ptr->ring_index + 1;
                 BOOST_ASSERT(next_ring_index >= 0);
 
                 // if one of the last rings of previous single geometry was ommited
@@ -1163,8 +1163,8 @@ struct linear_areal
             BOOST_ASSERT(s2 > 2);
             std::size_t const seg_count2 = s2 - 1;
 
-            std::size_t const p_seg_ij = turn.operations[op_id].seg_id.segment_index;
-            std::size_t const q_seg_ij = turn.operations[other_op_id].seg_id.segment_index;
+            std::size_t const p_seg_ij = static_cast<std::size_t>(turn.operations[op_id].seg_id.segment_index);
+            std::size_t const q_seg_ij = static_cast<std::size_t>(turn.operations[other_op_id].seg_id.segment_index);
 
             BOOST_ASSERT(p_seg_ij + 1 < boost::size(range1));
             BOOST_ASSERT(q_seg_ij + 1 < s2);
@@ -1187,7 +1187,7 @@ struct linear_areal
 // TODO: the following function should return immediately, however the worst case complexity is O(N)
 // It would be good to replace it with some O(1) mechanism
                 range2_iterator qk_it = find_next_non_duplicated(boost::begin(range2),
-                                                                 boost::begin(range2) + q_seg_jk,
+                                                                 range::pos(range2, q_seg_jk),
                                                                  boost::end(range2));
 
                 // Will this sequence of points be always correct?
@@ -1330,8 +1330,8 @@ struct linear_areal
         if ( first == last )
             return last;
 
-        int const multi_index = first->operations[1].seg_id.multi_index;
-        int const ring_index = first->operations[1].seg_id.ring_index;
+        signed_index_type const multi_index = first->operations[1].seg_id.multi_index;
+        signed_index_type const ring_index = first->operations[1].seg_id.ring_index;
 
         fun(*first);
         ++first;

--- a/include/boost/geometry/algorithms/detail/sections/range_by_section.hpp
+++ b/include/boost/geometry/algorithms/detail/sections/range_by_section.hpp
@@ -58,7 +58,8 @@ struct full_section_polygon
     {
         return section.ring_id.ring_index < 0
             ? geometry::exterior_ring(polygon)
-            : range::at(geometry::interior_rings(polygon), section.ring_id.ring_index);
+            : range::at(geometry::interior_rings(polygon),
+                        static_cast<std::size_t>(section.ring_id.ring_index));
     }
 };
 
@@ -74,13 +75,15 @@ struct full_section_multi
     static inline typename ring_return_type<MultiGeometry const>::type apply(
                 MultiGeometry const& multi, Section const& section)
     {
+        typedef typename boost::range_size<MultiGeometry>::type size_type;
+
         BOOST_ASSERT
             (
                 section.ring_id.multi_index >= 0
-                && section.ring_id.multi_index < int(boost::size(multi))
+                && size_type(section.ring_id.multi_index) < boost::size(multi)
             );
 
-        return Policy::apply(range::at(multi, section.ring_id.multi_index), section);
+        return Policy::apply(range::at(multi, size_type(section.ring_id.multi_index)), section);
     }
 };
 

--- a/include/boost/geometry/algorithms/detail/single_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/single_geometry.hpp
@@ -55,7 +55,8 @@ struct single_geometry<Geometry, true>
     static inline return_type apply(Geometry & g, Id const& id)
     {
         BOOST_ASSERT(id.multi_index >= 0);
-        return range::at(g, id.multi_index);
+        typedef typename boost::range_size<Geometry>::type size_type;
+        return range::at(g, static_cast<size_type>(id.multi_index));
     }
 };
 

--- a/include/boost/geometry/algorithms/detail/sub_range.hpp
+++ b/include/boost/geometry/algorithms/detail/sub_range.hpp
@@ -55,7 +55,11 @@ struct sub_range<Geometry, polygon_tag, false>
         }
         else
         {
-            std::size_t ri = static_cast<std::size_t>(id.ring_index);
+            typedef typename boost::range_size
+                <
+                    typename geometry::interior_type<Geometry>::type
+                >::type size_type;
+            size_type const ri = static_cast<size_type>(id.ring_index);
             return range::at(geometry::interior_rings(geometry), ri);
         }
     }
@@ -81,7 +85,9 @@ struct sub_range<Geometry, Tag, true>
     return_type apply(Geometry & geometry, Id const& id)
     {
         BOOST_ASSERT(0 <= id.multi_index);
-        return sub_sub_range::apply(range::at(geometry, id.multi_index), id);
+        typedef typename boost::range_size<Geometry>::type size_type;
+        size_type const mi = static_cast<size_type>(id.multi_index);
+        return sub_sub_range::apply(range::at(geometry, mi), id);
     }
 };
 

--- a/include/boost/geometry/algorithms/detail/within/point_in_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/within/point_in_geometry.hpp
@@ -5,8 +5,8 @@
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 // Copyright (c) 2014 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2013, 2014.
-// Modifications copyright (c) 2013, 2014, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013, 2014, 2015.
+// Modifications copyright (c) 2013-2015, Oracle and/or its affiliates.
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
@@ -21,6 +21,7 @@
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_WITHIN_POINT_IN_GEOMETRY_HPP
 
 #include <boost/assert.hpp>
+#include <boost/core/ignore_unused.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/range.hpp>
 #include <boost/type_traits/is_same.hpp>
@@ -58,7 +59,7 @@ inline T check_result_type(T result)
 template <typename Point, typename Range, typename Strategy> inline
 int point_in_range(Point const& point, Range const& range, Strategy const& strategy)
 {
-    boost::ignore_unused_variable_warning(strategy);
+    boost::ignore_unused(strategy);
 
     typedef typename boost::range_iterator<Range const>::type iterator_type;
     typename Strategy::state_type state;
@@ -147,7 +148,7 @@ struct point_in_geometry<Point2, point_tag>
     template <typename Point1, typename Strategy> static inline
     int apply(Point1 const& point1, Point2 const& point2, Strategy const& strategy)
     {
-        boost::ignore_unused_variable_warning(strategy);
+        boost::ignore_unused(strategy);
         return strategy.apply(point1, point2) ? 1 : -1;
     }
 };
@@ -158,6 +159,8 @@ struct point_in_geometry<Segment, segment_tag>
     template <typename Point, typename Strategy> static inline
     int apply(Point const& point, Segment const& segment, Strategy const& strategy)
     {
+        boost::ignore_unused(strategy);
+
         typedef typename geometry::point_type<Segment>::type point_type;
         point_type p0, p1;
 // TODO: don't copy points

--- a/include/boost/geometry/algorithms/length.hpp
+++ b/include/boost/geometry/algorithms/length.hpp
@@ -4,10 +4,11 @@
 // Copyright (c) 2008-2014 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2014 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2014.
-// Modifications copyright (c) 2014, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014, 2015.
+// Modifications copyright (c) 2014-2015, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
@@ -22,6 +23,7 @@
 #include <iterator>
 
 #include <boost/concept_check.hpp>
+#include <boost/core/ignore_unused.hpp>
 #include <boost/range.hpp>
 
 #include <boost/mpl/fold.hpp>
@@ -69,6 +71,7 @@ struct segment_length
     static inline typename default_length_result<Segment>::type apply(
             Segment const& segment, Strategy const& strategy)
     {
+        boost::ignore_unused(strategy);
         typedef typename point_type<Segment>::type point_type;
         point_type p1, p2;
         geometry::detail::assign_point_from_index<0>(segment, p1);
@@ -92,7 +95,7 @@ struct range_length
     static inline return_type apply(
             Range const& range, Strategy const& strategy)
     {
-        boost::ignore_unused_variable_warning(strategy);
+        boost::ignore_unused(strategy);
         typedef typename closeable_view<Range const, Closure>::type view_type;
         typedef typename boost::range_iterator
             <

--- a/include/boost/geometry/io/wkt/read.hpp
+++ b/include/boost/geometry/io/wkt/read.hpp
@@ -680,7 +680,7 @@ struct box_parser
         }
         check_end(it, end, wkt);
 
-        int index = 0;
+        unsigned int index = 0;
         std::size_t n = boost::size(points);
         if (n == 2)
         {

--- a/include/boost/geometry/iterators/closing_iterator.hpp
+++ b/include/boost/geometry/iterators/closing_iterator.hpp
@@ -42,12 +42,14 @@ struct closing_iterator
         boost::random_access_traversal_tag
     >
 {
+    typedef typename boost::range_difference<Range>::type difference_type;
+
     /// Constructor including the range it is based on
     explicit inline closing_iterator(Range& range)
         : m_range(&range)
         , m_iterator(boost::begin(range))
         , m_end(boost::end(range))
-        , m_size(boost::size(range))
+        , m_size(static_cast<difference_type>(boost::size(range)))
         , m_index(0)
     {}
 
@@ -56,7 +58,7 @@ struct closing_iterator
         : m_range(&range)
         , m_iterator(boost::end(range))
         , m_end(boost::end(range))
-        , m_size(boost::size(range))
+        , m_size(static_cast<difference_type>(boost::size(range)))
         , m_index((m_size == 0) ? 0 : m_size + 1)
     {}
 
@@ -66,8 +68,6 @@ struct closing_iterator
         , m_size(0)
         , m_index(0)
     {}
-
-    typedef std::ptrdiff_t difference_type;
 
 private:
     friend class boost::iterator_core_access;

--- a/include/boost/geometry/policies/relate/intersection_points.hpp
+++ b/include/boost/geometry/policies/relate/intersection_points.hpp
@@ -105,7 +105,7 @@ struct segments_intersection_points
         Ratio const& rb_from_wrt_a, Ratio const& rb_to_wrt_a)
     {
         return_type result;
-        int index = 0, count_a = 0, count_b = 0;
+        unsigned int index = 0, count_a = 0, count_b = 0;
         Ratio on_a[2];
 
         // The conditions "index < 2" are necessary for non-robust handling,

--- a/include/boost/geometry/util/range.hpp
+++ b/include/boost/geometry/util/range.hpp
@@ -2,14 +2,14 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2013, 2014.
-// Modifications copyright (c) 2013-2014 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013, 2014, 2015.
+// Modifications copyright (c) 2013-2015 Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
-
-// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 #ifndef BOOST_GEOMETRY_UTIL_RANGE_HPP
 #define BOOST_GEOMETRY_UTIL_RANGE_HPP
@@ -30,7 +30,51 @@
 
 namespace boost { namespace geometry { namespace range {
 
-// NOTE: For SinglePassRanges at could iterate over all elements until the i-th element is met.
+namespace detail {
+
+// NOTE: For SinglePassRanges pos could iterate over all elements until the i-th element was met.
+
+template <typename RandomAccessRange>
+struct pos
+{
+    typedef typename boost::range_iterator<RandomAccessRange>::type iterator;
+    typedef typename boost::range_size<RandomAccessRange>::type size_type;
+    typedef typename boost::range_difference<RandomAccessRange>::type difference_type;
+
+    static inline iterator apply(RandomAccessRange & rng, size_type i)
+    {
+        BOOST_RANGE_CONCEPT_ASSERT(( boost::RandomAccessRangeConcept<RandomAccessRange> ));
+        return boost::begin(rng) + static_cast<difference_type>(i);
+    }
+};
+
+} // namespace detail
+
+/*!
+\brief Short utility to conveniently return an iterator of a RandomAccessRange.
+\ingroup utility
+*/
+template <typename RandomAccessRange>
+inline typename boost::range_iterator<RandomAccessRange const>::type
+pos(RandomAccessRange const& rng,
+    typename boost::range_size<RandomAccessRange const>::type i)
+{
+    BOOST_ASSERT(i <= boost::size(rng));
+    return detail::pos<RandomAccessRange const>::apply(rng, i);
+}
+
+/*!
+\brief Short utility to conveniently return an iterator of a RandomAccessRange.
+\ingroup utility
+*/
+template <typename RandomAccessRange>
+inline typename boost::range_iterator<RandomAccessRange>::type
+pos(RandomAccessRange & rng,
+    typename boost::range_size<RandomAccessRange>::type i)
+{
+    BOOST_ASSERT(i <= boost::size(rng));
+    return detail::pos<RandomAccessRange>::apply(rng, i);
+}
 
 /*!
 \brief Short utility to conveniently return an element of a RandomAccessRange.
@@ -41,9 +85,8 @@ inline typename boost::range_value<RandomAccessRange const>::type const&
 at(RandomAccessRange const& rng,
    typename boost::range_size<RandomAccessRange const>::type i)
 {
-    BOOST_RANGE_CONCEPT_ASSERT(( boost::RandomAccessRangeConcept<RandomAccessRange const> ));
     BOOST_ASSERT(i < boost::size(rng));
-    return *(boost::begin(rng) + i);
+    return * detail::pos<RandomAccessRange const>::apply(rng, i);
 }
 
 /*!
@@ -55,9 +98,8 @@ inline typename boost::range_value<RandomAccessRange>::type &
 at(RandomAccessRange & rng,
    typename boost::range_size<RandomAccessRange>::type i)
 {
-    BOOST_RANGE_CONCEPT_ASSERT(( boost::RandomAccessRangeConcept<RandomAccessRange> ));
     BOOST_ASSERT(i < boost::size(rng));
-    return *(boost::begin(rng) + i);
+    return * detail::pos<RandomAccessRange>::apply(rng, i);
 }
 
 /*!

--- a/test/algorithms/distance/test_distance_se_common.hpp
+++ b/test/algorithms/distance/test_distance_se_common.hpp
@@ -75,10 +75,10 @@ struct check_equal
     };
 
     template <typename Geometry1, typename Geometry2>
-    static inline void apply(std::string const& case_id,
-                             std::string const& subcase_id,
-                             Geometry1 const& geometry1,
-                             Geometry2 const& geometry2,
+    static inline void apply(std::string const& /*case_id*/,
+                             std::string const& /*subcase_id*/,
+                             Geometry1 const& /*geometry1*/,
+                             Geometry2 const& /*geometry2*/,
                              T const& detected,
                              T const& expected)
     {

--- a/test/algorithms/multi_convex_hull.cpp
+++ b/test/algorithms/multi_convex_hull.cpp
@@ -54,22 +54,22 @@ void test_all()
     typedef bg::model::multi_polygon<bg::model::polygon<P> > mpoly;
 
     // All points below in upper-points and lower-points
-    test_geometry<mp>("MULTIPOINT((0 0),(5 0),(1 1),(4 1))", -1, 5, 4.0);
-    test_geometry<mp>("MULTIPOINT((0 1),(5 1),(1 0),(4 0))", -1, 5, 4.0);
+    test_geometry<mp>("MULTIPOINT((0 0),(5 0),(1 1),(4 1))", 0, 5, 4.0);
+    test_geometry<mp>("MULTIPOINT((0 1),(5 1),(1 0),(4 0))", 0, 5, 4.0);
 
     // All points in vertical line (this delivers an empty polygon with 3 points and closing point for closed)
-    test_geometry<mp>("MULTIPOINT((1 0),(5 0),(3 0),(4 0),(2 0))", -1, 4, 0.0);
+    test_geometry<mp>("MULTIPOINT((1 0),(5 0),(3 0),(4 0),(2 0))", 0, 4, 0.0);
 
     // One point only
-    test_geometry<mp>("MULTIPOINT((1 0))", -1, 4, 0.0);
+    test_geometry<mp>("MULTIPOINT((1 0))", 0, 4, 0.0);
 
     // Problem of 6019, reproduced by the convex hull robustness test:
     test_geometry<mp>("MULTIPOINT((2 9),(1 3),(9 4),(1 1),(1 0),(7 9),(2 5),(3 7),(3 6),(2 4))",
-            -1, 6, 48.0);
+            0, 6, 48.0);
 
     // Ticket 6019:
     test_geometry<mp>("MULTIPOINT((0 53),(0 103),(0 53),(0 3),(0 3),(0 0),(1 0),(1 1),(2 1),(2 0),(2 0),(2 0),(3 0),(3 1),(4 1),(4 0),(5 0),(0 3),(10 3),(10 2),(10 2),(10 2),(5 2),(5 0),(5 0),(55 0),(105 0))",
-            -1, 4, 5407.5);
+            0, 4, 5407.5);
     // Ticket 6021:
     test_geometry<mp>("multipoint((0 53), (0 103), (1 53))", 3, 4, 25);
 

--- a/test/algorithms/overlay/ccw_traverse.cpp
+++ b/test/algorithms/overlay/ccw_traverse.cpp
@@ -36,9 +36,12 @@ struct rev : boost::mpl::if_c<bg::point_order<Geometry>::value == bg::counterclo
 {};
 
 template <typename Geometry1, typename Geometry2>
-inline typename bg::coordinate_type<Geometry1>::type intersect(Geometry1 const& g1, Geometry2 const& g2, std::string const& name,
-               bg::detail::overlay::operation_type op)
+inline typename bg::coordinate_type<Geometry1>::type
+intersect(Geometry1 const& g1, Geometry2 const& g2, std::string const& name,
+          bg::detail::overlay::operation_type op)
 {
+    boost::ignore_unused(name);
+
     typedef typename bg::strategy::side::services::default_strategy
     <
         typename bg::cs_tag<Geometry1>::type

--- a/test/algorithms/overlay/get_turns.cpp
+++ b/test/algorithms/overlay/get_turns.cpp
@@ -56,7 +56,7 @@ struct test_get_turns
     template<typename G1, typename G2>
     static void apply(std::string const& id,
             std::size_t expected_count,
-            G1 const& g1, G2 const& g2, double precision)
+            G1 const& g1, G2 const& g2, double /*precision*/)
     {
         typedef typename bg::point_type<G2>::type point_type;
         typedef typename bg::rescale_policy_type<point_type>::type

--- a/test/algorithms/overlay/relative_order.cpp
+++ b/test/algorithms/overlay/relative_order.cpp
@@ -28,7 +28,7 @@
 
 
 template <typename P, typename T>
-void test_with_point(std::string const& caseid,
+void test_with_point(std::string const& /*caseid*/,
                 T pi_x, T pi_y, T pj_x, T pj_y,
                 T ri_x, T ri_y, T rj_x, T rj_y,
                 T si_x, T si_y, T sj_x, T sj_y,

--- a/test/algorithms/overlay/self_intersection_points.cpp
+++ b/test/algorithms/overlay/self_intersection_points.cpp
@@ -47,7 +47,7 @@ static void test_self_intersection_points(std::string const& case_id,
             int expected_count,
             Geometry const& geometry,
             bool check_has_intersections,
-            double precision = 0.001)
+            double /*precision*/ = 0.001)
 {
     typedef typename bg::point_type<Geometry>::type point_type;
     //typedef typename bg::rescale_policy_type<point_type>::type rescale_policy_type;

--- a/test/algorithms/overlay/test_get_turns.hpp
+++ b/test/algorithms/overlay/test_get_turns.hpp
@@ -87,7 +87,7 @@ struct equal_turn<1>
     template <typename T>
     bool operator()(T const& t) const
     {
-        unsigned count = turn_ptr->size();
+        std::string::size_type count = turn_ptr->size();
         BOOST_ASSERT(turn_ptr && count >= 1);
         return bg::method_char(t.method) == (*turn_ptr)[0]
             && ( count > 1

--- a/test/algorithms/remove_spikes.cpp
+++ b/test/algorithms/remove_spikes.cpp
@@ -53,7 +53,7 @@
 
 
 template <typename Geometry>
-inline void test_remove_spikes(std::string const& id,
+inline void test_remove_spikes(std::string const& /*id*/,
             Geometry& geometry,
             double expected_area, double expected_perimeter)
 {

--- a/test/geometry_test_common.hpp
+++ b/test/geometry_test_common.hpp
@@ -41,10 +41,13 @@
 #if ! defined(BOOST_GEOMETRY_NO_BOOST_TEST)
 
 // Until Boost.Test fixes it, silence warning issued by clang:
-// warning: unused variable 'check_is_close' [-Wunused-variable]
 #ifdef __clang__
 # pragma clang diagnostic push
+// warning: unused variable 'check_is_close' [-Wunused-variable]
 # pragma clang diagnostic ignored "-Wunused-variable"
+// warnings when -Wconversion is set
+# pragma clang diagnostic ignored "-Wsign-conversion"
+# pragma clang diagnostic ignored "-Wshorten-64-to-32"
 #endif
 
 # include <boost/test/floating_point_comparison.hpp>

--- a/test/util/range.cpp
+++ b/test/util/range.cpp
@@ -1,7 +1,7 @@
 // Boost.Geometry
 // Unit Test
 
-// Copyright (c) 2014 Oracle and/or its affiliates.
+// Copyright (c) 2014-2015 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -135,35 +135,35 @@ void test_all()
     BOOST_CHECK(bgr::at(v, 1) == 1);
     BOOST_CHECK(bgr::at(v, 2) == 3);
     BOOST_CHECK(bgr::back(v) == 9);
-    BOOST_CHECK(it == begin(v) + 2);
+    BOOST_CHECK(it == bgr::pos(v, 2));
 
     it = bgr::erase(v, begin(v) + 2, begin(v) + 2);
     BOOST_CHECK(boost::size(v) == 9); // {0,1,3..9}
     BOOST_CHECK(bgr::at(v, 1) == 1);
     BOOST_CHECK(bgr::at(v, 2) == 3);
     BOOST_CHECK(bgr::back(v) == 9);
-    BOOST_CHECK(it == begin(v) + 2);
+    BOOST_CHECK(it == bgr::pos(v, 2));
 
     it = bgr::erase(v, begin(v) + 2, begin(v) + 5);
     BOOST_CHECK(boost::size(v) == 6); // {0,1,6..9}
     BOOST_CHECK(bgr::at(v, 1) == 1);
     BOOST_CHECK(bgr::at(v, 2) == 6);
     BOOST_CHECK(bgr::back(v) == 9);
-    BOOST_CHECK(it == begin(v) + 2);
+    BOOST_CHECK(it == bgr::pos(v, 2));
 
     it = bgr::erase(v, begin(v));
     BOOST_CHECK(boost::size(v) == 5); // {1,6..9}
     BOOST_CHECK(bgr::at(v, 0) == 1);
     BOOST_CHECK(bgr::at(v, 1) == 6);
     BOOST_CHECK(bgr::back(v) == 9);
-    BOOST_CHECK(it == begin(v));
+    BOOST_CHECK(it == bgr::pos(v, 0));
 
     it = bgr::erase(v, begin(v), begin(v) + 3);
     BOOST_CHECK(boost::size(v) == 2); // {8,9}
     BOOST_CHECK(bgr::at(v, 0) == 8);
     BOOST_CHECK(bgr::at(v, 1) == 9);
     BOOST_CHECK(bgr::back(v) == 9);
-    BOOST_CHECK(it == begin(v));
+    BOOST_CHECK(it == bgr::pos(v, 0));
 
     it = bgr::erase(v, begin(v), end(v));
     BOOST_CHECK(boost::size(v) == 0);


### PR DESCRIPTION
This PR fixes integral conversion warnings by avoiding conversions or doing them explicitly.
It also adds a utility - `range::pos()` function which returns an iterator on ith position of a Range.

EDIT: unused parameter warnings are also fixed.