### PR TITLE
Unit tests for set operations of pointlike/pointlike geometries

### DIFF
--- a/test/algorithms/set_operations/difference/difference_pl_pl.cpp
+++ b/test/algorithms/set_operations/difference/difference_pl_pl.cpp
@@ -1,6 +1,6 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014, Oracle and/or its affiliates.
+// Copyright (c) 2014-2015, Oracle and/or its affiliates.
 
 // Licensed under the Boost Software License version 1.0.
 // http://www.boost.org/users/license.html
@@ -20,7 +20,7 @@
 
 #include <boost/test/included/unit_test.hpp>
 
-#include "../test_set_ops_pl_pl.hpp"
+#include "../test_set_ops_pointlike.hpp"
 
 #include <boost/geometry/multi/geometries/multi_point.hpp>
 
@@ -51,17 +51,19 @@ BOOST_AUTO_TEST_CASE( test_difference_point_point )
         > tester;
 
     tester::apply
-        (from_wkt<P>("POINT(0 0)"),
+        ("ppdf01",
+         from_wkt<P>("POINT(0 0)"),
          from_wkt<P>("POINT(1 1)"),
          from_wkt<MP>("MULTIPOINT(0 0)"),
-         from_wkt<MP>("MULTIPOINT(1 1)"),
-         "ppdf01");
+         from_wkt<MP>("MULTIPOINT(1 1)")
+         );
 
     tester::apply
-        (from_wkt<P>("POINT(0 0)"),
+        ("ppdf02",
          from_wkt<P>("POINT(0 0)"),
-         from_wkt<MP>("MULTIPOINT()"),
-         "ppdf02");
+         from_wkt<P>("POINT(0 0)"),
+         from_wkt<MP>("MULTIPOINT()")
+         );
 }
 
 
@@ -82,58 +84,66 @@ BOOST_AUTO_TEST_CASE( test_difference_multipoint_point )
         > tester;
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0)"),
+        ("mppdf01",
+         from_wkt<MP>("MULTIPOINT(0 0)"),
          from_wkt<P>("POINT(1 1)"),
          from_wkt<MP>("MULTIPOINT(0 0)"),
-         from_wkt<MP>("MULTIPOINT(1 1)"),
-         "mppdf01");
+         from_wkt<MP>("MULTIPOINT(1 1)")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0)"),
+        ("mppdf02",
+         from_wkt<MP>("MULTIPOINT(0 0)"),
          from_wkt<P>("POINT(0 0)"),
-         from_wkt<MP>("MULTIPOINT()"),
-         "mppdf02");
+         from_wkt<MP>("MULTIPOINT()")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0,0 0)"),
+        ("mppdf03",
+         from_wkt<MP>("MULTIPOINT(0 0,0 0)"),
          from_wkt<P>("POINT(1 1)"),
          from_wkt<MP>("MULTIPOINT(0 0,0 0)"),
-         from_wkt<MP>("MULTIPOINT(1 1)"),
-         "mppdf03");
+         from_wkt<MP>("MULTIPOINT(1 1)")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0,0 0)"),
+        ("mppdf04",
+         from_wkt<MP>("MULTIPOINT(0 0,0 0)"),
          from_wkt<P>("POINT(0 0)"),
-         from_wkt<MP>("MULTIPOINT()"),
-         "mppdf04");
+         from_wkt<MP>("MULTIPOINT()")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0,0 0,1 0)"),
+        ("mppdf05",
+         from_wkt<MP>("MULTIPOINT(0 0,0 0,1 0)"),
          from_wkt<P>("POINT(1 1)"),
          from_wkt<MP>("MULTIPOINT(0 0,0 0,1 0)"),
-         from_wkt<MP>("MULTIPOINT(1 1)"),
-         "mppdf05");
+         from_wkt<MP>("MULTIPOINT(1 1)")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0,0 0,1 0)"),
+        ("mppdf06",
+         from_wkt<MP>("MULTIPOINT(0 0,0 0,1 0)"),
          from_wkt<P>("POINT(1 0)"),
          from_wkt<MP>("MULTIPOINT(0 0,0 0)"),
-         from_wkt<MP>("MULTIPOINT()"),
-         "mppdf06");
+         from_wkt<MP>("MULTIPOINT()")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0,0 0,1 0)"),
+        ("mppdf07",
+         from_wkt<MP>("MULTIPOINT(0 0,0 0,1 0)"),
          from_wkt<P>("POINT(0 0)"),
          from_wkt<MP>("MULTIPOINT(1 0)"),
-         from_wkt<MP>("MULTIPOINT()"),
-         "mppdf07");
+         from_wkt<MP>("MULTIPOINT()")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT()"),
+        ("mppdf08",
+         from_wkt<MP>("MULTIPOINT()"),
          from_wkt<P>("POINT(0 0)"),
          from_wkt<MP>("MULTIPOINT()"),
-         from_wkt<MP>("MULTIPOINT(0 0)"),
-         "mppdf08");
+         from_wkt<MP>("MULTIPOINT(0 0)")
+         );
 }
 
 
