### PR TITLE
Fix degree_radian_converter

### DIFF
--- a/include/boost/geometry/core/radian_access.hpp
+++ b/include/boost/geometry/core/radian_access.hpp
@@ -1,8 +1,13 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
-// Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
-// Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
+// Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
+// Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
+
+// This file was modified by Oracle on 2015.
+// Modifications copyright (c) 2015, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
@@ -44,18 +49,24 @@ struct degree_radian_converter
 
     static inline coordinate_type get(Geometry const& geometry)
     {
+        static coordinate_type const d2r
+            = math::pi<coordinate_type>() / coordinate_type(180.0);
+
         return boost::numeric_cast
             <
                 coordinate_type
-            >(geometry::get<Dimension>(geometry) * geometry::math::d2r);
+            >(geometry::get<Dimension>(geometry) * d2r);
     }
 
     static inline void set(Geometry& geometry, coordinate_type const& radians)
     {
+        static coordinate_type const r2d
+            = coordinate_type(180.0) / math::pi<coordinate_type>();
+
         geometry::set<Dimension>(geometry, boost::numeric_cast
             <
                 coordinate_type
-            >(radians * geometry::math::r2d));
+            >(radians * r2d));
     }
 
 };

--- a/include/boost/geometry/core/radian_access.hpp
+++ b/include/boost/geometry/core/radian_access.hpp
@@ -49,24 +49,19 @@ struct degree_radian_converter
 
     static inline coordinate_type get(Geometry const& geometry)
     {
-        static coordinate_type const d2r
-            = math::pi<coordinate_type>() / coordinate_type(180.0);
-
         return boost::numeric_cast
             <
                 coordinate_type
-            >(geometry::get<Dimension>(geometry) * d2r);
+            >(geometry::get<Dimension>(geometry)
+              * math::d2r<coordinate_type>());
     }
 
     static inline void set(Geometry& geometry, coordinate_type const& radians)
     {
-        static coordinate_type const r2d
-            = coordinate_type(180.0) / math::pi<coordinate_type>();
-
         geometry::set<Dimension>(geometry, boost::numeric_cast
             <
                 coordinate_type
-            >(radians * r2d));
+            >(radians * math::r2d<coordinate_type>()));
     }
 
 };

--- a/include/boost/geometry/strategies/spherical/distance_cross_track.hpp
+++ b/include/boost/geometry/strategies/spherical/distance_cross_track.hpp
@@ -372,11 +372,16 @@ public :
         typedef typename return_type<Point, PointOfSegment>::type return_type;
 
 #ifdef BOOST_GEOMETRY_DEBUG_CROSS_TRACK
-        std::cout << "Course " << dsv(sp1) << " to " << dsv(p) << " " << crs_AD * geometry::math::r2d << std::endl;
-        std::cout << "Course " << dsv(sp1) << " to " << dsv(sp2) << " " << crs_AB * geometry::math::r2d << std::endl;
-        std::cout << "Course " << dsv(sp2) << " to " << dsv(p) << " " << crs_BD * geometry::math::r2d << std::endl;
-        std::cout << "Projection AD-AB " << projection1 << " : " << d_crs1 * geometry::math::r2d << std::endl;
-        std::cout << "Projection BD-BA " << projection2 << " : " << d_crs2 * geometry::math::r2d << std::endl;
+        std::cout << "Course " << dsv(sp1) << " to " << dsv(p) << " "
+                  << crs_AD * geometry::math::r2d<return_type>() << std::endl;
+        std::cout << "Course " << dsv(sp1) << " to " << dsv(sp2) << " "
+                  << crs_AB * geometry::math::r2d<return_type>() << std::endl;
+        std::cout << "Course " << dsv(sp2) << " to " << dsv(p) << " "
+                  << crs_BD * geometry::math::r2d << std::endl;
+        std::cout << "Projection AD-AB " << projection1 << " : "
+                  << d_crs1 * geometry::math::r2d<return_type>() << std::endl;
+        std::cout << "Projection BD-BA " << projection2 << " : "
+                  << d_crs2 * geometry::math::r2d<return_type>() << std::endl;
 #endif
 
         // http://williams.best.vwh.net/avform.htm#XTE

--- a/include/boost/geometry/strategies/strategy_transform.hpp
+++ b/include/boost/geometry/strategies/strategy_transform.hpp
@@ -1,8 +1,13 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
-// Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
-// Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
+// Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
+// Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
+
+// This file was modified by Oracle on 2015.
+// Modifications copyright (c) 2015 Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
@@ -28,6 +33,7 @@
 #include <boost/geometry/strategies/transform.hpp>
 
 #include <boost/geometry/util/math.hpp>
