### PR TITLE
Fix return_type of sub_range

### DIFF
--- a/include/boost/geometry/algorithms/detail/sub_range.hpp
+++ b/include/boost/geometry/algorithms/detail/sub_range.hpp
@@ -44,7 +44,7 @@ struct sub_range<Geometry, Tag, false>
 template <typename Geometry>
 struct sub_range<Geometry, polygon_tag, false>
 {
-    typedef typename geometry::ring_type<Geometry>::type & return_type;
+    typedef typename geometry::ring_type<Geometry>::type return_type;
 
     template <typename Id> static inline
     return_type apply(Geometry & geometry, Id const& id)


### PR DESCRIPTION
IMHO, `return_type` should not be defined by reference to `geometry::ring_type<Geometry>::type` but by value.

Here is a model of Polygon that demonstrates the problem, the key point being that the return type of `inners()` is a Range:
```
template <typename Point>
struct polygon
{
  typedef boost::iterator_range<const Point *> ring_t;
  typedef boost::iterator_range
    <
      typename std::vector<ring_t>::const_iterator
    > rings_t;

  ring_t outer() const { return rings.front(); }
  rings_t inners() const { return rings_t(rings.begin() + 1, rings.end()); }

  std::vector<ring_t> rings;
};

namespace boost { namespace geometry { namespace traits
{

template <typename Point> struct tag< polygon<const Point> > { typedef polygon_tag type; };

template <typename Point> struct ring_mutable_type< polygon<Point> > { typedef typename polygon<Point>::ring_t type; };
template <typename Point> struct ring_const_type< polygon<Point> > { typedef typename polygon<Point>::ring_t type; };

template <typename Point> struct interior_mutable_type< polygon<Point> > { typedef typename polygon<Point>::rings_t type; };
template <typename Point> struct interior_const_type< polygon<Point> > { typedef typename polygon<Point>::rings_t type; };

}}} // namespace boost::geometry::traits
```

With such a model, that hopefully satisfy the Polygon concepts, the collection of ring returned by `inners()` is an rvalue. That make the expression `return range::at(geometry::interior_rings(geometry), ri);` returns a dangling reference (actually it does not compile).

**IMPORTANT:** This PR is a solution to this specific problem, but requires more thinking since it's probably a breaking change for models whose interior ring type is a Container...