### PR TITLE
Feature/lazy not implemented

### DIFF
--- a/include/boost/geometry/algorithms/is_not_implemented.hpp
+++ b/include/boost/geometry/algorithms/is_not_implemented.hpp
@@ -1,0 +1,190 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2015, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_ALGORITHMS_IS_NOT_IMPLEMENTED_HPP
+#define BOOST_GEOMETRY_ALGORITHMS_IS_NOT_IMPLEMENTED_HPP
+
+
+#include <boost/mpl/begin.hpp>
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/deref.hpp>
+#include <boost/mpl/end.hpp>
+#include <boost/mpl/next.hpp>
+#include <boost/variant/variant_fwd.hpp>
+
+#include <boost/geometry/algorithms/not_implemented.hpp>
+
+
+namespace boost { namespace geometry {
+
+namespace detail { namespace is_not_implemented {
+
+template
+<
+    typename Seq, 
+    typename MetaPred, 
+    typename PrevState,
+    typename First = typename boost::mpl::begin<Seq>::type,
+    typename Last = typename boost::mpl::end<Seq>::type
+>
+struct for_each
+{
+    typedef typename for_each
+        <
+            Seq,
+            MetaPred,
+            typename MetaPred::template apply
+                <
+                    typename boost::mpl::deref<First>::type,
+                    PrevState
+                >,
+            typename boost::mpl::next<First>::type,
+            Last
+        >::type type;
+};
+
+template
+<
+    typename Seq, 
+    typename MetaPred,
+    typename PrevState,
+    typename Last
+>
+struct for_each<Seq, MetaPred, PrevState, Last, Last>
+{
+    typedef PrevState type;
+};
+
+template <typename MetaPolicy>
+struct reverse
+{
+    template <typename Geometry1, typename Geometry2>
+    struct apply
+        : MetaPolicy::template apply<Geometry2, Geometry1>
+    {};
+};
+
+template <typename Geometry, typename MetaPolicy>
+struct metapred
+{
+    template <typename SeqEl, typename PrevState>
+    struct apply
+        : boost::mpl::bool_
+            <
+                PrevState::value &&
+                MetaPolicy::template apply<Geometry, SeqEl>::value
+            >
+    {};
+};
+
+template <typename Seq2, typename MetaPolicy>
+struct metapred_2
+{
+    template <typename Seq1El, typename PrevState>
+    struct apply
+        : boost::mpl::bool_
+            <
+                PrevState::value &&
+                for_each
+                    <
+                        Seq2,
+                        metapred<Seq1El, MetaPolicy>,
+                        boost::mpl::bool_<true>
+                    >::type::value
+            >
+    {};
+};
+
+}} // namespace detail::is_not_implemented
+
+
+/*!
+ A utility for checking if an algorithm is not implemented for some Geometries.
+ For variants it checks all combinations of Geometries and sets value to false
+ only if all combinations are not implemented.
+ */
+template <typename Geometry1, typename Geometry2, typename MetaPolicy>
+struct is_not_implemented
+    : MetaPolicy::template apply<Geometry1, Geometry2>
+{};
+
+template
+<
+    typename Geometry1,
+    BOOST_VARIANT_ENUM_PARAMS(typename T),
+    typename MetaPolicy
+>
+struct is_not_implemented
+    <
+        Geometry1,
+        boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>,
+        MetaPolicy
+    >
+    : detail::is_not_implemented::for_each
+        <
+            typename boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>::types,
+            detail::is_not_implemented::metapred<Geometry1, MetaPolicy>,
+            boost::mpl::bool_<true>
+        >::type
+{};
+
+template
+<
+    BOOST_VARIANT_ENUM_PARAMS(typename T),
+    typename Geometry2,
+    typename MetaPolicy
+>
+struct is_not_implemented
+    <
+        boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>,
+        Geometry2,
+        MetaPolicy
+    >
+    : detail::is_not_implemented::for_each
+        <
+            typename boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>::types,
+            detail::is_not_implemented::metapred
+                <
+                    Geometry2,
+                    detail::is_not_implemented::reverse<MetaPolicy>
+                >,
+            boost::mpl::bool_<true>
+        >::type
+{};
+
+template
+<
+    BOOST_VARIANT_ENUM_PARAMS(typename T1),
+    BOOST_VARIANT_ENUM_PARAMS(typename T2),
+    typename MetaPolicy
+>
+struct is_not_implemented
+    <
+        boost::variant<BOOST_VARIANT_ENUM_PARAMS(T1)>,
+        boost::variant<BOOST_VARIANT_ENUM_PARAMS(T2)>,
+        MetaPolicy
+    >
+    : detail::is_not_implemented::for_each
+        <
+            typename boost::variant<BOOST_VARIANT_ENUM_PARAMS(T1)>::types,
+            detail::is_not_implemented::metapred_2
+                <
+                    typename boost::variant<BOOST_VARIANT_ENUM_PARAMS(T2)>::types,
+                    MetaPolicy
+                >,
+            boost::mpl::bool_<true>
+        >::type
+{
+};
+
+}} // namespace boost::geometry
+
+
+#endif // BOOST_GEOMETRY_ALGORITHMS_IS_NOT_IMPLEMENTED_HPP

