### PR TITLE
Fix point_type traits for variant over MPL sequence

### DIFF
--- a/include/boost/geometry/geometries/variant.hpp
+++ b/include/boost/geometry/geometries/variant.hpp
@@ -23,10 +23,10 @@ namespace boost { namespace geometry {
 
 
 template <BOOST_VARIANT_ENUM_PARAMS(typename T)>
-struct point_type<variant<BOOST_VARIANT_ENUM_PARAMS(T)> >
+struct point_type<boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)> >
     : point_type<
-        typename mpl::front<
-            typename variant<BOOST_VARIANT_ENUM_PARAMS(T)>::types
+        typename boost::mpl::front<
+            typename boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>::types
         >::type
     >
 {};

--- a/include/boost/geometry/geometries/variant.hpp
+++ b/include/boost/geometry/geometries/variant.hpp
@@ -16,14 +16,19 @@
 
 
 #include <boost/variant/variant_fwd.hpp>
+#include <boost/mpl/front.hpp>
 
 
 namespace boost { namespace geometry {
 
 
 template <BOOST_VARIANT_ENUM_PARAMS(typename T)>
-struct point_type<boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)> >
-    : point_type<T0>
+struct point_type<variant<BOOST_VARIANT_ENUM_PARAMS(T)> >
+    : point_type<
+        typename mpl::front<
+            typename variant<BOOST_VARIANT_ENUM_PARAMS(T)>::types
+        >::type
+    >
 {};
 
 


### PR DESCRIPTION
When variant types are generated from MPL sequences the actual variant
type is `boost::variant<over_sequence<Sequence...`
and thus T0 is `over_sequence<>`. This fix use the first bounded type `boost::variant<>::types`
instead of T0.