### PR TITLE
Distance: re-factor, polish and add new test cases

### DIFF
--- a/test/algorithms/distance/distance_areal_areal.cpp
+++ b/test/algorithms/distance/distance_areal_areal.cpp
@@ -1,7 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 // Unit Test
 
-// Copyright (c) 2014, Oracle and/or its affiliates.
+// Copyright (c) 2014-2015, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
@@ -79,12 +79,12 @@ void test_distance_polygon_multipolygon(Strategy const& strategy)
     tester::apply("polygon((12 0,14 0,19 0,19.9 -1,12 0))",
                   "multipolygon(((-10 -10,10 -10,10 10,-10 10,-10 -10)),\
                    ((20 -1,21 2,30 -10,20 -1)))",
-                  0.1, 0.01, strategy, true);
+                  0.1, 0.01, strategy);
 
     tester::apply("polygon((19 0,19.9 -1,12 0,20.5 0.5,19 0))",
                   "multipolygon(((-10 -10,10 -10,10 10,-10 10,-10 -10)),\
                    ((20 -1,21 2,30 -10,20 -1)))",
-                  0, 0, strategy, true);
+                  0, 0, strategy);
 }
 
 //===========================================================================
@@ -155,12 +155,12 @@ void test_distance_multipolygon_ring(Strategy const& strategy)
     tester::apply("multipolygon(((-10 -10,10 -10,10 10,-10 10,-10 -10)),\
                    ((20 -1,21 2,30 -10,20 -1)))",
                   "polygon((12 0,14 0,19 0,19.9 -1,12 0))",
-                  0.1, 0.01, strategy, true);
+                  0.1, 0.01, strategy);
 
     tester::apply("multipolygon(((-10 -10,10 -10,10 10,-10 10,-10 -10)),\
                    ((20 -1,21 2,30 -10,20 -1)))",
                   "polygon((19 0,19.9 -1,12 0,20.5 0.5,19 0))",
-                  0, 0, strategy, true);
+                  0, 0, strategy);
 }
 
 //===========================================================================

--- a/test/algorithms/distance/distance_linear_areal.cpp
+++ b/test/algorithms/distance/distance_linear_areal.cpp
@@ -1,7 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 // Unit Test
 
-// Copyright (c) 2014, Oracle and/or its affiliates.
+// Copyright (c) 2014-2015, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
@@ -84,27 +84,27 @@ void test_distance_linestring_polygon(Strategy const& strategy)
 
     tester::apply("linestring(-1 20,1 20,1 30)",
                   "polygon((-10 -10,10 -10,10 10,-10 10,-10 -10))",
-                  10, 100, strategy, true);
+                  10, 100, strategy);
   
     tester::apply("linestring(-5 1,-2 1)",
                   "polygon((0 0,10 0,10 10,0 10,0 0))",
-                  2, 4, strategy, true);
+                  2, 4, strategy);
 
     tester::apply("linestring(-1 20,1 20,1 5)",
                   "polygon((-10 -10,10 -10,10 10,-10 10,-10 -10))",
-                  0, 0, strategy, true);
+                  0, 0, strategy);
 
     tester::apply("linestring(-1 20,1 20,1 -20)",
                   "polygon((-10 -10,10 -10,10 10,-10 10,-10 -10))",
-                  0, 0, strategy, true);
+                  0, 0, strategy);
 
     tester::apply("linestring(-2 1)",
                   "polygon((0 0,10 0,10 10,0 10,0 0))",
-                  2, 4, strategy, true);
+                  2, 4, strategy);
 
     tester::apply("linestring(-5 1,-2 1)",
                   "polygon((0 0))",
-                  sqrt(5.0), 5, strategy, true);
+                  sqrt(5.0), 5, strategy);
 }
 
 //===========================================================================
@@ -123,7 +123,7 @@ void test_distance_linestring_open_polygon(Strategy const& strategy)
 
     tester::apply("linestring(-5 1,-2 1)",
                   "polygon((0 0,10 0,10 10,0 10))",
-                  2, 4, strategy, true);
+                  2, 4, strategy);
 }
 
 //===========================================================================