--- a/include/boost/geometry/algorithms/not_implemented.hpp
+++ b/include/boost/geometry/algorithms/not_implemented.hpp
@@ -20,6 +20,7 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_NOT_IMPLEMENTED_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_NOT_IMPLEMENTED_HPP
 
+#include <boost/geometry/core/exception.hpp>
 
 #include <boost/mpl/assert.hpp>
 #include <boost/mpl/identity.hpp>
@@ -96,7 +97,7 @@ template <> struct tag_to_term<geometry_collection_tag>     { typedef info::GEOM
 template <int D> struct tag_to_term<boost::mpl::int_<D> >   { typedef info::DIMENSION<D> type; };
 
 
-}
+} // namespace nyi
 
 
 template
@@ -124,6 +125,63 @@ struct not_implemented
       >
 {};
 
+
+template
+<
+    typename Result,
+    typename Term1 = void,
+    typename Term2 = void,
+    typename Term3 = void
+>
+struct lazy_not_implemented
+    : nyi::not_implemented_tag
+{
+#ifndef BOOST_NO_CXX11_VARIADIC_TEMPLATES
+    template <typename... T1>
+    static inline Result apply(T1 const&...)
+    {
+        not_implemented<Term1, Term2, Term3>();
+        return Result();
+    }
+#else
+    static inline Result apply()
+    {
+        not_implemented<Term1, Term2, Term3>();
+        return Result();
+    }
+
+    template <typename T1, typename T2>
+    static inline Result apply(T1 const&, T2 const&)
+    {
+        not_implemented<Term1, Term2, Term3>();
+        return Result();
+    }
+
+    template <typename T1, typename T2, typename T3>
+    static inline Result apply(T1 const&, T2 const&, T3 const&)
+    {
+        not_implemented<Term1, Term2, Term3>();
+        return Result();
+    }
+
+    template <typename T1, typename T2, typename T3, typename T4>
+    static inline Result apply(T1 const&, T2 const&, T3 const&, T4 const&)
+    {
+        not_implemented<Term1, Term2, Term3>();
+        return Result();
+    }
+#endif
+};
+
+
+struct not_implemented_exception
+    : boost::geometry::exception
+{
+    const char * what() const
+    {
+        return "THIS_OPERATION_IS_NOT_OR_NOT_YET_IMPLEMENTED for passed input types";
+    }    
+};
 
 }} // namespace boost::geometry
 

--- a/include/boost/geometry/algorithms/not_implemented.hpp
+++ b/include/boost/geometry/algorithms/not_implemented.hpp
@@ -8,6 +8,7 @@
 // Modifications copyright (c) 2015, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
@@ -128,7 +129,7 @@ struct not_implemented
 
 template
 <
-    typename Result,
+    typename Result = void,
     typename Term1 = void,
     typename Term2 = void,
     typename Term3 = void
@@ -173,11 +174,47 @@ struct lazy_not_implemented
 #endif
 };
 