+#include <boost/geometry/util/promote_floating_point.hpp>
 #include <boost/geometry/util/select_coordinate_type.hpp>
 
 namespace boost { namespace geometry
@@ -130,7 +136,15 @@ struct degree_radian_vv
         assert_dimension<P1, 2>();
         assert_dimension<P2, 2>();
 
-        detail::transform_coordinates<P1, P2, 0, 2, F>::transform(p1, p2, math::d2r);
+        typedef typename promote_floating_point
+            <
+                typename select_coordinate_type<P1, P2>::type
+            >::type calculation_type;
+
+        detail::transform_coordinates
+            <
+                P1, P2, 0, 2, F
+            >::transform(p1, p2, math::d2r<calculation_type>());
         return true;
     }
 };
@@ -143,7 +157,16 @@ struct degree_radian_vv_3
         assert_dimension<P1, 3>();
         assert_dimension<P2, 3>();
 
-        detail::transform_coordinates<P1, P2, 0, 2, F>::transform(p1, p2, math::d2r);
+        typedef typename promote_floating_point
+            <
+                typename select_coordinate_type<P1, P2>::type
+            >::type calculation_type;
+
+        detail::transform_coordinates
+            <
+                P1, P2, 0, 2, F
+            >::transform(p1, p2, math::d2r<calculation_type>());
+
         // Copy height or other third dimension
         set<2>(p2, get<2>(p1));
         return true;

--- a/include/boost/geometry/strategies/transform/matrix_transformers.hpp
+++ b/include/boost/geometry/strategies/transform/matrix_transformers.hpp
@@ -1,8 +1,13 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
-// Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
-// Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
+// Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
+// Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
+
+// This file was modified by Oracle on 2015.
+// Modifications copyright (c) 2015 Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
@@ -40,6 +45,7 @@
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/util/math.hpp>
+#include <boost/geometry/util/promote_floating_point.hpp>
 #include <boost/geometry/util/select_coordinate_type.hpp>
 #include <boost/geometry/util/select_most_precise.hpp>
 
@@ -340,7 +346,8 @@ struct as_radian<degree>
     template <typename T>
     static inline T get(T const& value)
     {
-        return value * math::d2r;
+        typedef typename promote_floating_point<T>::type promoted_type;
+        return value * math::d2r<promoted_type>();
     }
 
 };

--- a/include/boost/geometry/util/math.hpp
+++ b/include/boost/geometry/util/math.hpp
@@ -493,9 +493,20 @@ inline bool larger(T1 const& a, T2 const& b)
 }
 
 
+template <typename T>
+T d2r()
+{
+    static T const conversion_coefficient = geometry::math::pi<T>() / T(180.0);
+    return conversion_coefficient;
+}
 