@@ -142,23 +142,23 @@ void test_distance_multilinestring_polygon(Strategy const& strategy)
 
     tester::apply("multilinestring((-100 -100,-90 -90),(-1 20,1 20,1 30))",
                   "polygon((-10 -10,10 -10,10 10,-10 10,-10 -10))",
-                  10, 100, strategy, true);
+                  10, 100, strategy);
   
     tester::apply("multilinestring((-1 20,1 20,1 30),(-1 20,1 20,1 5))",
                   "polygon((-10 -10,10 -10,10 10,-10 10,-10 -10))",
-                  0, 0, strategy, true);
+                  0, 0, strategy);
 
     tester::apply("multilinestring((-1 20,1 20,1 30),(-1 20,1 20,1 -20))",
                   "polygon((-10 -10,10 -10,10 10,-10 10,-10 -10))",
-                  0, 0, strategy, true);
+                  0, 0, strategy);
 
     tester::apply("multilinestring((-100 -100,-90 -90),(1 20))",
                   "polygon((-10 -10,10 -10,10 10,-10 10,-10 -10))",
-                  10, 100, strategy, true);
+                  10, 100, strategy);
 
     tester::apply("multilinestring((-100 -100,-90 -90),(-1 20,1 20,1 30))",
                   "polygon((-110 -110))",
-                  sqrt(200.0), 200, strategy, true);
+                  sqrt(200.0), 200, strategy);
 }
 
 //===========================================================================
@@ -213,22 +213,22 @@ void test_distance_linestring_multipolygon(Strategy const& strategy)
     tester::apply("linestring(-1 20,1 20)",
                   "multipolygon(((-10 -10,10 -10,10 10,-10 10,-10 -10)),\
                    ((0 22,-1 30, 2 40,0 22)))",
-                  2, 4, strategy, true);
+                  2, 4, strategy);
     
     tester::apply("linestring(12 0,14 0)",
                   "multipolygon(((-10 -10,10 -10,10 10,-10 10,-10 -10)),\
                    ((20 -1,21 2,30 -10,20 -1)))",
-                  2, 4, strategy, true);
+                  2, 4, strategy);
 
     tester::apply("linestring(12 0,20.5 0.5)",
                   "multipolygon(((-10 -10,10 -10,10 10,-10 10,-10 -10)),\
                    ((20 -1,21 2,30 -10,20 -1)))",
-                  0, 0, strategy, true);
+                  0, 0, strategy);
 
     tester::apply("linestring(12 0,50 0)",
                   "multipolygon(((-10 -10,10 -10,10 10,-10 10,-10 -10)),\
                    ((20 -1,21 2,30 -10,20 -1)))",
-                  0, 0, strategy, true);
+                  0, 0, strategy);
 }
 
 //===========================================================================
@@ -247,11 +247,11 @@ void test_distance_linestring_open_multipolygon(Strategy const& strategy)
 
     tester::apply("linestring(-5 1,-2 1)",
                   "multipolygon(((0 0,10 0,10 10,0 10)))",
-                  2, 4, strategy, true);
+                  2, 4, strategy);
 
     tester::apply("linestring(-5 1,-3 1)",
                   "multipolygon(((20 20,21 20,21 21,20 21)),((0 0,10 0,10 10,0 10)))",
-                  3, 9, strategy, true);
+                  3, 9, strategy);
 }
 
 //===========================================================================
@@ -271,12 +271,12 @@ void test_distance_multilinestring_multipolygon(Strategy const& strategy)
     tester::apply("multilinestring((12 0,14 0),(19 0,19.9 -1))",
                   "multipolygon(((-10 -10,10 -10,10 10,-10 10,-10 -10)),\
                    ((20 -1,21 2,30 -10)))",
-                  0.1, 0.01, strategy, true);
+                  0.1, 0.01, strategy);
 
     tester::apply("multilinestring((19 0,19.9 -1),(12 0,20.5 0.5))",
                   "multipolygon(((-10 -10,10 -10,10 10,-10 10,-10 -10)),\
                    ((20 -1,21 2,30 -10,20 -1)))",
-                  0, 0, strategy, true);
+                  0, 0, strategy);
 }
 
 //===========================================================================
@@ -320,15 +320,15 @@ void test_distance_linestring_ring(Strategy const& strategy)
 
     tester::apply("linestring(-1 20,1 20,1 30)",
                   "polygon((-10 -10,10 -10,10 10,-10 10,-10 -10))",
-                  10, 100, strategy, true);
+                  10, 100, strategy);
   
     tester::apply("linestring(-1 20,1 20,1 5)",
                   "polygon((-10 -10,10 -10,10 10,-10 10,-10 -10))",
-                  0, 0, strategy, true);
+                  0, 0, strategy);
 
     tester::apply("linestring(-1 20,1 20,1 -20)",
                   "polygon((-10 -10,10 -10,10 10,-10 10,-10 -10))",
-                  0, 0, strategy, true);
+                  0, 0, strategy);
 }
 
 //===========================================================================
