### PR TITLE
Replace use of num_points by is_empty

### DIFF
--- a/include/boost/geometry/algorithms/centroid.hpp
+++ b/include/boost/geometry/algorithms/centroid.hpp
@@ -9,6 +9,7 @@
 // Modifications copyright (c) 2014-2015 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
@@ -55,7 +56,7 @@
 #include <boost/geometry/util/for_each_coordinate.hpp>
 #include <boost/geometry/util/select_coordinate_type.hpp>
 
-#include <boost/geometry/algorithms/num_points.hpp>
+#include <boost/geometry/algorithms/is_empty.hpp>
 
 #include <boost/geometry/algorithms/detail/centroid/translating_transformer.hpp>
 
@@ -360,7 +361,7 @@ struct centroid_multi
 #if ! defined(BOOST_GEOMETRY_CENTROID_NO_THROW)
         // If there is nothing in any of the ranges, it is not possible
         // to calculate the centroid
-        if (geometry::num_points(multi) == 0)
+        if (geometry::is_empty(multi))
         {
             throw centroid_exception();
         }

--- a/include/boost/geometry/algorithms/convex_hull.hpp
+++ b/include/boost/geometry/algorithms/convex_hull.hpp
@@ -1,13 +1,14 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
-// Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
-// Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
+// Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
+// Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 
 // This file was modified by Oracle on 2014, 2015.
 // Modifications copyright (c) 2014-2015 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
@@ -40,7 +41,7 @@
 
 #include <boost/geometry/views/detail/range_type.hpp>
 
-#include <boost/geometry/algorithms/num_points.hpp>
+#include <boost/geometry/algorithms/is_empty.hpp>
 #include <boost/geometry/algorithms/detail/as_range.hpp>
 #include <boost/geometry/algorithms/detail/assign_box_corners.hpp>
 
