### PR TITLE
Disable buffer test cases involving empty geometries

### DIFF
--- a/test/algorithms/buffer/buffer_linestring.cpp
+++ b/test/algorithms/buffer/buffer_linestring.cpp
@@ -174,7 +174,9 @@ void test_all()
     test_one<linestring, polygon>("field_sprayer1", field_sprayer1, join_round, end_round, 718.761877, 16.5, 6.5);
     test_one<linestring, polygon>("field_sprayer1", field_sprayer1, join_miter, end_round, 718.939628, 16.5, 6.5);
 
+#ifdef BOOST_GEOMETRY_TEST_BUFFER_TEST_EMPTY_GEOMETRIES
     test_one<linestring, polygon>("degenerate0", degenerate0, join_round, end_round, 0.0, 3.0);
+#endif // BOOST_GEOMETRY_TEST_BUFFER_TEST_EMPTY_GEOMETRIES
     test_one<linestring, polygon>("degenerate1", degenerate1, join_round, end_round, 28.25, 3.0);
     test_one<linestring, polygon>("degenerate2", degenerate2, join_round, end_round, 28.2503, 3.0);
     test_one<linestring, polygon>("degenerate3", degenerate3, join_round, end_round, 28.2503, 3.0);

--- a/test/algorithms/buffer/buffer_multi_linestring.cpp
+++ b/test/algorithms/buffer/buffer_multi_linestring.cpp
@@ -72,7 +72,9 @@ void test_all()
     test_one<multi_linestring_type, polygon>("two_bends", two_bends, join_miter, end_flat, 65.1834, 1.5, 1.5);
     test_one<multi_linestring_type, polygon>("two_bends", two_bends, join_miter, end_round, 75.2917, 1.5, 1.5);
 
+#ifdef BOOST_GEOMETRY_TEST_BUFFER_TEST_EMPTY_GEOMETRIES
     test_one<multi_linestring_type, polygon>("degenerate0", degenerate0, join_round, end_round, 0.0, 3.0, 3.0);
+#endif // BOOST_GEOMETRY_TEST_BUFFER_TEST_EMPTY_GEOMETRIES
     test_one<multi_linestring_type, polygon>("degenerate1", degenerate1, join_round, end_round, 28.2503, 3.0, 3.0);
     test_one<multi_linestring_type, polygon>("degenerate2", degenerate2, join_round, end_round, 56.0457, 3.0, 3.0);
     test_one<multi_linestring_type, polygon>("degenerate3", degenerate3, join_round, end_round, 80.4531, 3.0, 3.0);

--- a/test/algorithms/buffer/buffer_multi_polygon.cpp
+++ b/test/algorithms/buffer/buffer_multi_polygon.cpp
@@ -344,7 +344,9 @@ void test_all()
     test_one<multi_polygon_type, polygon_type>("nested_31", nested, join_round, end_flat, 399.771, 3.1);
     test_one<multi_polygon_type, polygon_type>("nested_31", nested, join_round, end_flat, 0, -3.1);
 
+#ifdef BOOST_GEOMETRY_TEST_BUFFER_TEST_EMPTY_GEOMETRIES
     test_one<multi_polygon_type, polygon_type>("degenerate0", degenerate0, join_round, end_flat, 0.0, 1.0);
+#endif // BOOST_GEOMETRY_TEST_BUFFER_TEST_EMPTY_GEOMETRIES
     test_one<multi_polygon_type, polygon_type>("degenerate1", degenerate1, join_round, end_flat, 5.708, 1.0);
     test_one<multi_polygon_type, polygon_type>("degenerate2", degenerate2, join_round, end_flat, 133.0166, 0.75);
 

--- a/test/algorithms/buffer/buffer_polygon.cpp
+++ b/test/algorithms/buffer/buffer_polygon.cpp
@@ -346,7 +346,9 @@ void test_all()
     test_one<polygon_type, polygon_type>("fork_c1", fork_c, join_miter, end_flat, 152, 1);
     test_one<polygon_type, polygon_type>("triangle", triangle, join_miter, end_flat, 14.6569, 1.0);
 
+#ifdef BOOST_GEOMETRY_TEST_BUFFER_TEST_EMPTY_GEOMETRIES
     test_one<polygon_type, polygon_type>("degenerate0", degenerate0, join_round, end_round, 0.0, 1.0);
+#endif // BOOST_GEOMETRY_TEST_BUFFER_TEST_EMPTY_GEOMETRIES
     test_one<polygon_type, polygon_type>("degenerate1", degenerate1, join_round, end_round, 3.1389, 1.0);
     test_one<polygon_type, polygon_type>("degenerate2", degenerate2, join_round, end_round, 3.1389, 1.0);
     test_one<polygon_type, polygon_type>("degenerate3", degenerate3, join_round, end_round, 143.1395, 1.0);


### PR DESCRIPTION
Some buffer test cases failed when `BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING`. These test cases involve testing empty geometries (e.g., `LINESTRING()`, `POLYGON(())`, etc.).
This PR disables these test cases.