+template <typename Term1, typename Term2, typename Term3>
+struct lazy_not_implemented<void, Term1, Term2, Term3>
+    : nyi::not_implemented_tag
+{
+#ifndef BOOST_NO_CXX11_VARIADIC_TEMPLATES
+    template <typename... T1>
+    static inline void apply(T1 const&...)
+    {
+        not_implemented<Term1, Term2, Term3>();
+    }
+#else
+    static inline void apply()
+    {
+        not_implemented<Term1, Term2, Term3>();
+    }
+
+    template <typename T1, typename T2>
+    static inline void apply(T1 const&, T2 const&)
+    {
+        not_implemented<Term1, Term2, Term3>();
+    }
+
+    template <typename T1, typename T2, typename T3>
+    static inline void apply(T1 const&, T2 const&, T3 const&)
+    {
+        not_implemented<Term1, Term2, Term3>();
+    }
+
+    template <typename T1, typename T2, typename T3, typename T4>
+    static inline void apply(T1 const&, T2 const&, T3 const&, T4 const&)
+    {
+        not_implemented<Term1, Term2, Term3>();
+    }
+#endif
+};
+
 
 struct not_implemented_exception
     : boost::geometry::exception
 {
-    const char * what() const
+    const char * what() const throw()
     {
         return "THIS_OPERATION_IS_NOT_OR_NOT_YET_IMPLEMENTED for passed input types";
     }    

--- a/include/boost/geometry/algorithms/within.hpp
+++ b/include/boost/geometry/algorithms/within.hpp
@@ -31,6 +31,7 @@
 
 #include <boost/geometry/algorithms/make.hpp>
 #include <boost/geometry/algorithms/not_implemented.hpp>
+#include <boost/geometry/algorithms/is_not_implemented.hpp>
 
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/closure.hpp>
@@ -350,14 +351,29 @@ struct within
     }
 };
 
+
+struct within_metapolicy
+{
+    template <typename Geometry1, typename Geometry2>
+    struct apply
+        : boost::is_base_of
+            <
+                nyi::not_implemented_tag,
+                dispatch::within<Geometry1, Geometry2>
+            >
+    {};
+};
+
+
 template
 <
     typename Geometry1,
     typename Geometry2,
-    bool NotImplemented = boost::is_base_of
+    bool NotImplemented = is_not_implemented
                             <
-                                nyi::not_implemented_tag,
-                                dispatch::within<Geometry1, Geometry2>
+                                Geometry1,
+                                Geometry2,
+                                within_metapolicy
                             >::value
 >
 struct within_variant

--- a/test/algorithms/relational_operations/within/Jamfile.v2
+++ b/test/algorithms/relational_operations/within/Jamfile.v2
@@ -21,5 +21,6 @@ test-suite boost-geometry-algorithms-within
     [ run within_areal_areal.cpp ]
     [ run within_linear_areal.cpp ]
     [ run within_linear_linear.cpp ]
+    [ run within_not_implemented.cpp ]
     [ run within_pointlike_xxx.cpp ]
     ;