@@ -154,25 +164,28 @@ BOOST_AUTO_TEST_CASE( test_difference_point_multipoint )
         > tester;
 
     tester::apply
-        (from_wkt<P>("POINT(0 0)"),
+        ("pmpdf01",
+         from_wkt<P>("POINT(0 0)"),
          from_wkt<MP>("MULTIPOINT(1 0,1 1,1 1)"),
          from_wkt<MP>("MULTIPOINT(0 0)"),
-         from_wkt<MP>("MULTIPOINT(1 0,1 1,1 1)"),
-         "pmpdf01");
+         from_wkt<MP>("MULTIPOINT(1 0,1 1,1 1)")
+         );
 
     tester::apply
-        (from_wkt<P>("POINT(0 0)"),
+        ("pmpdf02",
+         from_wkt<P>("POINT(0 0)"),
          from_wkt<MP>("MULTIPOINT(1 0,0 0,1 1,0 0)"),
          from_wkt<MP>("MULTIPOINT()"),
-         from_wkt<MP>("MULTIPOINT(1 0,1 1)"),
-         "pmpdf02");
+         from_wkt<MP>("MULTIPOINT(1 0,1 1)")
+         );
 
     tester::apply
-        (from_wkt<P>("POINT(0 0)"),
+        ("pmpdf03",
+         from_wkt<P>("POINT(0 0)"),
          from_wkt<MP>("MULTIPOINT()"),
          from_wkt<MP>("MULTIPOINT(0 0)"),
-         from_wkt<MP>("MULTIPOINT()"),
-         "pmpdf03");
+         from_wkt<MP>("MULTIPOINT()")
+         );
 }
 
 
@@ -192,35 +205,40 @@ BOOST_AUTO_TEST_CASE( test_difference_multipoint_multipoint )
         > tester;
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT(2 2,3 3,0 0,0 0,2 2,1 1,1 1,1 0,1 0)"),
+        ("mpmpdf01",
+         from_wkt<MP>("MULTIPOINT(2 2,3 3,0 0,0 0,2 2,1 1,1 1,1 0,1 0)"),
          from_wkt<MP>("MULTIPOINT(1 0,1 1,1 1,4 4)"),
          from_wkt<MP>("MULTIPOINT(2 2,3 3,0 0,0 0,2 2)"),
-         from_wkt<MP>("MULTIPOINT(4 4)"),
-         "mpmpdf01");
+         from_wkt<MP>("MULTIPOINT(4 4)")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0,1 1,1 0,1 1)"),
+        ("mpmpdf02",
+         from_wkt<MP>("MULTIPOINT(0 0,1 1,1 0,1 1)"),
          from_wkt<MP>("MULTIPOINT(1 0,0 0,1 1,0 0)"),
-         from_wkt<MP>("MULTIPOINT()"),
-         "mpmpdf02");
+         from_wkt<MP>("MULTIPOINT()")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT()"),
-         from_wkt<MP>("MULTIPOINT(1 0,0 0,1 1,0 0)"),
+        ("mpmpdf03",
          from_wkt<MP>("MULTIPOINT()"),
          from_wkt<MP>("MULTIPOINT(1 0,0 0,1 1,0 0)"),
-         "mpmpdf03");
+         from_wkt<MP>("MULTIPOINT()"),
+         from_wkt<MP>("MULTIPOINT(1 0,0 0,1 1,0 0)")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0,1 1,1 0,1 1)"),
-         from_wkt<MP>("MULTIPOINT()"),
+        ("mpmpdf04",
          from_wkt<MP>("MULTIPOINT(0 0,1 1,1 0,1 1)"),
          from_wkt<MP>("MULTIPOINT()"),
-         "mpmpdf04");
+         from_wkt<MP>("MULTIPOINT(0 0,1 1,1 0,1 1)"),
+         from_wkt<MP>("MULTIPOINT()")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT()"),
+        ("mpmpdf05",
          from_wkt<MP>("MULTIPOINT()"),
          from_wkt<MP>("MULTIPOINT()"),
-         "mpmpdf05");
+         from_wkt<MP>("MULTIPOINT()")
+         );
 }

