### PR TITLE
Rename occurrences of CS in extensions.

### DIFF
--- a/include/boost/geometry/extensions/gis/geographic/strategies/dms_parser.hpp
+++ b/include/boost/geometry/extensions/gis/geographic/strategies/dms_parser.hpp
@@ -254,15 +254,15 @@ namespace strategy
 
 #ifndef DOXYGEN_NO_STRATEGY_SPECIALIZATIONS
 
-template <template<typename> class CS>
-struct strategy_parse<geographic_tag, CS<degree> >
+template <template<typename> class CoordinateSystem>
+struct strategy_parse<geographic_tag, CoordinateSystem<degree> >
 {
     typedef strategy::dms_parser<false> type;
 };
 
 
-template <template<typename> class CS>
-struct strategy_parse<geographic_tag, CS<radian> >
+template <template<typename> class CoordinateSystem>
+struct strategy_parse<geographic_tag, CoordinateSystem<radian> >
 {
     typedef strategy::dms_parser<true> type;
 };

--- a/include/boost/geometry/extensions/gis/projections/proj/hatano.hpp
+++ b/include/boost/geometry/extensions/gis/projections/proj/hatano.hpp
@@ -49,8 +49,8 @@ namespace boost { namespace geometry { namespace projections
             static const int NITER = 20;
             static const double EPS = 1e-7;
             static const double ONETOL = 1.000001;
-            static const double CN = 2.67595;
-            static const double CS = 2.43763;
+            static const double CN_ = 2.67595;
+            static const double CS_ = 2.43763;
             static const double RCN = 0.37369906014686373063;
             static const double RCS = 0.41023453108141924738;
             static const double FYCN = 1.75859;
@@ -80,7 +80,7 @@ namespace boost { namespace geometry { namespace projections
                     double th1, c;
                     int i;
                 
-                    c = sin(lp_lat) * (lp_lat < 0. ? CS : CN);
+                    c = sin(lp_lat) * (lp_lat < 0. ? CS_ : CN_);
                     for (i = NITER; i; --i) {
                         lp_lat -= th1 = (lp_lat + sin(lp_lat) - c) / (1. + cos(lp_lat));
                         if (fabs(th1) < EPS) break;

--- a/include/boost/geometry/extensions/gis/projections/proj/mbtfpp.hpp
+++ b/include/boost/geometry/extensions/gis/projections/proj/mbtfpp.hpp
@@ -46,7 +46,7 @@ namespace boost { namespace geometry { namespace projections
 {
     #ifndef DOXYGEN_NO_DETAIL
     namespace detail { namespace mbtfpp{ 
-            static const double CS = .95257934441568037152;
+            static const double CS_ = .95257934441568037152;
             static const double FXC = .92582009977255146156;
             static const double FYC = 3.40168025708304504493;
             static const double C23 = .66666666666666666666;
@@ -70,7 +70,7 @@ namespace boost { namespace geometry { namespace projections
 
                 inline void fwd(geographic_type& lp_lon, geographic_type& lp_lat, cartesian_type& xy_x, cartesian_type& xy_y) const
                 {
-                    lp_lat = asin(CS * sin(lp_lat));
+                    lp_lat = asin(CS_ * sin(lp_lat));
                     xy_x = FXC * lp_lon * (2. * cos(C23 * lp_lat) - 1.);
                     xy_y = FYC * sin(C13 * lp_lat);
                 }
@@ -84,7 +84,7 @@ namespace boost { namespace geometry { namespace projections
                     } else
                         lp_lat = asin(lp_lat);
                     lp_lon = xy_x / ( FXC * (2. * cos(C23 * (lp_lat *= 3.)) - 1.) );
-                    if (fabs(lp_lat = sin(lp_lat) / CS) >= 1.) {
+                    if (fabs(lp_lat = sin(lp_lat) / CS_) >= 1.) {
                         if (fabs(lp_lat) > ONEEPS)    throw proj_exception();
                         else    lp_lat = (lp_lat < 0.) ? -HALFPI : HALFPI;
                     } else


### PR DESCRIPTION
This should fix several tests on Android and SunOS platforms where CS is a macro name.