### PR TITLE
Fix point arithmetic functions and centroid

### DIFF
--- a/include/boost/geometry/arithmetic/arithmetic.hpp
+++ b/include/boost/geometry/arithmetic/arithmetic.hpp
@@ -33,53 +33,53 @@ namespace detail
 {
 
 
-template <typename P>
+template <typename Point>
 struct param
 {
     typedef typename boost::call_traits
         <
-            typename coordinate_type<P>::type
+            typename coordinate_type<Point>::type
         >::param_type type;
 };
 
 
-template <typename C, template <typename> class Function>
+template <typename Value, template <typename> class Function>
 struct value_operation
 {
-    C m_value;
+    Value m_value;
 
-    inline value_operation(C const &value)
+    inline value_operation(Value const &value)
         : m_value(value)
     {}
 
-    template <typename PointDst, int I>
-    inline void apply(PointDst& dest_point) const
+    template <typename PointDst, std::size_t Index>
+    inline void apply(PointDst& point_dst) const
     {
-        set<I>(dest_point,
+        set<Index>(point_dst,
                Function
                 <
                     typename geometry::select_most_precise
                         <
-                            C,
+                            Value,
                             typename geometry::coordinate_type<PointDst>::type
                         >::type
-                >()(get<I>(dest_point), m_value));
+                >()(get<Index>(point_dst), m_value));
     }
 };
 
 template <typename PointSrc, template <typename> class Function>
 struct point_operation
 {
-    PointSrc const& m_source_point;
+    PointSrc const& m_point_src;
 
     inline point_operation(PointSrc const& point)
-        : m_source_point(point)
+        : m_point_src(point)
     {}
 
-    template <typename PointDst, int I>
-    inline void apply(PointDst& dest_point) const
+    template <typename PointDst, std::size_t Index>
+    inline void apply(PointDst& point_dst) const
     {
-        set<I>(dest_point,
+        set<Index>(point_dst,
                Function
                 <
                     typename geometry::select_most_precise
@@ -87,40 +87,40 @@ struct point_operation
                             typename geometry::coordinate_type<PointSrc>::type,
                             typename geometry::coordinate_type<PointDst>::type
                         >::type
-                >()(get<I>(dest_point), get<I>(m_source_point)));
+                >()(get<Index>(point_dst), get<Index>(m_point_src)));
     }
 };
 
 
-template <typename C>
+template <typename Value>
 struct value_assignment
 {
-    C m_value;
+    Value m_value;
 
-    inline value_assignment(C const &value)
+    inline value_assignment(Value const &value)
         : m_value(value)
     {}
 
-    template <typename P, int I>
-    inline void apply(P& point) const
+    template <typename PointDst, std::size_t Index>
+    inline void apply(PointDst& point_dst) const
     {
-        set<I>(point, m_value);
+        set<Index>(point_dst, m_value);
     }
 };
 
 template <typename PointSrc>
 struct point_assignment
 {
-    PointSrc const& m_source_point;
+    PointSrc const& m_point_src;
 
     inline point_assignment(PointSrc const& point)
-        : m_source_point(point)
+        : m_point_src(point)
     {}
 
-    template <typename PointDst, int I>
-    inline void apply(PointDst& dest_point) const
+    template <typename PointDst, std::size_t Index>
+    inline void apply(PointDst& point_dst) const
     {
-        set<I>(dest_point, get<I>(m_source_point));
+        set<Index>(point_dst, get<Index>(m_point_src));
     }
 };
 
@@ -141,7 +141,12 @@ inline void add_value(Point& p, typename detail::param<Point>::type value)
 {
     BOOST_CONCEPT_ASSERT( (concept::Point<Point>) );
 
-    for_each_coordinate(p, detail::value_operation<typename coordinate_type<Point>::type, std::plus>(value));
+    for_each_coordinate(p,
+                        detail::value_operation
+                            <
+                                typename coordinate_type<Point>::type,
+                                std::plus
+                            >(value));
 }
 
 /*!
@@ -176,7 +181,12 @@ inline void subtract_value(Point& p, typename detail::param<Point>::type value)
 {
     BOOST_CONCEPT_ASSERT( (concept::Point<Point>) );
 
-    for_each_coordinate(p, detail::value_operation<typename coordinate_type<Point>::type, std::minus>(value));
+    for_each_coordinate(p,
+                        detail::value_operation
+                            <
+                                typename coordinate_type<Point>::type,
+                                std::minus
+                            >(value));
 }
 
 /*!
@@ -211,7 +221,12 @@ inline void multiply_value(Point& p, typename detail::param<Point>::type value)
 {
     BOOST_CONCEPT_ASSERT( (concept::Point<Point>) );
 
-    for_each_coordinate(p, detail::value_operation<typename coordinate_type<Point>::type, std::multiplies>(value));
+    for_each_coordinate(p,
+                        detail::value_operation
+                            <
+                                typename coordinate_type<Point>::type,
+                                std::multiplies
+                            >(value));
 }
 
 /*!
@@ -247,7 +262,12 @@ inline void divide_value(Point& p, typename detail::param<Point>::type value)
 {
     BOOST_CONCEPT_ASSERT( (concept::Point<Point>) );
 
-    for_each_coordinate(p, detail::value_operation<typename coordinate_type<Point>::type, std::divides>(value));
+    for_each_coordinate(p,
+                        detail::value_operation
+                            <
+                                typename coordinate_type<Point>::type,
+                                std::divides
+                            >(value));
 }
 
 /*!
@@ -282,7 +302,11 @@ inline void assign_value(Point& p, typename detail::param<Point>::type value)
 {
     BOOST_CONCEPT_ASSERT( (concept::Point<Point>) );
 
-    for_each_coordinate(p, detail::value_assignment<typename coordinate_type<Point>::type>(value));
+    for_each_coordinate(p,
+                        detail::value_assignment
+                            <
+                                typename coordinate_type<Point>::type
+                            >(value));
 }
 
 /*!

--- a/test/algorithms/centroid.cpp
+++ b/test/algorithms/centroid.cpp
@@ -56,6 +56,15 @@ void test_polygon()
     // should (1.5 1) be returned?
     // if yes, then all other Polygons degenerated to Linestrings should be handled
     test_centroid<Polygon>("POLYGON((1 1,2 1,1 1,1 1))", 1.0, 1.0);
+
+    // reported 2015.04.24
+    // input INT, result FP
+    test_centroid
+        <
+            bg::model::polygon<bg::model::d2::point_xy<int> >,
+            typename bg::point_type<Polygon>::type,
+            typename bg::coordinate_type<Polygon>::type
+        >("POLYGON((1 1, 1 2, 2 2, 2 1, 1 1))", 1.5, 1.5);
 }
 
 
@@ -97,6 +106,23 @@ void test_2d()
 
     test_centroid<bg::model::box<P> >("POLYGON((1 2,3 4))", 2, 3);
     test_centroid<P>("POINT(3 3)", 3, 3);
+
+    // INT -> FP
+    test_centroid
+        <
+            bg::model::ring<bg::model::d2::point_xy<int> >,
+            P, typename bg::coordinate_type<P>::type
+        >("POLYGON((1 1, 1 2, 2 2, 2 1, 1 1))", 1.5, 1.5);
+    test_centroid
+        <
+            bg::model::linestring<bg::model::d2::point_xy<int> >,
+            P, typename bg::coordinate_type<P>::type
+        >("LINESTRING(1 1, 2 2)", 1.5, 1.5);
+    test_centroid
+        <
+            bg::model::box<bg::model::d2::point_xy<int> >,
+            P, typename bg::coordinate_type<P>::type
+        >("BOX(1 1, 2 2)", 1.5, 1.5);
 }
 
 

--- a/test/algorithms/test_centroid.hpp
+++ b/test/algorithms/test_centroid.hpp
@@ -30,6 +30,7 @@ struct check_result
     static void apply(Point1 const& actual, Point2 const& expected)
     {
         check_result<D-1>::apply(actual, expected);
+
         BOOST_CHECK_CLOSE(bg::get<D-1>(actual), bg::get<D-1>(expected), 0.001);
     }
 };
@@ -48,9 +49,9 @@ void test_with_other_calculation_type(Geometry const& geometry, Point& c1)
 {
     typedef typename bg::point_type<Geometry>::type point_type;
     // Calculate it with user defined strategy
-    point_type c2;
+    Point c2;
     bg::centroid(geometry, c2,
-        bg::strategy::centroid::bashein_detmer<point_type, point_type, CalculationType>());
+        bg::strategy::centroid::bashein_detmer<Point, point_type, CalculationType>());
 
     std::cout << typeid(CalculationType).name() << ": " << std::setprecision(20)
         << bg::get<0>(c2) << " " << bg::get<1>(c2)
@@ -58,13 +59,13 @@ void test_with_other_calculation_type(Geometry const& geometry, Point& c1)
         << std::endl;
 }
 
-template <typename Geometry, typename T>
+template <typename Geometry, typename Point, typename T>
 void test_centroid(std::string const& wkt, T const& d1, T const& d2, T const& d3 = T(), T const& d4 = T(), T const& d5 = T())
 {
     Geometry geometry;
     bg::read_wkt(wkt, geometry);
-    typedef typename bg::point_type<Geometry>::type point_type;
-    point_type c1;
+
+    Point c1;
 
     bg::centroid(geometry, c1);
     check_result<bg::dimension<Geometry>::type::value>::apply(c1, boost::make_tuple(d1, d2, d3, d4, d5));
@@ -83,6 +84,12 @@ void test_centroid(std::string const& wkt, T const& d1, T const& d2, T const& d3
 #endif
 
 #endif
+}
+
+template <typename Geometry, typename T>
+void test_centroid(std::string const& wkt, T const& d1, T const& d2, T const& d3 = T(), T const& d4 = T(), T const& d5 = T())
+{
+    test_centroid<Geometry, typename bg::point_type<Geometry>::type>(wkt, d1, d2, d3, d4, d5);
 }
 
 template <typename Geometry>


### PR DESCRIPTION
The intention of this PR is to fix this ticket: https://svn.boost.org/trac/boost/ticket/11236

In this particular case, at the end of centroid calculation the resulting point is moved using the origin (taken from the input geometry). The point arithmetic functions internally was calculating the results using always the type of the second operand (in one of the STL binary predicates like `std::plus`). In this particular case the resulting Point is using coordinates of type `double` and the input Polygon coordinates of type `int`. `bg::add_point()` internally calls `std::plus<int>` which truncates the `double` value before addition. Ths PR changes it by using the more precise type.