### PR TITLE
Workarounds for SunOS

### DIFF
--- a/include/boost/geometry/algorithms/detail/buffer/buffered_piece_collection.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/buffered_piece_collection.hpp
@@ -548,9 +548,8 @@ struct buffered_piece_collection
         // reliable integer-based ring. All turns can be compared (inside) to this
         // rings to see if they are inside.
 
-        for (typename piece_vector_type::iterator it = boost::begin(m_pieces);
-            it != boost::end(m_pieces);
-            ++it)
+        for (typename boost::range_iterator<piece_vector_type>::type
+                it = boost::begin(m_pieces); it != boost::end(m_pieces); ++it)
         {
             piece& pc = *it;
             int piece_segment_index = pc.first_seg_id.segment_index;
@@ -562,9 +561,9 @@ struct buffered_piece_collection
                 }
                 // Walk through them, in reverse to insert at right index
                 int index_offset = pc.robust_turns.size() - 1;
-                for (typename std::vector<robust_turn>::const_reverse_iterator
-                        rit = pc.robust_turns.rbegin();
-                    rit != pc.robust_turns.rend();
+                for (typename boost::range_reverse_iterator<const std::vector<robust_turn> >::type
+                        rit = boost::const_rbegin(pc.robust_turns);
+                    rit != boost::const_rend(pc.robust_turns);
                     ++rit, --index_offset)
                 {
                     int const index_in_vector = 1 + rit->seg_id.segment_index - piece_segment_index;

--- a/include/boost/geometry/algorithms/detail/distance/geometry_to_segment_or_box.hpp
+++ b/include/boost/geometry/algorithms/detail/distance/geometry_to_segment_or_box.hpp
@@ -220,7 +220,8 @@ public:
         comparable_return_type cd_min1(0);
         point_iterator_type pit_min;
         seg_or_box_iterator_type it_min1 = seg_or_box_points.begin();
-        seg_or_box_iterator_type it_min2 = ++seg_or_box_points.begin();
+        seg_or_box_iterator_type it_min2 = it_min1;
+        ++it_min2;
         bool first = true;
 
         for (point_iterator_type pit = points_begin(geometry);

--- a/include/boost/geometry/algorithms/detail/distance/geometry_to_segment_or_box.hpp
+++ b/include/boost/geometry/algorithms/detail/distance/geometry_to_segment_or_box.hpp
@@ -185,10 +185,10 @@ public:
                 Geometry const
             > segment_iterator_type;
 
-        typedef typename std::vector
+        typedef typename boost::range_const_iterator
             <
-                segment_or_box_point
-            >::const_iterator seg_or_box_iterator_type;
+                std::vector<segment_or_box_point>
+            >::type seg_or_box_const_iterator;
 
         typedef assign_new_min_iterator<SegmentOrBox> assign_new_value;
 
@@ -219,8 +219,8 @@ public:
         // segment or box
         comparable_return_type cd_min1(0);
         point_iterator_type pit_min;
-        seg_or_box_iterator_type it_min1 = seg_or_box_points.begin();
-        seg_or_box_iterator_type it_min2 = it_min1;
+        seg_or_box_const_iterator it_min1 = boost::const_begin(seg_or_box_points);
+        seg_or_box_const_iterator it_min2 = it_min1;
         ++it_min2;
         bool first = true;
 
@@ -230,11 +230,11 @@ public:
             comparable_return_type cd;
             std::pair
                 <
-                    seg_or_box_iterator_type, seg_or_box_iterator_type
+                    seg_or_box_const_iterator, seg_or_box_const_iterator
                 > it_pair
                 = point_to_point_range::apply(*pit,
-                                              seg_or_box_points.begin(),
-                                              seg_or_box_points.end(),
+                                              boost::const_begin(seg_or_box_points),
+                                              boost::const_end(seg_or_box_points),
                                               cstrategy,
                                               cd);
 
@@ -251,12 +251,11 @@ public:
         // segments of the geometry
         comparable_return_type cd_min2(0);
         segment_iterator_type sit_min;
-        typename std::vector<segment_or_box_point>::const_iterator it_min;
+        seg_or_box_const_iterator it_min;
 
         first = true;
-        for (typename std::vector<segment_or_box_point>::const_iterator it
-                 = seg_or_box_points.begin();
-             it != seg_or_box_points.end(); ++it, first = false)
+        for (seg_or_box_const_iterator it = boost::const_begin(seg_or_box_points);
+             it != boost::const_end(seg_or_box_points); ++it, first = false)
         {
             comparable_return_type cd;
             segment_iterator_type sit

--- a/include/boost/geometry/algorithms/detail/is_valid/has_duplicates.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/has_duplicates.hpp
@@ -48,7 +48,8 @@ struct has_duplicates
         geometry::equal_to<typename boost::range_value<Range>::type> equal;
 
         iterator it = boost::begin(view);
-        iterator next = ++boost::begin(view);
+        iterator next = it;
+        ++next;
         for (; next != boost::end(view); ++it, ++next)
         {
             if ( equal(*it, *next) )

--- a/include/boost/geometry/algorithms/detail/is_valid/has_duplicates.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/has_duplicates.hpp
@@ -36,7 +36,10 @@ struct has_duplicates
     static inline bool apply(Range const& range, VisitPolicy& visitor)
     {
         typedef typename closeable_view<Range const, Closure>::type view_type;
-        typedef typename boost::range_iterator<view_type const>::type iterator;
+        typedef typename boost::range_const_iterator
+            <
+                view_type const
+            >::type const_iterator;
 
         view_type view(range);
 
@@ -47,10 +50,10 @@ struct has_duplicates
 
         geometry::equal_to<typename boost::range_value<Range>::type> equal;
 
-        iterator it = boost::begin(view);
-        iterator next = it;
+        const_iterator it = boost::const_begin(view);
+        const_iterator next = it;
         ++next;
-        for (; next != boost::end(view); ++it, ++next)
+        for (; next != boost::const_end(view); ++it, ++next)
         {
             if ( equal(*it, *next) )
             {

--- a/include/boost/geometry/iterators/flatten_iterator.hpp
+++ b/include/boost/geometry/iterators/flatten_iterator.hpp
@@ -216,12 +216,8 @@ private:
             }
             while ( empty(m_outer_it) );
             m_inner_it = AccessInnerEnd::apply(*m_outer_it);
-            --m_inner_it;
-        }
-        else
-        {
-            --m_inner_it;
-        }
+        }        
+        --m_inner_it;
     }
 };
 

--- a/include/boost/geometry/iterators/flatten_iterator.hpp
+++ b/include/boost/geometry/iterators/flatten_iterator.hpp
@@ -215,7 +215,8 @@ private:
                 --m_outer_it;
             }
             while ( empty(m_outer_it) );
-            m_inner_it = --AccessInnerEnd::apply(*m_outer_it);
+            m_inner_it = AccessInnerEnd::apply(*m_outer_it);
+            --m_inner_it;
         }
         else
         {


### PR DESCRIPTION
The proposed changes are workarounds, the code compiles on other platforms. Though I think merging them could be beneficient. Plus, there would be more green in the matrix.

There are a few more failing tests for which workarounds (2 issues) could be added:
* Spherical [distance](http://www.boost.org/development/tests/develop/developer/output/oracle-intel-S2-stlport4-boost-bin-v2-libs-geometry-test-algorithms-distance-distance_se_pl_pl-test-sun-stlport4-release-address-model-32-architecture-x86-threading-multi.html) tests - the use of `comparable_type` private member in the definition of public member struct template `haversine<>::calculation_type<>`, it's hard to believe that this fails only in haversine.
* [point_iterator](http://www.boost.org/development/tests/develop/developer/output/oracle-intel-S2-stlport4-boost-bin-v2-libs-geometry-test-iterators-point_iterator-test-sun-stlport4-release-address-model-32-architecture-x86-threading-multi.html) test - the implicit conversion of reverse iterator to const reverse iterator in the test itself. E.g. only assignment/explicit conversion and comparison could be tested, without implicit conversion.

The workarounds would be trivial, what do you think?