### PR TITLE
Fix: replace access method for accessing the front element of rings

### DIFF
--- a/include/boost/geometry/algorithms/detail/buffer/buffered_piece_collection.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/buffered_piece_collection.hpp
@@ -698,9 +698,9 @@ struct buffered_piece_collection
     {
         BOOST_ASSERT(! offsetted_rings.empty());
         buffered_ring<Ring>& added = offsetted_rings.back();
-        if (! added.empty())
+        if (! boost::empty(added))
         {
-            added.back() = range::front(added);
+            range::back(added) = range::front(added);
         }
     }
 

--- a/include/boost/geometry/algorithms/detail/buffer/buffered_piece_collection.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/buffered_piece_collection.hpp
@@ -700,7 +700,7 @@ struct buffered_piece_collection
         buffered_ring<Ring>& added = offsetted_rings.back();
         if (! added.empty())
         {
-            added.back() = added.front();
+            added.back() = range::front(added);
         }
     }
 


### PR DESCRIPTION
Change access of a ring's front range element from using the `.front()` method by the `range::front` Boost.Geometry utility function.