--- a/test/algorithms/set_operations/intersection/intersection_pl_pl.cpp
+++ b/test/algorithms/set_operations/intersection/intersection_pl_pl.cpp
@@ -1,6 +1,6 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014, Oracle and/or its affiliates.
+// Copyright (c) 2014-2015, Oracle and/or its affiliates.
 
 // Licensed under the Boost Software License version 1.0.
 // http://www.boost.org/users/license.html
@@ -20,7 +20,7 @@
 
 #include <boost/test/included/unit_test.hpp>
 
-#include "../test_set_ops_pl_pl.hpp"
+#include "../test_set_ops_pointlike.hpp"
 
 #include <boost/geometry/multi/geometries/multi_point.hpp>
 
@@ -51,16 +51,18 @@ BOOST_AUTO_TEST_CASE( test_intersection_point_point )
         > tester;
 
     tester::apply
-        (from_wkt<P>("POINT(0 0)"),
+        ("ppi01",
+         from_wkt<P>("POINT(0 0)"),
          from_wkt<P>("POINT(1 1)"),
-         from_wkt<MP>("MULTIPOINT()"),
-         "ppi01");
+         from_wkt<MP>("MULTIPOINT()")
+         );
 
     tester::apply
-        (from_wkt<P>("POINT(0 0)"),
+        ("ppi02",
          from_wkt<P>("POINT(0 0)"),
-         from_wkt<MP>("MULTIPOINT(0 0)"),
-         "ppi02");
+         from_wkt<P>("POINT(0 0)"),
+         from_wkt<MP>("MULTIPOINT(0 0)")
+         );
 }
 
 
@@ -81,52 +83,60 @@ BOOST_AUTO_TEST_CASE( test_intersection_multipoint_point )
         > tester;
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0)"),
-         from_wkt<P>("POINT(1 1)"),
-         from_wkt<MP>("MULTIPOINT()"),
-         "mppi01");
-
-    tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0)"),
-         from_wkt<P>("POINT(0 0)"),
+        ("mppi01",
          from_wkt<MP>("MULTIPOINT(0 0)"),
-         "mppi02");
-
-    tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0,0 0)"),
          from_wkt<P>("POINT(1 1)"),
-         from_wkt<MP>("MULTIPOINT()"),
-         "mppi03");
+         from_wkt<MP>("MULTIPOINT()")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0,0 0)"),
-         from_wkt<P>("POINT(0 0)"),
+        ("mppi02",
          from_wkt<MP>("MULTIPOINT(0 0)"),
-         "mppi04");
+         from_wkt<P>("POINT(0 0)"),
+         from_wkt<MP>("MULTIPOINT(0 0)")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0,0 0,1 0)"),
+        ("mppi03",
+         from_wkt<MP>("MULTIPOINT(0 0,0 0)"),
          from_wkt<P>("POINT(1 1)"),
-         from_wkt<MP>("MULTIPOINT()"),
-         "mppi05");
+         from_wkt<MP>("MULTIPOINT()")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0,0 0,1 0)"),
+        ("mppi04",
+         from_wkt<MP>("MULTIPOINT(0 0,0 0)"),
+         from_wkt<P>("POINT(0 0)"),
+         from_wkt<MP>("MULTIPOINT(0 0)")
+         );
+
+    tester::apply
+        ("mppi05",
+         from_wkt<MP>("MULTIPOINT(0 0,0 0,1 0)"),
+         from_wkt<P>("POINT(1 1)"),
+         from_wkt<MP>("MULTIPOINT()")
+         );
+
+    tester::apply
+        ("mppi06",
+         from_wkt<MP>("MULTIPOINT(0 0,0 0,1 0)"),
          from_wkt<P>("POINT(1 0)"),
-         from_wkt<MP>("MULTIPOINT(1 0)"),
-         "mppi06");
+         from_wkt<MP>("MULTIPOINT(1 0)")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0,0 0,1 0)"),
+        ("mppi07",
+         from_wkt<MP>("MULTIPOINT(0 0,0 0,1 0)"),
          from_wkt<P>("POINT(0 0)"),
-         from_wkt<MP>("MULTIPOINT(0 0)"),
-         "mppi07");
+         from_wkt<MP>("MULTIPOINT(0 0)")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT()"),
-         from_wkt<P>("POINT(0 0)"),
+        ("mppi08",
          from_wkt<MP>("MULTIPOINT()"),
-         "mppi08");
+         from_wkt<P>("POINT(0 0)"),
+         from_wkt<MP>("MULTIPOINT()")
+         );
 }
 
 