@@ -301,7 +302,7 @@ template<typename Geometry, typename OutputGeometry, typename Strategy>
 inline void convex_hull(Geometry const& geometry,
             OutputGeometry& out, Strategy const& strategy)
 {
-    if (geometry::num_points(geometry) == 0)
+    if (geometry::is_empty(geometry))
     {
         // Leave output empty
         return;

--- a/include/boost/geometry/algorithms/detail/envelope/linestring.hpp
+++ b/include/boost/geometry/algorithms/detail/envelope/linestring.hpp
@@ -35,7 +35,7 @@
 #include <boost/geometry/util/math.hpp>
 
 #include <boost/geometry/algorithms/assign.hpp>
-#include <boost/geometry/algorithms/num_points.hpp>
+#include <boost/geometry/algorithms/is_empty.hpp>
 
 #include <boost/geometry/algorithms/detail/envelope/range.hpp>
 #include <boost/geometry/algorithms/detail/envelope/range_of_boxes.hpp>
@@ -92,7 +92,7 @@ struct envelope_linear_on_spheroid
                 Linear const
             > iterator_type;
 
-        BOOST_ASSERT(geometry::num_points(linear) != 0);
+        BOOST_ASSERT(! geometry::is_empty(linear));
 
         std::vector<interval_type> longitude_intervals;
         std::back_insert_iterator

--- a/include/boost/geometry/algorithms/detail/overlay/overlay.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/overlay.hpp
@@ -1,7 +1,12 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
-// Copyright (c) 2013 Adam Wulkiewicz, Lodz, Poland
+// Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2013-2015 Adam Wulkiewicz, Lodz, Poland
+
+// This file was modified by Oracle on 2015.
+// Modifications copyright (c) 2015, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -28,7 +33,7 @@
 
 #include <boost/geometry/algorithms/detail/recalculate.hpp>
 
-#include <boost/geometry/algorithms/num_points.hpp>
+#include <boost/geometry/algorithms/is_empty.hpp>
 #include <boost/geometry/algorithms/reverse.hpp>
 
 #include <boost/geometry/algorithms/detail/overlay/add_rings.hpp>
@@ -125,8 +130,7 @@ inline OutputIterator return_if_one_input_is_empty(Geometry1 const& geometry1,
     // Intersection: return nothing
     // Difference: return first of them
     if (Direction == overlay_intersection
-        || (Direction == overlay_difference
-            && geometry::num_points(geometry1) == 0))
+        || (Direction == overlay_difference && geometry::is_empty(geometry1)))
     {
         return out;
     }
@@ -162,14 +166,15 @@ struct overlay
                 OutputIterator out,
                 Strategy const& )
     {
-        if ( geometry::num_points(geometry1) == 0
-          && geometry::num_points(geometry2) == 0 )
+        bool const is_empty1 = geometry::is_empty(geometry1);
+        bool const is_empty2 = geometry::is_empty(geometry2);
+
+        if (is_empty1 && is_empty2)
         {
             return out;
         }
 
-        if ( geometry::num_points(geometry1) == 0
-          || geometry::num_points(geometry2) == 0 )
+        if (is_empty1 || is_empty2)
         {
             return return_if_one_input_is_empty
                 <

--- a/include/boost/geometry/algorithms/detail/throw_on_empty_input.hpp
+++ b/include/boost/geometry/algorithms/detail/throw_on_empty_input.hpp
@@ -1,8 +1,13 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
-// Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
-// Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
+// Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
+// Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
+
+// This file was modified by Oracle on 2015.
+// Modifications copyright (c) 2015, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -12,7 +17,7 @@
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_THROW_ON_EMPTY_INPUT_HPP
 
 #include <boost/geometry/core/exception.hpp>
-#include <boost/geometry/algorithms/num_points.hpp>
+#include <boost/geometry/algorithms/is_empty.hpp>
 
 // BSG 2012-02-06: we use this currently only for distance.
 // For other scalar results area,length,perimeter it is commented on purpose.
@@ -39,7 +44,7 @@ template <typename Geometry>
 inline void throw_on_empty_input(Geometry const& geometry)
 {
 #if ! defined(BOOST_GEOMETRY_EMPTY_INPUT_NO_THROW)
-    if (geometry::num_points(geometry) == 0)
+    if (geometry::is_empty(geometry))
     {
         throw empty_input_exception();
     }

--- a/include/boost/geometry/io/svg/svg_mapper.hpp
+++ b/include/boost/geometry/io/svg/svg_mapper.hpp
@@ -2,6 +2,11 @@
 
 // Copyright (c) 2009-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2015.
+// Modifications copyright (c) 2015, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -32,9 +37,8 @@
 
 #include <boost/geometry/algorithms/envelope.hpp>
 #include <boost/geometry/algorithms/expand.hpp>
+#include <boost/geometry/algorithms/is_empty.hpp>
 #include <boost/geometry/algorithms/transform.hpp>
-#include <boost/geometry/algorithms/num_points.hpp>
-#include <boost/geometry/strategies/transform.hpp>
 #include <boost/geometry/strategies/transform/map_transformer.hpp>
 #include <boost/geometry/views/segment_view.hpp>
 
@@ -310,7 +314,7 @@ public :
     template <typename Geometry>
     void add(Geometry const& geometry)
     {
-        if (num_points(geometry) > 0)
+        if (! geometry::is_empty(geometry))
         {
             expand(m_bounding_box,
                 return_envelope

--- a/test/algorithms/set_operations/union/test_union.hpp
+++ b/test/algorithms/set_operations/union/test_union.hpp
@@ -1,7 +1,13 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 // Unit Test
 
-// Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
+
+// This file was modified by Oracle on 2015.
+// Modifications copyright (c) 2015 Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -20,6 +26,7 @@
 
 #include <boost/geometry/algorithms/area.hpp>
 #include <boost/geometry/algorithms/correct.hpp>
+#include <boost/geometry/algorithms/is_empty.hpp>
 #include <boost/geometry/algorithms/length.hpp>
 #include <boost/geometry/algorithms/num_points.hpp>
 
@@ -79,7 +86,7 @@ void test_union(std::string const& caseid, G1 const& g1, G2 const& g2,
                 ++it, ++index)
         {
             // Skip the empty polygon created above to avoid the empty_input_exception
-            if (bg::num_points(*it) > 0)
+            if (! bg::is_empty(*it))
             {
                 area_inserted += bg::area(*it);
             }

--- a/test/algorithms/test_convex_hull.hpp
+++ b/test/algorithms/test_convex_hull.hpp
@@ -7,6 +7,7 @@
 // Modifications copyright (c) 2014-2015 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -21,6 +22,7 @@
 
 #include <boost/geometry/algorithms/convex_hull.hpp>
 #include <boost/geometry/algorithms/area.hpp>
+#include <boost/geometry/algorithms/is_empty.hpp>
 #include <boost/geometry/algorithms/num_points.hpp>
 #include <boost/geometry/algorithms/perimeter.hpp>
 
@@ -181,7 +183,7 @@ void test_empty_input()
         > hull;
 
     bg::convex_hull(geometry, hull);
-    BOOST_CHECK_MESSAGE(bg::num_points(hull) == 0, "Output convex hull should be empty" );
+    BOOST_CHECK_MESSAGE(bg::is_empty(hull), "Output convex hull should be empty" );
 }
 
 

--- a/test/robustness/overlay/buffer/recursive_polygons_buffer.cpp
+++ b/test/robustness/overlay/buffer/recursive_polygons_buffer.cpp
@@ -3,6 +3,11 @@
 
 // Copyright (c) 2012-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2015.
+// Modifications copyright (c) 2015 Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -60,7 +65,7 @@ void create_svg(std::string const& filename
     bg::buffer(box, box, 1.0);
     mapper.add(box);
 
-    if (bg::num_points(buffer) > 0)
+    if (! bg::is_empty(buffer))
     {
         bg::envelope(buffer, box);
         bg::buffer(box, box, 1.0);


### PR DESCRIPTION
This PR replaces instances of `bg::num_points() == 0` by `bg::is_empty()` and instances of `bg::num_points() > 0` by `! bg::is_empty()`.

This is done both in the `include` and `test` directories.