--- a/test/algorithms/relational_operations/within/within_not_implemented.cpp
+++ b/test/algorithms/relational_operations/within/within_not_implemented.cpp
@@ -1,0 +1,127 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2013-2015 Adam Wulkiewicz, Lodz, Poland.
+
+// This file was modified by Oracle on 2014, 2015.
+// Modifications copyright (c) 2014-2015 Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+
+#include "test_within.hpp"
+
+#include <boost/geometry/geometries/geometries.hpp>
+#include <boost/geometry/geometries/point_xy.hpp>
+
+
+bool true_pred(bg::not_implemented_exception const&) { return true; }
+
+
+int test_main( int , char* [] )
+{
+    typedef bg::model::d2::point_xy<int> pt_t;
+    typedef bg::model::multi_point<pt_t> mpt_t;
+    typedef bg::model::linestring<pt_t> ls_t;
+    typedef bg::model::ring<pt_t> ring_t;
+    typedef bg::model::polygon<pt_t> poly_t;
+    typedef bg::model::multi_polygon<poly_t> mpoly_t;
+
+    typedef boost::variant<pt_t> var_pt_t;
+    typedef boost::variant<poly_t> var_po_t;
+    typedef boost::variant<pt_t, poly_t> var_pt_po_t;
+    typedef boost::variant<poly_t, pt_t> var_po_pt_t;
+
+    pt_t pt(1, 1);
+    poly_t poly;
+    boost::geometry::read_wkt("POLYGON((0 0,0 5,5 5,5 0,0 0))", poly);
+
+    var_pt_po_t v1 = pt;
+    var_pt_po_t v2 = pt;
+    var_pt_po_t v3 = poly;
+
+    BOOST_CHECK(bg::within(v1, v2));
+    BOOST_CHECK(bg::within(v1, v3));
+    BOOST_CHECK_EXCEPTION(bg::within(v3, v1),
+                          bg::not_implemented_exception,
+                          true_pred);
+
+    using bg::resolve_variant::within_metapolicy;
+
+    // sanity check
+    BOOST_CHECK( (within_metapolicy::apply<poly_t, pt_t>::value));
+    BOOST_CHECK(!(within_metapolicy::apply<poly_t, poly_t>::value));
+    BOOST_CHECK(!(within_metapolicy::apply<pt_t, poly_t>::value));
+    BOOST_CHECK(!(within_metapolicy::apply<pt_t, pt_t>::value));
+
+    BOOST_CHECK( (bg::is_not_implemented<poly_t, pt_t, within_metapolicy>::value));
+    BOOST_CHECK(!(bg::is_not_implemented<poly_t, poly_t, within_metapolicy>::value));
+    BOOST_CHECK(!(bg::is_not_implemented<pt_t, poly_t, within_metapolicy>::value));
+    BOOST_CHECK(!(bg::is_not_implemented<pt_t, pt_t, within_metapolicy>::value));
+
+
+    BOOST_CHECK( (bg::is_not_implemented<poly_t, var_pt_t, within_metapolicy>::value));
+    BOOST_CHECK(!(bg::is_not_implemented<poly_t, var_po_t, within_metapolicy>::value));
+    BOOST_CHECK(!(bg::is_not_implemented<poly_t, var_pt_po_t, within_metapolicy>::value));
+    BOOST_CHECK(!(bg::is_not_implemented<poly_t, var_po_pt_t, within_metapolicy>::value));
+
+    BOOST_CHECK(!(bg::is_not_implemented<pt_t, var_pt_t, within_metapolicy>::value));
+    BOOST_CHECK(!(bg::is_not_implemented<pt_t, var_po_t, within_metapolicy>::value));
+    BOOST_CHECK(!(bg::is_not_implemented<pt_t, var_pt_po_t, within_metapolicy>::value));
+    BOOST_CHECK(!(bg::is_not_implemented<pt_t, var_po_pt_t, within_metapolicy>::value));
+
+
+    BOOST_CHECK(!(bg::is_not_implemented<var_pt_t, pt_t, within_metapolicy>::value));
+    BOOST_CHECK( (bg::is_not_implemented<var_po_t, pt_t, within_metapolicy>::value));
+    BOOST_CHECK(!(bg::is_not_implemented<var_pt_po_t, pt_t, within_metapolicy>::value));
+    BOOST_CHECK(!(bg::is_not_implemented<var_pt_po_t, pt_t, within_metapolicy>::value));
+
+    BOOST_CHECK(!(bg::is_not_implemented<var_pt_t, poly_t, within_metapolicy>::value));
+    BOOST_CHECK(!(bg::is_not_implemented<var_po_t, poly_t, within_metapolicy>::value));
+    BOOST_CHECK(!(bg::is_not_implemented<var_pt_po_t, poly_t, within_metapolicy>::value));
+    BOOST_CHECK(!(bg::is_not_implemented<var_pt_po_t, poly_t, within_metapolicy>::value));
+
+
+    BOOST_CHECK(!(bg::is_not_implemented<var_pt_t, var_pt_t, within_metapolicy>::value));
+    BOOST_CHECK(!(bg::is_not_implemented<var_pt_t, var_po_t, within_metapolicy>::value));
+    BOOST_CHECK(!(bg::is_not_implemented<var_pt_t, var_pt_po_t, within_metapolicy>::value));
+    BOOST_CHECK(!(bg::is_not_implemented<var_pt_t, var_po_pt_t, within_metapolicy>::value));
+
+    BOOST_CHECK( (bg::is_not_implemented<var_po_t, var_pt_t, within_metapolicy>::value));
+    BOOST_CHECK(!(bg::is_not_implemented<var_po_t, var_po_t, within_metapolicy>::value));
+    BOOST_CHECK(!(bg::is_not_implemented<var_po_t, var_pt_po_t, within_metapolicy>::value));
+    BOOST_CHECK(!(bg::is_not_implemented<var_po_t, var_po_pt_t, within_metapolicy>::value));
+
+    BOOST_CHECK(!(bg::is_not_implemented<var_pt_po_t, var_pt_po_t, within_metapolicy>::value));
+    BOOST_CHECK(!(bg::is_not_implemented<var_pt_po_t, var_po_pt_t, within_metapolicy>::value));
+    BOOST_CHECK(!(bg::is_not_implemented<var_po_pt_t, var_pt_po_t, within_metapolicy>::value));
+    BOOST_CHECK(!(bg::is_not_implemented<var_po_pt_t, var_po_pt_t, within_metapolicy>::value));
+
+
+    typedef boost::variant<pt_t, mpt_t, ls_t> var_p_ls_t;
+    typedef boost::variant<ring_t, poly_t, mpoly_t> var_a_t;
+    typedef boost::variant<pt_t, mpt_t, ls_t, poly_t> var_p_ls_po_t;
+    typedef boost::variant<ls_t, ring_t, poly_t, mpoly_t> var_ls_a_t;
+
+    // sanity check
+    BOOST_CHECK( (within_metapolicy::apply<ring_t, pt_t>::value));
+    BOOST_CHECK( (within_metapolicy::apply<ring_t, mpt_t>::value));
+    BOOST_CHECK( (within_metapolicy::apply<ring_t, ls_t>::value));
+    BOOST_CHECK( (within_metapolicy::apply<poly_t, pt_t>::value));
+    BOOST_CHECK( (within_metapolicy::apply<poly_t, mpt_t>::value));
+    BOOST_CHECK( (within_metapolicy::apply<poly_t, ls_t>::value));
+    BOOST_CHECK( (within_metapolicy::apply<mpoly_t, pt_t>::value));
+    BOOST_CHECK( (within_metapolicy::apply<mpoly_t, mpt_t>::value));
+    BOOST_CHECK( (within_metapolicy::apply<mpoly_t, ls_t>::value));
+
+    BOOST_CHECK(!(bg::is_not_implemented<var_p_ls_t, var_a_t, within_metapolicy>::value));
+    BOOST_CHECK( (bg::is_not_implemented<var_a_t, var_p_ls_t, within_metapolicy>::value));
+    BOOST_CHECK(!(bg::is_not_implemented<var_a_t, var_p_ls_po_t, within_metapolicy>::value));
+    BOOST_CHECK(!(bg::is_not_implemented<var_ls_a_t, var_p_ls_po_t, within_metapolicy>::value));
+
+    return 0;
+}


