### PR TITLE
Feature/models docs

### DIFF
--- a/doc/doxy/Doxyfile
+++ b/doc/doxy/Doxyfile
@@ -89,6 +89,7 @@ ALIASES                = qbk{1}="\xmlonly <qbk>\1</qbk> \endxmlonly" \
 			param_x="First coordinate (usually x-coordinate)" \
 			param_y="Second coordinate (usually y-coordinate)" \
 			param_z="Third coordinate (usually z-coordinate)" \
+                        constructor_default_no_init="Default constructor, no initialization" \
 			constructor_default{1}="Default constructor, creating an empty \1" \
 			constructor_begin_end{1}="Constructor with begin and end,  filling the \1" \
 			constructor_initializer_list{1}="Constructor taking std::initializer_list, filling the \1" \

--- a/doc/imports.qbk
+++ b/doc/imports.qbk
@@ -82,8 +82,15 @@
 [import src/examples/core/tag.cpp]
 [import src/examples/core/tag_cast.cpp]
 
-[import src/examples/geometries/point.cpp]
 [import src/examples/geometries/box.cpp]
+[import src/examples/geometries/linestring.cpp]
+[import src/examples/geometries/multi_linestring.cpp]
+[import src/examples/geometries/multi_point.cpp]
+[import src/examples/geometries/multi_polygon.cpp]
+[import src/examples/geometries/point.cpp]
+[import src/examples/geometries/polygon.cpp]
+[import src/examples/geometries/ring.cpp]
+[import src/examples/geometries/segment.cpp]
 
 [import src/examples/geometries/adapted/c_array.cpp]
 [import src/examples/geometries/adapted/boost_array.cpp]

--- a/doc/imports.qbk
+++ b/doc/imports.qbk
@@ -83,6 +83,8 @@
 [import src/examples/core/tag_cast.cpp]
 
 [import src/examples/geometries/point.cpp]
+[import src/examples/geometries/box.cpp]
+
 [import src/examples/geometries/adapted/c_array.cpp]
 [import src/examples/geometries/adapted/boost_array.cpp]
 [import src/examples/geometries/adapted/boost_fusion.cpp]

--- a/doc/imports.qbk
+++ b/doc/imports.qbk
@@ -87,6 +87,7 @@
 [import src/examples/geometries/multi_linestring.cpp]
 [import src/examples/geometries/multi_point.cpp]
 [import src/examples/geometries/multi_polygon.cpp]
+[import src/examples/geometries/point_xy.cpp]
 [import src/examples/geometries/point.cpp]
 [import src/examples/geometries/polygon.cpp]
 [import src/examples/geometries/ring.cpp]

--- a/doc/reference/geometries/box.qbk
+++ b/doc/reference/geometries/box.qbk
@@ -1,0 +1,16 @@
+[/============================================================================
+  Boost.Geometry (aka GGL, Generic Geometry Library)
+
+  Copyright (c) 2009-2012 Barend Gehrels, Amsterdam, the Netherlands.
+  Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
+  Copyright (c) 2009-2012 Bruno Lalande, Paris, France.
+  Copyright (c) 2015 Adam Wulkiewicz, Lodz, Poland.
+
+  Use, modification and distribution is subject to the Boost Software License,
+  Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+  http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================/]
+
+[heading Examples]
+[box]
+[box_output]

--- a/doc/reference/geometries/linestring.qbk
+++ b/doc/reference/geometries/linestring.qbk
@@ -1,0 +1,16 @@
+[/============================================================================
+  Boost.Geometry (aka GGL, Generic Geometry Library)
+
+  Copyright (c) 2009-2012 Barend Gehrels, Amsterdam, the Netherlands.
+  Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
+  Copyright (c) 2009-2012 Bruno Lalande, Paris, France.
+  Copyright (c) 2015 Adam Wulkiewicz, Lodz, Poland.
+
+  Use, modification and distribution is subject to the Boost Software License,
+  Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+  http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================/]
+
+[heading Examples]
+[linestring]
+[linestring_output]

--- a/doc/reference/geometries/multi_linestring.qbk
+++ b/doc/reference/geometries/multi_linestring.qbk
@@ -1,0 +1,16 @@
+[/============================================================================
+  Boost.Geometry (aka GGL, Generic Geometry Library)
+
+  Copyright (c) 2009-2012 Barend Gehrels, Amsterdam, the Netherlands.
+  Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
+  Copyright (c) 2009-2012 Bruno Lalande, Paris, France.
+  Copyright (c) 2015 Adam Wulkiewicz, Lodz, Poland.
+
+  Use, modification and distribution is subject to the Boost Software License,
+  Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+  http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================/]
+
+[heading Examples]
+[multi_linestring]
+[multi_linestring_output]

--- a/doc/reference/geometries/multi_point.qbk
+++ b/doc/reference/geometries/multi_point.qbk
@@ -1,0 +1,16 @@
+[/============================================================================
+  Boost.Geometry (aka GGL, Generic Geometry Library)
+
+  Copyright (c) 2009-2012 Barend Gehrels, Amsterdam, the Netherlands.
+  Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
+  Copyright (c) 2009-2012 Bruno Lalande, Paris, France.
+  Copyright (c) 2015 Adam Wulkiewicz, Lodz, Poland.
+
+  Use, modification and distribution is subject to the Boost Software License,
+  Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+  http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================/]
+
+[heading Examples]
+[multi_point]
+[multi_point_output]

--- a/doc/reference/geometries/multi_polygon.qbk
+++ b/doc/reference/geometries/multi_polygon.qbk
@@ -1,0 +1,16 @@
+[/============================================================================
+  Boost.Geometry (aka GGL, Generic Geometry Library)
+
+  Copyright (c) 2009-2012 Barend Gehrels, Amsterdam, the Netherlands.
+  Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
+  Copyright (c) 2009-2012 Bruno Lalande, Paris, France.
+  Copyright (c) 2015 Adam Wulkiewicz, Lodz, Poland.
+
+  Use, modification and distribution is subject to the Boost Software License,
+  Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+  http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================/]
+
+[heading Examples]
+[multi_polygon]
+[multi_polygon_output]

--- a/doc/reference/geometries/point_xy.qbk
+++ b/doc/reference/geometries/point_xy.qbk
@@ -1,0 +1,18 @@
+[/============================================================================
+  Boost.Geometry (aka GGL, Generic Geometry Library)
+
+  Copyright (c) 2009-2012 Barend Gehrels, Amsterdam, the Netherlands.
+  Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
+  Copyright (c) 2009-2012 Bruno Lalande, Paris, France.
+
+  Use, modification and distribution is subject to the Boost Software License,
+  Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+  http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================/]
+
+[heading Examples]
+[point_xy]
+[point_xy_output]
+
+[include reference/geometries/point_assign_warning.qbk]
+

--- a/doc/reference/geometries/polygon.qbk
+++ b/doc/reference/geometries/polygon.qbk
@@ -1,0 +1,16 @@
+[/============================================================================
+  Boost.Geometry (aka GGL, Generic Geometry Library)
+
+  Copyright (c) 2009-2012 Barend Gehrels, Amsterdam, the Netherlands.
+  Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
+  Copyright (c) 2009-2012 Bruno Lalande, Paris, France.
+  Copyright (c) 2015 Adam Wulkiewicz, Lodz, Poland.
+
+  Use, modification and distribution is subject to the Boost Software License,
+  Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+  http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================/]
+
+[heading Examples]
+[polygon]
+[polygon_output]

