### PR TITLE
A few updates for promote_integral

### DIFF
--- a/test/util/promote_integral.cpp
+++ b/test/util/promote_integral.cpp
@@ -148,10 +148,40 @@ struct test_max_values<Integral, Promoted, false>
 
 
 // helper function that returns the bit size of a type
+template
+<
+    typename T,
+    bool IsFundamental = boost::is_fundamental<T>::type::value
+>
+struct bit_size_impl : boost::mpl::size_t<0>
+{};
+
+template <typename T>
+struct bit_size_impl<T, true> : bg::detail::promote_integral::bit_size<T>::type
+{};
+
+#if !defined(BOOST_GEOMETRY_NO_MULTIPRECISION_INTEGER)
+template
+<
+    typename Backend,
+    boost::multiprecision::expression_template_option ExpressionTemplates
+>
+struct bit_size_impl
+    <
+        boost::multiprecision::number<Backend, ExpressionTemplates>,
+        false
+    > : bg::detail::promote_integral::bit_size
+        <
+            boost::multiprecision::number<Backend, ExpressionTemplates>
+        >
+{};
+#endif
+
+
 template <typename T>
 std::size_t bit_size()
 {
-    return bg::detail::promote_integral::bit_size<T>::type::value;
+    return bit_size_impl<T>::type::value;
 }
 
 template <bool PromoteUnsignedToUnsigned>


### PR DESCRIPTION
In this PR:
* The inline documentation for `promote_integral<>` is updated.
* All size measurements are done in bits (rather than mixing bits and bytes).
* Code is polished a bit.
* Choice for the promoted type is based on bit size rather than on the outcome of the `sizeof()` operator.