### PR TITLE
An attempt to fix sym_difference/get_turns failures on MinGW, QNX/QCC and PowerPC/GCC

### DIFF
--- a/include/boost/geometry/arithmetic/determinant.hpp
+++ b/include/boost/geometry/arithmetic/determinant.hpp
@@ -39,7 +39,13 @@ public :
     static inline ReturnType apply(U const& ux, U const& uy
                                  , V const& vx, V const& vy)
     {
-        return rt(ux) * rt(vy) - rt(uy) * rt(vx);
+        // NOTE: the explicit temporaries are here on purpose
+        // without them in some cases MinGW and probably QCC
+        // calculate different results than MSVC and GCC
+        ReturnType const t1 = rt(ux) * rt(vy);
+        ReturnType const t2 = rt(uy) * rt(vx);
+        return t1 - t2;
+        //return rt(ux) * rt(vy) - rt(uy) * rt(vx);
     }
 };
 

--- a/test/algorithms/overlay/get_turns_linear_linear.cpp
+++ b/test/algorithms/overlay/get_turns_linear_linear.cpp
@@ -290,6 +290,49 @@ void test_all()
                               expected("")(""));
     }
 
+    // 10.03.2015 results different for MinGW and MSVC/GCC
+    if ( BOOST_GEOMETRY_CONDITION((boost::is_same<T, double>::value)) )
+    {
+        test_geometry<ls, ls>("LINESTRING(0 0, 10 0, 20 1)",
+                              "LINESTRING(12 10, 13 0.3, 14 0.4, 15 0.5)",
+                              expected("mii++")("ccc==")("mux=="));
+        test_geometry<ls, ls>("LINESTRING(0 0, 10 0, 20 1)",
+                              "LINESTRING(15 0.5, 14 0.4, 13 0.3, 12 10)",
+                              expected("miu+=")("mui=+"));
+        test_geometry<ls, ls>("LINESTRING(20 1, 10 0, 0 0)",
+                              "LINESTRING(12 10, 13 0.3, 14 0.4, 15 0.5)",
+                              expected("mui=+")("mix+="));
+        test_geometry<ls, ls>("LINESTRING(20 1, 10 0, 0 0)",
+                              "LINESTRING(15 0.5, 14 0.4, 13 0.3, 12 10)",
+                              expected("muu==")("ccc==")("mii++"));
+
+        test_geometry<ls, ls>("LINESTRING(0 0, 10 0, 20 1)",
+                              "LINESTRING(13 0.3, 14 0.4, 15 0.5)",
+                              expected("mii++")("ccc==")("mux=="));
+        test_geometry<ls, ls>("LINESTRING(0 0, 10 0, 20 1)",
+                              "LINESTRING(15 0.5, 14 0.4, 13 0.3)",
+                              expected("mix+=")("mui=+"));
+        test_geometry<ls, ls>("LINESTRING(20 1, 10 0, 0 0)",
+                              "LINESTRING(13 0.3, 14 0.4, 15 0.5)",
+                              expected("mui=+")("mix+="));
+        test_geometry<ls, ls>("LINESTRING(20 1, 10 0, 0 0)",
+                              "LINESTRING(15 0.5, 14 0.4, 13 0.3)",
+                              expected("mux==")("ccc==")("mii++"));
+
+        test_geometry<ls, ls>("LINESTRING(0 0, 10 0, 20 1)",
+                              "LINESTRING(12 10, 13 0.3, 14 0.4)",
+                              expected("mii++")("mux=="));
+        test_geometry<ls, ls>("LINESTRING(0 0, 10 0, 20 1)",
+                              "LINESTRING(14 0.4, 13 0.3, 12 10)",
+                              expected("miu+=")("mui=+"));
+        test_geometry<ls, ls>("LINESTRING(20 1, 10 0, 0 0)",
+                              "LINESTRING(12 10, 13 0.3, 14 0.4)",
+                              expected("mui=+")("mix+="));
+        test_geometry<ls, ls>("LINESTRING(20 1, 10 0, 0 0)",
+                              "LINESTRING(14 0.4, 13 0.3, 12 10)",
+                              expected("muu==")("mii++"));
+    }
+
     // TODO:
     //test_geometry<ls, ls>("LINESTRING(0 0,2 0,1 0)", "LINESTRING(0 1,0 0,2 0)", "1FF00F102");
     //test_geometry<ls, ls>("LINESTRING(2 0,0 0,1 0)", "LINESTRING(0 1,0 0,2 0)", "1FF00F102");


### PR DESCRIPTION
This is an attempt to fix an issue observable on [MinGW on Win](http://www.boost.org/development/tests/develop/developer/output/MinGW-w64-4-6%20jc-bell-boost-bin-v2-libs-geometry-test-algorithms-set_operations-sym_difference-sym_difference_linear_linear-test-gcc-mingw-4-6-3-debug.html), probably [QCC on QNX](http://www.boost.org/development/tests/develop/developer/output/NA-QNX650-SP1-x86-boost-bin-v2-libs-geometry-test-algorithms-set_operations-sym_difference-sym_difference_linear_linear-test-qcc-4-4-2_x86-debug-debug-symbols-off.html) and maybe [GCC5.0 on PowerPC](http://www.boost.org/development/tests/develop/developer/output/trippels_powerpc64le_gcc-5-0_c++11-boost-bin-v2-libs-geometry-test-algorithms-set_operations-sym_difference-sym_difference_linear_linear-test-gcc-5-0-0-release-address-model-64-architecture-power-pch-off.html).

Consider a side calculation (`side_by_triangle`) for points `({13, 0.3}, {14, 0.4}, {20, 1})`. Internally calculated value of a determinant is `-2.2204460492503131e-016` on MSVC (there is no problem on the majority of tested compilers so I'm guessing that the value is similar for them). However for MinGW (I tested only this one from the "failing" ones mentioned above) the value is `-2.7755575615628914e-016`, but only if it's calculated as one expression (see the code). Maybe the rvalues are handled differently? Anyway if temporary values are explicitly defined and used the result is the same as the one calculated by the code compiled by MSVC (and probably the majority of compilers).

I'm not sure what's the cause, a bug, optimization or something else, I stopped digging at this stage. Maybe we should compare the assemblies and other compilers? Or maybe someone has an idea what's the cause? I also haven't checked the release build or various optimization parameters. So I don't find this workaround as a solid one. It's rather a test or a temporary workaround.

I think that such cases should be handled with more care. There is a class of issues related to the way how very small values of sides and cramer's rule are handled. If they were supported somehow more robustly by the intersection strategy then I'm guessing that this workaround wouldn't be needed and could be reverted.