-double const d2r = geometry::math::pi<double>() / 180.0;
-double const r2d = 1.0 / d2r;
+template <typename T>
+T r2d()
+{
+    static T const conversion_coefficient = T(180.0) / geometry::math::pi<T>();
+    return conversion_coefficient;
+}
+
 
 /*!
     \brief Calculates the haversine of an angle

--- a/test/algorithms/distance/distance_se_pl_l.cpp
+++ b/test/algorithms/distance/distance_se_pl_l.cpp
@@ -122,19 +122,19 @@ void test_distance_point_segment(Strategy const& strategy)
 #endif
     typedef test_distance_of_geometries<point_type, segment_type> tester;
 
+    double const d2r = bg::math::d2r<double>();
+
     tester::apply("p-s-01",
                   "POINT(0 0)",
                   "SEGMENT(2 0,3 0)",
-                  2.0 * bg::math::d2r * strategy.radius(),
-                  to_comparable(strategy,
-                                2.0 * bg::math::d2r * strategy.radius()),
+                  2.0 * d2r * strategy.radius(),
+                  to_comparable(strategy, 2.0 * d2r * strategy.radius()),
                   strategy);
     tester::apply("p-s-02",
                   "POINT(2.5 3)",
                   "SEGMENT(2 0,3 0)",
-                  3.0 * bg::math::d2r * strategy.radius(),
-                  to_comparable(strategy,
-                                3.0 * bg::math::d2r * strategy.radius()),
+                  3.0 * d2r * strategy.radius(),
+                  to_comparable(strategy, 3.0 * d2r * strategy.radius()),
                   strategy);
     tester::apply("p-s-03",
                   "POINT(2 0)",
@@ -163,44 +163,38 @@ void test_distance_point_segment(Strategy const& strategy)
     tester::apply("p-s-07",
                   "POINT(90 1e-3)",
                   "SEGMENT(0.5 0,175.5 0)",
-                  1e-3 * bg::math::d2r * strategy.radius(),
-                  to_comparable(strategy,
-                                1e-3 * bg::math::d2r * strategy.radius()),
+                  1e-3 * d2r * strategy.radius(),
+                  to_comparable(strategy, 1e-3 * d2r * strategy.radius()),
                   strategy);
     tester::apply("p-s-08",
                   "POINT(90 1e-4)",
                   "SEGMENT(0.5 0,175.5 0)",
-                  1e-4 * bg::math::d2r * strategy.radius(),
-                  to_comparable(strategy,
-                                1e-4 * bg::math::d2r * strategy.radius()),
+                  1e-4 * d2r * strategy.radius(),
+                  to_comparable(strategy, 1e-4 * d2r * strategy.radius()),
                   strategy);
     tester::apply("p-s-09",
                   "POINT(90 1e-5)",
                   "SEGMENT(0.5 0,175.5 0)",
-                  1e-5 * bg::math::d2r * strategy.radius(),
-                  to_comparable(strategy,
-                                1e-5 * bg::math::d2r * strategy.radius()),
+                  1e-5 * d2r * strategy.radius(),
+                  to_comparable(strategy, 1e-5 * d2r * strategy.radius()),
                   strategy);
     tester::apply("p-s-10",
                   "POINT(90 1e-6)",
                   "SEGMENT(0.5 0,175.5 0)",
-                  1e-6 * bg::math::d2r * strategy.radius(),
-                  to_comparable(strategy,
-                                1e-6 * bg::math::d2r * strategy.radius()),
+                  1e-6 * d2r * strategy.radius(),
+                  to_comparable(strategy, 1e-6 * d2r * strategy.radius()),
                   strategy);
     tester::apply("p-s-11",
                   "POINT(90 1e-7)",
                   "SEGMENT(0.5 0,175.5 0)",
-                  1e-7 * bg::math::d2r * strategy.radius(),
-                  to_comparable(strategy,
-                                1e-7 * bg::math::d2r * strategy.radius()),
+                  1e-7 * d2r * strategy.radius(),
+                  to_comparable(strategy, 1e-7 * d2r * strategy.radius()),
                   strategy);
     tester::apply("p-s-12",
                   "POINT(90 1e-8)",
                   "SEGMENT(0.5 0,175.5 0)",
-                  1e-8 * bg::math::d2r * strategy.radius(),
-                  to_comparable(strategy,
-                                1e-8 * bg::math::d2r * strategy.radius()),
+                  1e-8 * d2r * strategy.radius(),
+                  to_comparable(strategy, 1e-8 * d2r * strategy.radius()),
                   strategy);
 }
 
@@ -215,26 +209,25 @@ void test_distance_point_linestring(Strategy const& strategy)
 #endif
     typedef test_distance_of_geometries<point_type, linestring_type> tester;
 
+    double const d2r = bg::math::d2r<double>();
+
     tester::apply("p-l-01",
                   "POINT(0 0)",
                   "LINESTRING(2 0,2 0)",
-                  2.0 * bg::math::d2r * strategy.radius(),
-                  to_comparable(strategy,
-                                2.0 * bg::math::d2r * strategy.radius()),
+                  2.0 * d2r * strategy.radius(),
+                  to_comparable(strategy, 2.0 * d2r * strategy.radius()),
                   strategy);
     tester::apply("p-l-02",
                   "POINT(0 0)",
                   "LINESTRING(2 0,3 0)",
-                  2.0 * bg::math::d2r * strategy.radius(),
-                  to_comparable(strategy,
-                                2.0 * bg::math::d2r * strategy.radius()),
+                  2.0 * d2r * strategy.radius(),
+                  to_comparable(strategy, 2.0 * d2r * strategy.radius()),
                   strategy);
     tester::apply("p-l-03",
                   "POINT(2.5 3)",
                   "LINESTRING(2 0,3 0)",
-                  3.0 * bg::math::d2r * strategy.radius(),
-                  to_comparable(strategy,
-                                3.0 * bg::math::d2r * strategy.radius()),
+                  3.0 * d2r * strategy.radius(),
+                  to_comparable(strategy, 3.0 * d2r * strategy.radius()),
                   strategy);
     tester::apply("p-l-04",
                   "POINT(2 0)",
@@ -254,9 +247,8 @@ void test_distance_point_linestring(Strategy const& strategy)
     tester::apply("p-l-07",
                   "POINT(7.5 10)",
                   "LINESTRING(1 0,2 0,3 0,4 0,5 0,6 0,7 0,8 0,9 0)",
-                  10.0 * bg::math::d2r * strategy.radius(),
-                  to_comparable(strategy,
-                                10.0 * bg::math::d2r * strategy.radius()),
+                  10.0 * d2r * strategy.radius(),
+                  to_comparable(strategy, 10.0 * d2r * strategy.radius()),
                   strategy);
     tester::apply("p-l-08",
                   "POINT(7.5 10)",
@@ -282,19 +274,19 @@ void test_distance_point_multilinestring(Strategy const& strategy)
             point_type, multi_linestring_type
         > tester;
 
+    double const d2r = bg::math::d2r<double>();
+
     tester::apply("p-ml-01",
                   "POINT(0 0)",
                   "MULTILINESTRING((-5 0,-3 0),(2 0,3 0))",
-                  2.0 * bg::math::d2r * strategy.radius(),
-                  to_comparable(strategy,
-                                2.0 * bg::math::d2r * strategy.radius()),
+                  2.0 * d2r * strategy.radius(),
+                  to_comparable(strategy, 2.0 * d2r * strategy.radius()),
                   strategy);
     tester::apply("p-ml-02",
                   "POINT(2.5 3)",
                   "MULTILINESTRING((-5 0,-3 0),(2 0,3 0))",
-                  3.0 * bg::math::d2r * strategy.radius(),
-                  to_comparable(strategy,
-                                3.0 * bg::math::d2r * strategy.radius()),
+                  3.0 * d2r * strategy.radius(),
+                  to_comparable(strategy, 3.0 * d2r * strategy.radius()),
                   strategy);
     tester::apply("p-ml-03",
                   "POINT(2 0)",
@@ -431,6 +423,8 @@ void test_distance_multipoint_segment(Strategy const& strategy)
 #endif
     typedef test_distance_of_geometries<multi_point_type, segment_type> tester;
 
+    double d2r = bg::math::d2r<double>();
+
     tester::apply("mp-s-01",
                   "MULTIPOINT(0 0,1 0,0 1,1 1)",
                   "SEGMENT(2 0,0 2)",
@@ -442,9 +436,8 @@ void test_distance_multipoint_segment(Strategy const& strategy)
     tester::apply("mp-s-02",
                   "MULTIPOINT(0 0,1 0,0 1,1 1)",
                   "SEGMENT(0 -3,1 -10)",
-                  3.0 * bg::math::d2r * strategy.radius(),
-                  to_comparable(strategy,
-                                3.0 * bg::math::d2r * strategy.radius()),
+                  3.0 * d2r * strategy.radius(),
+                  to_comparable(strategy, 3.0 * d2r * strategy.radius()),
                   strategy);
     tester::apply("mp-s-03",
                   "MULTIPOINT(0 0,1 0,0 1,1 1)",

--- a/test/algorithms/distance/distance_se_pl_pl.cpp
+++ b/test/algorithms/distance/distance_se_pl_pl.cpp
@@ -89,7 +89,7 @@ void test_distance_point_point(Strategy const& strategy,
                   "POINT(180 -10)",
                   (is_comparable_strategy
                    ? 1.0
-                   : (180.0 * bg::math::d2r * strategy.radius())),
+                   : (bg::math::pi<double>() * strategy.radius())),
                   1.0,
                   strategy);
     tester::apply("p-p-04",
@@ -97,7 +97,7 @@ void test_distance_point_point(Strategy const& strategy,
                   "POINT(180 0)",
                   (is_comparable_strategy
                    ? 1.0
-                   : (180.0 * bg::math::d2r * strategy.radius())),
+                   : (bg::math::pi<double>() * strategy.radius())),
                   1.0,
                   strategy);
 }

--- a/test/algorithms/transform.cpp
+++ b/test/algorithms/transform.cpp
@@ -130,24 +130,34 @@ int test_main(int, char* [])
     test_all<bg::model::d2::point_xy<int>, bg::model::d2::point_xy<float> >(1.0);
 
     test_all<bg::model::point<double, 2, bg::cs::spherical<bg::degree> >,
-        bg::model::point<double, 2, bg::cs::spherical<bg::radian> > >(bg::math::d2r);
+        bg::model::point<double, 2, bg::cs::spherical<bg::radian> > >(bg::math::d2r<double>());
     test_all<bg::model::point<double, 2, bg::cs::spherical<bg::radian> >,
-        bg::model::point<double, 2, bg::cs::spherical<bg::degree> > >(bg::math::r2d);
+        bg::model::point<double, 2, bg::cs::spherical<bg::degree> > >(bg::math::r2d<double>());
 
     test_all<bg::model::point<int, 2, bg::cs::spherical<bg::degree> >,
-        bg::model::point<float, 2, bg::cs::spherical<bg::radian> > >(bg::math::d2r);
+        bg::model::point<float, 2, bg::cs::spherical<bg::radian> > >(bg::math::d2r<float>());
 
     test_transformations<float, bg::degree>(4, 52, 1);
     test_transformations<double, bg::degree>(4, 52, 1);
 
-    test_transformations<float, bg::radian>(3 * bg::math::d2r, 51 * bg::math::d2r, 1);
-    test_transformations<double, bg::radian>(3 * bg::math::d2r, 51 * bg::math::d2r, 1);
+    test_transformations
+        <
+            float, bg::radian
+        >(3 * bg::math::d2r<float>(), 51 * bg::math::d2r<float>(), 1);
+
+    test_transformations
+        <
+            double, bg::radian
+        >(3 * bg::math::d2r<double>(), 51 * bg::math::d2r<double>(), 1);
 
 #if defined(HAVE_TTMATH)
     typedef bg::model::d2::point_xy<ttmath_big > PT;
     test_all<PT, PT>();
     test_transformations<ttmath_big, bg::degree>(4, 52, 1);
-    test_transformations<ttmath_big, bg::radian>(3 * bg::math::d2r, 51 * bg::math::d2r, 1);
+    test_transformations
+        <
+            ttmath_big, bg::radian
+        >(3 * bg::math::d2r<ttmath_big>(), 51 * bg::math::d2r<ttmath_big>(), 1);
 #endif
 
     return 0;

--- a/test/strategies/vincenty.cpp
+++ b/test/strategies/vincenty.cpp
@@ -121,24 +121,27 @@ void test_vincenty(double lon1, double lat1, double lon2, double lat2,
 
     // formula
     {
-        bg::detail::vincenty_inverse<calc_t> vi(lon1 * bg::math::d2r,
-                                                lat1 * bg::math::d2r,
-                                                lon2 * bg::math::d2r,
-                                                lat2 * bg::math::d2r,
+        double const d2r = bg::math::d2r<double>();
+        double const r2d = bg::math::r2d<double>();
+
+        bg::detail::vincenty_inverse<calc_t> vi(lon1 * d2r,
+                                                lat1 * d2r,
+                                                lon2 * d2r,
+                                                lat2 * d2r,
                                                 spheroid);
         calc_t dist = vi.distance();
         calc_t az12 = vi.azimuth12();
         calc_t az21 = vi.azimuth21();
 
-        calc_t az12_deg = az12 * bg::math::r2d;
-        calc_t az21_deg = az21 * bg::math::r2d;
+        calc_t az12_deg = az12 * r2d;
+        calc_t az21_deg = az21 * r2d;
         
         BOOST_CHECK_CLOSE(dist, calc_t(expected_distance), tolerance);
         check_deg("az12_deg", az12_deg, calc_t(expected_azimuth_12), tolerance, error);
         check_deg("az21_deg", az21_deg, calc_t(expected_azimuth_21), tolerance, error);
 
-        bg::detail::vincenty_direct<calc_t> vd(lon1 * bg::math::d2r,
-                                               lat1 * bg::math::d2r,
+        bg::detail::vincenty_direct<calc_t> vd(lon1 * d2r,
+                                               lat1 * d2r,
                                                dist,
                                                az12,
                                                spheroid);
@@ -146,9 +149,9 @@ void test_vincenty(double lon1, double lat1, double lon2, double lat2,
         calc_t direct_lat2 = vd.lat2();
         calc_t direct_az21 = vd.azimuth21();
 
-        calc_t direct_lon2_deg = direct_lon2 * bg::math::r2d;
-        calc_t direct_lat2_deg = direct_lat2 * bg::math::r2d;
-        calc_t direct_az21_deg = direct_az21 * bg::math::r2d;
+        calc_t direct_lon2_deg = direct_lon2 * r2d;
+        calc_t direct_lat2_deg = direct_lat2 * r2d;
+        calc_t direct_az21_deg = direct_az21 * r2d;
         
         check_deg("direct_lon2_deg", direct_lon2_deg, calc_t(lon2), tolerance, error);
         check_deg("direct_lat2_deg", direct_lat2_deg, calc_t(lat2), tolerance, error);


### PR DESCRIPTION
In this PR I modify the implementation of `degree_radian_converter` to use conversion constants that are consistent with the coordinate type of the geometry passed to the converter.

This is important for keeping the accuracy of user-defined number types (e.g., `ttmath`).
