### PR TITLE
Fix for Boost Trac Ticket 11268

### DIFF
--- a/include/boost/geometry/algorithms/detail/overlay/clip_linestring.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/clip_linestring.hpp
@@ -160,10 +160,12 @@ template
     typename OutputLinestring,
     typename OutputIterator,
     typename Range,
+    typename RobustPolicy,
     typename Box,
     typename Strategy
 >
 OutputIterator clip_range_with_box(Box const& b, Range const& range,
+            RobustPolicy const&,
             OutputIterator out, Strategy const& strategy)
 {
     if (boost::begin(range) == boost::end(range))

--- a/include/boost/geometry/algorithms/detail/overlay/clip_linestring.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/clip_linestring.hpp
@@ -1,6 +1,11 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
+
+// This file was modified by Oracle on 2015.
+// Modifications copyright (c) 2015 Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at

--- a/include/boost/geometry/algorithms/detail/overlay/intersection_insert.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/intersection_insert.hpp
@@ -410,13 +410,13 @@ struct intersection_insert
     template <typename RobustPolicy, typename OutputIterator, typename Strategy>
     static inline OutputIterator apply(Linestring const& linestring,
             Box const& box,
-            RobustPolicy const& ,
+            RobustPolicy const& robust_policy,
             OutputIterator out, Strategy const& )
     {
         typedef typename point_type<GeometryOut>::type point_type;
         strategy::intersection::liang_barsky<Box, point_type> lb_strategy;
         return detail::intersection::clip_range_with_box
-            <GeometryOut>(box, linestring, out, lb_strategy);
+            <GeometryOut>(box, linestring, robust_policy, out, lb_strategy);
     }
 };
 
@@ -488,7 +488,7 @@ struct intersection_insert
     template <typename RobustPolicy, typename OutputIterator, typename Strategy>
     static inline OutputIterator apply(Segment const& segment,
             Box const& box,
-            RobustPolicy const& ,// TODO: propagate to clip_range_with_box
+            RobustPolicy const& robust_policy,
             OutputIterator out, Strategy const& )
     {
         geometry::segment_view<Segment> range(segment);
@@ -496,7 +496,7 @@ struct intersection_insert
         typedef typename point_type<GeometryOut>::type point_type;
         strategy::intersection::liang_barsky<Box, point_type> lb_strategy;
         return detail::intersection::clip_range_with_box
-            <GeometryOut>(box, range, out, lb_strategy);
+            <GeometryOut>(box, range, robust_policy, out, lb_strategy);
     }
 };
 

--- a/test/algorithms/set_operations/intersection/intersection.cpp
+++ b/test/algorithms/set_operations/intersection/intersection.cpp
@@ -434,6 +434,38 @@ void test_areal_linear()
 
 }
 
+
+template <typename Linestring, typename Box>
+void test_linear_box()
+{
+    typedef bg::model::multi_linestring<Linestring> multi_linestring_type;
+
+    test_one_lp<Linestring, Box, Linestring>
+        ("case-l-b-01",
+         "BOX(-10 -10,10 10)",
+         "LINESTRING(-20 -20, 0 0,20 20)",
+         1, 3, 20 * sqrt(2.0));
+
+    test_one_lp<Linestring, Box, Linestring>
+        ("case-l-b-02",
+         "BOX(-10 -10,10 10)",
+         "LINESTRING(-20 -20, 20 20)",
+         1, 2, 20.0 * sqrt(2.0));
+
+    test_one_lp<Linestring, Box, Linestring>
+        ("case-l-b-02",
+         "BOX(-10 -10,10 10)",
+         "LINESTRING(-20 -20, 20 20,15 0,0 -15)",
+         2, 4, 25.0 * sqrt(2.0));
+
+    test_one_lp<Linestring, Box, multi_linestring_type>
+        ("case-ml-b-01",
+         "BOX(-10 -10,10 10)",
+         "MULTILINESTRING((-20 -20, 20 20),(0 -15,15 0))",
+         2, 4, 25.0 * sqrt(2.0));
+}
+
+
 template <typename P>
 void test_all()
 {
@@ -455,6 +487,8 @@ void test_all()
     test_areal_linear<polygon_ccw, linestring>();
     test_areal_linear<polygon_ccw_open, linestring>();
 #endif
+
+    test_linear_box<linestring, box>();
 
     // Test polygons clockwise and counter clockwise
     test_areal<polygon>();


### PR DESCRIPTION
This PR solves the issue reported in [Boost Trac Ticket 11268](https://svn.boost.org/trac/boost/ticket/11268).

The problem was that the function `detail::intersection::clip_range_with_box()` was passed a different number of arguments that the one the function was expecting.

**Fix:** the function, as well as those calling it, hve been modified to expect (respectively, pass) the correct number of arguments. 