@@ -146,40 +156,46 @@ BOOST_AUTO_TEST_CASE( test_intersection_multipoint_multipoint )
         > tester;
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT(2 2,3 3,0 0,0 0,2 2,1 1,1 1,1 0,1 0)"),
+        ("mpmpi01",
+         from_wkt<MP>("MULTIPOINT(2 2,3 3,0 0,0 0,2 2,1 1,1 1,1 0,1 0)"),
          from_wkt<MP>("MULTIPOINT(1 0,1 1,1 1,1 1)"),
-         from_wkt<MP>("MULTIPOINT(1 0,1 1,1 1,1 1)"),
-         "mpmpi01");
+         from_wkt<MP>("MULTIPOINT(1 0,1 1,1 1,1 1)")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0,1 1,1 0,1 1)"),
-         from_wkt<MP>("MULTIPOINT(1 0,0 0,1 1,0 0)"),
+        ("mpmp02",
          from_wkt<MP>("MULTIPOINT(0 0,1 1,1 0,1 1)"),
          from_wkt<MP>("MULTIPOINT(1 0,0 0,1 1,0 0)"),
-         "mpmpi02");
+         from_wkt<MP>("MULTIPOINT(0 0,1 1,1 0,1 1)"),
+         from_wkt<MP>("MULTIPOINT(1 0,0 0,1 1,0 0)")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT()"),
+        ("mpmpi03",
+         from_wkt<MP>("MULTIPOINT()"),
          from_wkt<MP>("MULTIPOINT(1 0,0 0,1 1,0 0)"),
-         from_wkt<MP>("MULTIPOINT()"),
-         "mpmpi03");
+         from_wkt<MP>("MULTIPOINT()")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0,1 1,1 0,1 1)"),
+        ("mpmpi04",
+         from_wkt<MP>("MULTIPOINT(0 0,1 1,1 0,1 1)"),
          from_wkt<MP>("MULTIPOINT()"),
-         from_wkt<MP>("MULTIPOINT()"),
-         "mpmpi04");
+         from_wkt<MP>("MULTIPOINT()")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT()"),
+        ("mpmpi05",
          from_wkt<MP>("MULTIPOINT()"),
          from_wkt<MP>("MULTIPOINT()"),
-         "mpmpi05");
+         from_wkt<MP>("MULTIPOINT()")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0,1 0,2 0,3 0,0 0,1 0,2 0)"),
+        ("mpmpi06",
+         from_wkt<MP>("MULTIPOINT(0 0,1 0,2 0,3 0,0 0,1 0,2 0)"),
          from_wkt<MP>("MULTIPOINT(0 1,0 2,1 0,0 0,2 0)"),
-         from_wkt<MP>("MULTIPOINT(1 0,0 0,2 0)"),
-         "mpmpi06");
+         from_wkt<MP>("MULTIPOINT(1 0,0 0,2 0)")
+         );
 }
 

--- a/test/algorithms/set_operations/union/union_pl_pl.cpp
+++ b/test/algorithms/set_operations/union/union_pl_pl.cpp
@@ -1,6 +1,6 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014, Oracle and/or its affiliates.
+// Copyright (c) 2014-2015, Oracle and/or its affiliates.
 
 // Licensed under the Boost Software License version 1.0.
 // http://www.boost.org/users/license.html
