### PR TITLE
Fix MSVC error regarding undiscovered function equals_point_point

### DIFF
--- a/include/boost/geometry/strategies/cartesian/side_by_triangle.hpp
+++ b/include/boost/geometry/strategies/cartesian/side_by_triangle.hpp
@@ -112,9 +112,9 @@ public :
             // For robustness purposes, first check if any two points are
             // the same; in this case simply return that the points are
             // collinear
-            if (detail::equals::equals_point_point(p1, p2)
-                || detail::equals::equals_point_point(p1, p)
-                || detail::equals::equals_point_point(p2, p))
+            if (geometry::detail::equals::equals_point_point(p1, p2)
+                || geometry::detail::equals::equals_point_point(p1, p)
+                || geometry::detail::equals::equals_point_point(p2, p))
             {
                 return PromotedType(0);
             }


### PR DESCRIPTION
MSVC thinks that that the `detail::equals` namespace qualifying the call to `equals_point_point` is a nested namespace inside `boost::geometry::strategy::side`.

Fix: qualify the call to `equals_point_point` by `geometry::detail::equals`.