### PR TITLE
Fix point_iterator with raw pointer base

### DIFF
--- a/include/boost/geometry/iterators/point_iterator.hpp
+++ b/include/boost/geometry/iterators/point_iterator.hpp
@@ -11,6 +11,7 @@
 #define BOOST_GEOMETRY_ITERATORS_POINT_ITERATOR_HPP
 
 #include <boost/assert.hpp>
+#include <boost/iterator/iterator_adaptor.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 #include <boost/range.hpp>
@@ -245,33 +246,26 @@ struct points_end<MultiPolygon, multi_polygon_tag>
 // MK:: need to add doc here
 template <typename Geometry>
 class point_iterator
-    : public detail::point_iterator::iterator_type<Geometry>::type
+    : public boost::iterator_adaptor <
+        point_iterator<Geometry>
+      , typename detail::point_iterator::iterator_type<Geometry>::type
+    >
 {
 private:
     typedef typename detail::point_iterator::iterator_type<Geometry>::type base;
-
-    inline base* base_ptr()
-    {
-        return this;
-    }
-
-    inline base const* base_ptr() const
-    {
-        return this;
-    }
 
     template <typename OtherGeometry> friend class point_iterator;
     template <typename G> friend inline point_iterator<G> points_begin(G&);
     template <typename G> friend inline point_iterator<G> points_end(G&);
 
-    inline point_iterator(base const& base_it) : base(base_it) {}
+    inline point_iterator(base const& base_it) : point_iterator::iterator_adaptor_(base_it) {}
 
 public:
     inline point_iterator() {}
 
     template <typename OtherGeometry>
     inline point_iterator(point_iterator<OtherGeometry> const& other)
-        : base(*other.base_ptr())
+        : point_iterator::iterator_adaptor_(other.base())
     {
         static const bool is_conv
             = boost::is_convertible<
@@ -288,32 +282,6 @@ public:
         BOOST_MPL_ASSERT_MSG((is_conv),
                              NOT_CONVERTIBLE,
                              (point_iterator<OtherGeometry>));
-    }
-
-    inline point_iterator& operator++() // prefix
-    {
-        base::operator++();
-        return *this;
-    }
-
-    inline point_iterator& operator--() // prefix
-    {
-        base::operator--();
-        return *this;
-    }
-
-    inline point_iterator operator++(int) // postfix
-    {
-        point_iterator copy(*this);
-        base::operator++();
-        return copy;
-    }
-
-    inline point_iterator operator--(int) // postfix
-    {
-        point_iterator copy(*this);
-        base::operator--();
-        return copy;
     }
 };
 

--- a/include/boost/geometry/iterators/point_iterator.hpp
+++ b/include/boost/geometry/iterators/point_iterator.hpp
@@ -246,19 +246,19 @@ struct points_end<MultiPolygon, multi_polygon_tag>
 // MK:: need to add doc here
 template <typename Geometry>
 class point_iterator
-    : public boost::iterator_adaptor <
-        point_iterator<Geometry>
-      , typename detail::point_iterator::iterator_type<Geometry>::type
-    >
+    : public boost::iterator_adaptor
+        <
+            point_iterator<Geometry>,
+            typename detail::point_iterator::iterator_type<Geometry>::type
+        >
 {
 private:
-    typedef typename detail::point_iterator::iterator_type<Geometry>::type base;
-
     template <typename OtherGeometry> friend class point_iterator;
     template <typename G> friend inline point_iterator<G> points_begin(G&);
     template <typename G> friend inline point_iterator<G> points_end(G&);
 
-    inline point_iterator(base const& base_it) : point_iterator::iterator_adaptor_(base_it) {}
+    inline point_iterator(typename point_iterator::base_type& base_it)
+        : point_iterator::iterator_adaptor_(base_it) {}
 
 public:
     inline point_iterator() {}

--- a/include/boost/geometry/iterators/point_reverse_iterator.hpp
+++ b/include/boost/geometry/iterators/point_reverse_iterator.hpp
@@ -27,7 +27,7 @@ class point_reverse_iterator
     : public std::reverse_iterator<point_iterator<Geometry> >
 {
 private:
-    typedef std::reverse_iterator<point_iterator<Geometry> > base;
+    typedef std::reverse_iterator<point_iterator<Geometry> > base_type;
 
     template <typename OtherGeometry> friend class point_reverse_iterator;
     template <typename G>
@@ -36,7 +36,8 @@ private:
     template <typename G>
     friend inline point_reverse_iterator<G> points_rend(G&);
 
-    inline point_reverse_iterator(base const& base_it) : base(base_it) {}
+    inline point_reverse_iterator(base_type const& base_it)
+        : base_type(base_it) {}
 
 public:
     inline point_reverse_iterator() {}
@@ -44,7 +45,7 @@ public:
     template <typename OtherGeometry>
     inline
     point_reverse_iterator(point_reverse_iterator<OtherGeometry> const& other)
-        : base(other.base())
+        : base_type(other.base())
     {
         static const bool is_conv = boost::is_convertible
             <

--- a/include/boost/geometry/iterators/point_reverse_iterator.hpp
+++ b/include/boost/geometry/iterators/point_reverse_iterator.hpp
@@ -29,16 +29,6 @@ class point_reverse_iterator
 private:
     typedef std::reverse_iterator<point_iterator<Geometry> > base;
 
-    inline base* base_ptr()
-    {
-        return this;
-    }
-
-    inline base const* base_ptr() const
-    {
-        return this;
-    }
-
     template <typename OtherGeometry> friend class point_reverse_iterator;
     template <typename G>
     friend inline point_reverse_iterator<G> points_rbegin(G&);
@@ -54,7 +44,7 @@ public:
     template <typename OtherGeometry>
     inline
     point_reverse_iterator(point_reverse_iterator<OtherGeometry> const& other)
-        : base(*other.base_ptr())
+        : base(other.base())
     {
         static const bool is_conv = boost::is_convertible
             <


### PR DESCRIPTION
Fix `point_iterator` (and adapt `reverse_point_iterator` to the fix) to support linestrings/rings implemented with raw pointer as iterator. The issue can be reproduced with:
```
boost::iterator_range<const point_t *> l;
points_begin(l);
```
The compiler complain that `const point_t *` is not a legal base class of `point_iterator`.

The fix uses `boost::iterator_adaptor` that implements base() a synonyme of base_ptr() that consequently has been removed. The operators are also redondant and removed.