--- a/doc/reference/geometries/ring.qbk
+++ b/doc/reference/geometries/ring.qbk
@@ -1,0 +1,16 @@
+[/============================================================================
+  Boost.Geometry (aka GGL, Generic Geometry Library)
+
+  Copyright (c) 2009-2012 Barend Gehrels, Amsterdam, the Netherlands.
+  Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
+  Copyright (c) 2009-2012 Bruno Lalande, Paris, France.
+  Copyright (c) 2015 Adam Wulkiewicz, Lodz, Poland.
+
+  Use, modification and distribution is subject to the Boost Software License,
+  Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+  http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================/]
+
+[heading Examples]
+[ring]
+[ring_output]

--- a/doc/reference/geometries/segment.qbk
+++ b/doc/reference/geometries/segment.qbk
@@ -1,0 +1,16 @@
+[/============================================================================
+  Boost.Geometry (aka GGL, Generic Geometry Library)
+
+  Copyright (c) 2009-2012 Barend Gehrels, Amsterdam, the Netherlands.
+  Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
+  Copyright (c) 2009-2012 Bruno Lalande, Paris, France.
+  Copyright (c) 2015 Adam Wulkiewicz, Lodz, Poland.
+
+  Use, modification and distribution is subject to the Boost Software License,
+  Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+  http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================/]
+
+[heading Examples]
+[segment]
+[segment_output]

--- a/doc/src/examples/geometries/Jamfile.v2
+++ b/doc/src/examples/geometries/Jamfile.v2
@@ -13,8 +13,16 @@ project boost-geometry-doc-src-example-geometries
     : # requirements
     ;
 
-exe point : point.cpp ;
 exe box : box.cpp ;
+exe linestring : linestring.cpp ;
+exe point : point.cpp ;
+exe point_xy : point_xy.cpp ;
+exe polygon : polygon.cpp ;
+exe multi_linestring : multi_linestring.cpp ;
+exe multi_point : multi_point.cpp ;
+exe multi_polygon : multi_polygon.cpp ;
+exe ring : ring.cpp ;
+exe segment : segment.cpp ;
 
 build-project adapted ;
 build-project register ;

--- a/doc/src/examples/geometries/Jamfile.v2
+++ b/doc/src/examples/geometries/Jamfile.v2
@@ -14,6 +14,7 @@ project boost-geometry-doc-src-example-geometries
     ;
 
 exe point : point.cpp ;
+exe box : box.cpp ;
 
 build-project adapted ;
 build-project register ;

--- a/doc/src/examples/geometries/box.cpp
+++ b/doc/src/examples/geometries/box.cpp
@@ -21,10 +21,10 @@ int main()
     typedef bg::model::point<double, 2, bg::cs::cartesian> point_t;
     typedef bg::model::box<point_t> box_t;
 
-    box_t box1; /*< Default-construct a box >*/
-    box_t box2(point_t(0.0, 0.0), point_t(5.0, 5.0)); /*< Construct, assigning min and max corner point >*/
+    box_t box1; /*< Default-construct a box. >*/
+    box_t box2(point_t(0.0, 0.0), point_t(5.0, 5.0)); /*< Construct, assigning min and max corner point. >*/
 #ifndef BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX
-    box_t box3{{0.0, 0.0}, {5.0, 5.0}}; /*< Construct, using C++11 unified initialization syntax >*/
+    box_t box3{{0.0, 0.0}, {5.0, 5.0}}; /*< Construct, using C++11 unified initialization syntax. >*/
 #endif
 
     bg::set<bg::min_corner, 0>(box1, 1.0); /*< Set a coordinate, generic. >*/
@@ -32,12 +32,12 @@ int main()
     box1.max_corner().set<0>(3.0); /*< Set a coordinate, class-specific ([*Note]: prefer `bg::set();`). >*/
     box1.max_corner().set<1>(4.0);
 
-    double x0 = bg::get<bg::min_corner, 0>(box1); /*< Get a coordinate. >*/
-    double y0 = bg::get<bg::min_corner, 1>(box1);
-    double x1 = box1.max_corner().get<0>(); /*< Get a coordinate, class-specific ([*Note]: prefer `bg::get();`). >*/
-    double y1 = box1.max_corner().get<1>();
+    double min_x = bg::get<bg::min_corner, 0>(box1); /*< Get a coordinate, generic. >*/
+    double min_y = bg::get<bg::min_corner, 1>(box1);
+    double max_x = box1.max_corner().get<0>(); /*< Get a coordinate, class-specific ([*Note]: prefer `bg::get();`). >*/
+    double max_y = box1.max_corner().get<1>();
 
-    std::cout << x0 << ", " << y0 << ", " << x1 << ", " << y1 << std::endl;
+    std::cout << min_x << ", " << min_y << ", " << max_x << ", " << max_y << std::endl;
 
     return 0;
 }

--- a/doc/src/examples/geometries/box.cpp
+++ b/doc/src/examples/geometries/box.cpp
@@ -1,0 +1,55 @@
+// Boost.Geometry
+// QuickBook Example
+
+// Copyright (c) 2011-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2015 Adam Wulkiewicz, Lodz, Poland.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+//[box
+//` Declaration and use of the Boost.Geometry model::box, modelling the Box Concept
+
+#include <iostream>
+#include <boost/geometry.hpp>
+
+namespace bg = boost::geometry;
+
+int main()
+{
+    typedef bg::model::point<double, 2, bg::cs::cartesian> point_t;
+    typedef bg::model::box<point_t> box_t;
+
+    box_t box1; /*< Default-construct a box >*/
+    box_t box2(point_t(0.0, 0.0), point_t(5.0, 5.0)); /*< Construct, assigning min and max corner point >*/
+#ifndef BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX
+    box_t box3{{0.0, 0.0}, {5.0, 5.0}}; /*< Construct, using C++11 unified initialization syntax >*/
+#endif
+
+    bg::set<bg::min_corner, 0>(box1, 1.0); /*< Set a coordinate, generic. >*/
+    bg::set<bg::min_corner, 1>(box1, 2.0);
+    box1.max_corner().set<0>(3.0); /*< Set a coordinate, class-specific ([*Note]: prefer `bg::set();`). >*/
+    box1.max_corner().set<1>(4.0);
+
+    double x0 = bg::get<bg::min_corner, 0>(box1); /*< Get a coordinate. >*/
+    double y0 = bg::get<bg::min_corner, 1>(box1);
+    double x1 = box1.max_corner().get<0>(); /*< Get a coordinate, class-specific ([*Note]: prefer `bg::get();`). >*/
+    double y1 = box1.max_corner().get<1>();
+
+    std::cout << x0 << ", " << y0 << ", " << x1 << ", " << y1 << std::endl;
+
+    return 0;
+}
+
+//]
+
+
+//[box_output
+/*`
+Output:
+[pre
+1, 2, 3, 4
+]
+*/
+//]

--- a/doc/src/examples/geometries/box.cpp
+++ b/doc/src/examples/geometries/box.cpp
@@ -23,18 +23,21 @@ int main()
 
     box_t box1; /*< Default-construct a box. >*/
     box_t box2(point_t(0.0, 0.0), point_t(5.0, 5.0)); /*< Construct, assigning min and max corner point. >*/
+
 #ifndef BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX
+
     box_t box3{{0.0, 0.0}, {5.0, 5.0}}; /*< Construct, using C++11 unified initialization syntax. >*/
+
 #endif
 
     bg::set<bg::min_corner, 0>(box1, 1.0); /*< Set a coordinate, generic. >*/
     bg::set<bg::min_corner, 1>(box1, 2.0);
-    box1.max_corner().set<0>(3.0); /*< Set a coordinate, class-specific ([*Note]: prefer `bg::set();`). >*/
+    box1.max_corner().set<0>(3.0); /*< Set a coordinate, class-specific ([*Note]: prefer `bg::set()`). >*/
     box1.max_corner().set<1>(4.0);
 
     double min_x = bg::get<bg::min_corner, 0>(box1); /*< Get a coordinate, generic. >*/
     double min_y = bg::get<bg::min_corner, 1>(box1);
