### PR TITLE
[strategies][cartesian][buffer][point_circle] fix internal point count

### DIFF
--- a/include/boost/geometry/strategies/cartesian/buffer_point_circle.hpp
+++ b/include/boost/geometry/strategies/cartesian/buffer_point_circle.hpp
@@ -1,5 +1,12 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
-// Copyright (c) 2012-2014 Barend Gehrels, Amsterdam, the Netherlands.
+
+// Copyright (c) 2012-2015 Barend Gehrels, Amsterdam, the Netherlands.
+
+// This file was modified by Oracle on 2015.
+// Modifications copyright (c) 2015, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -45,9 +52,10 @@ class point_circle
 {
 public :
     //! \brief Constructs the strategy
-    //! \param count number of points for the created circle
+    //! \param count number of points for the created circle (if count
+    //! is smaller than 3, count is internally set to 3)
     explicit point_circle(std::size_t count = 90)
-        : m_count(count)
+        : m_count((count < 3u) ? 3u : count)
     {}
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS


### PR DESCRIPTION
for small input values (less than 3): when the input point count is less
than 3, set the internal point count to 3; this is important for generating
valid polygons;