### PR TITLE
Buffer fixes.

### DIFF
--- a/include/boost/geometry/algorithms/detail/buffer/buffer_inserter.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/buffer_inserter.hpp
@@ -911,7 +911,7 @@ inline void buffer_inserter(GeometryInput const& geometry_input, OutputIterator 
         collection.reverse();
     }
 
-    if (distance_strategy.negative() && areal)
+    if (BOOST_GEOMETRY_CONDITION(distance_strategy.negative() && areal))
     {
         collection.discard_nonintersecting_deflated_rings();
     }

--- a/include/boost/geometry/algorithms/detail/buffer/get_piece_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/get_piece_turns.hpp
@@ -43,7 +43,10 @@ struct buffer_assign_turn
         typename Point2,
         typename IntersectionInfo
     >
-    static inline void apply(Info& info, Point1 const& p1, Point2 const& p2, IntersectionInfo const& iinfo)
+    static inline void apply(Info& info,
+                             Point1 const& /*p1*/,
+                             Point2 const& /*p2*/,
+                             IntersectionInfo const& iinfo)
     {
         info.rob_pi = iinfo.rpi();
         info.rob_pj = iinfo.rpj();

--- a/include/boost/geometry/algorithms/detail/buffer/turn_in_piece_visitor.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/turn_in_piece_visitor.hpp
@@ -307,6 +307,7 @@ class analyse_turn_wrt_piece
                 bool is_original,
                 Point const& offsetted)
     {
+        boost::ignore_unused(offsetted);
 #if defined(BOOST_GEOMETRY_BUFFER_USE_SIDE_OF_INTERSECTION)
         typedef geometry::model::referring_segment<Point const> segment_type;
         segment_type const p(turn.rob_pi, turn.rob_pj);


### PR DESCRIPTION
The intention of this PR is to:
- provide a temporary fix for msvc-8.0 caused by the use of Multiprecision. It replaces Multiprecision `cpp_int` with manually implemented solution.
- suppress some compiler warnings.