### PR TITLE
Fix: allow geometry test common to be included in all unit tests

### DIFF
--- a/test/geometry_test_common.hpp
+++ b/test/geometry_test_common.hpp
@@ -72,9 +72,11 @@
 #endif
 
 # include <boost/test/floating_point_comparison.hpp>
+#ifndef BOOST_TEST_MODULE
 # include <boost/test/included/test_exec_monitor.hpp>
 //#  include <boost/test/included/prg_exec_monitor.hpp>
 # include <boost/test/impl/execution_monitor.ipp>
+#endif
 
 #ifdef __clang__
 # pragma clang diagnostic pop


### PR DESCRIPTION
In this PR I guard the inclusion of Unit.Test related include by the macro `BOOST_TEST_MODULE`.
This macro is defined in many unit tests (distance, set-ops, validity, simplicity and possibly others), and is used for using Boost.Test is a different way than in traditionally written unit tests.

When `<geometry_test_common.hpp>` is included in those tests, the `test_main()` function is defined twice and gives a compilation error.

With the guarding proposed in this PR, `<geometry_test_common.hpp>` can be safely included in those unit tests as well, without any problems.