-    double max_x = box1.max_corner().get<0>(); /*< Get a coordinate, class-specific ([*Note]: prefer `bg::get();`). >*/
+    double max_x = box1.max_corner().get<0>(); /*< Get a coordinate, class-specific ([*Note]: prefer `bg::get()`). >*/
     double max_y = box1.max_corner().get<1>();
 
     std::cout << min_x << ", " << min_y << ", " << max_x << ", " << max_y << std::endl;

--- a/doc/src/examples/geometries/linestring.cpp
+++ b/doc/src/examples/geometries/linestring.cpp
@@ -1,0 +1,51 @@
+// Boost.Geometry
+// QuickBook Example
+
+// Copyright (c) 2011-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2015 Adam Wulkiewicz, Lodz, Poland.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+//[linestring
+//` Declaration and use of the Boost.Geometry model::linestring, modelling the Linestring Concept
+
+#include <iostream>
+#include <boost/geometry.hpp>
+#include <boost/geometry/geometries/geometries.hpp>
+
+namespace bg = boost::geometry;
+
+int main()
+{
+    typedef bg::model::point<double, 2, bg::cs::cartesian> point_t;
+    typedef bg::model::linestring<point_t> linestring_t;
+
+    linestring_t ls1; /*< Default-construct a linestring. >*/
+#ifndef BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX
+    linestring_t ls2{{0.0, 0.0}, {1.0, 0.0}, {1.0, 2.0}}; /*< Construct a linestring containing three points, using C++11 unified initialization syntax. >*/
+#endif
+
+    bg::append(ls1, point_t(0.0, 0.0)); /*< Append point. >*/
+    bg::append(ls1, point_t(1.0, 0.0));
+    bg::append(ls1, point_t(1.0, 2.0));
+
+    double l = bg::length(ls1);
+
+    std::cout << l << std::endl;
+
+    return 0;
+}
+
+//]
+
+
+//[linestring_output
+/*`
+Output:
+[pre
+3
+]
+*/
+//]

--- a/doc/src/examples/geometries/linestring.cpp
+++ b/doc/src/examples/geometries/linestring.cpp
@@ -23,8 +23,12 @@ int main()
     typedef bg::model::linestring<point_t> linestring_t;
 
     linestring_t ls1; /*< Default-construct a linestring. >*/
-#ifndef BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX
+
+#if !defined(BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX) \
+ && !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+
     linestring_t ls2{{0.0, 0.0}, {1.0, 0.0}, {1.0, 2.0}}; /*< Construct a linestring containing three points, using C++11 unified initialization syntax. >*/
+
 #endif
 
     bg::append(ls1, point_t(0.0, 0.0)); /*< Append point. >*/

--- a/doc/src/examples/geometries/multi_linestring.cpp
+++ b/doc/src/examples/geometries/multi_linestring.cpp
@@ -24,9 +24,13 @@ int main()
     typedef bg::model::multi_linestring<linestring_t> mlinestring_t;
 
     mlinestring_t mls1; /*< Default-construct a multi_linestring. >*/
-#ifndef BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX
+
+#if !defined(BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX) \
+ && !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+
     mlinestring_t mls2{{{0.0, 0.0}, {0.0, 1.0}, {2.0, 1.0}},
                        {{1.0, 0.0}, {2.0, 0.0}}}; /*< Construct a multi_linestring containing two linestrings, using C++11 unified initialization syntax. >*/
+
 #endif
 
     mls1.resize(2); /*< Resize a multi_linestring, store two linestrings. >*/

--- a/doc/src/examples/geometries/multi_linestring.cpp
+++ b/doc/src/examples/geometries/multi_linestring.cpp
@@ -1,0 +1,58 @@
+// Boost.Geometry
+// QuickBook Example
+
+// Copyright (c) 2011-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2015 Adam Wulkiewicz, Lodz, Poland.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+//[multi_linestring
+//` Declaration and use of the Boost.Geometry model::multi_linestring, modelling the MultiLinestring Concept
+
+#include <iostream>
+#include <boost/geometry.hpp>
+#include <boost/geometry/geometries/geometries.hpp>
+
+namespace bg = boost::geometry;
+
+int main()
+{
+    typedef bg::model::point<double, 2, bg::cs::cartesian> point_t;
+    typedef bg::model::linestring<point_t> linestring_t;
+    typedef bg::model::multi_linestring<linestring_t> mlinestring_t;
+
+    mlinestring_t mls1; /*< Default-construct a multi_linestring. >*/
+#ifndef BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX
+    mlinestring_t mls2{{{0.0, 0.0}, {0.0, 1.0}, {2.0, 1.0}},
+                       {{1.0, 0.0}, {2.0, 0.0}}}; /*< Construct a multi_linestring containing two linestrings, using C++11 unified initialization syntax. >*/
+#endif
+
+    mls1.resize(2); /*< Resize a multi_linestring, store two linestrings. >*/
+
+    bg::append(mls1[0], point_t(0.0, 0.0)); /*< Append point to the first linestring. >*/
+    bg::append(mls1[0], point_t(0.0, 1.0));
+    bg::append(mls1[0], point_t(2.0, 1.0));
+
+    bg::append(mls1[1], point_t(1.0, 0.0)); /*< Append point to the second linestring. >*/
+    bg::append(mls1[1], point_t(2.0, 0.0));
+
+    double l = bg::length(mls1);
+
+    std::cout << l << std::endl;
+
+    return 0;
+}
+
+//]
+
+
+//[multi_linestring_output
+/*`
+Output:
+[pre
+4
+]
+*/
+//]

--- a/doc/src/examples/geometries/multi_point.cpp
+++ b/doc/src/examples/geometries/multi_point.cpp
@@ -1,0 +1,51 @@
+// Boost.Geometry
+// QuickBook Example
+
+// Copyright (c) 2011-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2015 Adam Wulkiewicz, Lodz, Poland.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+//[multi_point
+//` Declaration and use of the Boost.Geometry model::multi_point, modelling the MultiPoint Concept
+
+#include <iostream>
+#include <boost/geometry.hpp>
+#include <boost/geometry/geometries/geometries.hpp>
+
+namespace bg = boost::geometry;
+
+int main()
+{
+    typedef bg::model::point<double, 2, bg::cs::cartesian> point_t;
+    typedef bg::model::multi_point<point_t> mpoint_t;
+
+    mpoint_t mpt1; /*< Default-construct a multi_point. >*/
+#ifndef BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX
+    mpoint_t mpt2{{{0.0, 0.0}, {1.0, 1.0}, {2.0, 2.0}}}; /*< Construct a multi_point containing three points, using C++11 unified initialization syntax. >*/
+#endif
+
+    bg::append(mpt1, point_t(0.0, 0.0)); /*< Append point to the multi_point. >*/
+    bg::append(mpt1, point_t(1.0, 1.0));
+    bg::append(mpt1, point_t(2.0, 2.0));
+
+    std::size_t count = bg::num_points(mpt1);
+
+    std::cout << count << std::endl;
+
+    return 0;
+}
+
+//]
+
+
+//[multi_point_output
+/*`
+Output:
+[pre
+3
+]
+*/
+//]

--- a/doc/src/examples/geometries/multi_point.cpp
+++ b/doc/src/examples/geometries/multi_point.cpp
@@ -23,8 +23,12 @@ int main()
     typedef bg::model::multi_point<point_t> mpoint_t;
 
     mpoint_t mpt1; /*< Default-construct a multi_point. >*/
-#ifndef BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX
+
+#if !defined(BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX) \
+ && !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+
     mpoint_t mpt2{{{0.0, 0.0}, {1.0, 1.0}, {2.0, 2.0}}}; /*< Construct a multi_point containing three points, using C++11 unified initialization syntax. >*/
