### PR TITLE
[strategies][cart_intersect] Compare ratios denominators consistently.

### DIFF
--- a/include/boost/geometry/strategies/cartesian/cart_intersect.hpp
+++ b/include/boost/geometry/strategies/cartesian/cart_intersect.hpp
@@ -200,7 +200,8 @@ struct relate_cartesian_segments
                 get<1>(robust_b1) - get<1>(robust_a1),
                 robust_db0, robust_db);
 
-            if (robust_da0 == 0)
+            robust_coordinate_type const zero = 0;
+            if (math::equals(robust_da0, zero) || math::equals(robust_db0, zero))
             {
                 // If this is the case, no rescaling is done for FP precision.
                 // We set it to collinear, but it indicates a robustness issue.


### PR DESCRIPTION
Compare both ratios' potential denominators, corresponding to both
segments. Furthermore, take into account the machine epsilon.

Without this change an assertion `ratio.denominator() != 0` can fail in intersection_points.hpp line 62, in segments_intersection_points policy. And indeed it fails e.g. in get_turns_linear_linear.cpp unit test if compiled in MinGW with -O2.

Furthermore, if compiled with -O2, the tests which "normally" was passing fails. Some of those cases are fixed if the denominators are compared WRT machine epsilon.

However not all of them. AFAIU the reason is different and related to the way how the determinant is calculated. See this PR: https://github.com/boostorg/geometry/pull/259 and this ticket: https://svn.boost.org/trac/boost/ticket/8379.