### PR TITLE
Fix: make partition work for forward ranges

### DIFF
--- a/include/boost/geometry/algorithms/detail/partition.hpp
+++ b/include/boost/geometry/algorithms/detail/partition.hpp
@@ -1,6 +1,11 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2011-2014 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2011-2015 Barend Gehrels, Amsterdam, the Netherlands.
+
+// This file was modified by Oracle on 2015.
+// Modifications copyright (c) 2015 Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -9,18 +14,19 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_PARTITION_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_PARTITION_HPP
 
+#include <cstddef>
 #include <vector>
-#include <boost/range/algorithm/copy.hpp>
-#include <boost/geometry/algorithms/assign.hpp>
+#include <boost/range.hpp>
+#include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
+#include <boost/geometry/algorithms/assign.hpp>
+
 
 namespace boost { namespace geometry
 {
 
 namespace detail { namespace partition
 {
-
-typedef std::vector<std::size_t> index_vector_type;
 
 template <int Dimension, typename Box>
 inline void divide_box(Box const& box, Box& lower_box, Box& upper_box)
@@ -38,31 +44,33 @@ inline void divide_box(Box const& box, Box& lower_box, Box& upper_box)
     geometry::set<min_corner, Dimension>(upper_box, mid);
 }
 
-// Divide collection into three subsets: lower, upper and oversized
+// Divide forward_range into three subsets: lower, upper and oversized
 // (not-fitting)
 // (lower == left or bottom, upper == right or top)
-template <typename OverlapsPolicy, typename InputCollection, typename Box>
+template
+<
+    typename OverlapsPolicy,
+    typename ForwardRange,
+    typename Box,
+    typename IteratorVector
+>
 inline void divide_into_subsets(Box const& lower_box,
         Box const& upper_box,
-        InputCollection const& collection,
-        index_vector_type const& input,
-        index_vector_type& lower,
-        index_vector_type& upper,
-        index_vector_type& exceeding)
+        ForwardRange const& /*forward_range*/,
+        IteratorVector const& input,
+        IteratorVector& lower,
+        IteratorVector& upper,
+        IteratorVector& exceeding)
 {
-    typedef boost::range_iterator
+    typedef typename boost::range_iterator
         <
-            index_vector_type const
-        >::type index_iterator_type;
+            IteratorVector const
+        >::type it_type;
 
-    for(index_iterator_type it = boost::begin(input);
-        it != boost::end(input);
-        ++it)
+    for(it_type it = boost::begin(input); it != boost::end(input); ++it)
     {
-        bool const lower_overlapping = OverlapsPolicy::apply(lower_box,
-                    collection[*it]);
-        bool const upper_overlapping = OverlapsPolicy::apply(upper_box,
-                    collection[*it]);
+        bool const lower_overlapping = OverlapsPolicy::apply(lower_box, **it);
+        bool const upper_overlapping = OverlapsPolicy::apply(upper_box, **it);
 
         if (lower_overlapping && upper_overlapping)
         {
@@ -84,23 +92,34 @@ inline void divide_into_subsets(Box const& lower_box,
     }
 }
 
-template <typename ExpandPolicy, typename Box, typename InputCollection>
+template
+<
+    typename ExpandPolicy,
+    typename Box,
+    typename ForwardRange,
+    typename IteratorVector
+>
 inline void expand_with_elements(Box& total,
-                InputCollection const& collection,
-                index_vector_type const& input)
+                ForwardRange const& /*forward_range*/,
+                IteratorVector const& input)
 {
-    typedef boost::range_iterator<index_vector_type const>::type it_type;
+    typedef typename boost::range_iterator<IteratorVector const>::type it_type;
     for(it_type it = boost::begin(input); it != boost::end(input); ++it)
     {
-        ExpandPolicy::apply(total, collection[*it]);
+        ExpandPolicy::apply(total, **it);
     }
 }
 
 
-// Match collection with itself
-template <typename InputCollection, typename Policy>
-inline void handle_one(InputCollection const& collection,
-        index_vector_type const& input,
+// Match forward_range with itself
+template
+<
+    typename ForwardRange,
+    typename Policy,
+    typename IteratorVector
+>
+inline void handle_one(ForwardRange const& /*forward_range*/,
+        IteratorVector const& input,
         Policy& policy)
 {
     if (boost::size(input) == 0)
@@ -108,75 +127,87 @@ inline void handle_one(InputCollection const& collection,
         return;
     }
 
-    typedef boost::range_iterator<index_vector_type const>::type
-                index_iterator_type;
+    typedef typename boost::range_iterator<IteratorVector const>::type it_type;
 
     // Quadratic behaviour at lowest level (lowest quad, or all exceeding)
-    for(index_iterator_type it1 = boost::begin(input);
-        it1 != boost::end(input);
-        ++it1)
+    for (it_type it1 = boost::begin(input); it1 != boost::end(input); ++it1)
     {
-        index_iterator_type it2 = it1;
-        for(++it2; it2 != boost::end(input); ++it2)
+        it_type it2 = it1;
+        for (++it2; it2 != boost::end(input); ++it2)
         {
-            policy.apply(collection[*it1], collection[*it2]);
+            policy.apply(**it1, **it2);
         }
     }
 }
 
-// Match collection 1 with collection 2
+// Match forward range 1 with forward range 2
 template
 <
-    typename InputCollection1,
-    typename InputCollection2,
-    typename Policy
+    typename ForwardRange1,
+    typename ForwardRange2,
+    typename Policy,
+    typename IteratorVector1,
+    typename IteratorVector2
 >
 inline void handle_two(
-        InputCollection1 const& collection1, index_vector_type const& input1,
-        InputCollection2 const& collection2, index_vector_type const& input2,
+        ForwardRange1 const& /*forward_range1*/, IteratorVector1 const& input1,
+        ForwardRange2 const& /*forward_range2*/, IteratorVector2 const& input2,
         Policy& policy)
 {
+    typedef typename boost::range_iterator
+        <
+            IteratorVector1 const
+        >::type iterator_type1;
+
+    typedef typename boost::range_iterator
+        <
+            IteratorVector2 const
+        >::type iterator_type2;
+
     if (boost::size(input1) == 0 || boost::size(input2) == 0)
     {
         return;
     }
 
-    typedef boost::range_iterator
-        <
-            index_vector_type const
-        >::type index_iterator_type;
-
-    for(index_iterator_type it1 = boost::begin(input1);
+    for(iterator_type1 it1 = boost::begin(input1);
         it1 != boost::end(input1);
         ++it1)
     {
-        for(index_iterator_type it2 = boost::begin(input2);
+        for(iterator_type2 it2 = boost::begin(input2);
             it2 != boost::end(input2);
             ++it2)
         {
-            policy.apply(collection1[*it1], collection2[*it2]);
+            policy.apply(**it1, **it2);
         }
     }
 }
 
-inline bool recurse_ok(index_vector_type const& input,
+template <typename IteratorVector>
+inline bool recurse_ok(IteratorVector const& input,
                 std::size_t min_elements, std::size_t level)
 {
     return boost::size(input) >= min_elements
         && level < 100;
 }
 
-inline bool recurse_ok(index_vector_type const& input1,
-                index_vector_type const& input2,
+template <typename IteratorVector1, typename IteratorVector2>
+inline bool recurse_ok(IteratorVector1 const& input1,
+                IteratorVector2 const& input2,
                 std::size_t min_elements, std::size_t level)
 {
     return boost::size(input1) >= min_elements
         && recurse_ok(input2, min_elements, level);
 }
 
-inline bool recurse_ok(index_vector_type const& input1,
-                index_vector_type const& input2,
-                index_vector_type const& input3,
+template
+<
+    typename IteratorVector1,
+    typename IteratorVector2,
+    typename IteratorVector3
+>
+inline bool recurse_ok(IteratorVector1 const& input1,
+                IteratorVector2 const& input2,
+                IteratorVector3 const& input3,
                 std::size_t min_elements, std::size_t level)
 {
     return boost::size(input1) >= min_elements
@@ -193,7 +224,7 @@ template
     typename ExpandPolicy2,
     typename VisitBoxPolicy
 >
-class partition_two_collections;
+class partition_two_ranges;
 
 
 template
@@ -204,79 +235,91 @@ template
     typename ExpandPolicy,
     typename VisitBoxPolicy
 >
-class partition_one_collection
+class partition_one_range
 {
-    typedef std::vector<std::size_t> index_vector_type;
-
-    template <typename InputCollection>
-    static inline Box get_new_box(InputCollection const& collection,
-                    index_vector_type const& input)
+    template <typename ForwardRange, typename IteratorVector>
+    static inline Box get_new_box(ForwardRange const& forward_range,
+                    IteratorVector const& input)
     {
         Box box;
         geometry::assign_inverse(box);
-        expand_with_elements<ExpandPolicy>(box, collection, input);
+        expand_with_elements<ExpandPolicy>(box, forward_range, input);
         return box;
     }
 
-    template <typename InputCollection, typename Policy>
+    template
+    <
+        typename ForwardRange,
+        typename Policy,
+        typename IteratorVector
+    >
     static inline void next_level(Box const& box,
-            InputCollection const& collection,
-            index_vector_type const& input,
+            ForwardRange const& forward_range,
+            IteratorVector const& input,
             std::size_t level, std::size_t min_elements,
             Policy& policy, VisitBoxPolicy& box_policy)
     {
         if (recurse_ok(input, min_elements, level))
         {
-            partition_one_collection
+            partition_one_range
             <
                 1 - Dimension,
                 Box,
                 OverlapsPolicy,
                 ExpandPolicy,
                 VisitBoxPolicy
-            >::apply(box, collection, input,
+            >::apply(box, forward_range, input,
                 level + 1, min_elements, policy, box_policy);
         }
         else
         {
-            handle_one(collection, input, policy);
+            handle_one(forward_range, input, policy);
         }
     }
 
-    // Function to switch to two collections if there are geometries exceeding
-    // the separation line
-    template <typename InputCollection, typename Policy>
+    // Function to switch to two forward ranges if there are
+    // geometries exceeding the separation line
+    template
+    <
+        typename ForwardRange,
+        typename Policy,
+        typename IteratorVector
+    >
     static inline void next_level2(Box const& box,
-            InputCollection const& collection,
-            index_vector_type const& input1,
-            index_vector_type const& input2,
+            ForwardRange const& forward_range,
+            IteratorVector const& input1,
+            IteratorVector const& input2,
             std::size_t level, std::size_t min_elements,
             Policy& policy, VisitBoxPolicy& box_policy)
     {
-
         if (recurse_ok(input1, input2, min_elements, level))
         {
-            partition_two_collections
+            partition_two_ranges
             <
                 1 - Dimension,
                 Box,
                 OverlapsPolicy, OverlapsPolicy,
                 ExpandPolicy, ExpandPolicy,
                 VisitBoxPolicy
-            >::apply(box, collection, input1, collection, input2,
+            >::apply(box, forward_range, input1, forward_range, input2,
                 level + 1, min_elements, policy, box_policy);
         }
         else
         {
-            handle_two(collection, input1, collection, input2, policy);
+            handle_two(forward_range, input1, forward_range, input2, policy);
         }
     }
 
 public :
-    template <typename InputCollection, typename Policy>
+    template
+    <
+        typename ForwardRange,
+        typename Policy,
+        typename IteratorVector
+    >
     static inline void apply(Box const& box,
-            InputCollection const& collection,
-            index_vector_type const& input,
+            ForwardRange const& forward_range,
+            IteratorVector const& input,
             std::size_t level,
             std::size_t min_elements,
             Policy& policy, VisitBoxPolicy& box_policy)
@@ -286,32 +329,32 @@ public :
         Box lower_box, upper_box;
         divide_box<Dimension>(box, lower_box, upper_box);
 
-        index_vector_type lower, upper, exceeding;
-        divide_into_subsets<OverlapsPolicy>(lower_box, upper_box, collection,
+        IteratorVector lower, upper, exceeding;
+        divide_into_subsets<OverlapsPolicy>(lower_box, upper_box, forward_range,
                     input, lower, upper, exceeding);
 
         if (boost::size(exceeding) > 0)
         {
             // Get the box of exceeding-only
-            Box exceeding_box = get_new_box(collection, exceeding);
+            Box exceeding_box = get_new_box(forward_range, exceeding);
 
             // Recursively do exceeding elements only, in next dimension they
             // will probably be less exceeding within the new box
-            next_level(exceeding_box, collection, exceeding, level,
+            next_level(exceeding_box, forward_range, exceeding, level,
                 min_elements, policy, box_policy);
 
-            // Switch to two collections, combine exceeding with lower resp upper
-            // but not lower/lower, upper/upper
-            next_level2(exceeding_box, collection, exceeding, lower, level,
+            // Switch to two forward ranges, combine exceeding with
+            // lower resp upper, but not lower/lower, upper/upper
+            next_level2(exceeding_box, forward_range, exceeding, lower, level,
                 min_elements, policy, box_policy);
-            next_level2(exceeding_box, collection, exceeding, upper, level,
+            next_level2(exceeding_box, forward_range, exceeding, upper, level,
                 min_elements, policy, box_policy);
         }
 
         // Recursively call operation both parts
-        next_level(lower_box, collection, lower, level, min_elements,
+        next_level(lower_box, forward_range, lower, level, min_elements,
                         policy, box_policy);
-        next_level(upper_box, collection, upper, level, min_elements,
+        next_level(upper_box, forward_range, upper, level, min_elements,
                         policy, box_policy);
     }
 };
@@ -326,25 +369,25 @@ template
     typename ExpandPolicy2,
     typename VisitBoxPolicy
 >
-class partition_two_collections
+class partition_two_ranges
 {
-    typedef std::vector<std::size_t> index_vector_type;
-
     template
     <
-        typename InputCollection1,
-        typename InputCollection2,
-        typename Policy
+        typename ForwardRange1,
+        typename ForwardRange2,
+        typename Policy,
+        typename IteratorVector1,
+        typename IteratorVector2
     >
     static inline void next_level(Box const& box,
-            InputCollection1 const& collection1,
-            index_vector_type const& input1,
-            InputCollection2 const& collection2,
-            index_vector_type const& input2,
+            ForwardRange1 const& forward_range1,
+            IteratorVector1 const& input1,
+            ForwardRange2 const& forward_range2,
+            IteratorVector2 const& input2,
             std::size_t level, std::size_t min_elements,
             Policy& policy, VisitBoxPolicy& box_policy)
     {
-        partition_two_collections
+        partition_two_ranges
         <
             1 - Dimension,
             Box,
@@ -353,7 +396,7 @@ class partition_two_collections
             ExpandPolicy1,
             ExpandPolicy2,
             VisitBoxPolicy
-        >::apply(box, collection1, input1, collection2, input2,
+        >::apply(box, forward_range1, input1, forward_range2, input2,
                 level + 1, min_elements,
                 policy, box_policy);
     }
@@ -361,42 +404,49 @@ class partition_two_collections
     template
     <
         typename ExpandPolicy,
-        typename InputCollection
+        typename ForwardRange,
+        typename IteratorVector
     >
-    static inline Box get_new_box(InputCollection const& collection,
-                    index_vector_type const& input)
+    static inline Box get_new_box(ForwardRange const& forward_range,
+                    IteratorVector const& input)
     {
         Box box;
         geometry::assign_inverse(box);
-        expand_with_elements<ExpandPolicy>(box, collection, input);
+        expand_with_elements<ExpandPolicy>(box, forward_range, input);
         return box;
     }
 
     template
     <
-        typename InputCollection1,
-        typename InputCollection2
+        typename ForwardRange1,
+        typename ForwardRange2,
+        typename IteratorVector1,
+        typename IteratorVector2
     >
-    static inline Box get_new_box(InputCollection1 const& collection1,
-                    index_vector_type const& input1,
-                    InputCollection2 const& collection2,
-                    index_vector_type const& input2)
+    static inline Box get_new_box(ForwardRange1 const& forward_range1,
+                    IteratorVector1 const& input1,
+                    ForwardRange2 const& forward_range2,
+                    IteratorVector2 const& input2)
     {
-        Box box = get_new_box<ExpandPolicy1>(collection1, input1);
-        expand_with_elements<ExpandPolicy2>(box, collection2, input2);
+        Box box = get_new_box<ExpandPolicy1>(forward_range1, input1);
+        expand_with_elements<ExpandPolicy2>(box, forward_range2, input2);
         return box;
     }
 
 public :
     template
     <
-        typename InputCollection1,
-        typename InputCollection2,
-        typename Policy
+        typename ForwardRange1,
+        typename ForwardRange2,
+        typename Policy,
+        typename IteratorVector1,
+        typename IteratorVector2
     >
     static inline void apply(Box const& box,
-            InputCollection1 const& collection1, index_vector_type const& input1,
-            InputCollection2 const& collection2, index_vector_type const& input2,
+            ForwardRange1 const& forward_range1,
+            IteratorVector1 const& input1,
+            ForwardRange2 const& forward_range2,
+            IteratorVector2 const& input2,
             std::size_t level,
             std::size_t min_elements,
             Policy& policy, VisitBoxPolicy& box_policy)
@@ -406,12 +456,12 @@ public :
         Box lower_box, upper_box;
         divide_box<Dimension>(box, lower_box, upper_box);
 
-        index_vector_type lower1, upper1, exceeding1;
-        index_vector_type lower2, upper2, exceeding2;
-        divide_into_subsets<OverlapsPolicy1>(lower_box, upper_box, collection1,
-                    input1, lower1, upper1, exceeding1);
-        divide_into_subsets<OverlapsPolicy2>(lower_box, upper_box, collection2,
-                    input2, lower2, upper2, exceeding2);
+        IteratorVector1 lower1, upper1, exceeding1;
+        IteratorVector2 lower2, upper2, exceeding2;
+        divide_into_subsets<OverlapsPolicy1>(lower_box, upper_box,
+                    forward_range1, input1, lower1, upper1, exceeding1);
+        divide_into_subsets<OverlapsPolicy2>(lower_box, upper_box,
+                    forward_range2, input2, lower2, upper2, exceeding2);
 
         if (boost::size(exceeding1) > 0)
         {
@@ -419,35 +469,39 @@ public :
 
             if (recurse_ok(exceeding1, exceeding2, min_elements, level))
             {
-                Box exceeding_box = get_new_box(collection1, exceeding1,
-                            collection2, exceeding2);
-                next_level(exceeding_box, collection1, exceeding1,
-                                collection2, exceeding2, level,
+                Box exceeding_box = get_new_box(forward_range1, exceeding1,
+                            forward_range2, exceeding2);
+                next_level(exceeding_box, forward_range1, exceeding1,
+                                forward_range2, exceeding2, level,
                                 min_elements, policy, box_policy);
             }
             else
             {
-                handle_two(collection1, exceeding1, collection2, exceeding2,
-                            policy);
+                handle_two(forward_range1, exceeding1, forward_range2,
+                           exceeding2, policy);
             }
 
             // All exceeding from 1 with lower and upper of 2:
 
-            // (Check sizes of all three collections to avoid recurse into
+            // (Check sizes of all three forward ranges to avoid recurse into
             // the same combinations again and again)
             if (recurse_ok(lower2, upper2, exceeding1, min_elements, level))
             {
                 Box exceeding_box
-                    = get_new_box<ExpandPolicy1>(collection1, exceeding1);
-                next_level(exceeding_box, collection1, exceeding1,
-                    collection2, lower2, level, min_elements, policy, box_policy);
-                next_level(exceeding_box, collection1, exceeding1,
-                    collection2, upper2, level, min_elements, policy, box_policy);
+                    = get_new_box<ExpandPolicy1>(forward_range1, exceeding1);
+                next_level(exceeding_box, forward_range1, exceeding1,
+                    forward_range2, lower2, level, min_elements,
+                    policy, box_policy);
+                next_level(exceeding_box, forward_range1, exceeding1,
+                    forward_range2, upper2, level, min_elements,
+                    policy, box_policy);
             }
             else
             {
-                handle_two(collection1, exceeding1, collection2, lower2, policy);
-                handle_two(collection1, exceeding1, collection2, upper2, policy);
+                handle_two(forward_range1, exceeding1, forward_range2, lower2,
+                    policy);
+                handle_two(forward_range1, exceeding1, forward_range2, upper2,
+                    policy);
             }
         }
 
@@ -457,36 +511,42 @@ public :
             if (recurse_ok(lower1, upper1, exceeding2, min_elements, level))
             {
                 Box exceeding_box
-                    = get_new_box<ExpandPolicy2>(collection2, exceeding2);
-                next_level(exceeding_box, collection1, lower1,
-                    collection2, exceeding2, level, min_elements, policy, box_policy);
-                next_level(exceeding_box, collection1, upper1,
-                    collection2, exceeding2, level, min_elements, policy, box_policy);
+                    = get_new_box<ExpandPolicy2>(forward_range2, exceeding2);
+                next_level(exceeding_box, forward_range1, lower1,
+                    forward_range2, exceeding2, level, min_elements,
+                    policy, box_policy);
+                next_level(exceeding_box, forward_range1, upper1,
+                    forward_range2, exceeding2, level, min_elements,
+                    policy, box_policy);
             }
             else
             {
-                handle_two(collection1, lower1, collection2, exceeding2, policy);
-                handle_two(collection1, upper1, collection2, exceeding2, policy);
+                handle_two(forward_range1, lower1, forward_range2, exceeding2,
+                    policy);
+                handle_two(forward_range1, upper1, forward_range2, exceeding2,
+                    policy);
             }
         }
 
         if (recurse_ok(lower1, lower2, min_elements, level))
         {
-            next_level(lower_box, collection1, lower1, collection2, lower2, level,
+            next_level(lower_box, forward_range1, lower1,
+                            forward_range2, lower2, level,
                             min_elements, policy, box_policy);
         }
         else
         {
-            handle_two(collection1, lower1, collection2, lower2, policy);
+            handle_two(forward_range1, lower1, forward_range2, lower2, policy);
         }
         if (recurse_ok(upper1, upper2, min_elements, level))
         {
-            next_level(upper_box, collection1, upper1, collection2, upper2, level,
+            next_level(upper_box, forward_range1, upper1,
+                            forward_range2, upper2, level,
                             min_elements, policy, box_policy);
         }
         else
         {
-            handle_two(collection1, upper1, collection2, upper2, policy);
+            handle_two(forward_range1, upper1, forward_range2, upper2, policy);
         }
     }
 };
@@ -523,63 +583,67 @@ template
 >
 class partition
 {
-    typedef std::vector<std::size_t> index_vector_type;
-
-    template <typename ExpandPolicy, typename IncludePolicy, typename InputCollection>
-    static inline void expand_to_collection(InputCollection const& collection,
-                Box& total, index_vector_type& index_vector)
+    template
+    <
+        typename ExpandPolicy,
+        typename IncludePolicy,
+        typename ForwardRange,
+        typename IteratorVector
+    >
+    static inline void expand_to_range(ForwardRange const& forward_range,
+                Box& total, IteratorVector& iterator_vector)
     {
-        std::size_t index = 0;
-        for(typename boost::range_iterator<InputCollection const>::type it
-            = boost::begin(collection);
-            it != boost::end(collection);
-            ++it, ++index)
+        for(typename boost::range_iterator<ForwardRange const>::type it
+            = boost::begin(forward_range);
+            it != boost::end(forward_range);
+            ++it)
         {
             if (IncludePolicy::apply(*it))
             {
                 ExpandPolicy::apply(total, *it);
-                index_vector.push_back(index);
+                iterator_vector.push_back(it);
             }
         }
     }
 
 public :
-    template <typename InputCollection, typename VisitPolicy>
-    static inline void apply(InputCollection const& collection,
+    template <typename ForwardRange, typename VisitPolicy>
+    static inline void apply(ForwardRange const& forward_range,
             VisitPolicy& visitor,
             std::size_t min_elements = 16,
             VisitBoxPolicy box_visitor = detail::partition::visit_no_policy()
             )
     {
-        if (std::size_t(boost::size(collection)) > min_elements)
+        typedef typename boost::range_iterator
+            <
+                ForwardRange const
+            >::type iterator_type;
+
+        if (std::size_t(boost::size(forward_range)) > min_elements)
         {
-            index_vector_type index_vector;
+            std::vector<iterator_type> iterator_vector;
             Box total;
             assign_inverse(total);
-            expand_to_collection<ExpandPolicy1, IncludePolicy1>(collection,
-                    total, index_vector);
+            expand_to_range<ExpandPolicy1, IncludePolicy1>(forward_range,
+                    total, iterator_vector);
 
-            detail::partition::partition_one_collection
+            detail::partition::partition_one_range
                 <
                     0, Box,
                     OverlapsPolicy1,
                     ExpandPolicy1,
                     VisitBoxPolicy
-                >::apply(total, collection, index_vector, 0, min_elements,
+                >::apply(total, forward_range, iterator_vector, 0, min_elements,
                                 visitor, box_visitor);
         }
         else
         {
-            typedef typename boost::range_iterator
-                <
-                    InputCollection const
-                >::type iterator_type;
-            for(iterator_type it1 = boost::begin(collection);
-                it1 != boost::end(collection);
+            for(iterator_type it1 = boost::begin(forward_range);
+                it1 != boost::end(forward_range);
                 ++it1)
             {
                 iterator_type it2 = it1;
-                for(++it2; it2 != boost::end(collection); ++it2)
+                for(++it2; it2 != boost::end(forward_range); ++it2)
                 {
                     visitor.apply(*it1, *it2);
                 }
@@ -589,53 +653,57 @@ public :
 
     template
     <
-        typename InputCollection1,
-        typename InputCollection2,
+        typename ForwardRange1,
+        typename ForwardRange2,
         typename VisitPolicy
     >
-    static inline void apply(InputCollection1 const& collection1,
-                InputCollection2 const& collection2,
+    static inline void apply(ForwardRange1 const& forward_range1,
+                ForwardRange2 const& forward_range2,
                 VisitPolicy& visitor,
                 std::size_t min_elements = 16,
-                VisitBoxPolicy box_visitor = detail::partition::visit_no_policy()
+                VisitBoxPolicy box_visitor
+                    = detail::partition::visit_no_policy()
                 )
     {
-        if (std::size_t(boost::size(collection1)) > min_elements
-            && std::size_t(boost::size(collection2)) > min_elements)
+        typedef typename boost::range_iterator
+            <
+                ForwardRange1 const
+            >::type iterator_type1;
+
+        typedef typename boost::range_iterator
+            <
+                ForwardRange2 const
+            >::type iterator_type2;
+
+        if (std::size_t(boost::size(forward_range1)) > min_elements
+            && std::size_t(boost::size(forward_range2)) > min_elements)
         {
-            index_vector_type index_vector1, index_vector2;
+            std::vector<iterator_type1> iterator_vector1;
+            std::vector<iterator_type2> iterator_vector2;
             Box total;
             assign_inverse(total);
-            expand_to_collection<ExpandPolicy1, IncludePolicy1>(collection1,
-                    total, index_vector1);
-            expand_to_collection<ExpandPolicy2, IncludePolicy2>(collection2,
-                    total, index_vector2);
+            expand_to_range<ExpandPolicy1, IncludePolicy1>(forward_range1,
+                    total, iterator_vector1);
+            expand_to_range<ExpandPolicy2, IncludePolicy2>(forward_range2,
+                    total, iterator_vector2);
 
-            detail::partition::partition_two_collections
+            detail::partition::partition_two_ranges
                 <
                     0, Box, OverlapsPolicy1, OverlapsPolicy2,
                     ExpandPolicy1, ExpandPolicy2, VisitBoxPolicy
                 >::apply(total,
-                    collection1, index_vector1,
-                    collection2, index_vector2,
+                    forward_range1, iterator_vector1,
+                    forward_range2, iterator_vector2,
                     0, min_elements, visitor, box_visitor);
         }
         else
         {
-            typedef typename boost::range_iterator
-                <
-                    InputCollection1 const
-                >::type iterator_type1;
-            typedef typename boost::range_iterator
-                <
-                    InputCollection2 const
-                >::type iterator_type2;
-            for(iterator_type1 it1 = boost::begin(collection1);
-                it1 != boost::end(collection1);
+            for(iterator_type1 it1 = boost::begin(forward_range1);
+                it1 != boost::end(forward_range1);
                 ++it1)
             {
-                for(iterator_type2 it2 = boost::begin(collection2);
-                    it2 != boost::end(collection2);
+                for(iterator_type2 it2 = boost::begin(forward_range2);
+                    it2 != boost::end(forward_range2);
                     ++it2)
                 {
                     visitor.apply(*it1, *it2);


### PR DESCRIPTION
The current `partition<>` implementation, the one or two input collections passed are assumed internally to be random access containers (to be precise, it is required that the collection's `operator[]` is defined).
In fact, this is requirement is a bit too strict. `partition<>` can easily work even for forward ranges, and this is the focus of this PR.

In this PR, `partition<>` has been modified so as to work for forward ranges. This eliminates among other things the need for the range to define `operator[]`. The idea behind the re-implementation is as follows: instead of storing and keeping track of indices of collection items (these are the indices that are used as arguments in `operator[]` calls), iterators to collection items are stored and manipulated. The `index_vector_type` is consistently replaced by a vector of iterators (possibly of two different types if the two input collections are different). Accessing the collection items in this context simply amounts to de-referencing the iterators stored in the iterator vectors. The only operators used with respect to the iterators of the input collections are `operator++` and `operator*`.

On the practical side: this allows to use partition with ranges which are not random access. Two such cases are ranges coming from BG's `point_iterator<>` and `segment_iterator<>` which are bidirectional iterators.

All algorithm unit tests pass with the re-designed `partition<>`.