### PR TITLE
[strategies][cartesian][buffer][end_round] fix internal point count

### DIFF
--- a/include/boost/geometry/strategies/cartesian/buffer_end_round.hpp
+++ b/include/boost/geometry/strategies/cartesian/buffer_end_round.hpp
@@ -95,8 +95,9 @@ public :
 
     //! \brief Constructs the strategy
     //! \param points_per_circle points which would be used for a full circle
+    //! (if points_per_circle is smaller than 4, it is internally set to 4)
     explicit inline end_round(std::size_t points_per_circle = 90)
-        : m_points_per_circle(points_per_circle)
+        : m_points_per_circle((points_per_circle < 4u) ? 4u : points_per_circle)
     {}
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS


### PR DESCRIPTION
for small input values (less than 4): when the input point count is less
than 4, set the internal point count to 4; for values less than 4 the
generated ends do not look round;