### PR TITLE
Fix/cart intersect

### DIFF
--- a/include/boost/geometry/policies/relate/direction.hpp
+++ b/include/boost/geometry/policies/relate/direction.hpp
@@ -240,20 +240,11 @@ struct segments_direction
 
     template <typename Segment1, typename Segment2, typename Ratio>
     static inline return_type segments_collinear(
-        Segment1 const& , Segment2 const& ,
+        Segment1 const& , Segment2 const& , bool opposite,
         int a1_wrt_b, int a2_wrt_b, int b1_wrt_a, int b2_wrt_a,
         Ratio const& ra_from_wrt_b, Ratio const& ra_to_wrt_b,
         Ratio const& /*rb_from_wrt_a*/, Ratio const& /*rb_to_wrt_a*/)
     {
-        // If segments are opposite, the ratio of the FROM w.r.t. the other
-        // is larger than the ratio of the TO w.r.t. the other
-        bool const opposite = ra_to_wrt_b < ra_from_wrt_b;
-        // NOTE: an alternative version could compare ratios only
-        // if both ax_wrt_b positions were equal, otherwise use int positions
-        /*bool const opposite = a1_wrt_b == a2_wrt_b
-                            ? ra_to_wrt_b < ra_from_wrt_b
-                            : a2_wrt_b < a1_wrt_b;*/
-        
         return_type r('c', opposite);
 
         // IMPORTANT: the order of conditions is different as in intersection_points.hpp

--- a/include/boost/geometry/policies/relate/direction.hpp
+++ b/include/boost/geometry/policies/relate/direction.hpp
@@ -206,22 +206,60 @@ struct segments_direction
         }
     }
 
