### PR TITLE
Remove misleading overloads of front() and back() in range and fix a missing const in sub_range

### DIFF
--- a/include/boost/geometry/algorithms/detail/sub_range.hpp
+++ b/include/boost/geometry/algorithms/detail/sub_range.hpp
@@ -14,7 +14,12 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_SUB_RANGE_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_SUB_RANGE_HPP
 
+#include <boost/geometry/algorithms/not_implemented.hpp>
+#include <boost/geometry/core/tags.hpp>
+#include <boost/geometry/core/ring_type.hpp>
 #include <boost/geometry/util/range.hpp>
+
+#include <boost/range/size.hpp>
 
 namespace boost { namespace geometry {
 
@@ -44,7 +49,7 @@ struct sub_range<Geometry, Tag, false>
 template <typename Geometry>
 struct sub_range<Geometry, polygon_tag, false>
 {
-    typedef typename geometry::ring_type<Geometry>::type & return_type;
+    typedef typename geometry::ring_type<Geometry>::type const& return_type;
 
     template <typename Id> static inline
     return_type apply(Geometry & geometry, Id const& id)

--- a/include/boost/geometry/util/range.hpp
+++ b/include/boost/geometry/util/range.hpp
@@ -107,20 +107,8 @@ at(RandomAccessRange & rng,
 \ingroup utility
 */
 template <typename Range>
-inline typename boost::range_value<Range>::type const&
+inline typename boost::range_reference<Range>::type
 front(Range const& rng)
-{
-    BOOST_ASSERT(!boost::empty(rng));
-    return *boost::begin(rng);
-}
-
-/*!
-\brief Short utility to conveniently return the front element of a Range.
-\ingroup utility
-*/
-template <typename Range>
-inline typename boost::range_value<Range>::type &
-front(Range & rng)
 {
     BOOST_ASSERT(!boost::empty(rng));
     return *boost::begin(rng);
@@ -133,27 +121,13 @@ front(Range & rng)
 \ingroup utility
 */
 template <typename BidirectionalRange>
-inline typename boost::range_value<BidirectionalRange>::type const&
+inline typename boost::range_reference<BidirectionalRange>::type
 back(BidirectionalRange const& rng)
 {
     BOOST_RANGE_CONCEPT_ASSERT(( boost::BidirectionalRangeConcept<BidirectionalRange const> ));
     BOOST_ASSERT(!boost::empty(rng));
     return *(boost::rbegin(rng));
 }
-
-/*!
-\brief Short utility to conveniently return the back element of a BidirectionalRange.
-\ingroup utility
-*/
-template <typename BidirectionalRange>
-inline typename boost::range_value<BidirectionalRange>::type &
-back(BidirectionalRange & rng)
-{
-    BOOST_RANGE_CONCEPT_ASSERT(( boost::BidirectionalRangeConcept<BidirectionalRange> ));
-    BOOST_ASSERT(!boost::empty(rng));
-    return *(boost::rbegin(rng));
-}
-
 
 /*!
 \brief Short utility to conveniently clear a mutable range.


### PR DESCRIPTION
Remove misleading overloads of `front()` and `back()` since the constness of a Range does not mean that the underlying iterator (and so value type) is const (e.g. you can have a const Range of mutable iterators and vice versa). Use `boost::range_reference<>`.

In the same vein, I wonder if `range::resize()`, `range::clear()` and `range::push_back()` should be moved in a new file "util/container.hpp" to make it more obvious that these fonctions require Containers ?