### PR DESCRIPTION
This PR adds 2 new utilities which could be used to improve the Variant support:

- lazy_not_implemented - a replacement for not_implemented which checks static assertions in `apply()` member functions instead of a struct body. It allows to check if the algorithm is not implemented at compile-time without the static assertion failure. A side effect is the generation of lesser number of errors v.s. not_implemented.
- is_not_implemented - a tool which can be used to check if e.g. an algorithm is implemented for some specific Geometries. It takes 2 types and a `MetaPolicy` which must define a `struct apply<G1, G2>` defining a value indicating if e.g. an algorithm is implemented. It's specialized for `boost::variant` and "returns" true only if all of the combinations of Variants elements are not defined.

Both of those tools allows to check in compile-time if an algorithm should be able to work for specific Variant types if only the user stored supported Geometries in those Variants. So compile-time errors works like before. In the case of Variants, for supported combinations the code calling the algorithm is generated and for not supported combinations the code throwing `bg::not_implemented_exception` is generated. This allows to use an algorithm like this:

    point_t pt;
    polygon_t poly;
    variant<point_t, polygon_t> v1, v2;
    variant<polygon_t> v3;
    variant<point_t> v4;

    within(pt, poly); // compiles
    //within(poly, pt); // does not compile

    within(v1, v2); // compiles and runs (Pt/Pt)

    v1 = poly;
    within(v1, v2); // compiles but throws an exception (Poly/Pt)

    within(v3, v4); // does not compile, all combinations not supported, actually only one (Poly/Pt)