+    static inline int arrival_from_position_value(int /*v_from*/, int v_to)
+    {
+        return v_to == 2 ? 1
+             : v_to == 1 || v_to == 3 ? 0
+             //: v_from >= 1 && v_from <= 3 ? -1
+             : -1;
+
+        // NOTE: this should be an equivalent of the above for the other order
+        /* (v_from < 3 && v_to > 3) || (v_from > 3 && v_to < 3) ? 1
+         : v_from == 3 || v_to == 3 ? 0
+         : -1;*/
+    }
+
+    static inline void analyse_position_value(int pos_val,
+                                              int & in_segment_count,
+                                              int & on_end_count,
+                                              int & outside_segment_count)
+    {
+        if ( pos_val == 1 || pos_val == 3 )
+        {
+            on_end_count++;
+        }
+        else if ( pos_val == 2 )
+        {
+            in_segment_count++;
+        }
+        else
+        {
+            outside_segment_count++;
+        }
+    }
+
     template <typename Segment1, typename Segment2, typename Ratio>
     static inline return_type segments_collinear(
-        Segment1 const& , Segment2 const&,
+        Segment1 const& , Segment2 const& ,
+        int a1_wrt_b, int a2_wrt_b, int b1_wrt_a, int b2_wrt_a,
         Ratio const& ra_from_wrt_b, Ratio const& ra_to_wrt_b,
-        Ratio const& rb_from_wrt_a, Ratio const& rb_to_wrt_a)
+        Ratio const& /*rb_from_wrt_a*/, Ratio const& /*rb_to_wrt_a*/)
     {
         // If segments are opposite, the ratio of the FROM w.r.t. the other
         // is larger than the ratio of the TO w.r.t. the other
         bool const opposite = ra_to_wrt_b < ra_from_wrt_b;
-
+        // NOTE: an alternative version could compare ratios only
+        // if both ax_wrt_b positions were equal, otherwise use int positions
+        /*bool const opposite = a1_wrt_b == a2_wrt_b
+                            ? ra_to_wrt_b < ra_from_wrt_b
+                            : a2_wrt_b < a1_wrt_b;*/
+        
         return_type r('c', opposite);
 
         // IMPORTANT: the order of conditions is different as in intersection_points.hpp
         // We assign A in 0 and B in 1
-        r.arrival[0] = arrival_value(ra_from_wrt_b, ra_to_wrt_b);
-        r.arrival[1] = arrival_value(rb_from_wrt_a, rb_to_wrt_a);
+        r.arrival[0] = arrival_from_position_value(a1_wrt_b, a2_wrt_b);
+        r.arrival[1] = arrival_from_position_value(b1_wrt_a, b2_wrt_a);
 
         // Analyse them
         int a_in_segment_count = 0;
@@ -230,13 +268,13 @@ struct segments_direction
         int b_in_segment_count = 0;
         int b_on_end_count = 0;
         int b_outside_segment_count = 0;
-        analyze(ra_from_wrt_b,
+        analyse_position_value(a1_wrt_b,
             a_in_segment_count, a_on_end_count, a_outside_segment_count);
-        analyze(ra_to_wrt_b,
+        analyse_position_value(a2_wrt_b,
             a_in_segment_count, a_on_end_count, a_outside_segment_count);
-        analyze(rb_from_wrt_a,
+        analyse_position_value(b1_wrt_a,
             b_in_segment_count, b_on_end_count, b_outside_segment_count);
-        analyze(rb_to_wrt_a,
+        analyse_position_value(b2_wrt_a,
             b_in_segment_count, b_on_end_count, b_outside_segment_count);
 
         if (a_on_end_count == 1

--- a/include/boost/geometry/policies/relate/intersection_points.hpp
+++ b/include/boost/geometry/policies/relate/intersection_points.hpp
@@ -101,6 +101,7 @@ struct segments_intersection_points
     template <typename Segment1, typename Segment2, typename Ratio>
     static inline return_type segments_collinear(
         Segment1 const& a, Segment2 const& b,
+        int a1_wrt_b, int a2_wrt_b, int b1_wrt_a, int b2_wrt_a,
         Ratio const& ra_from_wrt_b, Ratio const& ra_to_wrt_b,
         Ratio const& rb_from_wrt_a, Ratio const& rb_to_wrt_a)
     {
@@ -112,7 +113,7 @@ struct segments_intersection_points
         // if index would be 2 this indicate an (currently uncatched) error
 
         // IMPORTANT: the order of conditions is different as in direction.hpp
-        if (ra_from_wrt_b.on_segment()
+        if (a1_wrt_b >= 1 && a1_wrt_b <= 3 // ra_from_wrt_b.on_segment()
             && index < 2)
         {
             //     a1--------->a2
@@ -126,7 +127,7 @@ struct segments_intersection_points
             index++;
             count_a++;
         }
-        if (rb_from_wrt_a.in_segment()
+        if (b1_wrt_a == 2 //rb_from_wrt_a.in_segment()
             && index < 2)
         {
             // We take the first intersection point of B
@@ -143,7 +144,7 @@ struct segments_intersection_points
             count_b++;
         }
 
-        if (ra_to_wrt_b.on_segment()
+        if (a2_wrt_b >= 1 && a2_wrt_b <= 3 //ra_to_wrt_b.on_segment()
             && index < 2)
         {
             // Similarly, second IP (here a2)
@@ -155,7 +156,7 @@ struct segments_intersection_points
             index++;
             count_a++;
         }
-        if (rb_to_wrt_a.in_segment()
+        if (b2_wrt_a == 2 // rb_to_wrt_a.in_segment()
             && index < 2)
         {
             detail::assign_point_from_index<1>(b, result.intersections[index]);

--- a/include/boost/geometry/policies/relate/intersection_points.hpp
+++ b/include/boost/geometry/policies/relate/intersection_points.hpp
@@ -100,7 +100,7 @@ struct segments_intersection_points
 
     template <typename Segment1, typename Segment2, typename Ratio>
     static inline return_type segments_collinear(
-        Segment1 const& a, Segment2 const& b,
+        Segment1 const& a, Segment2 const& b, bool /*opposite*/,
         int a1_wrt_b, int a2_wrt_b, int b1_wrt_a, int b2_wrt_a,
         Ratio const& ra_from_wrt_b, Ratio const& ra_to_wrt_b,
         Ratio const& rb_from_wrt_a, Ratio const& rb_to_wrt_a)

--- a/include/boost/geometry/policies/relate/tupled.hpp
+++ b/include/boost/geometry/policies/relate/tupled.hpp
@@ -48,6 +48,7 @@ struct segments_tupled
     template <typename Segment1, typename Segment2, typename Ratio>
     static inline return_type segments_collinear(
                     Segment1 const& segment1, Segment2 const& segment2,
+                    bool opposite,
                     int pa1, int pa2, int pb1, int pb2,
                     Ratio const& ra1, Ratio const& ra2,
                     Ratio const& rb1, Ratio const& rb2)
@@ -55,9 +56,11 @@ struct segments_tupled
         return boost::make_tuple
             (
                 Policy1::segments_collinear(segment1, segment2,
+                                            opposite,
                                             pa1, pa2, pb1, pb2,
                                             ra1, ra2, rb1, rb2),
                 Policy2::segments_collinear(segment1, segment2,
+                                            opposite,
                                             pa1, pa2, pb1, pb2,
                                             ra1, ra2, rb1, rb2)
             );

--- a/include/boost/geometry/policies/relate/tupled.hpp
+++ b/include/boost/geometry/policies/relate/tupled.hpp
@@ -47,13 +47,19 @@ struct segments_tupled
 
     template <typename Segment1, typename Segment2, typename Ratio>
     static inline return_type segments_collinear(
-        Segment1 const& segment1, Segment2 const& segment2,
-        Ratio const& ra1, Ratio const& ra2, Ratio const& rb1, Ratio const& rb2)
+                    Segment1 const& segment1, Segment2 const& segment2,
+                    int pa1, int pa2, int pb1, int pb2,
+                    Ratio const& ra1, Ratio const& ra2,
+                    Ratio const& rb1, Ratio const& rb2)
     {
         return boost::make_tuple
             (
-                Policy1::segments_collinear(segment1, segment2, ra1, ra2, rb1, rb2),
-                Policy2::segments_collinear(segment1, segment2, ra1, ra2, rb1, rb2)
+                Policy1::segments_collinear(segment1, segment2,
+                                            pa1, pa2, pb1, pb2,
+                                            ra1, ra2, rb1, rb2),
+                Policy2::segments_collinear(segment1, segment2,
+                                            pa1, pa2, pb1, pb2,
+                                            ra1, ra2, rb1, rb2)
             );
     }
 

--- a/include/boost/geometry/strategies/cartesian/cart_intersect.hpp
+++ b/include/boost/geometry/strategies/cartesian/cart_intersect.hpp
@@ -412,7 +412,9 @@ private:
             return Policy::disjoint();
         }
 
-        return Policy::segments_collinear(a, b,
+        bool const opposite = math::sign(length_a) != math::sign(length_b);
+
+        return Policy::segments_collinear(a, b, opposite,
                                           a1_wrt_b, a2_wrt_b, b1_wrt_a, b2_wrt_a,
                                           ra_from, ra_to, rb_from, rb_to);
     }

--- a/include/boost/geometry/strategies/cartesian/cart_intersect.hpp
+++ b/include/boost/geometry/strategies/cartesian/cart_intersect.hpp
@@ -371,39 +371,50 @@ private:
         RatioType rb_to(ob_2 - oa_1, length_a);
 
         // use absolute measure to detect endpoints intersection
-        // NOTE: some of those conditions shouldn't be met in the same time,
-        // e.g. a1 == b1 && a2 == b1 but they're checked anyway
-        // CONSIDER: below the ratio is modified if it should indicate that
-        // the endpoints intersect (but maybe it doesn't)
-        // should also the opposite case be handled explicitly? That is,
-        // if ratio indicates that the endpoints intersect but they aren't?
-        if (math::equals(oa_1, ob_1))
+        // NOTE: it'd be possible to calculate bx_wrt_a using ax_wrt_b values
+        int const a1_wrt_b = position_value(oa_1, ob_1, ob_2);
+        int const a2_wrt_b = position_value(oa_2, ob_1, ob_2);
+        int const b1_wrt_a = position_value(ob_1, oa_1, oa_2);
+        int const b2_wrt_a = position_value(ob_2, oa_1, oa_2);
+        
+        // fix the ratios if necessary
+        // CONSIDER: fixing ratios also in other cases, if they're inconsistent
+        // e.g. if ratio == 1 or 0 (so IP at the endpoint)
+        // but position value indicates that the IP is in the middle of the segment
+        // because one of the segments is very long
+        // In such case the ratios could be moved into the middle direction
+        // by some small value (e.g. EPS+1ULP)
+        if (a1_wrt_b == 1)
         {
             ra_from.assign(0, 1);
             rb_from.assign(0, 1);
         }
-        if (math::equals(oa_2, ob_1))
+        else if (a1_wrt_b == 3)
+        {
+            ra_from.assign(1, 1);
+            rb_to.assign(0, 1);
+        } 
+
+        if (a2_wrt_b == 1)
         {
             ra_to.assign(0, 1);
             rb_from.assign(1, 1);
         }
-        if (math::equals(oa_1, ob_2))
-        {
-            ra_from.assign(1, 1);
-            rb_to.assign(0, 1);
-        }        
-        if (math::equals(oa_2, ob_2))
+        else if (a2_wrt_b == 3)
         {
             ra_to.assign(1, 1);
             rb_to.assign(1, 1);
         }
 
-        if ((ra_from.left() && ra_to.left()) || (ra_from.right() && ra_to.right()))
+        if ((a1_wrt_b < 1 && a2_wrt_b < 1) || (a1_wrt_b > 3 && a2_wrt_b > 3))
+        //if ((ra_from.left() && ra_to.left()) || (ra_from.right() && ra_to.right()))
         {
             return Policy::disjoint();
         }
 
-        return Policy::segments_collinear(a, b, ra_from, ra_to, rb_from, rb_to);
+        return Policy::segments_collinear(a, b,
+                                          a1_wrt_b, a2_wrt_b, b1_wrt_a, b2_wrt_a,
+                                          ra_from, ra_to, rb_from, rb_to);
     }
 
     /// Relate segments where one is degenerate
@@ -432,6 +443,24 @@ private:
         }
 
         return Policy::one_degenerate(degenerate_segment, ratio, a_degenerate);
+    }
+
+    template <typename ProjCoord1, typename ProjCoord2>
+    static inline int position_value(ProjCoord1 const& ca1,
+                                     ProjCoord2 const& cb1,
+                                     ProjCoord2 const& cb2)
+    {
+        // S1x  0   1    2     3   4
+        // S2       |---------->
+        return math::equals(ca1, cb1) ? 1
+             : math::equals(ca1, cb2) ? 3
+             : cb1 < cb2 ?
+                ( ca1 < cb1 ? 0
+                : ca1 > cb2 ? 4
+                : 2 )
+              : ( ca1 > cb1 ? 0
+                : ca1 < cb2 ? 4
+                : 2 );
     }
 };
 

--- a/test/algorithms/overlay/get_turns_linear_linear.cpp
+++ b/test/algorithms/overlay/get_turns_linear_linear.cpp
@@ -285,6 +285,9 @@ void test_all()
         test_geometry<ls, ls>("LINESTRING(-2305843009213693956 4611686018427387906, -33 -92, 78 83)",
                               "LINESTRING(31 -97, -46 57, -20 -4)",
                               expected("")(""));
+        test_geometry<ls, ls>("LINESTRING(31 -97, -46 57, -20 -4)",
+                              "LINESTRING(-2305843009213693956 4611686018427387906, -33 -92, 78 83)",
+                              expected("")(""));
     }
 
     // TODO:

--- a/test/algorithms/overlay/get_turns_linear_linear.cpp
+++ b/test/algorithms/overlay/get_turns_linear_linear.cpp
@@ -217,8 +217,8 @@ void test_all()
     // 29.01.2015
     if ( BOOST_GEOMETRY_CONDITION((boost::is_same<T, double>::value)) )
     {
-        // FAILING
-        /*test_geometry<ls, ls>("LINESTRING(3 -0.6,0 -0.9)",
+        // FAILING - possibly wrong IPs
+        test_geometry<ls, ls>("LINESTRING(3 -0.6,0 -0.9)",
                               "LINESTRING(4 2.232432,1 -0.8,9 0)",
                               expected("mui=+")("miu+="));
 
@@ -232,7 +232,7 @@ void test_all()
 
         test_geometry<ls, ls>("LINESTRING(3 -0.6, 0 -0.9, -1 -1, -2 -2)",
                               "LINESTRING(4 2.232432,-1 -1, 0 -0.9, 9 0)",
-                              expected("tui=+")("ecc==")("miu+="));*/
+                              expected("tui=+")("ecc==")("miu+="));
     }
 
     test_geometry<ls, ls>("LINESTRING(3 0,0 0)",
@@ -266,20 +266,26 @@ void test_all()
 
     if ( BOOST_GEOMETRY_CONDITION((boost::is_same<T, double>::value)) )
     {
-        // FAILING
-        /*
+        // BUG - the operations are correct but IP coordinates are wrong
         test_geometry<ls, ls>("LINESTRING(8 5,5 1,-2 3,1 10)",
                               "LINESTRING(1.9375 1.875, 1.7441860465116283 1.9302325581395348, -0.7692307692307692 2.6483516483516487, -2 3, -1.0071942446043165 5.316546762589928)",
-                              expected("mii++")("cuu==")("tuu++"));
+                              expected("mii++")("ccc==")("tuu++"));
         test_geometry<ls, ls>("LINESTRING(8 5,5 1,-2 3,1 10)",
                               "LINESTRING(1.9375 1.875, 1.7441860465116283 1.9302325581395348, -0.7692307692307692 2.6483516483516487, -2 3, -0.5 6.5)",
-                              expected("mii++")("cuu==")("tii++")("mux=="));
+                              expected("mii++")("ccc==")("tii++")("mux=="));
+
+        // FAILING - wrong number of turns
         test_geometry<ls, ls>("LINESTRING(-0.5 7,8 1,0 -0.2)",
                               "LINESTRING(2 8,4 0.4,8 1,0 5)",
-                              expected(""));
-        */
-    }
+                              //expected("iuu++")("mui=+")("tiu+="));
+                              expected("")(""));
 
+        // assertion failure in 1.57
+        // FAILING - no assertion failure but the result is not very good
+        test_geometry<ls, ls>("LINESTRING(-2305843009213693956 4611686018427387906, -33 -92, 78 83)",
+                              "LINESTRING(31 -97, -46 57, -20 -4)",
+                              expected("")(""));
+    }
 
     // TODO:
     //test_geometry<ls, ls>("LINESTRING(0 0,2 0,1 0)", "LINESTRING(0 1,0 0,2 0)", "1FF00F102");

--- a/test/algorithms/overlay/test_get_turns.hpp
+++ b/test/algorithms/overlay/test_get_turns.hpp
@@ -88,8 +88,10 @@ struct equal_turn<1>
     bool operator()(T const& t) const
     {
         std::string::size_type count = turn_ptr->size();
-        BOOST_ASSERT(turn_ptr && count >= 1);
-        return bg::method_char(t.method) == (*turn_ptr)[0]
+        //BOOST_ASSERT(turn_ptr && count >= 1);
+        return ( count > 0
+               ? bg::method_char(t.method) == (*turn_ptr)[0]
+               : true )
             && ( count > 1
                ? bg::operation_char(t.operations[0].operation) == (*turn_ptr)[1]
                : true )

--- a/test/algorithms/relational_operations/disjoint/disjoint.cpp
+++ b/test/algorithms/relational_operations/disjoint/disjoint.cpp
@@ -190,6 +190,12 @@ void test_all()
 
     test_disjoint<ls, polygon>("col-op", "LINESTRING(10 10,11 10)", "POLYGON((0 0,0 10,10 10,10 0,0 0))", false);
     test_disjoint<ls, polygon>("col-op", "LINESTRING(9 10,11 10)", "POLYGON((0 0,0 10,10 10,10 0,0 0))", false);
+
+    // assertion failure in 1.57
+    test_disjoint<ls, ls>("point_ll_assert_1_57",
+                          "LINESTRING(-2305843009213693956 4611686018427387906, -33 -92, 78 83)",
+                          "LINESTRING(31 -97, -46 57, -20 -4)",
+                          false);
 }
 
 

--- a/test/algorithms/relational_operations/disjoint/multi_disjoint.cpp
+++ b/test/algorithms/relational_operations/disjoint/multi_disjoint.cpp
@@ -105,11 +105,15 @@ void test_all()
         "POINT(0 0)",
         false);
 
-//    assertion failure in 1.57
-//    test_disjoint<ls, mls>("point_l_ls_assert",
-//        "LINESTRING(-2305843009213693956 4611686018427387906, -33 -92, 78 83)",
-//        "MULTILINESTRING((20 100, 31 -97, -46 57, -20 -4),(-71 -4))",
-//        false);
+    // assertion failure in 1.57
+    test_disjoint<ls, mls>("point_l_ml_assert_1_57",
+        "LINESTRING(-2305843009213693956 4611686018427387906, -33 -92, 78 83)",
+        "MULTILINESTRING((20 100, 31 -97, -46 57, -20 -4))",
+        false);
+    test_disjoint<ls, mls>("point_l_ml_assert_1_57",
+        "LINESTRING(-2305843009213693956 4611686018427387906, -33 -92, 78 83)",
+        "MULTILINESTRING((20 100, 31 -97, -46 57, -20 -4),(-71 -4))",
+        false);
 }
 
 int test_main(int, char* [])


### PR DESCRIPTION
This PR increases the robustness of the code calculating the intersection of 2 collinear segments. Instead of the ratios which depend on lendth of the segments the coordinates are compared using operator< in addition to the checks for equality which was recently added. The relative position of a point and a segment is mapped into integer range [0, 4] like this:

    // S1pt   0  1     2    3  4
    // S2        |---------->

The integer values correspond to a ratio values ranges `(-oo, 0)` `{0}` `(0, 1)` `{1}` and `(1, +oo)` respectively. So e.g. the less compare works as expected for those int values, e.g. a value indicating left is still lesser than a value indicating middle and right. The data required to calculate them should be the segments' endpoints projected into 1-dimensional space, e.g. in the case of cartesian CS it's a more significant axis (X or Y), so exactly the same as with ratios.

Without this change in some cases the results of direction and intersection policy are not consistent, and varying depending on the order of the segments. This behavior can be observed e.g. if one of the segments is a lot longer than the second one, e.g.:

    "LINESTRING(-2305843009213693956 4611686018427387906, -33 -92, 78 83)"
    "LINESTRING(31 -97, -46 57, -20 -4)"

It's not enough to use the numerators and denominators contained in ratios because they are calculated by subtraction of coordinates, so for a very big difference of coordinates the error is also very big. And the result strongly depends on the coordinates being subtracted. In cases like the above at the same time logically excluding conditions can be met, e.g. segment detected in the middle of the other one and intersecting the endpoint. Then e.g. for segments detected as overlapping only 1 intersection point is generated (but there should be 2) which later in get turns causes an assertion failure. Note that the same effect should be observable if one of the segment had "normal" length and the other one was very short.

Even with this change the "invalid" ratios are stored in the intersection result and used e.g. in the code sorting turns. We could think about storing those position values with the ratios or think about some better representation of a position/distance of a point on a segment.