### PR TITLE
Add two-pi and half-pi constants

### DIFF
--- a/include/boost/geometry/extensions/contrib/ttmath_stub.hpp
+++ b/include/boost/geometry/extensions/contrib/ttmath_stub.hpp
@@ -190,15 +190,49 @@ namespace detail
     {
         static inline ttmath::Big<Exponent, Mantissa> apply()
         {
+            static ttmath::Big<Exponent, Mantissa> const half_pi(
+                "1.57079632679489661923132169163975144209858469968755291048747229615390820314310449931401741267105853399107404325664115332354692230477529111586267970406424055872514205135096926055277982231147447746519098");
+            return half_pi;
+        }
+    };
+
+    // Partial specialization for ttmath
+    template <ttmath::uint Exponent, ttmath::uint Mantissa>
+    struct define_half_pi<ttmath::Big<Exponent, Mantissa> >
+    {
+        static inline ttmath::Big<Exponent, Mantissa> apply()
+        {
             static ttmath::Big<Exponent, Mantissa> const the_pi(
                 "3.14159265358979323846264338327950288419716939937510582097494459230781640628620899862803482534211706798214808651328230664709384460955058223172535940812848111745028410270193852110555964462294895493038196");
             return the_pi;
         }
     };
 
+    // Partial specialization for ttmath
+    template <ttmath::uint Exponent, ttmath::uint Mantissa>
+    struct define_two_pi<ttmath::Big<Exponent, Mantissa> >
+    {
+        static inline ttmath::Big<Exponent, Mantissa> apply()
+        {
+            static ttmath::Big<Exponent, Mantissa> const two_pi(
+                "6.28318530717958647692528676655900576839433879875021164194988918461563281257241799725606965068423413596429617302656461329418768921910116446345071881625696223490056820540387704221111928924589790986076392");
+            return two_pi;
+        }
+    };
+
+    template <>
+    struct define_half_pi<ttmath_big>
+            : public define_half_pi<ttmath::Big<1,4> >
+    {};
+
     template <>
     struct define_pi<ttmath_big>
             : public define_pi<ttmath::Big<1,4> >
+    {};
+
+    template <>
+    struct define_two_pi<ttmath_big>
+            : public define_two_pi<ttmath::Big<1,4> >
     {};
 
     template <ttmath::uint Exponent, ttmath::uint Mantissa>

--- a/include/boost/geometry/extensions/contrib/ttmath_stub.hpp
+++ b/include/boost/geometry/extensions/contrib/ttmath_stub.hpp
@@ -186,7 +186,7 @@ namespace detail
 
     // Partial specialization for ttmath
     template <ttmath::uint Exponent, ttmath::uint Mantissa>
