### PR TITLE
Simplify detail::not_

### DIFF
--- a/include/boost/geometry/algorithms/detail/not.hpp
+++ b/include/boost/geometry/algorithms/detail/not.hpp
@@ -1,8 +1,13 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
-// Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
-// Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
+// Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
+// Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
+
+// This file was modified by Oracle on 2015.
+// Modifications copyright (c) 2015, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
@@ -32,10 +37,12 @@ namespace detail
 \param geometry2 \param_geometry
 \return Negation of the result of the policy
  */
-template <typename Geometry1, typename Geometry2, typename Policy>
+template <typename Policy>
 struct not_
 {
-    static inline bool apply(Geometry1 const &geometry1, Geometry2 const& geometry2)
+    template <typename Geometry1, typename Geometry2>
+    static inline bool apply(Geometry1 const& geometry1,
+                             Geometry2 const& geometry2)
     {
         return ! Policy::apply(geometry1, geometry2);
     }

--- a/include/boost/geometry/algorithms/equals.hpp
+++ b/include/boost/geometry/algorithms/equals.hpp
@@ -1,14 +1,15 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
-// Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
-// Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
-// Copyright (c) 2014 Adam Wulkiewicz, Lodz, Poland.
+// Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
+// Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
+// Copyright (c) 2014-2015 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2014.
-// Modifications copyright (c) 2014 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014, 2015.
+// Modifications copyright (c) 2014-2015 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
@@ -236,8 +237,6 @@ template <typename P1, typename P2, std::size_t DimensionCount, bool Reverse>
 struct equals<P1, P2, point_tag, point_tag, DimensionCount, Reverse>
     : geometry::detail::not_
         <
-            P1,
-            P2,
             detail::disjoint::point_point<P1, P2, 0, DimensionCount>
         >
 {};


### PR DESCRIPTION
Modify the implementation of `detail::not_` by moving the geometry template parameters inside the class.
This way it is simpler to use `detail::not_` as it is not required to specify the geometries.