@@ -20,7 +20,7 @@
 
 #include <boost/test/included/unit_test.hpp>
 
-#include "../test_set_ops_pl_pl.hpp"
+#include "../test_set_ops_pointlike.hpp"
 
 #include <boost/geometry/multi/geometries/multi_point.hpp>
 
@@ -51,16 +51,18 @@ BOOST_AUTO_TEST_CASE( test_union_point_point )
         > tester;
 
     tester::apply
-        (from_wkt<P>("POINT(0 0)"),
+        ("ppu01",
+         from_wkt<P>("POINT(0 0)"),
          from_wkt<P>("POINT(1 1)"),
-         from_wkt<MP>("MULTIPOINT(0 0,1 1)"),
-         "ppu01");
+         from_wkt<MP>("MULTIPOINT(0 0,1 1)")
+         );
 
     tester::apply
-        (from_wkt<P>("POINT(0 0)"),
+        ("ppu02",
          from_wkt<P>("POINT(0 0)"),
-         from_wkt<MP>("MULTIPOINT(0 0)"),
-         "ppu02");
+         from_wkt<P>("POINT(0 0)"),
+         from_wkt<MP>("MULTIPOINT(0 0)")
+         );
 }
 
 
@@ -81,52 +83,60 @@ BOOST_AUTO_TEST_CASE( test_union_multipoint_point )
         > tester;
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0)"),
-         from_wkt<P>("POINT(1 1)"),
-         from_wkt<MP>("MULTIPOINT(0 0,1 1)"),
-         "mppu01");
-
-    tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0)"),
-         from_wkt<P>("POINT(0 0)"),
+        ("mppu01",
          from_wkt<MP>("MULTIPOINT(0 0)"),
-         "mppu02");
-
-    tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0,0 0)"),
          from_wkt<P>("POINT(1 1)"),
-         from_wkt<MP>("MULTIPOINT(0 0,0 0,1 1)"),
-         "mppu03");
+         from_wkt<MP>("MULTIPOINT(0 0,1 1)")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0,0 0)"),
-         from_wkt<P>("POINT(0 0)"),
+        ("mppu02",
          from_wkt<MP>("MULTIPOINT(0 0)"),
-         "mppu04");
+         from_wkt<P>("POINT(0 0)"),
+         from_wkt<MP>("MULTIPOINT(0 0)")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0,0 0,1 0)"),
+        ("mppu03",
+         from_wkt<MP>("MULTIPOINT(0 0,0 0)"),
          from_wkt<P>("POINT(1 1)"),
-         from_wkt<MP>("MULTIPOINT(0 0,0 0,1 0,1 1)"),
-         "mppu05");
+         from_wkt<MP>("MULTIPOINT(0 0,0 0,1 1)")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0,0 0,1 0)"),
-         from_wkt<P>("POINT(1 0)"),
+        ("mppu04",
+         from_wkt<MP>("MULTIPOINT(0 0,0 0)"),
+         from_wkt<P>("POINT(0 0)"),
+         from_wkt<MP>("MULTIPOINT(0 0)")
+         );
+
+    tester::apply
+        ("mppu05",
          from_wkt<MP>("MULTIPOINT(0 0,0 0,1 0)"),
-         "mppu06");
+         from_wkt<P>("POINT(1 1)"),
+         from_wkt<MP>("MULTIPOINT(0 0,0 0,1 0,1 1)")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0,0 0,1 0)"),
-         from_wkt<P>("POINT(0 0)"),
-         from_wkt<MP>("MULTIPOINT(0 0,1 0)"),
-         "mppu07");
+        ("mppu06",
+         from_wkt<MP>("MULTIPOINT(0 0,0 0,1 0)"),
+         from_wkt<P>("POINT(1 0)"),
+         from_wkt<MP>("MULTIPOINT(0 0,0 0,1 0)")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT()"),
+        ("mppu07",
+         from_wkt<MP>("MULTIPOINT(0 0,0 0,1 0)"),
          from_wkt<P>("POINT(0 0)"),
-         from_wkt<MP>("MULTIPOINT(0 0)"),
-         "mppu08");
+         from_wkt<MP>("MULTIPOINT(0 0,1 0)")
+         );
+
+    tester::apply
+        ("mppu08",
+         from_wkt<MP>("MULTIPOINT()"),
+         from_wkt<P>("POINT(0 0)"),
+         from_wkt<MP>("MULTIPOINT(0 0)")
+         );
 }
 
 
