### PR TITLE
Detection of access to uninitialized or destroyed geometries.

### DIFF
--- a/include/boost/geometry/geometries/box.hpp
+++ b/include/boost/geometry/geometries/box.hpp
@@ -22,6 +22,9 @@
 #include <boost/geometry/algorithms/convert.hpp>
 #include <boost/geometry/geometries/concepts/point_concept.hpp>
 
+#if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
+#include <boost/assert.hpp>
+#endif
 
 
 namespace boost { namespace geometry
@@ -54,13 +57,24 @@ class box
 
 public:
 
-#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+#if !defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
+#if !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)
     /// \constructor_default_no_init
     box() = default;
 #else
     /// \constructor_default_no_init
     inline box()
     {}
+#endif
+#else // defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
+    inline box()
+    {
+        m_magic = 1;
+    }
+    ~box()
+    {
+        m_magic = 0;
+    }
 #endif
 
     /*!
@@ -70,18 +84,50 @@ public:
     {
         geometry::convert(min_corner, m_min_corner);
         geometry::convert(max_corner, m_max_corner);
+
+#if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
+        m_magic = 1;
+#endif
     }
 
-    inline Point const& min_corner() const { return m_min_corner; }
-    inline Point const& max_corner() const { return m_max_corner; }
+    inline Point const& min_corner() const
+    {
+#if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
+        BOOST_ASSERT(m_magic == 1);
+#endif
+        return m_min_corner;
+    }
+    inline Point const& max_corner() const
+    {
+#if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
+        BOOST_ASSERT(m_magic == 1);
+#endif
+        return m_max_corner;
+    }
 
-    inline Point& min_corner() { return m_min_corner; }
-    inline Point& max_corner() { return m_max_corner; }
+    inline Point& min_corner()
+    {
+#if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
+        BOOST_ASSERT(m_magic == 1);
+#endif
+        return m_min_corner;
+    }
+    inline Point& max_corner()
+    {
+#if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
+        BOOST_ASSERT(m_magic == 1);
+#endif
+        return m_max_corner;
+    }
 
 private:
 
     Point m_min_corner;
     Point m_max_corner;
+
+#if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
+    int m_magic;
+#endif
 };
 
 

--- a/include/boost/geometry/geometries/box.hpp
+++ b/include/boost/geometry/geometries/box.hpp
@@ -69,11 +69,11 @@ public:
 #else // defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
     inline box()
     {
-        m_magic = 1;
+        m_created = 1;
     }
     ~box()
     {
-        m_magic = 0;
+        m_created = 0;
     }
 #endif
 
@@ -86,21 +86,21 @@ public:
         geometry::convert(max_corner, m_max_corner);
 
 #if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
-        m_magic = 1;
+        m_created = 1;
 #endif
     }
 
     inline Point const& min_corner() const
     {
 #if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
-        BOOST_ASSERT(m_magic == 1);
+        BOOST_ASSERT(m_created == 1);
 #endif
         return m_min_corner;
     }
     inline Point const& max_corner() const
     {
 #if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
-        BOOST_ASSERT(m_magic == 1);
+        BOOST_ASSERT(m_created == 1);
 #endif
         return m_max_corner;
     }
@@ -108,14 +108,14 @@ public:
     inline Point& min_corner()
     {
 #if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
-        BOOST_ASSERT(m_magic == 1);
+        BOOST_ASSERT(m_created == 1);
 #endif
         return m_min_corner;
     }
     inline Point& max_corner()
     {
 #if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
-        BOOST_ASSERT(m_magic == 1);
+        BOOST_ASSERT(m_created == 1);
 #endif
         return m_max_corner;
     }
@@ -126,7 +126,7 @@ private:
     Point m_max_corner;
 
 #if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
-    int m_magic;
+    int m_created;
 #endif
 };
 

--- a/include/boost/geometry/geometries/point.hpp
+++ b/include/boost/geometry/geometries/point.hpp
@@ -31,6 +31,11 @@
 #include <boost/geometry/core/coordinate_system.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 
+#if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
+#include <algorithm>
+#include <boost/assert.hpp>
+#endif
+
 namespace boost { namespace geometry
 {
 
@@ -112,13 +117,26 @@ class point
 
 public:
 
-#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+#if !defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
+#if !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)
     /// \constructor_default_no_init
     point() = default;
 #else
     /// \constructor_default_no_init
     inline point()
     {}
+#endif
+#else // defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
+    point()
+    {
+        m_magic = 1;
+        std::fill_n(m_magic_values, DimensionCount, 0);
+    }
+    ~point()
+    {
+        m_magic = 0;
+        std::fill_n(m_magic_values, DimensionCount, 0);
+    }
 #endif
 
     /// @brief Constructor to set one value
@@ -127,6 +145,11 @@ public:
         detail::array_assign<DimensionCount, 0>::apply(m_values, v0);
         detail::array_assign<DimensionCount, 1>::apply(m_values, CoordinateType());
         detail::array_assign<DimensionCount, 2>::apply(m_values, CoordinateType());
+
+#if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
+        m_magic = 1;
+        std::fill_n(m_magic_values, (std::min)(std::size_t(3), DimensionCount), 1);
+#endif
     }
 
     /// @brief Constructor to set two values
@@ -135,6 +158,11 @@ public:
         detail::array_assign<DimensionCount, 0>::apply(m_values, v0);
         detail::array_assign<DimensionCount, 1>::apply(m_values, v1);
         detail::array_assign<DimensionCount, 2>::apply(m_values, CoordinateType());
+
+#if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
+        m_magic = 1;
+        std::fill_n(m_magic_values, (std::min)(std::size_t(3), DimensionCount), 1);
+#endif
     }
 
     /// @brief Constructor to set three values
@@ -144,6 +172,11 @@ public:
         detail::array_assign<DimensionCount, 0>::apply(m_values, v0);
         detail::array_assign<DimensionCount, 1>::apply(m_values, v1);
         detail::array_assign<DimensionCount, 2>::apply(m_values, v2);
+
+#if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
+        m_magic = 1;
+        std::fill_n(m_magic_values, (std::min)(std::size_t(3), DimensionCount), 1);
+#endif
     }
 
     /// @brief Get a coordinate
@@ -152,6 +185,10 @@ public:
     template <std::size_t K>
     inline CoordinateType const& get() const
     {
+#if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
+        BOOST_ASSERT(m_magic == 1);
+        BOOST_ASSERT(m_magic_values[K] == 1);
+#endif
         BOOST_STATIC_ASSERT(K < DimensionCount);
         return m_values[K];
     }
@@ -162,6 +199,10 @@ public:
     template <std::size_t K>
     inline void set(CoordinateType const& value)
     {
+#if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
+        BOOST_ASSERT(m_magic == 1);
+        m_magic_values[K] = 1;
+#endif
         BOOST_STATIC_ASSERT(K < DimensionCount);
         m_values[K] = value;
     }
@@ -169,6 +210,11 @@ public:
 private:
 
     CoordinateType m_values[DimensionCount];
+
+#if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
+    int m_magic;
+    int m_magic_values[DimensionCount];
+#endif
 };
 
 

--- a/include/boost/geometry/geometries/point.hpp
+++ b/include/boost/geometry/geometries/point.hpp
@@ -129,13 +129,13 @@ public:
 #else // defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
     point()
     {
-        m_magic = 1;
-        std::fill_n(m_magic_values, DimensionCount, 0);
+        m_created = 1;
+        std::fill_n(m_values_initialized, DimensionCount, 0);
     }
     ~point()
     {
-        m_magic = 0;
-        std::fill_n(m_magic_values, DimensionCount, 0);
+        m_created = 0;
+        std::fill_n(m_values_initialized, DimensionCount, 0);
     }
 #endif
 
@@ -147,8 +147,8 @@ public:
         detail::array_assign<DimensionCount, 2>::apply(m_values, CoordinateType());
 
 #if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
-        m_magic = 1;
-        std::fill_n(m_magic_values, (std::min)(std::size_t(3), DimensionCount), 1);
+        m_created = 1;
+        std::fill_n(m_values_initialized, (std::min)(std::size_t(3), DimensionCount), 1);
 #endif
     }
 
@@ -160,8 +160,8 @@ public:
         detail::array_assign<DimensionCount, 2>::apply(m_values, CoordinateType());
 
 #if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
-        m_magic = 1;
-        std::fill_n(m_magic_values, (std::min)(std::size_t(3), DimensionCount), 1);
+        m_created = 1;
+        std::fill_n(m_values_initialized, (std::min)(std::size_t(3), DimensionCount), 1);
 #endif
     }
 
@@ -174,8 +174,8 @@ public:
         detail::array_assign<DimensionCount, 2>::apply(m_values, v2);
 
 #if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
-        m_magic = 1;
-        std::fill_n(m_magic_values, (std::min)(std::size_t(3), DimensionCount), 1);
+        m_created = 1;
+        std::fill_n(m_values_initialized, (std::min)(std::size_t(3), DimensionCount), 1);
 #endif
     }
 
@@ -186,8 +186,8 @@ public:
     inline CoordinateType const& get() const
     {
 #if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
-        BOOST_ASSERT(m_magic == 1);
-        BOOST_ASSERT(m_magic_values[K] == 1);
+        BOOST_ASSERT(m_created == 1);
+        BOOST_ASSERT(m_values_initialized[K] == 1);
 #endif
         BOOST_STATIC_ASSERT(K < DimensionCount);
         return m_values[K];
@@ -200,8 +200,8 @@ public:
     inline void set(CoordinateType const& value)
     {
 #if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
-        BOOST_ASSERT(m_magic == 1);
-        m_magic_values[K] = 1;
+        BOOST_ASSERT(m_created == 1);
+        m_values_initialized[K] = 1;
 #endif
         BOOST_STATIC_ASSERT(K < DimensionCount);
         m_values[K] = value;
@@ -212,8 +212,8 @@ private:
     CoordinateType m_values[DimensionCount];
 
 #if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
-    int m_magic;
-    int m_magic_values[DimensionCount];
+    int m_created;
+    int m_values_initialized[DimensionCount];
 #endif
 };
 


### PR DESCRIPTION
If `BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING` is defined getters and setters checks if the data being read was properly initialized and if the object was properly created and wasn't destroyed.

With this change it's easy to detect e.g. the use of references to destroyed temporaries or the use of uninitialized objects.
