### PR TITLE
Fix: remove deprecated include paths - Part II

### DIFF
--- a/test/algorithms/set_operations/difference/difference_pl_pl.cpp
+++ b/test/algorithms/set_operations/difference/difference_pl_pl.cpp
@@ -1,6 +1,6 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014, Oracle and/or its affiliates.
+// Copyright (c) 2014-2015, Oracle and/or its affiliates.
 
 // Licensed under the Boost Software License version 1.0.
 // http://www.boost.org/users/license.html
@@ -22,7 +22,7 @@
 
 #include "../test_set_ops_pl_pl.hpp"
 
-#include <boost/geometry/multi/geometries/multi_point.hpp>
+#include <boost/geometry/geometries/multi_point.hpp>
 
 typedef bg::model::point<double,2,bg::cs::cartesian>  point_type;
 typedef bg::model::multi_point<point_type>  multi_point_type;

--- a/test/algorithms/set_operations/intersection/intersection_pl_pl.cpp
+++ b/test/algorithms/set_operations/intersection/intersection_pl_pl.cpp
@@ -1,6 +1,6 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014, Oracle and/or its affiliates.
+// Copyright (c) 2014-2015, Oracle and/or its affiliates.
 
 // Licensed under the Boost Software License version 1.0.
 // http://www.boost.org/users/license.html
@@ -22,7 +22,7 @@
 
 #include "../test_set_ops_pl_pl.hpp"
 
-#include <boost/geometry/multi/geometries/multi_point.hpp>
+#include <boost/geometry/geometries/multi_point.hpp>
 
 typedef bg::model::point<double,2,bg::cs::cartesian>  point_type;
 typedef bg::model::multi_point<point_type>  multi_point_type;

--- a/test/algorithms/set_operations/union/union_pl_pl.cpp
+++ b/test/algorithms/set_operations/union/union_pl_pl.cpp
@@ -1,6 +1,6 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014, Oracle and/or its affiliates.
+// Copyright (c) 2014-2015, Oracle and/or its affiliates.
 
 // Licensed under the Boost Software License version 1.0.
 // http://www.boost.org/users/license.html
@@ -22,7 +22,7 @@
 
 #include "../test_set_ops_pl_pl.hpp"
 
-#include <boost/geometry/multi/geometries/multi_point.hpp>
+#include <boost/geometry/geometries/multi_point.hpp>
 
 typedef bg::model::point<double,2,bg::cs::cartesian>  point_type;
 typedef bg::model::multi_point<point_type>  multi_point_type;


### PR DESCRIPTION
This is a follow up PR of #264, that fixes the include paths of files modified in PR #256.
It has been created separately so as to avoid any potential merge conflicts.

This PR must be merged after PR #256 and PR #264 are merged.

I have already tested that merging PR #256, PR #264 and this PR in that order does not produce any conflicts.