@@ -146,42 +156,47 @@ BOOST_AUTO_TEST_CASE( test_union_multipoint_multipoint )
         > tester;
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT(2 2,3 3,0 0,0 0,2 2,1 1,1 1,1 0,1 0)"),
+        ("mpmpu01",
+         from_wkt<MP>("MULTIPOINT(2 2,3 3,0 0,0 0,2 2,1 1,1 1,1 0,1 0)"),
          from_wkt<MP>("MULTIPOINT(1 0,1 1,1 1,1 1)"),
          from_wkt<MP>("MULTIPOINT(2 2,3 3,0 0,0 0,2 2,1 1,1 1,1 0,1 0)"),
-         from_wkt<MP>("MULTIPOINT(1 0,1 1,1 1,1 1,2 2,3 3,0 0,0 0,2 2)"),
-         "mpmpu01");
+         from_wkt<MP>("MULTIPOINT(1 0,1 1,1 1,1 1,2 2,3 3,0 0,0 0,2 2)")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0,1 1,1 0,1 1)"),
-         from_wkt<MP>("MULTIPOINT(1 0,0 0,1 1,0 0)"),
+        ("mpmpu02",
          from_wkt<MP>("MULTIPOINT(0 0,1 1,1 0,1 1)"),
          from_wkt<MP>("MULTIPOINT(1 0,0 0,1 1,0 0)"),
-         "mpmpu02");
-
-    tester::apply
-        (from_wkt<MP>("MULTIPOINT()"),
-         from_wkt<MP>("MULTIPOINT(1 0,0 0,1 1,0 0)"),
-         from_wkt<MP>("MULTIPOINT(1 0,0 0,1 1,0 0)"),
-         "mpmpu03");
-
-    tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0,1 1,1 0,1 1)"),
-         from_wkt<MP>("MULTIPOINT()"),
          from_wkt<MP>("MULTIPOINT(0 0,1 1,1 0,1 1)"),
-         "mpmpu04");
+         from_wkt<MP>("MULTIPOINT(1 0,0 0,1 1,0 0)")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT()"),
+        ("mpmpu03",
          from_wkt<MP>("MULTIPOINT()"),
-         from_wkt<MP>("MULTIPOINT()"),
-         "mpmpu05");
+         from_wkt<MP>("MULTIPOINT(1 0,0 0,1 1,0 0)"),
+         from_wkt<MP>("MULTIPOINT(1 0,0 0,1 1,0 0)")
+         );
 
     tester::apply
-        (from_wkt<MP>("MULTIPOINT(0 0,1 0,2 0,3 0,0 0,1 0,2 0)"),
+        ("mpmpu04",
+         from_wkt<MP>("MULTIPOINT(0 0,1 1,1 0,1 1)"),
+         from_wkt<MP>("MULTIPOINT()"),
+         from_wkt<MP>("MULTIPOINT(0 0,1 1,1 0,1 1)")
+         );
+
+    tester::apply
+        ("mpmpu05",
+         from_wkt<MP>("MULTIPOINT()"),
+         from_wkt<MP>("MULTIPOINT()"),
+         from_wkt<MP>("MULTIPOINT()")
+         );
+
+    tester::apply
+        ("mpmpu06",
+         from_wkt<MP>("MULTIPOINT(0 0,1 0,2 0,3 0,0 0,1 0,2 0)"),
          from_wkt<MP>("MULTIPOINT(0 1,0 2,1 0,0 0,2 0)"),
          from_wkt<MP>("MULTIPOINT(0 0,1 0,2 0,3 0,0 0,1 0,2 0,0 1,0 2)"),
-         from_wkt<MP>("MULTIPOINT(0 1,0 2,1 0,0 0,2 0,3 0)"),
-         "mpmpu06");
+         from_wkt<MP>("MULTIPOINT(0 1,0 2,1 0,0 0,2 0,3 0)")
+         );
 }
-


### PR DESCRIPTION
In this PR:
* polish tests of set operations for pointlike/pointlike geometries (make the case ID the first argument of the tester)
* modify the common set operations test code so that it can be applied to set operations of pointlike/linear geometries as well