### PR TITLE
Fix number of generated points in join_round buffer strategy

### DIFF
--- a/include/boost/geometry/strategies/cartesian/buffer_join_round.hpp
+++ b/include/boost/geometry/strategies/cartesian/buffer_join_round.hpp
@@ -96,10 +96,8 @@ private :
         // visually correct also for a low number of points / circle
         // n is set to be at least 2 so that at least one interior
         // point is generated
-        int const n = static_cast<int>
-            (
-                 (std::max)(m_points_per_circle * dangle / two_pi, two)
-            );
+        int const n = (std::max)
+            (static_cast<int>(m_points_per_circle * dangle / two_pi), 2);
 
         PromotedType const diff = dangle / static_cast<PromotedType>(n);
         PromotedType a = angle1 - diff;

--- a/include/boost/geometry/strategies/cartesian/buffer_join_round.hpp
+++ b/include/boost/geometry/strategies/cartesian/buffer_join_round.hpp
@@ -1,6 +1,11 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2012-2014 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2012-2015 Barend Gehrels, Amsterdam, the Netherlands.
+
+// This file was modified by Oracle on 2015.
+// Modifications copyright (c) 2015, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -8,6 +13,8 @@
 
 #ifndef BOOST_GEOMETRY_STRATEGIES_CARTESIAN_BUFFER_JOIN_ROUND_HPP
 #define BOOST_GEOMETRY_STRATEGIES_CARTESIAN_BUFFER_JOIN_ROUND_HPP
+
+#include <algorithm>
 
 #include <boost/assert.hpp>
 #include <boost/geometry/core/cs.hpp>
@@ -83,15 +90,18 @@ private :
         {
             angle2 -= two_pi;
         }
+        PromotedType const dangle = angle1 - angle2;
 
         // Divide the angle into an integer amount of steps to make it
         // visually correct also for a low number of points / circle
+        // n is set to be at least 2 so that at least one interior
+        // point is generated
         int const n = static_cast<int>
             (
-                m_points_per_circle * (angle1 - angle2) / two_pi
+                 (std::max)(m_points_per_circle * dangle / two_pi, two)
             );
 
-        PromotedType const diff = (angle1 - angle2) / static_cast<PromotedType>(n);
+        PromotedType const diff = dangle / static_cast<PromotedType>(n);
         PromotedType a = angle1 - diff;
         for (int i = 0; i < n - 1; i++, a -= diff)
         {


### PR DESCRIPTION
Make sure that at least one interior point is generated by the strategy.