+
 #endif
 
     bg::append(mpt1, point_t(0.0, 0.0)); /*< Append point to the multi_point. >*/

--- a/doc/src/examples/geometries/multi_polygon.cpp
+++ b/doc/src/examples/geometries/multi_polygon.cpp
@@ -24,10 +24,14 @@ int main()
     typedef bg::model::multi_polygon<polygon_t> mpolygon_t; /*< Clockwise, closed multi_polygon. >*/
 
     mpolygon_t mpoly1; /*< Default-construct a multi_polygon. >*/
-#ifndef BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX
+
+#if !defined(BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX) \
+ && !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+
     mpolygon_t mpoly2{{{{0.0, 0.0}, {0.0, 5.0}, {5.0, 5.0}, {5.0, 0.0}, {0.0, 0.0}},
                        {{1.0, 1.0}, {4.0, 1.0}, {4.0, 4.0}, {1.0, 4.0}, {1.0, 1.0}}},
                       {{{5.0, 5.0}, {5.0, 6.0}, {6.0, 6.0}, {6.0, 5.0}, {5.0, 5.0}}}}; /*< Construct a multi_polygon containing two polygons, using C++11 unified initialization syntax. >*/
+
 #endif
 
     mpoly1.resize(2); /*< Resize a multi_polygon, store two polygons. >*/

--- a/doc/src/examples/geometries/multi_polygon.cpp
+++ b/doc/src/examples/geometries/multi_polygon.cpp
@@ -1,0 +1,71 @@
+// Boost.Geometry
+// QuickBook Example
+
+// Copyright (c) 2011-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2015 Adam Wulkiewicz, Lodz, Poland.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+//[multi_polygon
+//` Declaration and use of the Boost.Geometry model::multi_polygon, modelling the MultiPolygon Concept
+
+#include <iostream>
+#include <boost/geometry.hpp>
+#include <boost/geometry/geometries/geometries.hpp>
+
+namespace bg = boost::geometry;
+
+int main()
+{
+    typedef bg::model::point<double, 2, bg::cs::cartesian> point_t;
+    typedef bg::model::polygon<point_t> polygon_t; /*< Default parameters, clockwise, closed polygon. >*/
+    typedef bg::model::multi_polygon<polygon_t> mpolygon_t; /*< Clockwise, closed multi_polygon. >*/
+
+    mpolygon_t mpoly1; /*< Default-construct a multi_polygon. >*/
+#ifndef BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX
+    mpolygon_t mpoly2{{{{0.0, 0.0}, {0.0, 5.0}, {5.0, 5.0}, {5.0, 0.0}, {0.0, 0.0}},
+                       {{1.0, 1.0}, {4.0, 1.0}, {4.0, 4.0}, {1.0, 4.0}, {1.0, 1.0}}},
+                      {{{5.0, 5.0}, {5.0, 6.0}, {6.0, 6.0}, {6.0, 5.0}, {5.0, 5.0}}}}; /*< Construct a multi_polygon containing two polygons, using C++11 unified initialization syntax. >*/
+#endif
+
+    mpoly1.resize(2); /*< Resize a multi_polygon, store two polygons. >*/
+
+    bg::append(mpoly1[0].outer(), point_t(0.0, 0.0)); /*< Append point to the exterior ring of the first polygon. >*/
+    bg::append(mpoly1[0].outer(), point_t(0.0, 5.0));
+    bg::append(mpoly1[0].outer(), point_t(5.0, 5.0));
+    bg::append(mpoly1[0].outer(), point_t(5.0, 0.0));
+    bg::append(mpoly1[0].outer(), point_t(0.0, 0.0));
+
+    mpoly1[0].inners().resize(1); /*< Resize a container of interior rings of the first polygon. >*/
+    bg::append(mpoly1[0].inners()[0], point_t(1.0, 1.0)); /*< Append point to the interior ring of the first polygon. >*/
+    bg::append(mpoly1[0].inners()[0], point_t(4.0, 1.0));
+    bg::append(mpoly1[0].inners()[0], point_t(4.0, 4.0));
+    bg::append(mpoly1[0].inners()[0], point_t(1.0, 4.0));
+    bg::append(mpoly1[0].inners()[0], point_t(1.0, 1.0));
+
+    bg::append(mpoly1[1].outer(), point_t(5.0, 5.0)); /*< Append point to the exterior ring of the second polygon. >*/
+    bg::append(mpoly1[1].outer(), point_t(5.0, 6.0));
+    bg::append(mpoly1[1].outer(), point_t(6.0, 6.0));
+    bg::append(mpoly1[1].outer(), point_t(6.0, 5.0));
+    bg::append(mpoly1[1].outer(), point_t(5.0, 5.0));
+
+    double a = bg::area(mpoly1);
+
+    std::cout << a << std::endl;
+
+    return 0;
+}
+
+//]
+
+
+//[multi_polygon_output
+/*`
+Output:
+[pre
+17
+]
+*/
+//]