@@ -347,15 +347,15 @@ void test_distance_multilinestring_ring(Strategy const& strategy)
 
     tester::apply("multilinestring((-100 -100,-90 -90),(-1 20,1 20,1 30))",
                   "polygon((-10 -10,10 -10,10 10,-10 10,-10 -10))",
-                  10, 100, strategy, true);
+                  10, 100, strategy);
   
     tester::apply("multilinestring((-1 20,1 20,1 30),(-1 20,1 20,1 5))",
                   "polygon((-10 -10,10 -10,10 10,-10 10,-10 -10))",
-                  0, 0, strategy, true);
+                  0, 0, strategy);
 
     tester::apply("multilinestring((-1 20,1 20,1 30),(-1 20,1 20,1 -20))",
                   "polygon((-10 -10,10 -10,10 10,-10 10,-10 -10))",
-                  0, 0, strategy, true);
+                  0, 0, strategy);
 }
 
 //===========================================================================

--- a/test/algorithms/distance/distance_linear_linear.cpp
+++ b/test/algorithms/distance/distance_linear_linear.cpp
@@ -1,7 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 // Unit Test
 
-// Copyright (c) 2014, Oracle and/or its affiliates.
+// Copyright (c) 2014-2015, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
@@ -194,11 +194,11 @@ void test_distance_linestring_multilinestring(Strategy const& strategy)
 
     tester::apply("linestring(1 1,2 2,3 3)",
                   "multilinestring((2 1,1 2,4 0),(1 -10,2 1.9,2.1 -10,4 0))",
-                  0, 0, strategy, true);
+                  0, 0, strategy);
 
     tester::apply("linestring(1 1,2 2,3 3)",
                   "multilinestring((1 -10,2 0,2.1 -10,4 0),(1 -10,2 1.9,2.1 -10,4 0))",
-                  sqrt(0.005), 0.005, strategy, true);
+                  sqrt(0.005), 0.005, strategy);
 
     tester::apply("linestring(1 1,2 2)",
                   "multilinestring((2.5 0,4 0,5 0),(3 3,3 3))",

--- a/test/algorithms/distance/distance_pointlike_areal.cpp
+++ b/test/algorithms/distance/distance_pointlike_areal.cpp
@@ -1,7 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 // Unit Test
 
-// Copyright (c) 2014, Oracle and/or its affiliates.
+// Copyright (c) 2014-2015, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 

--- a/test/algorithms/distance/distance_pointlike_linear.cpp
+++ b/test/algorithms/distance/distance_pointlike_linear.cpp
@@ -1,7 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 // Unit Test
 
-// Copyright (c) 2014, Oracle and/or its affiliates.
+// Copyright (c) 2014-2015, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
@@ -49,6 +49,11 @@ void test_distance_point_segment(Strategy const& strategy)
     tester::apply("point(2 0)", "segment(2 0,3 0)", 0, 0, strategy);
     tester::apply("point(3 0)", "segment(2 0,3 0)", 0, 0, strategy);
     tester::apply("point(2.5 0)", "segment(2 0,3 0)", 0, 0, strategy);
+
+    // distance is a NaN
+    tester::apply("POINT(4.297374e+307 8.433875e+307)",
+                  "SEGMENT(26 87,13 95)",
+                  0, 0, strategy, false);
 }
 
 //===========================================================================
@@ -70,6 +75,11 @@ void test_distance_point_linestring(Strategy const& strategy)
 
     // linestring with a single point
     tester::apply("point(0 0)", "linestring(2 0)", 2, 4, strategy);
+
+    // distance is a NaN
+    tester::apply("POINT(4.297374e+307 8.433875e+307)",
+                  "LINESTRING(26 87,13 95)",
+                  0, 0, strategy, false);
 }
 
 //===========================================================================

--- a/test/algorithms/distance/distance_pointlike_pointlike.cpp
+++ b/test/algorithms/distance/distance_pointlike_pointlike.cpp
@@ -1,7 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 // Unit Test
 
-// Copyright (c) 2014, Oracle and/or its affiliates.
+// Copyright (c) 2014-2015, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
@@ -44,6 +44,11 @@ void test_distance_point_point(Strategy const& strategy)
     tester::apply("point(1 1)",
                   "point(1 1)",
                   0, 0, strategy);
+
+    // distance overflows
+    tester::apply("point(0 0)",
+                  "point(4.297374e+307 8.433875e+307)",
+                  0, 0, strategy, false);
 }
 
 //===========================================================================


### PR DESCRIPTION
In this PR:
* The common distance testing code has been re-factored and polished.
* It is now allowed to check test cases where the distance computed is not a finite floating-point number.
* Added a test case where the distance overflows.
* Added a test case where the distance computed is a `NaN`.