### PR TITLE
Fix for Boost Trac tickets #10658, #10835 and #11121

### DIFF
--- a/doc/release_notes.qbk
+++ b/doc/release_notes.qbk
@@ -45,6 +45,7 @@
 * [@https://svn.boost.org/trac/boost/ticket/10666 10666] MSVC compiler warning C4127: conditional expression is constant
 * [@https://svn.boost.org/trac/boost/ticket/10747 10747] Error in rescaling causing errors in areal/areal set operations
 * [@https://svn.boost.org/trac/boost/ticket/10770 10770] Buffer fails for large distances, or rough round joins, where concavities where not intersected properly
+* [@https://svn.boost.org/trac/boost/ticket/10658 10658] sym_difference yields bad result for int polygons
 * [@https://svn.boost.org/trac/boost/ticket/10835 10835] Difference of multilinestring and polygon yields wrong result
 * [@https://svn.boost.org/trac/boost/ticket/10861 10861] Rtree failing to compile for Value being a pair or a tuple containing pointer to Geometry and the default equal_to<> used
 * [@https://svn.boost.org/trac/boost/ticket/10863 10863] Template parameter name coliding with B0 macro name defined in termios.h (duplicate of 10467)
@@ -59,6 +60,7 @@
 * [@https://svn.boost.org/trac/boost/ticket/10960 10960] Invalid result of get_turns() for L/A, missing turn.
 * [@https://svn.boost.org/trac/boost/ticket/10961 10961] Invalid result of get_turns() for L/A, invalid turn for a Linear spike.
 * [@https://svn.boost.org/trac/boost/ticket/11112 11112] Compilation failure on Solaris due to a CS name clash (used for a macro on this platform)
+* [@https://svn.boost.org/trac/boost/ticket/11121 11121] Invalid result of difference() for integral coordinates
 
 [*Bugfixes]
 

--- a/doc/release_notes.qbk
+++ b/doc/release_notes.qbk
@@ -45,6 +45,7 @@
 * [@https://svn.boost.org/trac/boost/ticket/10666 10666] MSVC compiler warning C4127: conditional expression is constant
 * [@https://svn.boost.org/trac/boost/ticket/10747 10747] Error in rescaling causing errors in areal/areal set operations
 * [@https://svn.boost.org/trac/boost/ticket/10770 10770] Buffer fails for large distances, or rough round joins, where concavities where not intersected properly
+* [@https://svn.boost.org/trac/boost/ticket/10835 10835] Difference of multilinestring and polygon yields wrong result
 * [@https://svn.boost.org/trac/boost/ticket/10861 10861] Rtree failing to compile for Value being a pair or a tuple containing pointer to Geometry and the default equal_to<> used
 * [@https://svn.boost.org/trac/boost/ticket/10863 10863] Template parameter name coliding with B0 macro name defined in termios.h (duplicate of 10467)
 * [@https://svn.boost.org/trac/boost/ticket/10887 10887] Invalid result of within() and relate() for Linear/MultiPolygon

--- a/include/boost/geometry/policies/relate/intersection_points.hpp
+++ b/include/boost/geometry/policies/relate/intersection_points.hpp
@@ -71,10 +71,14 @@ struct segments_intersection_points
         promoted_type dx_promoted = boost::numeric_cast<promoted_type>(dx);
         promoted_type dy_promoted = boost::numeric_cast<promoted_type>(dy);
 
-        set<0>(point, boost::numeric_cast<coordinate_type>(
-                get<0, 0>(segment) + numerator * dx_promoted / denominator));
-        set<1>(point, boost::numeric_cast<coordinate_type>(
-                get<0, 1>(segment) + numerator * dy_promoted / denominator));
+        set<0>(point, get<0, 0>(segment) + boost::numeric_cast
+            <
+                coordinate_type
+            >(numerator * dx_promoted / denominator));
+        set<1>(point, get<0, 1>(segment) + boost::numeric_cast
+            <
+                coordinate_type
+            >(numerator * dy_promoted / denominator));
     }
 
 

--- a/include/boost/geometry/policies/relate/intersection_points.hpp
+++ b/include/boost/geometry/policies/relate/intersection_points.hpp
@@ -19,6 +19,7 @@
 #include <boost/geometry/algorithms/detail/assign_indexed_point.hpp>
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/strategies/side_info.hpp>
+#include <boost/geometry/util/promote_integral.hpp>
 #include <boost/geometry/util/select_calculation_type.hpp>
 #include <boost/geometry/util/select_most_precise.hpp>
 #include <boost/geometry/util/math.hpp>
@@ -60,12 +61,20 @@ struct segments_intersection_points
         // denominator. In case of integer this results in an integer
         // division.
         BOOST_ASSERT(ratio.denominator() != 0);
+
+        typedef typename promote_integral<coordinate_type>::type promoted_type;
+
+        promoted_type numerator
+            = boost::numeric_cast<promoted_type>(ratio.numerator());
+        promoted_type denominator
+            = boost::numeric_cast<promoted_type>(ratio.denominator());
+        promoted_type dx_promoted = boost::numeric_cast<promoted_type>(dx);
+        promoted_type dy_promoted = boost::numeric_cast<promoted_type>(dy);
+
         set<0>(point, boost::numeric_cast<coordinate_type>(
-                get<0, 0>(segment)
-                    + ratio.numerator() * dx / ratio.denominator()));
+                get<0, 0>(segment) + numerator * dx_promoted / denominator));
         set<1>(point, boost::numeric_cast<coordinate_type>(
-                get<0, 1>(segment)
-                    + ratio.numerator() * dy / ratio.denominator()));
+                get<0, 1>(segment) + numerator * dy_promoted / denominator));
     }
 
 

--- a/include/boost/geometry/util/promote_integral.hpp
+++ b/include/boost/geometry/util/promote_integral.hpp
@@ -1,0 +1,156 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2015, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+#ifndef BOOST_GEOMETRY_UTIL_PROMOTE_INTEGRAL_HPP
+#define BOOST_GEOMETRY_UTIL_PROMOTE_INTEGRAL_HPP
+
+// For now deactivate the use of multiprecision integers
+// TODO: activate it later
+#define BOOST_GEOMETRY_NO_MULTIPRECISION_INTEGER
+
+#include <climits>
+
+#include <boost/mpl/empty.hpp>
+#include <boost/mpl/front.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/mpl/list.hpp>
+#include <boost/mpl/pop_front.hpp>
+
+#if !defined(BOOST_GEOMETRY_NO_MULTIPRECISION_INTEGER)
+#include <boost/multiprecision/cpp_int.hpp>
+#endif
+
+#include <boost/type_traits/is_integral.hpp>
+
+
+namespace boost { namespace geometry
+{
+
+#ifndef DOXYGEN_NO_DETAIL
+namespace detail { namespace promote_integral
+{
+
+template
+<
+    typename T,
+    typename List,
+    bool IsEmpty = boost::mpl::empty<List>::type::value
+>
+struct promote_to_larger
+{
+    typedef typename boost::mpl::if_c
+        <
+            (sizeof(typename boost::mpl::front<List>::type) >= 2 * sizeof(T)),
+            typename boost::mpl::front<List>::type,
+            typename promote_to_larger
+                <
+                    T, typename boost::mpl::pop_front<List>::type
+                >::type
+        >::type type;
+};
+
+// The following specialization is required to finish the loop over
+// all list elements: the empty MPL list does not support
+// boost::mpl::front and boost::mpl::pop_front, and thus without this
+// specialization we get a compilation error
+template <typename T, typename TypeList>
+struct promote_to_larger<T, TypeList, true>
+{
+    // if promotion fails, keep the number T
+    // (and cross fingers that overflow will not occur)
+    typedef T type;
+};
+
+}} // namespace detail::promote_integral
+#endif // DOXYGEN_NO_DETAIL
+
+
+
+/*!
+    \brief Meta-function to define an integral type with size
+    than is at least twice the size of T
+    \ingroup utility
+    \details
+    This meta-function tries to promote the fundamental integral type
+    T to a another integral type with size at least twice the size of T.
+
+    To do this, two times the size of T is tested against the sizes of:
+         short, int, long, boost::long_long_type, boost::int128_t
+    and the one that matches is chosen.
+
+    If the macro BOOST_GEOMETRY_NO_MULTIPRECISION_INTEGER is not
+    defined, boost's multiprecision integer cpp_int<> is used as a
+    last resort.
+
+    If BOOST_GEOMETRY_NO_MULTIPRECISION_INTEGER is defined and an
+    appropriate type cannot be detected, the input type is returned as is.
+
+    Finally, if the passed type is either a floating-point type or a
+    user-defined type it is returned as is.
+
+    \note boost::long_long_type is considered only if the macro
+    BOOST_HAS_LONG_LONG is defined
+
+    \note boost::int128_type is considered only if the macro
+    BOOST_HAS_INT128 is defined
+*/
+template <typename T, bool UseCheckedMultiprecisionInteger = false>
+class promote_integral
+{
+private:
+#if !defined(BOOST_GEOMETRY_NO_MULTIPRECISION_INTEGER)
+    typedef typename boost::mpl::if_c
+        <
+            UseCheckedMultiprecisionInteger,
+            boost::multiprecision::checked,
+            boost::multiprecision::unchecked
+        >::type checking_policy_type;
+
+    typedef boost::multiprecision::number
+        <
+            boost::multiprecision::cpp_int_backend
+                <
+                    2 * CHAR_BIT * sizeof(T),
+                    2 * CHAR_BIT * sizeof(T),
+                    boost::multiprecision::signed_magnitude,
+                    checking_policy_type,
+                    void
+                >
+        > multiprecision_integer_type;
+#endif
+
+    typedef boost::mpl::list
+        <
+            short, int, long
+#if defined(BOOST_HAS_LONG_LONG)
+            , boost::long_long_type
+#endif
+#if defined(BOOST_HAS_INT128)
+            , boost::int128_type
+#endif
+#if !defined(BOOST_GEOMETRY_NO_MULTIPRECISION_INTEGER)
+            , multiprecision_integer_type
+#endif
+        > integral_types;
+
+public:
+    typedef typename boost::mpl::if_c
+        <
+            boost::is_integral<T>::type::value,
+            typename detail::promote_integral::promote_to_larger
+                <
+                    T, integral_types
+                >::type,
+            T
+        >::type type;
+};
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_UTIL_PROMOTE_INTEGRAL_HPP

--- a/include/boost/geometry/util/promote_integral.hpp
+++ b/include/boost/geometry/util/promote_integral.hpp
@@ -26,6 +26,7 @@
 #include <boost/multiprecision/cpp_int.hpp>
 #endif
 
+#include <boost/type_traits/integral_constant.hpp>
 #include <boost/type_traits/is_integral.hpp>
 
 
@@ -108,8 +109,16 @@ private:
     typedef typename boost::mpl::if_c
         <
             UseCheckedMultiprecisionInteger,
-            boost::multiprecision::checked,
-            boost::multiprecision::unchecked
+            boost::integral_constant
+                <
+                    boost::multiprecision::cpp_int_check_type,
+                    boost::multiprecision::checked
+                >,
+            boost::integral_constant
+                <
+                    boost::multiprecision::cpp_int_check_type,
+                    boost::multiprecision::unchecked
+                >
         >::type checking_policy_type;
 
     typedef boost::multiprecision::number
@@ -119,7 +128,7 @@ private:
                     2 * CHAR_BIT * sizeof(T),
                     2 * CHAR_BIT * sizeof(T),
                     boost::multiprecision::signed_magnitude,
-                    checking_policy_type,
+                    checking_policy_type::value,
                     void
                 >
         > multiprecision_integer_type;

--- a/include/boost/geometry/util/promote_integral.hpp
+++ b/include/boost/geometry/util/promote_integral.hpp
@@ -235,6 +235,12 @@ private:
     typedef boost::mpl::list
         <
             unsigned short, unsigned int, unsigned long, std::size_t
+#if defined(BOOST_HAS_LONG_LONG)
+            , boost::ulong_long_type
+#endif
+#if defined(BOOST_HAS_INT128)
+            , boost::uint128_type
+#endif
 #if !defined(BOOST_GEOMETRY_NO_MULTIPRECISION_INTEGER)
             , typename multiprecision_unsigned_integer_type
                 <

--- a/include/boost/geometry/util/promote_integral.hpp
+++ b/include/boost/geometry/util/promote_integral.hpp
@@ -23,6 +23,7 @@
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/list.hpp>
 #include <boost/mpl/next.hpp>
+#include <boost/mpl/size_t.hpp>
 
 #if !defined(BOOST_GEOMETRY_NO_MULTIPRECISION_INTEGER)
 #include <boost/multiprecision/cpp_int.hpp>
@@ -206,11 +207,8 @@ private:
     typedef typename boost::mpl::if_c
         <
             (PromoteUnsignedToUnsigned && is_unsigned),
-            boost::integral_constant<std::size_t, (2 * sizeof(T))>,
-            boost::integral_constant
-                <
-                    std::size_t, (2 * sizeof(T) + (is_unsigned ? 1 : -1))
-                >
+            boost::mpl::size_t<(2 * sizeof(T))>,
+            boost::mpl::size_t<(2 * sizeof(T) + (is_unsigned ? 1 : -1))>
         >::type min_size_type;
 
     // Define the list of signed integral types we are goind to use

--- a/test/algorithms/overlay/overlay_cases.hpp
+++ b/test/algorithms/overlay/overlay_cases.hpp
@@ -1,7 +1,13 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 // Unit Test
 //
-// Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
+
+// This file was modified by Oracle on 2015.
+// Modifications copyright (c) 2015, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -833,7 +839,29 @@ static std::string ticket_10747_e[2] =
         "POLYGON((0.00000025165824 0.00000025165824,0.00000041943040 0.00000025165824,0.00000041943040 0.00000041943040,0.00000025165824 0.00000041943040,0.00000025165824 0.00000025165824))"
     };
 
+static std::string ticket_10658[2] =
+    {
+        "POLYGON((516 1608,1308 1932,2094 2466,2094 32767,516 32767,516 1608))",
+        "POLYGON((516 2484,1308 3066,2094 3150,2094 32767,516 32767,516 2484))"
+    };
 
+static std::string ticket_10835[3] =
+    {
+        "MULTILINESTRING((5239 2113,1020 2986))",
+        "POLYGON((5233 2113,5200 2205,1020 2205,1020 2022,5200 2022))",
+        "POLYGON((5233 2986,5200 3078,1020 3078,1020 2895,5200 2895))"
+    };
 
+static std::string ticket_10868[2] =
+    {
+        "POLYGON((42817136 -3774506,43029074 -3929862,31446819 18947953,30772384 19615678,30101303 19612322,30114725 16928001,33520458 6878575,35332375 2413654,35725796 2024148))",
+        "POLYGON((-33386239 -33721784,33721785 -33386239,33386240 33721785,-33721784 33386240))"
+    };
+
+static std::string ticket_11121[2] =
+    {
+        "POLYGON((-8042 -1485,-8042 250,-8042 250,15943 254,15943 -1485,-8042 -1485))",
+        "POLYGON((-7901 -1485,-7901 529,-7901 529,15802 544,15802 -1485,-7901 -1485))"
+    };
 
 #endif // BOOST_GEOMETRY_TEST_OVERLAY_CASES_HPP

--- a/test/algorithms/set_operations/difference/difference.cpp
+++ b/test/algorithms/set_operations/difference/difference.cpp
@@ -604,8 +604,8 @@ int test_main(int, char* [])
     test_specific<bg::model::d2::point_xy<int>, false, false>();
 
     test_ticket_10835<int>
-        ("MULTILINESTRING((5239 2113,5233 2114),(4794 2205,1020 2986))",
-         "MULTILINESTRING((5239 2113,5233 2114),(4794 2205,1460 2895))");
+        ("MULTILINESTRING((5239 2113,5233 2114),(4795 2205,1020 2986))",
+         "MULTILINESTRING((5239 2113,5233 2114),(4795 2205,1460 2895))");
 
     test_ticket_10835<double>
         ("MULTILINESTRING((5239 2113,5232.52 2114.34),(4794.39 2205,1020 2986))",

--- a/test/algorithms/set_operations/difference/difference.cpp
+++ b/test/algorithms/set_operations/difference/difference.cpp
@@ -1,7 +1,12 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 // Unit Test
 
-// Copyright (c) 2010-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2010-2015 Barend Gehrels, Amsterdam, the Netherlands.
+
+// This file was modified by Oracle on 2015.
+// Modifications copyright (c) 2015, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -17,6 +22,7 @@
 // #define BOOST_GEOMETRY_NO_ROBUSTNESS
 
 #include <boost/geometry/algorithms/correct.hpp>
+#include <boost/geometry/algorithms/is_valid.hpp>
 #include <boost/geometry/algorithms/perimeter.hpp>
 
 #include <boost/geometry/multi/algorithms/correct.hpp>
@@ -88,9 +94,32 @@ void test_areal_linear()
 }
 
 template <typename CoordinateType>
+void test_ticket_10658(std::string const& wkt_out)
+{
+    typedef bg::model::point<CoordinateType, 2, bg::cs::cartesian> point_type;
+    typedef bg::model::polygon
+        <
+            point_type, /*ClockWise*/false, /*Closed*/false
+        > polygon_type;
+    typedef bg::model::multi_polygon<polygon_type> multipolygon_type;
+
+    polygon_type polygon1;
+    bg::read_wkt(ticket_10658[0], polygon1);
+    polygon_type polygon2;
+    bg::read_wkt(ticket_10658[1], polygon2);
+
+    multipolygon_type multipolygon_out;
+    bg::sym_difference(polygon1, polygon2, multipolygon_out);
+    std::stringstream stream;
+    stream << bg::wkt(multipolygon_out);
+
+    BOOST_CHECK_EQUAL(stream.str(), wkt_out);
+}
+
+template <typename CoordinateType>
 void test_ticket_10835(std::string const& wkt_out1, std::string const& wkt_out2)
 {
-    typedef bg::model::point<CoordinateType,2,bg::cs::cartesian> point_type;
+    typedef bg::model::point<CoordinateType, 2, bg::cs::cartesian> point_type;
     typedef bg::model::linestring<point_type> linestring_type;
     typedef bg::model::multi_linestring<linestring_type> multilinestring_type;
     typedef bg::model::polygon
@@ -99,13 +128,11 @@ void test_ticket_10835(std::string const& wkt_out1, std::string const& wkt_out2)
         > polygon_type;
 
     multilinestring_type multilinestring;
-    bg::read_wkt("MULTILINESTRING((5239 2113,1020 2986))", multilinestring);
+    bg::read_wkt(ticket_10835[0], multilinestring);
     polygon_type polygon1;
-    bg::read_wkt("POLYGON((5233 2113,5200 2205,1020 2205,1020 2022,5200 2022))",
-                 polygon1);
+    bg::read_wkt(ticket_10835[1], polygon1);
     polygon_type polygon2;
-    bg::read_wkt("POLYGON((5233 2986,5200 3078,1020 3078,1020 2895,5200 2895))",
-                 polygon2);
+    bg::read_wkt(ticket_10835[2], polygon2);
 
     multilinestring_type multilinestringOut1;
     bg::difference(multilinestring, polygon1, multilinestringOut1);
@@ -121,6 +148,31 @@ void test_ticket_10835(std::string const& wkt_out1, std::string const& wkt_out2)
     stream << bg::wkt(multilinestringOut2);
 
     BOOST_CHECK_EQUAL(stream.str(), wkt_out2);
+}
+
+template <typename CoordinateType>
+void test_ticket_11121()
+{
+    typedef bg::model::point<CoordinateType,2,bg::cs::cartesian> point_type;
+    typedef bg::model::polygon
+        <
+            point_type, /*ClockWise*/false, /*Closed*/false
+        > polygon_type;
+    typedef bg::model::multi_polygon<polygon_type> multipolygon_type;
+
+    polygon_type polygon1;
+    bg::read_wkt(ticket_11121[0], polygon1);
+    polygon_type polygon2;
+    bg::read_wkt(ticket_11121[1], polygon2);
+
+    multipolygon_type diff12, diff21, sym_diff;
+    bg::difference(polygon1, polygon2, diff12);
+    bg::difference(polygon2, polygon1, diff21);
+    bg::sym_difference(polygon1, polygon2, sym_diff);
+
+    BOOST_CHECK(bg::is_valid(diff12));
+    BOOST_CHECK(bg::is_valid(diff21));
+    BOOST_CHECK(bg::is_valid(sym_diff));
 }
 
 template <typename P>
@@ -591,6 +643,16 @@ void test_specific()
         ggl_list_20120717_volker[0], ggl_list_20120717_volker[1],
         1, 11, 3371540,
         1, 4, 384, 0.001);
+
+    test_one<polygon, polygon, polygon>("ticket_10658",
+        ticket_10658[0], ticket_10658[1],
+        1, 6, 1510434,
+        0, 0, 0);
+
+    test_one<polygon, polygon, polygon>("ticket_11121",
+        ticket_11121[0], ticket_11121[1],
+        2, 8, 489763.5,
+        1, 4, 6743503.5);
 }
 
 
@@ -603,6 +665,12 @@ int test_main(int, char* [])
 
     test_specific<bg::model::d2::point_xy<int>, false, false>();
 
+    test_ticket_10658<int>
+        ("MULTIPOLYGON(((516 2484,516 1608,1308 1932,2094 2466,2094 3150,1308 3066,516 2484)))");
+
+    test_ticket_10658<double>
+        ("MULTIPOLYGON(((516 2484,516 1608,1308 1932,2094 2466,2094 3150,1308 3066,516 2484)))");
+
     test_ticket_10835<int>
         ("MULTILINESTRING((5239 2113,5233 2114),(4795 2205,1020 2986))",
          "MULTILINESTRING((5239 2113,5233 2114),(4795 2205,1460 2895))");
@@ -610,6 +678,8 @@ int test_main(int, char* [])
     test_ticket_10835<double>
         ("MULTILINESTRING((5239 2113,5232.52 2114.34),(4794.39 2205,1020 2986))",
          "MULTILINESTRING((5239 2113,5232.52 2114.34),(4794.39 2205,1459.78 2895))");
+
+    test_ticket_11121<int>();
 
 #if ! defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE)
     test_all<bg::model::d2::point_xy<float> >();

--- a/test/algorithms/set_operations/difference/difference.cpp
+++ b/test/algorithms/set_operations/difference/difference.cpp
@@ -590,7 +590,7 @@ void test_specific()
     test_one<polygon, polygon, polygon>("ggl_list_20120717_volker",
         ggl_list_20120717_volker[0], ggl_list_20120717_volker[1],
         1, 11, 3371540,
-        0, 0, 0, 0.001); // output is discarded
+        1, 4, 384, 0.001);
 }
 
 

--- a/test/algorithms/set_operations/intersection/intersection.cpp
+++ b/test/algorithms/set_operations/intersection/intersection.cpp
@@ -17,6 +17,7 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+#include <climits>
 #include <iostream>
 #include <string>
 
@@ -29,6 +30,7 @@
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/register/linestring.hpp>
 
+#include <boost/geometry/util/condition.hpp>
 #include <boost/geometry/util/rational.hpp>
 
 #include "test_intersection.hpp"
@@ -677,6 +679,14 @@ int test_main(int, char* [])
     test_ticket_10868<int64_t>("MULTIPOLYGON(((33520458 6878575,33480192 14931538,31446819 18947953,30772384 19615678,30101303 19612322,30114725 16928001,33520458 6878575)))");
 #endif
 
+    if (BOOST_GEOMETRY_CONDITION(sizeof(long) * CHAR_BIT >= 64))
+    {
+        test_ticket_10868<long>("MULTIPOLYGON(((33520458 6878575,33480192 14931538,31446819 18947953,30772384 19615678,30101303 19612322,30114725 16928001,33520458 6878575)))");
+    }
+
+#if defined(BOOST_HAS_LONG_LONG)
+    test_ticket_10868<boost::long_long_type>("MULTIPOLYGON(((33520458 6878575,33480192 14931538,31446819 18947953,30772384 19615678,30101303 19612322,30114725 16928001,33520458 6878575)))");
+#endif
+
     return 0;
 }
-

--- a/test/algorithms/set_operations/intersection/intersection.cpp
+++ b/test/algorithms/set_operations/intersection/intersection.cpp
@@ -1,9 +1,14 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 // Unit Test
 
-// Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
-// Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
-// Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
+// Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
+// Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
+
+// This file was modified by Oracle on 2015.
+// Modifications copyright (c) 2015, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
@@ -34,6 +39,7 @@
 #include <test_common/test_point.hpp>
 #include <test_common/with_pointer.hpp>
 #include <test_geometries/custom_segment.hpp>
+
 
 BOOST_GEOMETRY_REGISTER_LINESTRING_TEMPLATED(std::vector)
 
@@ -613,6 +619,32 @@ void test_boxes_nd()
     test_boxes_per_d(p3(0,0,0), p3(5,5,5), p3(3,3,3), p3(6,6,6), true);
 }
 
+template <typename CoordinateType>
+void test_ticket_10868(std::string const& wkt_out)
+{
+    typedef bg::model::point<CoordinateType, 2, bg::cs::cartesian> point_type;
+    typedef bg::model::polygon
+        <
+            point_type, /*ClockWise*/false, /*Closed*/false
+        > polygon_type;
+    typedef bg::model::multi_polygon<polygon_type> multipolygon_type;
+
+    polygon_type polygon1;
+    bg::read_wkt(ticket_10868[0], polygon1);
+    polygon_type polygon2;
+    bg::read_wkt(ticket_10868[1], polygon2);
+
+    multipolygon_type multipolygon_out;
+    bg::intersection(polygon1, polygon2, multipolygon_out);
+    std::stringstream stream;
+    stream << bg::wkt(multipolygon_out);
+
+    BOOST_CHECK_EQUAL(stream.str(), wkt_out);
+
+    test_one<polygon_type, polygon_type, polygon_type>("ticket_10868",
+        ticket_10868[0], ticket_10868[1],
+        1, 7, 20266195244586);
+}
 
 int test_main(int, char* [])
 {
@@ -635,6 +667,15 @@ int test_main(int, char* [])
 #endif
 
     test_boxes_nd<double>();
+
+#ifdef BOOST_GEOMETRY_TEST_INCLUDE_FAILING_TESTS
+    // ticket #10868 still fails for 32-bit integers
+    test_ticket_10868<int32_t>("MULTIPOLYGON(((33520458 6878575,33480192 14931538,31446819 18947953,30772384 19615678,30101303 19612322,30114725 16928001,33520458 6878575)))");
+#endif
+
+#if defined(BOOST_HAS_INT64_T)
+    test_ticket_10868<int64_t>("MULTIPOLYGON(((33520458 6878575,33480192 14931538,31446819 18947953,30772384 19615678,30101303 19612322,30114725 16928001,33520458 6878575)))");
+#endif
 
     return 0;
 }

--- a/test/algorithms/set_operations/intersection/intersection.cpp
+++ b/test/algorithms/set_operations/intersection/intersection.cpp
@@ -25,6 +25,7 @@
 // Test which would fail then are disabled automatically
 // #define BOOST_GEOMETRY_NO_ROBUSTNESS
 
+#include <boost/config.hpp>
 #include <boost/core/ignore_unused.hpp>
 
 #include <boost/geometry/geometries/point_xy.hpp>
@@ -675,7 +676,7 @@ int test_main(int, char* [])
     test_ticket_10868<int32_t>("MULTIPOLYGON(((33520458 6878575,33480192 14931538,31446819 18947953,30772384 19615678,30101303 19612322,30114725 16928001,33520458 6878575)))");
 #endif
 
-#if defined(BOOST_HAS_INT64_T)
+#if !defined(BOOST_NO_INT64) || defined(BOOST_HAS_INT64_T) || defined(BOOST_HAS_MS_INT64)
     test_ticket_10868<int64_t>("MULTIPOLYGON(((33520458 6878575,33480192 14931538,31446819 18947953,30772384 19615678,30101303 19612322,30114725 16928001,33520458 6878575)))");
 #endif
 

--- a/test/string_from_type.hpp
+++ b/test/string_from_type.hpp
@@ -1,8 +1,13 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
-// Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
-// Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
+// Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
+// Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
+
+// This file was modified by Oracle on 2015.
+// Modifications copyright (c) 2015, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
@@ -55,8 +60,20 @@ template <> struct string_from_type<short int>
 template <> struct string_from_type<int>
 { static std::string name() { return "i"; }  };
 
-template <> struct string_from_type<boost::long_long_type>
+template <> struct string_from_type<long>
 { static std::string name() { return "l"; }  };
+
+#if defined(BOOST_HAS_LONG_LONG)
+// this is what g++ and clang++ use
+template <> struct string_from_type<boost::long_long_type>
+{ static std::string name() { return "x"; }  };
+#endif
+
+#if defined(BOOST_HAS_INT128)
+// this is what g++ and clang++ use
+template <> struct string_from_type<boost::int128_type>
+{ static std::string name() { return "n"; }  };
+#endif
 
 #if defined(HAVE_TTMATH)
     template <> struct string_from_type<ttmath_big>

--- a/test/util/Jamfile.v2
+++ b/test/util/Jamfile.v2
@@ -1,11 +1,11 @@
 # Boost.Geometry (aka GGL, Generic Geometry Library)
 #
-# Copyright (c) 2007-2014 Barend Gehrels, Amsterdam, the Netherlands.
-# Copyright (c) 2008-2014 Bruno Lalande, Paris, France.
-# Copyright (c) 2009-2014 Mateusz Loskot, London, UK.
+# Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
+# Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
+# Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 #
-# This file was modified by Oracle on 2014.
-# Modifications copyright (c) 2014, Oracle and/or its affiliates.
+# This file was modified by Oracle on 2014, 2015.
+# Modifications copyright (c) 2014-2015, Oracle and/or its affiliates.
 #
 # Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 #
@@ -18,6 +18,7 @@ test-suite boost-geometry-util
     [ run calculation_type.cpp ]
     [ run for_each_coordinate.cpp ]
     [ run math_sqrt.cpp ]
+    [ run promote_integral.cpp ]
     [ run range.cpp ]
     [ run rational.cpp ]
     [ run select_most_precise.cpp ]

--- a/test/util/promote_integral.cpp
+++ b/test/util/promote_integral.cpp
@@ -19,16 +19,14 @@
 
 #include <boost/test/included/unit_test.hpp>
 
-//#include <boost/config.hpp>
+#include <boost/config.hpp>
 #include <boost/type_traits/is_same.hpp>
 
 #include <geometry_test_common.hpp>
 
 #include <boost/geometry/util/promote_integral.hpp>
 
-#if !defined(BOOST_GEOMETRY_NO_MULTIPRECISION_INTEGER)
 #include <boost/multiprecision/cpp_int.hpp>
-#endif
 
 #if defined(BOOST_GEOMETRY_TEST_DEBUG) && defined(BOOST_HAS_INT128)
 std::ostream& operator<<(std::ostream& os, boost::int128_type i)
@@ -159,7 +157,6 @@ BOOST_AUTO_TEST_CASE( test_int128 )
 }
 #endif
 
-#if !defined(BOOST_GEOMETRY_NO_MULTIPRECISION_INTEGER)
 BOOST_AUTO_TEST_CASE( test_custom_types )
 {
     namespace bm = boost::multiprecision;
@@ -167,8 +164,8 @@ BOOST_AUTO_TEST_CASE( test_custom_types )
         <
             bm::cpp_int_backend
                 <
-                    CHAR_BIT * sizeof(short) + 1,
-                    CHAR_BIT * sizeof(short) + 1,
+                    17,
+                    17,
                     bm::signed_magnitude,
                     bm::unchecked,
                     void
@@ -191,7 +188,6 @@ BOOST_AUTO_TEST_CASE( test_custom_types )
     test_promote_integral<custom_integral_type1, custom_integral_type1>();
     test_promote_integral<custom_integral_type2, custom_integral_type2>();
 }
-#endif
 
 BOOST_AUTO_TEST_CASE( test_floating_point )
 {

--- a/test/util/promote_integral.cpp
+++ b/test/util/promote_integral.cpp
@@ -1,0 +1,206 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+// Unit Test
+
+// Copyright (c) 2015, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+#ifndef BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE test_promote_integral
+#endif
+
+#if !defined(BOOST_GEOMETRY_NO_MULTIPRECISION_INTEGER)
+#include <climits>
+#endif
+#include <iostream>
+
+#include <boost/test/included/unit_test.hpp>
+
+//#include <boost/config.hpp>
+#include <boost/type_traits/is_same.hpp>
+
+#include <geometry_test_common.hpp>
+
+#include <boost/geometry/util/promote_integral.hpp>
+
+#if !defined(BOOST_GEOMETRY_NO_MULTIPRECISION_INTEGER)
+#include <boost/multiprecision/cpp_int.hpp>
+#endif
+
+#if defined(BOOST_GEOMETRY_TEST_DEBUG) && defined(BOOST_HAS_INT128)
+std::ostream& operator<<(std::ostream& os, boost::int128_type i)
+{
+    os << double(i);
+    return os;
+}
+#endif
+
+
+namespace bg = boost::geometry;
+
+template <typename Type, typename ExpectedPromotedType>
+inline void test_promote_integral()
+{
+    typedef typename bg::promote_integral<Type>::type promoted_integral_type;
+    bool const same_types = boost::is_same
+        <
+            promoted_integral_type, ExpectedPromotedType
+        >::type::value;
+
+    BOOST_CHECK(same_types);
+
+#ifdef BOOST_GEOMETRY_TEST_DEBUG
+    std::cout << "type : " << typeid(Type).name()
+              << ", sizeof: " << sizeof(Type)
+              << ", max value: "
+              << std::numeric_limits<Type>::max()
+              << std::endl;
+    std::cout << "detected promoted type : "
+              << typeid(promoted_integral_type).name()
+              << ", sizeof: " << sizeof(promoted_integral_type)
+              << ", max value: "
+              << std::numeric_limits<promoted_integral_type>::max()
+              << std::endl;
+    std::cout << "expected promoted type : "
+              << typeid(ExpectedPromotedType).name()
+              << ", sizeof: " << sizeof(ExpectedPromotedType)
+              << ", max value: "
+              << std::numeric_limits<ExpectedPromotedType>::max()
+              << std::endl;
+    std::cout << std::endl;
+#endif
+}
+
+template <typename T>
+void test_promotion()
+{
+    if (sizeof(short) >= 2 * sizeof(T))
+    {
+        test_promote_integral<T, short>();
+    }
+    else if (sizeof(int) >= 2 * sizeof(T))
+    {
+        test_promote_integral<T, int>();
+    }
+    else if (sizeof(long) >= 2 * sizeof(T))
+    {
+        test_promote_integral<T, long>();
+    }
+#if defined(BOOST_HAS_LONG_LONG)
+    else if (sizeof(boost::long_long_type) >= 2 * sizeof(T))
+    {
+        test_promote_integral<T, boost::long_long_type>();
+    }
+#endif
+#if defined(BOOST_HAS_INT128)
+    else if (sizeof(boost::int128_type) >= 2 * sizeof(T))
+    {
+        test_promote_integral<T, boost::int128_type>();
+    }
+#endif
+    else
+    {
+#if !defined(BOOST_GEOMETRY_NO_MULTIPRECISION_INTEGER)
+        namespace bm = boost::multiprecision;
+        typedef bm::number
+            <
+                bm::cpp_int_backend
+                    <
+                        2 * CHAR_BIT * sizeof(T),
+                        2 * CHAR_BIT * sizeof(T),
+                        bm::signed_magnitude,
+                        bm::unchecked,
+                        void
+                    >
+            > multiprecision_integer_type;
+
+        test_promote_integral<T, multiprecision_integer_type>();
+#else
+        test_promote_integral<T, T>();
+#endif
+    }
+}
+
+
+BOOST_AUTO_TEST_CASE( test_char )
+{
+    test_promotion<char>();
+}
+
+BOOST_AUTO_TEST_CASE( test_short )
+{
+    test_promotion<short>();
+}
+
+BOOST_AUTO_TEST_CASE( test_int )
+{
+    test_promotion<int>();
+}
+
+BOOST_AUTO_TEST_CASE( test_long )
+{
+    test_promotion<long>();
+}
+
+#ifdef BOOST_HAS_LONG_LONG
+BOOST_AUTO_TEST_CASE( test_long_long )
+{
+    test_promotion<boost::long_long_type>();
+}
+#endif
+
+#if defined(BOOST_HAS_INT128)
+BOOST_AUTO_TEST_CASE( test_int128 )
+{
+    test_promotion<boost::int128_type>();
+}
+#endif
+
+#if !defined(BOOST_GEOMETRY_NO_MULTIPRECISION_INTEGER)
+BOOST_AUTO_TEST_CASE( test_custom_types )
+{
+    namespace bm = boost::multiprecision;
+    typedef bm::number
+        <
+            bm::cpp_int_backend
+                <
+                    CHAR_BIT * sizeof(short) + 1,
+                    CHAR_BIT * sizeof(short) + 1,
+                    bm::signed_magnitude,
+                    bm::unchecked,
+                    void
+                >
+        > custom_integral_type1;
+
+    typedef bm::number
+        <
+            bm::cpp_int_backend
+                <
+                    500,
+                    500,
+                    bm::signed_magnitude,
+                    bm::unchecked,
+                    void
+                >
+        > custom_integral_type2;
+
+    // for user defined number types we do not do any promotion
+    test_promote_integral<custom_integral_type1, custom_integral_type1>();
+    test_promote_integral<custom_integral_type2, custom_integral_type2>();
+}
+#endif
+
+BOOST_AUTO_TEST_CASE( test_floating_point )
+{
+    // for floating-point types we do not do any promotion
+    test_promote_integral<float, float>();
+    test_promote_integral<double, double>();
+    test_promote_integral<long double, long double>();
+
+#ifdef HAVE_TTMATH
+    test_promote_integral<ttmath_big, ttmath_big>();
+#endif
+}

--- a/test/util/promote_integral.cpp
+++ b/test/util/promote_integral.cpp
@@ -15,6 +15,7 @@
 #if !defined(BOOST_GEOMETRY_NO_MULTIPRECISION_INTEGER)
 #include <climits>
 #endif
+#include <cstddef>
 #include <iostream>
 
 #include <boost/test/included/unit_test.hpp>
@@ -126,21 +127,31 @@ void test_promotion()
 BOOST_AUTO_TEST_CASE( test_char )
 {
     test_promotion<char>();
+    test_promotion<signed char>();
+    test_promotion<unsigned char>();
 }
 
 BOOST_AUTO_TEST_CASE( test_short )
 {
     test_promotion<short>();
+    test_promotion<unsigned short>();
 }
 
 BOOST_AUTO_TEST_CASE( test_int )
 {
     test_promotion<int>();
+    test_promotion<unsigned int>();
 }
 
 BOOST_AUTO_TEST_CASE( test_long )
 {
     test_promotion<long>();
+    test_promotion<unsigned long>();
+}
+
+BOOST_AUTO_TEST_CASE( test_std_size_t )
+{
+    test_promotion<std::size_t>();
 }
 
 #ifdef BOOST_HAS_LONG_LONG

--- a/test/util/promote_integral.cpp
+++ b/test/util/promote_integral.cpp
@@ -16,15 +16,21 @@
 #include <climits>
 #endif
 #include <cstddef>
+#include <algorithm>
+#include <limits>
 #include <iostream>
+#include <string>
+#include <sstream>
 
 #include <boost/test/included/unit_test.hpp>
 
 #include <boost/config.hpp>
 #include <boost/type_traits/is_same.hpp>
+#include <boost/type_traits/is_unsigned.hpp>
 
 #include <geometry_test_common.hpp>
 
+#include <boost/geometry/util/condition.hpp>
 #include <boost/geometry/util/promote_integral.hpp>
 
 #include <boost/multiprecision/cpp_int.hpp>
@@ -32,7 +38,25 @@
 #if defined(BOOST_GEOMETRY_TEST_DEBUG) && defined(BOOST_HAS_INT128)
 std::ostream& operator<<(std::ostream& os, boost::int128_type i)
 {
-    os << double(i);
+    if (i == 0)
+    {
+        os << "0";
+        return os;
+    }
+    if (i < 0)
+    {
+        i = -i;
+        os << "-";
+    }
+    std::stringstream stream;
+    while (i > 0)
+    {
+        stream << static_cast<int>(i % 10);
+        i /= 10;
+    }
+    std::string str = stream.str();
+    std::reverse(str.begin(), str.end());
+    os << str;
     return os;
 }
 #endif
@@ -40,135 +64,305 @@ std::ostream& operator<<(std::ostream& os, boost::int128_type i)
 
 namespace bg = boost::geometry;
 
-template <typename Type, typename ExpectedPromotedType>
-inline void test_promote_integral()
+template
+<
+    typename T,
+    bool Signed = boost::is_fundamental<T>::type::value
+    && ! boost::is_unsigned<T>::type::value
+>
+struct absolute_value
 {
-    typedef typename bg::promote_integral<Type>::type promoted_integral_type;
-    bool const same_types = boost::is_same
-        <
-            promoted_integral_type, ExpectedPromotedType
-        >::type::value;
-
-    BOOST_CHECK(same_types);
-
-#ifdef BOOST_GEOMETRY_TEST_DEBUG
-    std::cout << "type : " << typeid(Type).name()
-              << ", sizeof: " << sizeof(Type)
-              << ", max value: "
-              << std::numeric_limits<Type>::max()
-              << std::endl;
-    std::cout << "detected promoted type : "
-              << typeid(promoted_integral_type).name()
-              << ", sizeof: " << sizeof(promoted_integral_type)
-              << ", max value: "
-              << std::numeric_limits<promoted_integral_type>::max()
-              << std::endl;
-    std::cout << "expected promoted type : "
-              << typeid(ExpectedPromotedType).name()
-              << ", sizeof: " << sizeof(ExpectedPromotedType)
-              << ", max value: "
-              << std::numeric_limits<ExpectedPromotedType>::max()
-              << std::endl;
-    std::cout << std::endl;
-#endif
-}
+    static inline T apply(T const& t)
+    {
+        return t < 0 ? -t : t;
+    }
+};
 
 template <typename T>
-void test_promotion()
+struct absolute_value<T, false>
 {
-    if (sizeof(short) >= 2 * sizeof(T))
+    static inline T apply(T const& t)
     {
-        test_promote_integral<T, short>();
+        return t;
     }
-    else if (sizeof(int) >= 2 * sizeof(T))
+};
+
+
+
+template
+<
+    typename Integral,
+    typename Promoted,
+    bool Signed = ! boost::is_unsigned<Promoted>::type::value
+>
+struct test_max_values
+{
+    static inline void apply()
     {
-        test_promote_integral<T, int>();
+        Promoted max_value = std::numeric_limits<Integral>::max();
+        max_value *= max_value;
+        BOOST_CHECK(absolute_value<Promoted>::apply(max_value) == max_value);
     }
-    else if (sizeof(long) >= 2 * sizeof(T))
+};
+
+template <typename Integral, typename Promoted>
+struct test_max_values<Integral, Promoted, false>
+{
+    static inline void apply()
     {
-        test_promote_integral<T, long>();
+        Promoted max_value = std::numeric_limits<Integral>::max();
+        Promoted max_value_sqr = max_value * max_value;
+        BOOST_CHECK(max_value_sqr < std::numeric_limits<Promoted>::max()
+                    &&
+                    max_value_sqr > max_value);
     }
+};
+
+template <bool PromoteUnsignedToUnsigned>
+struct test_promote_integral
+{
+    template <typename Type, typename ExpectedPromotedType>
+    static inline void apply(std::string const& case_id)
+    {
+        typedef typename bg::promote_integral
+            <
+                Type, PromoteUnsignedToUnsigned
+            >::type promoted_integral_type;
+
+        bool const same_types = boost::is_same
+            <
+                promoted_integral_type, ExpectedPromotedType
+            >::type::value;
+
+        BOOST_CHECK_MESSAGE(same_types,
+                            "case ID: " << case_id
+                            << "input type: " << typeid(Type).name()
+                            << "; detected: "
+                            << typeid(promoted_integral_type).name()
+                            << "; expected: "
+                            << typeid(ExpectedPromotedType).name());
+
+        if (BOOST_GEOMETRY_CONDITION((! boost::is_same
+                <
+                    Type, promoted_integral_type
+                >::type::value)))
+        {
+            test_max_values<Type, promoted_integral_type>::apply();
+        }
+
+#ifdef BOOST_GEOMETRY_TEST_DEBUG
+        std::cout << "case ID: " << case_id << std::endl
+                  << "type : " << typeid(Type).name()
+                  << ", sizeof: " << sizeof(Type)
+                  << ", max value: "
+                  << std::numeric_limits<Type>::max()
+                  << std::endl;
+        std::cout << "detected promoted type : "
+                  << typeid(promoted_integral_type).name()
+                  << ", sizeof: " << sizeof(promoted_integral_type)
+                  << ", max value: "
+                  << std::numeric_limits<promoted_integral_type>::max()
+                  << std::endl;
+        std::cout << "expected promoted type : "
+                  << typeid(ExpectedPromotedType).name()
+                  << ", sizeof: " << sizeof(ExpectedPromotedType)
+                  << ", max value: "
+                  << std::numeric_limits<ExpectedPromotedType>::max()
+                  << std::endl;
+        std::cout << std::endl;
+#endif
+    }
+};
+
+template
+<
+    typename T,
+    bool PromoteUnsignedToUnsigned = false,
+    bool IsSigned = ! boost::is_unsigned<T>::type::value
+>
+struct test_promotion
+{
+    static inline void apply(std::string case_id)
+    {
+#ifdef BOOST_GEOMETRY_TEST_DEBUG
+        std::cout << "*** "
+                  << (IsSigned ? "signed" : "unsigned")
+                  << " -> signed ***" << std::endl;
+#endif
+
+        typedef test_promote_integral<PromoteUnsignedToUnsigned> tester;
+
+        case_id += (PromoteUnsignedToUnsigned ? "-t" : "-f");
+
+        std::size_t min_size = 2 * sizeof(T) - 1;
+        if (BOOST_GEOMETRY_CONDITION(! IsSigned))
+        {
+            min_size += 2;
+        }
+
+        if (BOOST_GEOMETRY_CONDITION(sizeof(short) >= min_size))
+        {
+            tester::template apply<T, short>(case_id);
+        }
+        else if (BOOST_GEOMETRY_CONDITION(sizeof(int) >= min_size))
+        {
+            tester::template apply<T, int>(case_id);
+        }
+        else if (BOOST_GEOMETRY_CONDITION(sizeof(long) >= min_size))
+        {
+            tester::template apply<T, long>(case_id);
+        }
 #if defined(BOOST_HAS_LONG_LONG)
-    else if (sizeof(boost::long_long_type) >= 2 * sizeof(T))
-    {
-        test_promote_integral<T, boost::long_long_type>();
-    }
+        else if (BOOST_GEOMETRY_CONDITION(sizeof(boost::long_long_type)
+                                          >= min_size))
+        {
+            tester::template apply<T, boost::long_long_type>(case_id);
+        }
 #endif
 #if defined(BOOST_HAS_INT128)
-    else if (sizeof(boost::int128_type) >= 2 * sizeof(T))
-    {
-        test_promote_integral<T, boost::int128_type>();
-    }
+        else if (BOOST_GEOMETRY_CONDITION(sizeof(boost::int128_type)
+                                          >= min_size))
+        {
+            tester::template apply<T, boost::int128_type>(case_id);
+        }
 #endif
-    else
-    {
+        else
+        {
 #if !defined(BOOST_GEOMETRY_NO_MULTIPRECISION_INTEGER)
-        namespace bm = boost::multiprecision;
-        typedef bm::number
-            <
-                bm::cpp_int_backend
+            namespace bm = boost::multiprecision;
+            typedef bm::number
+                <
+                    bm::cpp_int_backend
                     <
-                        2 * CHAR_BIT * sizeof(T),
-                        2 * CHAR_BIT * sizeof(T),
+                        2 * CHAR_BIT * sizeof(T) + (IsSigned ? -1 : 1),
+                        2 * CHAR_BIT * sizeof(T) + (IsSigned ? -1 : 1),
                         bm::signed_magnitude,
                         bm::unchecked,
                         void
                     >
-            > multiprecision_integer_type;
+                > multiprecision_integer_type;
 
-        test_promote_integral<T, multiprecision_integer_type>();
+            tester::template apply<T, multiprecision_integer_type>(case_id);
 #else
-        test_promote_integral<T, T>();
+            tester::template apply<T, T>(case_id);
 #endif
+        }
     }
-}
+};
+
+template <typename T>
+struct test_promotion<T, true, false>
+{
+    static inline void apply(std::string case_id)
+    {
+#ifdef BOOST_GEOMETRY_TEST_DEBUG
+        std::cout << "*** unsigned -> unsigned ***" << std::endl;
+#endif
+        case_id += "-t";
+
+        typedef test_promote_integral<true> tester;
+
+        std::size_t const min_size = 2 * sizeof(T);
+
+        if (BOOST_GEOMETRY_CONDITION(sizeof(unsigned short) >= min_size))
+        {
+            tester::apply<T, unsigned short>(case_id);
+        }
+        else if (BOOST_GEOMETRY_CONDITION(sizeof(unsigned int) >= min_size))
+        {
+            tester::apply<T, unsigned int>(case_id);
+        }
+        else if (BOOST_GEOMETRY_CONDITION(sizeof(unsigned long) >= min_size))
+        {
+            tester::apply<T, unsigned long>(case_id);
+        }
+        else if (BOOST_GEOMETRY_CONDITION(sizeof(std::size_t) >= min_size))
+        {
+            tester::apply<T, std::size_t>(case_id);
+        }
+        else
+        {
+#if !defined(BOOST_GEOMETRY_NO_MULTIPRECISION_INTEGER)
+            namespace bm = boost::multiprecision;
+            typedef bm::number
+                <
+                    bm::cpp_int_backend
+                    <
+                        CHAR_BIT * min_size,
+                        CHAR_BIT * min_size,
+                        bm::unsigned_magnitude,
+                        bm::unchecked,
+                        void
+                    >
+                > multiprecision_integer_type;
+
+            tester::apply<T, multiprecision_integer_type>(case_id);
+#else
+            tester::apply<T, T>(case_id);
+#endif
+        }
+    }
+};
+
 
 
 BOOST_AUTO_TEST_CASE( test_char )
 {
-    test_promotion<char>();
-    test_promotion<signed char>();
-    test_promotion<unsigned char>();
+    test_promotion<char>::apply("char");
+    test_promotion<char, true>::apply("char");
+    test_promotion<signed char>::apply("schar");
+    test_promotion<signed char, true>::apply("schar");
+    test_promotion<unsigned char>::apply("uchar");
+    test_promotion<unsigned char, true>::apply("uchar");
 }
 
 BOOST_AUTO_TEST_CASE( test_short )
 {
-    test_promotion<short>();
-    test_promotion<unsigned short>();
+    test_promotion<short>::apply("short");
+    test_promotion<short, true>::apply("short");
+    test_promotion<unsigned short>::apply("ushort");
+    test_promotion<unsigned short, true>::apply("ushort");
 }
 
 BOOST_AUTO_TEST_CASE( test_int )
 {
-    test_promotion<int>();
-    test_promotion<unsigned int>();
+    test_promotion<int>::apply("int");
+    test_promotion<int, true>::apply("int");
+    test_promotion<unsigned int>::apply("uint");
+    test_promotion<unsigned int, true>::apply("uint");
 }
 
 BOOST_AUTO_TEST_CASE( test_long )
 {
-    test_promotion<long>();
-    test_promotion<unsigned long>();
+    test_promotion<long>::apply("long");
+    test_promotion<long, true>::apply("long");
+    test_promotion<unsigned long>::apply("ulong");
+    test_promotion<unsigned long, true>::apply("ulong");
 }
 
 BOOST_AUTO_TEST_CASE( test_std_size_t )
 {
-    test_promotion<std::size_t>();
+    test_promotion<std::size_t>::apply("size_t");
+    test_promotion<std::size_t, true>::apply("size_t");
 }
 
 #ifdef BOOST_HAS_LONG_LONG
 BOOST_AUTO_TEST_CASE( test_long_long )
 {
-    test_promotion<boost::long_long_type>();
+    test_promotion<boost::long_long_type>::apply("long long");
+    test_promotion<boost::long_long_type, true>::apply("long long");
 }
 #endif
 
 #if defined(BOOST_HAS_INT128)
 BOOST_AUTO_TEST_CASE( test_int128 )
 {
-    test_promotion<boost::int128_type>();
+    test_promotion<boost::int128_type>::apply("int128_t");
+    test_promotion<boost::int128_type, true>::apply("int128_t");
 }
 #endif
 
-BOOST_AUTO_TEST_CASE( test_custom_types )
+BOOST_AUTO_TEST_CASE( test_user_types )
 {
     namespace bm = boost::multiprecision;
     typedef bm::number
@@ -181,7 +375,19 @@ BOOST_AUTO_TEST_CASE( test_custom_types )
                     bm::unchecked,
                     void
                 >
-        > custom_integral_type1;
+        > user_signed_type1;
+
+    typedef bm::number
+        <
+            bm::cpp_int_backend
+                <
+                    17,
+                    17,
+                    bm::unsigned_magnitude,
+                    bm::unchecked,
+                    void
+                >
+        > user_unsigned_type1;
 
     typedef bm::number
         <
@@ -193,21 +399,50 @@ BOOST_AUTO_TEST_CASE( test_custom_types )
                     bm::unchecked,
                     void
                 >
-        > custom_integral_type2;
+        > user_signed_type2;
+
+    typedef bm::number
+        <
+            bm::cpp_int_backend
+                <
+                    500,
+                    500,
+                    bm::unsigned_magnitude,
+                    bm::unchecked,
+                    void
+                >
+        > user_unsigned_type2;
 
     // for user defined number types we do not do any promotion
-    test_promote_integral<custom_integral_type1, custom_integral_type1>();
-    test_promote_integral<custom_integral_type2, custom_integral_type2>();
+    typedef test_promote_integral<true> tester1;
+    typedef test_promote_integral<false> tester2;
+    tester1::apply<user_signed_type1, user_signed_type1>("u1s");
+    tester1::apply<user_signed_type2, user_signed_type2>("u2s");
+    tester1::apply<user_unsigned_type1, user_unsigned_type1>("u1u");
+    tester1::apply<user_unsigned_type2, user_unsigned_type2>("u2u");
+
+    tester2::apply<user_signed_type1, user_signed_type1>("u1s");
+    tester2::apply<user_signed_type2, user_signed_type2>("u2s");
+    tester2::apply<user_unsigned_type1, user_unsigned_type1>("u1u");
+    tester2::apply<user_unsigned_type2, user_unsigned_type2>("u1u");
 }
 
 BOOST_AUTO_TEST_CASE( test_floating_point )
 {
+    typedef test_promote_integral<true> tester1;
+    typedef test_promote_integral<false> tester2;
+
     // for floating-point types we do not do any promotion
-    test_promote_integral<float, float>();
-    test_promote_integral<double, double>();
-    test_promote_integral<long double, long double>();
+    tester1::apply<float, float>("fp-f");
+    tester1::apply<double, double>("fp-d");
+    tester1::apply<long double, long double>("fp-ld");
+
+    tester2::apply<float, float>("fp-f");
+    tester2::apply<double, double>("fp-d");
+    tester2::apply<long double, long double>("fp-ld");
 
 #ifdef HAVE_TTMATH
-    test_promote_integral<ttmath_big, ttmath_big>();
+    tester1::apply<ttmath_big, ttmath_big>("fp-tt");
+    tester2::apply<ttmath_big, ttmath_big>("fp-tt");
 #endif
 }


### PR DESCRIPTION
This PR addresses Boost [Trac Ticket #10835](https://svn.boost.org/trac/boost/ticket/10835).

The problem reported in the ticket was due to overflow in integer operations when the intersections points (for the second linear/areal difference) were computed.

The way the problem is addressed in this PR is by promoting the integral coordinates to another integral type of larger size, for which overflow does not happen; the outcome of the arithmetic operations with the promoted integral type is then cast back to the original integral type.

On a technical level, to perform this promotion, a new meta-function `promote_integral<>` has been implemented. This meta-function promotes a fundamental integral type `T` to a another integral type (possibly a multi-precision one) with size twice the size of `T`. At this point the support for promotion to a multi-precision integer is by default activated.