--- a/doc/src/examples/geometries/point.cpp
+++ b/doc/src/examples/geometries/point.cpp
@@ -19,11 +19,12 @@ int main()
 {
     bg::model::point<double, 2, bg::cs::cartesian> point1;
     bg::model::point<double, 3, bg::cs::cartesian> point2(1.0, 2.0, 3.0); /*< Construct, assigning three coordinates >*/
-    point1.set<0>(1.0); /*< Set a coordinate. [*Note]: prefer using `bg::set<0>(point1, 1.0);` >*/
-    point1.set<1>(2.0);
 
-    double x = point1.get<0>(); /*< Get a coordinate. [*Note]: prefer using `x = bg::get<0>(point1);` >*/
-    double y = point1.get<1>();
+    bg::set<0>(point1, 1.0); /*< Set a coordinate. >*/
+    bg::set<1>(point1, 2.0);
+
+    double x = bg::get<0>(point1); /*< Get a coordinate. >*/
+    double y = bg::get<1>(point1);
 
     std::cout << x << ", " << y << std::endl;
     return 0;

--- a/doc/src/examples/geometries/point.cpp
+++ b/doc/src/examples/geometries/point.cpp
@@ -20,11 +20,11 @@ int main()
     bg::model::point<double, 2, bg::cs::cartesian> point1;
     bg::model::point<double, 3, bg::cs::cartesian> point2(1.0, 2.0, 3.0); /*< Construct, assigning three coordinates >*/
 
-    bg::set<0>(point1, 1.0); /*< Set a coordinate. >*/
-    bg::set<1>(point1, 2.0);
+    bg::set<0>(point1, 1.0); /*< Set a coordinate, generic. >*/
+    point1.set<1>(2.0); /*< Set a coordinate, class-specific ([*Note]: prefer `bg::set();`). >*/
 
-    double x = bg::get<0>(point1); /*< Get a coordinate. >*/
-    double y = bg::get<1>(point1);
+    double x = bg::get<0>(point1); /*< Get a coordinate, generic. >*/
+    double y = point1.get<1>(); /*< Get a coordinate, class-specific ([*Note]: prefer `bg::get();`). >*/
 
     std::cout << x << ", " << y << std::endl;
     return 0;

--- a/doc/src/examples/geometries/point.cpp
+++ b/doc/src/examples/geometries/point.cpp
@@ -21,10 +21,10 @@ int main()
     bg::model::point<double, 3, bg::cs::cartesian> point2(1.0, 2.0, 3.0); /*< Construct, assigning three coordinates >*/
 
     bg::set<0>(point1, 1.0); /*< Set a coordinate, generic. >*/
-    point1.set<1>(2.0); /*< Set a coordinate, class-specific ([*Note]: prefer `bg::set();`). >*/
+    point1.set<1>(2.0); /*< Set a coordinate, class-specific ([*Note]: prefer `bg::set()`). >*/
 
     double x = bg::get<0>(point1); /*< Get a coordinate, generic. >*/
-    double y = point1.get<1>(); /*< Get a coordinate, class-specific ([*Note]: prefer `bg::get();`). >*/
+    double y = point1.get<1>(); /*< Get a coordinate, class-specific ([*Note]: prefer `bg::get()`). >*/
 
     std::cout << x << ", " << y << std::endl;
     return 0;

--- a/doc/src/examples/geometries/point_xy.cpp
+++ b/doc/src/examples/geometries/point_xy.cpp
@@ -1,0 +1,44 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+// QuickBook Example
+
+// Copyright (c) 2011-2012 Barend Gehrels, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+//[point_xy
+//` Declaration and use of the Boost.Geometry model::d2::point_xy, modelling the Point Concept
+
+#include <iostream>
+#include <boost/geometry.hpp>
+#include <boost/geometry/geometries/point_xy.hpp>
+
+namespace bg = boost::geometry;
+
+int main()
+{
+    bg::model::d2::point_xy<double> point1;
+    bg::model::d2::point_xy<double> point2(1.0, 2.0); /*< Construct, assigning coordinates. >*/
+
+    bg::set<0>(point1, 1.0); /*< Set a coordinate, generic. >*/
+    point1.y(2.0); /*< Set a coordinate, class-specific ([*Note]: prefer `bg::set();`). >*/
+
+    double x = bg::get<0>(point1); /*< Get a coordinate, generic. >*/
+    double y = point1.y(); /*< Get a coordinate, class-specific ([*Note]: prefer `bg::get();`). >*/
+
+    std::cout << x << ", " << y << std::endl;
+    return 0;
+}
+
+//]
+
+
+//[point_xy_output
+/*`
+Output:
+[pre
+1, 2
+]
+*/
+//]

--- a/doc/src/examples/geometries/point_xy.cpp
+++ b/doc/src/examples/geometries/point_xy.cpp
@@ -22,10 +22,10 @@ int main()
     bg::model::d2::point_xy<double> point2(1.0, 2.0); /*< Construct, assigning coordinates. >*/
 
     bg::set<0>(point1, 1.0); /*< Set a coordinate, generic. >*/
-    point1.y(2.0); /*< Set a coordinate, class-specific ([*Note]: prefer `bg::set();`). >*/
+    point1.y(2.0); /*< Set a coordinate, class-specific ([*Note]: prefer `bg::set()`). >*/
 
     double x = bg::get<0>(point1); /*< Get a coordinate, generic. >*/
-    double y = point1.y(); /*< Get a coordinate, class-specific ([*Note]: prefer `bg::get();`). >*/
+    double y = point1.y(); /*< Get a coordinate, class-specific ([*Note]: prefer `bg::get()`). >*/
 
     std::cout << x << ", " << y << std::endl;
     return 0;

--- a/doc/src/examples/geometries/polygon.cpp
+++ b/doc/src/examples/geometries/polygon.cpp
@@ -23,9 +23,13 @@ int main()
     typedef bg::model::polygon<point_t> polygon_t; /*< Default parameters, clockwise, closed polygon. >*/
 
     polygon_t poly1; /*< Default-construct a polygon. >*/
-#ifndef BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX
+
+#if !defined(BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX) \
+ && !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+
     polygon_t polygon2{{{0.0, 0.0}, {0.0, 5.0}, {5.0, 5.0}, {5.0, 0.0}, {0.0, 0.0}},
                        {{1.0, 1.0}, {4.0, 1.0}, {4.0, 4.0}, {1.0, 4.0}, {1.0, 1.0}}}; /*< Construct a polygon containing an exterior and interior ring, using C++11 unified initialization syntax. >*/
+
 #endif
 
     bg::append(poly1.outer(), point_t(0.0, 0.0)); /*< Append point to the exterior ring. >*/

--- a/doc/src/examples/geometries/polygon.cpp
+++ b/doc/src/examples/geometries/polygon.cpp
@@ -1,0 +1,61 @@
+// Boost.Geometry
+// QuickBook Example
+
+// Copyright (c) 2011-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2015 Adam Wulkiewicz, Lodz, Poland.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+//[polygon
+//` Declaration and use of the Boost.Geometry model::polygon, modelling the Polygon Concept
+
+#include <iostream>
+#include <boost/geometry.hpp>
+#include <boost/geometry/geometries/geometries.hpp>
+
+namespace bg = boost::geometry;
+
+int main()
+{
+    typedef bg::model::point<double, 2, bg::cs::cartesian> point_t;
+    typedef bg::model::polygon<point_t> polygon_t; /*< Default parameters, clockwise, closed polygon. >*/
+
+    polygon_t poly1; /*< Default-construct a polygon. >*/
+#ifndef BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX
+    polygon_t polygon2{{{0.0, 0.0}, {0.0, 5.0}, {5.0, 5.0}, {5.0, 0.0}, {0.0, 0.0}},
+                       {{1.0, 1.0}, {4.0, 1.0}, {4.0, 4.0}, {1.0, 4.0}, {1.0, 1.0}}}; /*< Construct a polygon containing an exterior and interior ring, using C++11 unified initialization syntax. >*/
+#endif
+
+    bg::append(poly1.outer(), point_t(0.0, 0.0)); /*< Append point to the exterior ring. >*/
+    bg::append(poly1.outer(), point_t(0.0, 5.0));
+    bg::append(poly1.outer(), point_t(5.0, 5.0));
+    bg::append(poly1.outer(), point_t(5.0, 0.0));
+    bg::append(poly1.outer(), point_t(0.0, 0.0));
+
+    poly1.inners().resize(1); /*< Resize a container of interior rings. >*/
+    bg::append(poly1.inners()[0], point_t(1.0, 1.0)); /*< Append point to the interior ring. >*/
+    bg::append(poly1.inners()[0], point_t(4.0, 1.0));
+    bg::append(poly1.inners()[0], point_t(4.0, 4.0));
+    bg::append(poly1.inners()[0], point_t(1.0, 4.0));
+    bg::append(poly1.inners()[0], point_t(1.0, 1.0));
+
+    double a = bg::area(poly1);
+
+    std::cout << a << std::endl;
+
+    return 0;
+}
+
+//]
+
+
+//[polygon_output
+/*`
+Output:
+[pre
+16
+]
+*/
+//]

--- a/doc/src/examples/geometries/ring.cpp
+++ b/doc/src/examples/geometries/ring.cpp
@@ -1,0 +1,53 @@
+// Boost.Geometry
+// QuickBook Example
+
+// Copyright (c) 2011-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2015 Adam Wulkiewicz, Lodz, Poland.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+//[ring
+//` Declaration and use of the Boost.Geometry model::ring, modelling the Ring Concept
+
+#include <iostream>
+#include <boost/geometry.hpp>
+#include <boost/geometry/geometries/geometries.hpp>
+
+namespace bg = boost::geometry;
+
+int main()
+{
+    typedef bg::model::point<double, 2, bg::cs::cartesian> point_t;
+    typedef bg::model::ring<point_t> ring_t; /*< Default parameters, clockwise, closed ring. >*/
+
+    ring_t ring1; /*< Default-construct a ring. >*/
+#ifndef BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX
+    ring_t ring2{{0.0, 0.0}, {0.0, 5.0}, {5.0, 5.0}, {5.0, 0.0}, {0.0, 0.0}}; /*< Construct a ring containing four points plus one closing point, using C++11 unified initialization syntax. >*/
+#endif
+
+    bg::append(ring1, point_t(0.0, 0.0)); /*< Append point. >*/
+    bg::append(ring1, point_t(0.0, 5.0));
+    bg::append(ring1, point_t(5.0, 5.0));
+    bg::append(ring1, point_t(5.0, 0.0));
+    bg::append(ring1, point_t(0.0, 0.0));
+
+    double a = bg::area(ring1);
+
+    std::cout << a << std::endl;
+
+    return 0;
+}
+
+//]
+
+
+//[ring_output
+/*`
+Output:
+[pre
+25
+]
+*/
+//]

--- a/doc/src/examples/geometries/ring.cpp
+++ b/doc/src/examples/geometries/ring.cpp
@@ -23,8 +23,12 @@ int main()
     typedef bg::model::ring<point_t> ring_t; /*< Default parameters, clockwise, closed ring. >*/
 
     ring_t ring1; /*< Default-construct a ring. >*/
-#ifndef BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX
+
+#if !defined(BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX) \
+ && !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+
     ring_t ring2{{0.0, 0.0}, {0.0, 5.0}, {5.0, 5.0}, {5.0, 0.0}, {0.0, 0.0}}; /*< Construct a ring containing four points plus one closing point, using C++11 unified initialization syntax. >*/
+
 #endif
 
     bg::append(ring1, point_t(0.0, 0.0)); /*< Append point. >*/

--- a/doc/src/examples/geometries/segment.cpp
+++ b/doc/src/examples/geometries/segment.cpp
@@ -24,8 +24,11 @@ int main()
 
     segment_t seg1; /*< Default-construct a segment. >*/
     segment_t seg2(point_t(0.0, 0.0), point_t(5.0, 5.0)); /*< Construct, assigning the first and the second point. >*/
+
 #ifndef BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX
+
     segment_t seg3{{0.0, 0.0}, {5.0, 5.0}}; /*< Construct, using C++11 unified initialization syntax. >*/
+
 #endif
 
     bg::set<0, 0>(seg1, 1.0); /*< Set a coordinate. >*/

--- a/doc/src/examples/geometries/segment.cpp
+++ b/doc/src/examples/geometries/segment.cpp
@@ -1,0 +1,56 @@
+// Boost.Geometry
+// QuickBook Example
+
+// Copyright (c) 2011-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2015 Adam Wulkiewicz, Lodz, Poland.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+//[segment
+//` Declaration and use of the Boost.Geometry model::segment, modelling the Segment Concept
+
+#include <iostream>
+#include <boost/geometry.hpp>
+#include <boost/geometry/geometries/geometries.hpp>
+
+namespace bg = boost::geometry;
+
+int main()
+{
+    typedef bg::model::point<double, 2, bg::cs::cartesian> point_t;
+    typedef bg::model::segment<point_t> segment_t;
+
+    segment_t seg1; /*< Default-construct a segment. >*/
+    segment_t seg2(point_t(0.0, 0.0), point_t(5.0, 5.0)); /*< Construct, assigning the first and the second point. >*/
+#ifndef BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX
+    segment_t seg3{{0.0, 0.0}, {5.0, 5.0}}; /*< Construct, using C++11 unified initialization syntax. >*/
+#endif
+
+    bg::set<0, 0>(seg1, 1.0); /*< Set a coordinate. >*/
+    bg::set<0, 1>(seg1, 2.0);
+    bg::set<1, 0>(seg1, 3.0);
+    bg::set<1, 1>(seg1, 4.0);
+
+    double x0 = bg::get<0, 0>(seg1); /*< Get a coordinate. >*/
+    double y0 = bg::get<0, 1>(seg1);
+    double x1 = bg::get<1, 0>(seg1);
+    double y1 = bg::get<1, 1>(seg1);
+
+    std::cout << x0 << ", " << y0 << ", " << x1 << ", " << y1 << std::endl;
+
+    return 0;
+}
+
+//]
+
+
+//[segment_output
+/*`
+Output:
+[pre
+1, 2, 3, 4
+]
+*/
+//]

--- a/include/boost/geometry/geometries/box.hpp
+++ b/include/boost/geometry/geometries/box.hpp
@@ -50,6 +50,7 @@ class box
 
 public:
 
+    /// \constructor_default_no_init
     inline box() {}
 
     /*!

--- a/include/boost/geometry/geometries/box.hpp
+++ b/include/boost/geometry/geometries/box.hpp
@@ -30,18 +30,21 @@ namespace boost { namespace geometry
 namespace model
 {
 
-
 /*!
-    \brief Class box: defines a box made of two describing points
-    \ingroup geometries
-    \details Box is always described by a min_corner() and a max_corner() point. If another
-        rectangle is used, use linear_ring or polygon.
-    \note Boxes are for selections and for calculating the envelope of geometries. Not all algorithms
-    are implemented for box. Boxes are also used in Spatial Indexes.
-    \tparam Point point type. The box takes a point type as template parameter.
-    The point type can be any point type.
-    It can be 2D but can also be 3D or more dimensional.
-    The box can also take a latlong point type as template parameter.
+\brief Class box: defines a box made of two describing points
+\ingroup geometries
+\details Box is always described by a min_corner() and a max_corner() point. If another
+    rectangle is used, use linear_ring or polygon.
+\note Boxes are for selections and for calculating the envelope of geometries. Not all algorithms
+are implemented for box. Boxes are also used in Spatial Indexes.
+\tparam Point point type. The box takes a point type as template parameter.
+The point type can be any point type.
+It can be 2D but can also be 3D or more dimensional.
+The box can also take a latlong point type as template parameter.
+
+\qbk{[include reference/geometries/box.qbk]}
+\qbk{before.synopsis, [heading Model of]}
+\qbk{before.synopsis, [link geometry.reference.concepts.concept_box Box Concept]}
  */
 
 template<typename Point>

--- a/include/boost/geometry/geometries/box.hpp
+++ b/include/boost/geometry/geometries/box.hpp
@@ -17,6 +17,7 @@
 #include <cstddef>
 
 #include <boost/concept/assert.hpp>
+#include <boost/config.hpp>
 
 #include <boost/geometry/algorithms/convert.hpp>
 #include <boost/geometry/geometries/concepts/point_concept.hpp>
@@ -50,8 +51,14 @@ class box
 
 public:
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
     /// \constructor_default_no_init
-    inline box() {}
+    box() = default;
+#else
+    /// \constructor_default_no_init
+    inline box()
+    {}
+#endif
 
     /*!
         \brief Constructor taking the minimum corner point and the maximum corner point

--- a/include/boost/geometry/geometries/linestring.hpp
+++ b/include/boost/geometry/geometries/linestring.hpp
@@ -26,11 +26,9 @@
 
 #include <boost/geometry/geometries/concepts/point_concept.hpp>
 
-#ifdef BOOST_GEOMETRY_EXPERIMENTAL_ENABLE_INITIALIZER_LIST
 #include <boost/config.hpp>
 #ifndef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
 #include <initializer_list>
-#endif
 #endif
 
 namespace boost { namespace geometry
@@ -76,7 +74,6 @@ public :
         : base_type(begin, end)
     {}
 
-#ifdef BOOST_GEOMETRY_EXPERIMENTAL_ENABLE_INITIALIZER_LIST
 #ifndef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
 
     /// \constructor_initializer_list{linestring}
@@ -97,7 +94,6 @@ public :
 //    }
 //#endif
 
-#endif
 #endif
 };
 

--- a/include/boost/geometry/geometries/linestring.hpp
+++ b/include/boost/geometry/geometries/linestring.hpp
@@ -44,6 +44,7 @@ namespace model
 \tparam Container \tparam_container
 \tparam Allocator \tparam_allocator
 
+\qbk{[include reference/geometries/linestring.qbk]}
 \qbk{before.synopsis,
 [heading Model of]
 [link geometry.reference.concepts.concept_linestring Linestring Concept]

--- a/include/boost/geometry/geometries/multi_linestring.hpp
+++ b/include/boost/geometry/geometries/multi_linestring.hpp
@@ -23,11 +23,9 @@
 #include <boost/geometry/core/tags.hpp>
 #include <boost/geometry/geometries/concepts/linestring_concept.hpp>
 
-#ifdef BOOST_GEOMETRY_EXPERIMENTAL_ENABLE_INITIALIZER_LIST
 #include <boost/config.hpp>
 #ifndef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
 #include <initializer_list>
-#endif
 #endif
 
 namespace boost { namespace geometry
@@ -58,7 +56,10 @@ class multi_linestring : public Container<LineString, Allocator<LineString> >
 {
     BOOST_CONCEPT_ASSERT( (concept::Linestring<LineString>) );
 
-#ifdef BOOST_GEOMETRY_EXPERIMENTAL_ENABLE_INITIALIZER_LIST
+#ifndef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
+
+    // default constructor and base_type definitions are required only
+    // if the constructor taking std::initializer_list is defined
 
     typedef Container<LineString, Allocator<LineString> > base_type;
 
@@ -67,8 +68,6 @@ public:
     multi_linestring()
         : base_type()
     {}
-
-#ifndef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
 
     /// \constructor_initializer_list{multi_linestring}
     inline multi_linestring(std::initializer_list<LineString> l)
@@ -88,7 +87,6 @@ public:
 //    }
 //#endif
 
-#endif
 #endif
 };
 

--- a/include/boost/geometry/geometries/multi_linestring.hpp
+++ b/include/boost/geometry/geometries/multi_linestring.hpp
@@ -41,6 +41,7 @@ namespace model
         e.g. a highway (with interruptions)
 \ingroup geometries
 
+\qbk{[include reference/geometries/multi_linestring.qbk]}
 \qbk{before.synopsis,
 [heading Model of]
 [link geometry.reference.concepts.concept_multi_linestring MultiLineString Concept]

--- a/include/boost/geometry/geometries/multi_point.hpp
+++ b/include/boost/geometry/geometries/multi_point.hpp
@@ -23,11 +23,9 @@
 #include <boost/geometry/core/tags.hpp>
 #include <boost/geometry/geometries/concepts/point_concept.hpp>
 
-#ifdef BOOST_GEOMETRY_EXPERIMENTAL_ENABLE_INITIALIZER_LIST
 #include <boost/config.hpp>
 #ifndef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
 #include <initializer_list>
-#endif
 #endif
 
 namespace boost { namespace geometry
@@ -74,7 +72,6 @@ public :
         : base_type(begin, end)
     {}
 
-#ifdef BOOST_GEOMETRY_EXPERIMENTAL_ENABLE_INITIALIZER_LIST
 #ifndef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
 
     /// \constructor_initializer_list{multi_point}
@@ -95,7 +92,6 @@ public :
 //    }
 //#endif
 
-#endif
 #endif
 };
 

--- a/include/boost/geometry/geometries/multi_point.hpp
+++ b/include/boost/geometry/geometries/multi_point.hpp
@@ -43,6 +43,8 @@ namespace model
 \tparam Allocator \tparam_allocator
 \details Multipoint can be used to group points belonging to each other,
         e.g. a constellation, or the result set of an intersection
+
+\qbk{[include reference/geometries/multi_point.qbk]}
 \qbk{before.synopsis,
 [heading Model of]
 [link geometry.reference.concepts.concept_multi_point MultiPoint Concept]

--- a/include/boost/geometry/geometries/multi_polygon.hpp
+++ b/include/boost/geometry/geometries/multi_polygon.hpp
@@ -40,6 +40,7 @@ namespace model
         e.g. Hawaii
 \ingroup geometries
 
+\qbk{[include reference/geometries/multi_polygon.qbk]}
 \qbk{before.synopsis,
 [heading Model of]
 [link geometry.reference.concepts.concept_multi_polygon MultiPolygon Concept]

--- a/include/boost/geometry/geometries/multi_polygon.hpp
+++ b/include/boost/geometry/geometries/multi_polygon.hpp
@@ -23,11 +23,9 @@
 #include <boost/geometry/core/tags.hpp>
 #include <boost/geometry/geometries/concepts/polygon_concept.hpp>
 
-#ifdef BOOST_GEOMETRY_EXPERIMENTAL_ENABLE_INITIALIZER_LIST
 #include <boost/config.hpp>
 #ifndef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
 #include <initializer_list>
-#endif
 #endif
 
 namespace boost { namespace geometry
@@ -57,7 +55,10 @@ class multi_polygon : public Container<Polygon, Allocator<Polygon> >
 {
     BOOST_CONCEPT_ASSERT( (concept::Polygon<Polygon>) );
 
-#ifdef BOOST_GEOMETRY_EXPERIMENTAL_ENABLE_INITIALIZER_LIST
+#ifndef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
+
+    // default constructor and base_type definitions are required only
+    // if the constructor taking std::initializer_list is defined
 
     typedef Container<Polygon, Allocator<Polygon> > base_type;
 
@@ -66,8 +67,6 @@ public:
     multi_polygon()
         : base_type()
     {}
-
-#ifndef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
 
     /// \constructor_initializer_list{multi_polygon}
     inline multi_polygon(std::initializer_list<Polygon> l)
@@ -87,7 +86,6 @@ public:
 //    }
 //#endif
 
-#endif
 #endif
 };
 

--- a/include/boost/geometry/geometries/point.hpp
+++ b/include/boost/geometry/geometries/point.hpp
@@ -108,7 +108,7 @@ private:
 
 public:
 
-    /// @brief Default constructor, no initialization
+    /// \constructor_default_no_init
     inline point()
     {
         BOOST_STATIC_ASSERT(DimensionCount >= 1);

--- a/include/boost/geometry/geometries/point.hpp
+++ b/include/boost/geometry/geometries/point.hpp
@@ -22,8 +22,8 @@
 
 #include <cstddef>
 
+#include <boost/mpl/assert.hpp>
 #include <boost/mpl/int.hpp>
-#include <boost/static_assert.hpp>
 
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
@@ -100,7 +100,10 @@ template
 >
 class point
 {
-private:
+    BOOST_MPL_ASSERT_MSG((DimensionCount >= 1),
+                         DIMENSION_GREATER_THAN_ZERO_EXPECTED,
+                         (boost::mpl::int_<DimensionCount>));
+
     // The following enum is used to fully instantiate the
     // CoordinateSystem class and check the correctness of the units
     // passed for non-Cartesian coordinate systems.
@@ -110,9 +113,7 @@ public:
 
     /// \constructor_default_no_init
     inline point()
-    {
-        BOOST_STATIC_ASSERT(DimensionCount >= 1);
-    }
+    {}
 
     /// @brief Constructor to set one value
     explicit inline point(CoordinateType const& v0)

--- a/include/boost/geometry/geometries/point.hpp
+++ b/include/boost/geometry/geometries/point.hpp
@@ -22,6 +22,7 @@
 
 #include <cstddef>
 
+#include <boost/config.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/mpl/int.hpp>
 
@@ -111,9 +112,14 @@ class point
 
 public:
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+    /// \constructor_default_no_init
+    point() = default;
+#else
     /// \constructor_default_no_init
     inline point()
     {}
+#endif
 
     /// @brief Constructor to set one value
     explicit inline point(CoordinateType const& v0)

--- a/include/boost/geometry/geometries/point_xy.hpp
+++ b/include/boost/geometry/geometries/point_xy.hpp
@@ -16,6 +16,7 @@
 
 #include <cstddef>
 
+#include <boost/config.hpp>
 #include <boost/mpl/int.hpp>
 
 #include <boost/geometry/core/cs.hpp>
@@ -45,10 +46,14 @@ class point_xy : public model::point<CoordinateType, 2, CoordinateSystem>
 {
 public:
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+    /// \constructor_default_no_init
+    point_xy() = default;
+#else
     /// \constructor_default_no_init
     inline point_xy()
-        : model::point<CoordinateType, 2, CoordinateSystem>()
     {}
+#endif
 
     /// Constructor with x/y values
     inline point_xy(CoordinateType const& x, CoordinateType const& y)

--- a/include/boost/geometry/geometries/point_xy.hpp
+++ b/include/boost/geometry/geometries/point_xy.hpp
@@ -45,7 +45,7 @@ class point_xy : public model::point<CoordinateType, 2, CoordinateSystem>
 {
 public:
 
-    /// Default constructor, does not initialize anything
+    /// \constructor_default_no_init
     inline point_xy()
         : model::point<CoordinateType, 2, CoordinateSystem>()
     {}

--- a/include/boost/geometry/geometries/point_xy.hpp
+++ b/include/boost/geometry/geometries/point_xy.hpp
@@ -33,6 +33,7 @@ namespace model { namespace d2
 \tparam CoordinateType numeric type, for example, double, float, int
 \tparam CoordinateSystem coordinate system, defaults to cs::cartesian
 
+\qbk{[include reference/geometries/point_xy.qbk]}
 \qbk{before.synopsis,
 [heading Model of]
 [link geometry.reference.concepts.concept_point Point Concept]

--- a/include/boost/geometry/geometries/polygon.hpp
+++ b/include/boost/geometry/geometries/polygon.hpp
@@ -55,6 +55,7 @@ namespace model
 \note The container collecting the points in the rings can be different
     from the container collecting the inner rings. They all default to vector.
 
+\qbk{[include reference/geometries/polygon.qbk]}
 \qbk{before.synopsis,
 [heading Model of]
 [link geometry.reference.concepts.concept_polygon Polygon Concept]

--- a/include/boost/geometry/geometries/polygon.hpp
+++ b/include/boost/geometry/geometries/polygon.hpp
@@ -27,11 +27,9 @@
 #include <boost/geometry/geometries/concepts/point_concept.hpp>
 #include <boost/geometry/geometries/ring.hpp>
 
-#ifdef BOOST_GEOMETRY_EXPERIMENTAL_ENABLE_INITIALIZER_LIST
 #include <boost/config.hpp>
 #ifndef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
 #include <initializer_list>
-#endif
 #endif
 
 namespace boost { namespace geometry
@@ -91,7 +89,10 @@ public:
     inline ring_type& outer() { return m_outer; }
     inline inner_container_type & inners() { return m_inners; }
 
-#ifdef BOOST_GEOMETRY_EXPERIMENTAL_ENABLE_INITIALIZER_LIST
+#ifndef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
+
+    // default constructor definition is required only
+    // if the constructor taking std::initializer_list is defined
 
     /// \constructor_default{polygon}
     inline polygon()
@@ -99,7 +100,6 @@ public:
         , m_inners()
     {}
 
-#ifndef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
     /// \constructor_initializer_list{polygon}
     inline polygon(std::initializer_list<ring_type> l)
         : m_outer(l.size() > 0 ? *l.begin() : ring_type())
@@ -128,7 +128,6 @@ public:
 //    }
 //#endif
 
-#endif
 #endif
 
     /// Utility method, clears outer and inner rings

--- a/include/boost/geometry/geometries/ring.hpp
+++ b/include/boost/geometry/geometries/ring.hpp
@@ -48,6 +48,7 @@ namespace model
 \tparam Container container type, for example std::vector, std::deque
 \tparam Allocator container-allocator-type
 
+\qbk{[include reference/geometries/ring.qbk]}
 \qbk{before.synopsis,
 [heading Model of]
 [link geometry.reference.concepts.concept_ring Ring Concept]

--- a/include/boost/geometry/geometries/ring.hpp
+++ b/include/boost/geometry/geometries/ring.hpp
@@ -27,11 +27,9 @@
 
 #include <boost/geometry/geometries/concepts/point_concept.hpp>
 
-#ifdef BOOST_GEOMETRY_EXPERIMENTAL_ENABLE_INITIALIZER_LIST
 #include <boost/config.hpp>
 #ifndef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
 #include <initializer_list>
-#endif
 #endif
 
 namespace boost { namespace geometry
@@ -80,7 +78,6 @@ public :
         : base_type(begin, end)
     {}
 
-#ifdef BOOST_GEOMETRY_EXPERIMENTAL_ENABLE_INITIALIZER_LIST
 #ifndef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
 
     /// \constructor_initializer_list{ring}
@@ -101,7 +98,6 @@ public :
 //    }
 //#endif
 
-#endif
 #endif
 };
 

--- a/include/boost/geometry/geometries/segment.hpp
+++ b/include/boost/geometry/geometries/segment.hpp
@@ -39,6 +39,8 @@ namespace model
 template<typename Point>
 class segment : public std::pair<Point, Point>
 {
+    BOOST_CONCEPT_ASSERT( (concept::Point<Point>) );
+
 public :
     /// \constructor_default_no_init
     inline segment()

--- a/include/boost/geometry/geometries/segment.hpp
+++ b/include/boost/geometry/geometries/segment.hpp
@@ -40,9 +40,13 @@ template<typename Point>
 class segment : public std::pair<Point, Point>
 {
 public :
+    /// \constructor_default_no_init
     inline segment()
     {}
 
+    /*!
+        \brief Constructor taking the first and the second point
+    */
     inline segment(Point const& p1, Point const& p2)
     {
         this->first = p1;
@@ -83,6 +87,9 @@ public:
     point_type& first;
     point_type& second;
 
+    /*!
+        \brief Constructor taking the first and the second point
+    */
     inline referring_segment(point_type& p1, point_type& p2)
         : first(p1)
         , second(p2)

--- a/include/boost/geometry/geometries/segment.hpp
+++ b/include/boost/geometry/geometries/segment.hpp
@@ -42,9 +42,15 @@ class segment : public std::pair<Point, Point>
     BOOST_CONCEPT_ASSERT( (concept::Point<Point>) );
 
 public :
+
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+    /// \constructor_default_no_init
+    segment() = default;
+#else
     /// \constructor_default_no_init
     inline segment()
     {}
+#endif
 
     /*!
         \brief Constructor taking the first and the second point

--- a/include/boost/geometry/geometries/segment.hpp
+++ b/include/boost/geometry/geometries/segment.hpp
@@ -35,6 +35,12 @@ namespace model
  by two distinct end points, and contains every point on the line between its end points.
 \note There is also a point-referring-segment, class referring_segment,
    containing point references, where points are NOT copied
+
+\qbk{[include reference/geometries/segment.qbk]}
+\qbk{before.synopsis,
+[heading Model of]
+[link geometry.reference.concepts.concept_segment Segment Concept]
+}
 */
 template<typename Point>
 class segment : public std::pair<Point, Point>

--- a/test/geometries/Jamfile.v2
+++ b/test/geometries/Jamfile.v2
@@ -25,6 +25,6 @@ test-suite boost-geometry-geometries
     #    custom_linestring_test_fail_clear
     #]
     [ run custom_linestring.cpp ]
-    [ run geometries.cpp : : : <define>BOOST_GEOMETRY_EXPERIMENTAL_ENABLE_INITIALIZER_LIST ]
+    [ run geometries.cpp ]
     [ run segment.cpp ]
     ;


### PR DESCRIPTION
This PR is a continuation of https://github.com/boostorg/geometry/pull/279. It adds examples for models, in particular showing the creation of models using the C++11 unified syntax and `std::initializer_list`.