-    struct define_pi<ttmath::Big<Exponent, Mantissa> >
+    struct define_half_pi<ttmath::Big<Exponent, Mantissa> >
     {
         static inline ttmath::Big<Exponent, Mantissa> apply()
         {
@@ -198,7 +198,7 @@ namespace detail
 
     // Partial specialization for ttmath
     template <ttmath::uint Exponent, ttmath::uint Mantissa>
-    struct define_half_pi<ttmath::Big<Exponent, Mantissa> >
+    struct define_pi<ttmath::Big<Exponent, Mantissa> >
     {
         static inline ttmath::Big<Exponent, Mantissa> apply()
         {

--- a/include/boost/geometry/strategies/cartesian/buffer_end_round.hpp
+++ b/include/boost/geometry/strategies/cartesian/buffer_end_round.hpp
@@ -1,6 +1,11 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2012-2014 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2012-2015 Barend Gehrels, Amsterdam, the Netherlands.
+
+// This file was modified by Oracle on 2015.
+// Modifications copyright (c) 2015, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -62,8 +67,7 @@ private :
                 DistanceType const& buffer_distance,
                 RangeOut& range_out) const
     {
-        PromotedType const two = 2.0;
-        PromotedType const two_pi = two * geometry::math::pi<PromotedType>();
+        PromotedType const two_pi = geometry::math::two_pi<PromotedType>();
 
         std::size_t point_buffer_count = m_points_per_circle;
 

--- a/include/boost/geometry/strategies/cartesian/buffer_join_round.hpp
+++ b/include/boost/geometry/strategies/cartesian/buffer_join_round.hpp
@@ -2,6 +2,11 @@
 
 // Copyright (c) 2012-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2015.
+// Modifications copyright (c) 2015, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -76,8 +81,7 @@ private :
         PromotedType const dx2 = get<0>(perp2) - get<0>(vertex);
         PromotedType const dy2 = get<1>(perp2) - get<1>(vertex);
 
-        PromotedType const two = 2.0;
-        PromotedType const two_pi = two * geometry::math::pi<PromotedType>();
+        PromotedType const two_pi = geometry::math::two_pi<PromotedType>();
 
         PromotedType const angle1 = atan2(dy1, dx1);
         PromotedType angle2 = atan2(dy2, dx2);

--- a/include/boost/geometry/strategies/cartesian/buffer_point_circle.hpp
+++ b/include/boost/geometry/strategies/cartesian/buffer_point_circle.hpp
@@ -85,8 +85,7 @@ public :
         promoted_type const buffer_distance = distance_strategy.apply(point, point,
                         strategy::buffer::buffer_side_left);
 
-        promoted_type const two = 2.0;
-        promoted_type const two_pi = two * geometry::math::pi<promoted_type>();
+        promoted_type const two_pi = geometry::math::two_pi<promoted_type>();
 
         promoted_type const diff = two_pi / promoted_type(m_count);
         promoted_type a = 0;

--- a/include/boost/geometry/strategies/spherical/area_huiller.hpp
+++ b/include/boost/geometry/strategies/spherical/area_huiller.hpp
@@ -1,6 +1,11 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
+
+// This file was modified by Oracle on 2015.
+// Modifications copyright (c) 2015, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -113,8 +118,10 @@ public :
             calculation_type const half = 0.5;
             calculation_type const two = 2.0;
             calculation_type const four = 4.0;
-            calculation_type const two_pi = two * geometry::math::pi<calculation_type>();
-            calculation_type const half_pi = half * geometry::math::pi<calculation_type>();
+            calculation_type const two_pi
+                = geometry::math::two_pi<calculation_type>();
+            calculation_type const half_pi
+                = geometry::math::half_pi<calculation_type>();
 
             // Distance p1 p2
             calculation_type a = state.distance_over_unit_sphere.apply(p1, p2);

--- a/include/boost/geometry/util/math.hpp
+++ b/include/boost/geometry/util/math.hpp
@@ -354,7 +354,8 @@ struct modulo<Fundamental, true>
 
 
 /*!
-\brief Short construct to enable partial specialization for PI, currently not possible in Math.
+\brief Short constructs to enable partial specialization for PI, 2*PI
+       and PI/2, currently not possible in Math.
 */
 template <typename T>
 struct define_pi
@@ -363,6 +364,26 @@ struct define_pi
     {
         // Default calls Boost.Math
         return boost::math::constants::pi<T>();
+    }
+};
+
+template <typename T>
+struct define_two_pi
+{
+    static inline T apply()
+    {
+        // Default calls Boost.Math
+        return boost::math::constants::two_pi<T>();
+    }
+};
+
+template <typename T>
+struct define_half_pi
+{
+    static inline T apply()
+    {
+        // Default calls Boost.Math
+        return boost::math::constants::half_pi<T>();
     }
 };
 
@@ -406,6 +427,12 @@ struct round<Result, Source, true, false>
 
 template <typename T>
 inline T pi() { return detail::define_pi<T>::apply(); }
+
+template <typename T>
+inline T two_pi() { return detail::define_two_pi<T>::apply(); }
+
+template <typename T>
+inline T half_pi() { return detail::define_half_pi<T>::apply(); }
 
 template <typename T>
 inline T relaxed_epsilon(T const& factor)


### PR DESCRIPTION
This PR:
* Adds to more constants in `boost::geometry::math` namespace: `2*π` and `π/2`.
* `ttmath_big` and `ttmath::Big<Exponent, Mantissa>` are modified to support these two new constants.
* Strategies that compute these two constants via `math::pi<>()`, now use the corresponding functions directly.