### PR TITLE
Replace BOOST_ASSERT with BOOST_GEOMETRY_ASSERT

### DIFF
--- a/include/boost/geometry/algorithms/detail/buffer/buffer_inserter.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/buffer_inserter.hpp
@@ -12,11 +12,12 @@
 #include <cstddef>
 #include <iterator>
 
-#include <boost/assert.hpp>
+
 #include <boost/core/ignore_unused.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 #include <boost/range.hpp>
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/closure.hpp>
 #include <boost/geometry/core/exterior_ring.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
@@ -293,7 +294,7 @@ struct buffer_range
                 return error_code;
             }
 
-            BOOST_ASSERT(! generated_side.empty());
+            BOOST_GEOMETRY_ASSERT(! generated_side.empty());
 
             result = strategy::buffer::result_normal;
 

--- a/include/boost/geometry/algorithms/detail/buffer/buffered_piece_collection.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/buffered_piece_collection.hpp
@@ -13,10 +13,10 @@
 #include <cstddef>
 #include <set>
 
-#include <boost/assert.hpp>
 #include <boost/core/ignore_unused.hpp>
 #include <boost/range.hpp>
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/point_type.hpp>
 
@@ -599,7 +599,7 @@ struct buffered_piece_collection
                     ++rit, --index_offset)
                 {
                     int const index_in_vector = 1 + rit->seg_id.segment_index - piece_segment_index;
-                    BOOST_ASSERT
+                    BOOST_GEOMETRY_ASSERT
                     (
                         index_in_vector > 0
                         && index_in_vector < pc.offsetted_count
@@ -613,7 +613,7 @@ struct buffered_piece_collection
             }
         }
 
-        BOOST_ASSERT(assert_indices_in_robust_rings());
+        BOOST_GEOMETRY_ASSERT(assert_indices_in_robust_rings());
 #endif
     }
 
@@ -801,7 +801,7 @@ struct buffered_piece_collection
 
     inline void update_closing_point()
     {
-        BOOST_ASSERT(! offsetted_rings.empty());
+        BOOST_GEOMETRY_ASSERT(! offsetted_rings.empty());
         buffered_ring<Ring>& added = offsetted_rings.back();
         if (! boost::empty(added))
         {
@@ -821,7 +821,7 @@ struct buffered_piece_collection
         // For now, it is made equal because due to numerical instability,
         // it can be a tiny bit off, possibly causing a self-intersection
 
-        BOOST_ASSERT(boost::size(m_pieces) > 0);
+        BOOST_GEOMETRY_ASSERT(boost::size(m_pieces) > 0);
         if (! ring.empty()
             && current_segment_id.segment_index
                 == m_pieces.back().first_seg_id.segment_index)
@@ -832,7 +832,7 @@ struct buffered_piece_collection
 
     inline void set_piece_center(point_type const& center)
     {
-        BOOST_ASSERT(! m_pieces.empty());
+        BOOST_GEOMETRY_ASSERT(! m_pieces.empty());
         geometry::recalculate(m_pieces.back().robust_center, center,
                 m_robust_policy);
     }
@@ -858,7 +858,7 @@ struct buffered_piece_collection
 
         if (! current_robust_ring.empty())
         {
-            BOOST_ASSERT
+            BOOST_GEOMETRY_ASSERT
             (
                 geometry::equals(current_robust_ring.front(),
                     current_robust_ring.back())
@@ -872,13 +872,13 @@ struct buffered_piece_collection
 
     inline void set_current_ring_concave()
     {
-        BOOST_ASSERT(boost::size(offsetted_rings) > 0);
+        BOOST_GEOMETRY_ASSERT(boost::size(offsetted_rings) > 0);
         offsetted_rings.back().has_concave = true;
     }
 
     inline int add_point(point_type const& p)
     {
-        BOOST_ASSERT(boost::size(offsetted_rings) > 0);
+        BOOST_GEOMETRY_ASSERT(boost::size(offsetted_rings) > 0);
 
         buffered_ring<Ring>& current_ring = offsetted_rings.back();
         update_last_point(p, current_ring);
@@ -926,11 +926,11 @@ struct buffered_piece_collection
             return;
         }
 
-        BOOST_ASSERT(pc.first_seg_id.multi_index >= 0);
-        BOOST_ASSERT(pc.last_segment_index >= 0);
+        BOOST_GEOMETRY_ASSERT(pc.first_seg_id.multi_index >= 0);
+        BOOST_GEOMETRY_ASSERT(pc.last_segment_index >= 0);
 
         pc.offsetted_count = pc.last_segment_index - pc.first_seg_id.segment_index;
-        BOOST_ASSERT(pc.offsetted_count >= 0);
+        BOOST_GEOMETRY_ASSERT(pc.offsetted_count >= 0);
 
         pc.robust_ring.reserve(pc.offsetted_count + helper_points_size);
 
@@ -1074,7 +1074,7 @@ struct buffered_piece_collection
     template <typename Range>
     inline void add_range_to_piece(piece& pc, Range const& range, bool add_front)
     {
-        BOOST_ASSERT(boost::size(range) != 0u);
+        BOOST_GEOMETRY_ASSERT(boost::size(range) != 0u);
 
         typename Range::const_iterator it = boost::begin(range);
 
@@ -1110,7 +1110,7 @@ struct buffered_piece_collection
     inline void add_side_piece(point_type const& p1, point_type const& p2,
             Range const& range, bool first)
     {
-        BOOST_ASSERT(boost::size(range) >= 2u);
+        BOOST_GEOMETRY_ASSERT(boost::size(range) >= 2u);
 
         piece& pc = create_piece(strategy::buffer::buffered_segment, ! first);
         add_range_to_piece(pc, range, first);

--- a/include/boost/geometry/algorithms/detail/buffer/buffered_ring.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/buffered_ring.hpp
@@ -14,6 +14,7 @@
 
 #include <boost/range.hpp>
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/point_type.hpp>
 
@@ -225,7 +226,7 @@ struct get_ring<detail::buffer::buffered_ring_collection_tag>
                 ring_identifier const& id,
                 MultiGeometry const& multi_ring)
     {
-        BOOST_ASSERT
+        BOOST_GEOMETRY_ASSERT
             (
                 id.multi_index >= 0
                 && id.multi_index < int(boost::size(multi_ring))

--- a/include/boost/geometry/algorithms/detail/buffer/turn_in_piece_visitor.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/turn_in_piece_visitor.hpp
@@ -14,6 +14,8 @@
 
 #include <boost/range.hpp>
 
+#include <boost/geometry/core/assert.hpp>
+
 #include <boost/geometry/arithmetic/dot_product.hpp>
 #include <boost/geometry/algorithms/assign.hpp>
 #include <boost/geometry/algorithms/comparable_distance.hpp>
@@ -214,7 +216,7 @@ public :
         boost::ignore_unused(strategy);
 #endif
 
-        BOOST_ASSERT(! piece.sections.empty());
+        BOOST_GEOMETRY_ASSERT(! piece.sections.empty());
 
         coordinate_type const point_y = geometry::get<1>(turn.robust_point);
 

--- a/include/boost/geometry/algorithms/detail/closest_feature/geometry_to_range.hpp
+++ b/include/boost/geometry/algorithms/detail/closest_feature/geometry_to_range.hpp
@@ -12,8 +12,7 @@
 
 #include <iterator>
 
-#include <boost/assert.hpp>
-
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/point_type.hpp>
 #include <boost/geometry/strategies/distance.hpp>
 #include <boost/geometry/util/math.hpp>
@@ -49,7 +48,7 @@ private:
                              RangeIterator& it_min,
                              Distance& dist_min)
     {
-        BOOST_ASSERT( first != last );
+        BOOST_GEOMETRY_ASSERT( first != last );
 
         Distance const zero = Distance(0);
 

--- a/include/boost/geometry/algorithms/detail/closest_feature/point_to_range.hpp
+++ b/include/boost/geometry/algorithms/detail/closest_feature/point_to_range.hpp
@@ -12,9 +12,9 @@
 
 #include <utility>
 
-#include <boost/assert.hpp>
 #include <boost/range.hpp>
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/closure.hpp>
 #include <boost/geometry/strategies/distance.hpp>
 #include <boost/geometry/util/math.hpp>
@@ -51,7 +51,7 @@ protected:
                              iterator_type& it_min2,
                              Distance& dist_min)
     {
-        BOOST_ASSERT( first != last );
+        BOOST_GEOMETRY_ASSERT( first != last );
 
         Distance const zero = Distance(0);
 
@@ -162,7 +162,7 @@ private:
                              iterator_type& it_min2,
                              Distance& dist_min)
     {
-        BOOST_ASSERT( first != last );
+        BOOST_GEOMETRY_ASSERT( first != last );
 
         base_type::apply(point, first, last, strategy,
                          it_min1, it_min2, dist_min);

--- a/include/boost/geometry/algorithms/detail/closest_feature/range_to_range.hpp
+++ b/include/boost/geometry/algorithms/detail/closest_feature/range_to_range.hpp
@@ -15,8 +15,7 @@
 #include <iterator>
 #include <utility>
 
-#include <boost/assert.hpp>
-
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/point_type.hpp>
 #include <boost/geometry/strategies/distance.hpp>
 #include <boost/geometry/algorithms/dispatch/distance.hpp>
@@ -56,8 +55,8 @@ private:
     {
         typedef index::rtree<RTreeValueType, index::linear<8> > rtree_type;
 
-        BOOST_ASSERT( rtree_first != rtree_last );
-        BOOST_ASSERT( queries_first != queries_last );
+        BOOST_GEOMETRY_ASSERT( rtree_first != rtree_last );
+        BOOST_GEOMETRY_ASSERT( queries_first != queries_last );
 
         Distance const zero = Distance(0);
         dist_min = zero;
@@ -73,13 +72,13 @@ private:
         {
             std::size_t n = rt.query(index::nearest(*qit, 1), &t_v);
 
-            BOOST_ASSERT( n > 0 );
-            // n above is unused outside BOOST_ASSERT, hence the call
-            // to boost::ignore_unused below
+            BOOST_GEOMETRY_ASSERT( n > 0 );
+            // n above is unused outside BOOST_GEOMETRY_ASSERT,
+            // hence the call to boost::ignore_unused below
             //
             // however, t_v (initialized by the call to rt.query(...))
             // is used below, which is why we cannot put the call to
-            // rt.query(...) inside BOOST_ASSERT
+            // rt.query(...) inside BOOST_GEOMETRY_ASSERT
             boost::ignore_unused(n);
 
             Distance dist = dispatch::distance

--- a/include/boost/geometry/algorithms/detail/disjoint/multipoint_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/multipoint_geometry.hpp
@@ -13,9 +13,9 @@
 #include <algorithm>
 #include <vector>
 
-#include <boost/assert.hpp>
 #include <boost/range.hpp>
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/geometries/box.hpp>
@@ -77,7 +77,7 @@ public:
     static inline bool apply(MultiPoint1 const& multipoint1,
                              MultiPoint2 const& multipoint2)
     {
-        BOOST_ASSERT( boost::size(multipoint1) <= boost::size(multipoint2) );
+        BOOST_GEOMETRY_ASSERT( boost::size(multipoint1) <= boost::size(multipoint2) );
 
         typedef typename boost::range_value<MultiPoint1>::type point1_type;
 

--- a/include/boost/geometry/algorithms/detail/distance/range_to_geometry_rtree.hpp
+++ b/include/boost/geometry/algorithms/detail/distance/range_to_geometry_rtree.hpp
@@ -13,8 +13,7 @@
 #include <iterator>
 #include <utility>
 
-#include <boost/assert.hpp>
-
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/point_type.hpp>
 
 #include <boost/geometry/iterators/has_one_element.hpp>
@@ -70,7 +69,7 @@ public:
     {
         namespace sds = strategy::distance::services;
 
-        BOOST_ASSERT( first != last );
+        BOOST_GEOMETRY_ASSERT( first != last );
 
         if ( geometry::has_one_element(first, last) )
         {

--- a/include/boost/geometry/algorithms/detail/distance/segment_to_box.hpp
+++ b/include/boost/geometry/algorithms/detail/distance/segment_to_box.hpp
@@ -15,13 +15,13 @@
 #include <functional>
 #include <vector>
 
-#include <boost/assert.hpp>
 #include <boost/core/ignore_unused.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 #include <boost/type_traits/is_same.hpp>
 
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/closure.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/point_type.hpp>
@@ -561,7 +561,7 @@ private:
         typedef compare_less_equal<ReturnType, true> less_equal;
 
         // assert that the segment has non-negative slope
-        BOOST_ASSERT( ( math::equals(geometry::get<0>(p0), geometry::get<0>(p1))
+        BOOST_GEOMETRY_ASSERT( ( math::equals(geometry::get<0>(p0), geometry::get<0>(p1))
                         && geometry::get<1>(p0) < geometry::get<1>(p1))
                       ||
                       ( geometry::get<0>(p0) < geometry::get<0>(p1)
@@ -617,7 +617,7 @@ private:
         typedef compare_less_equal<ReturnType, false> greater_equal;
 
         // assert that the segment has negative slope
-        BOOST_ASSERT( geometry::get<0>(p0) < geometry::get<0>(p1)
+        BOOST_GEOMETRY_ASSERT( geometry::get<0>(p0) < geometry::get<0>(p1)
                       && geometry::get<1>(p0) > geometry::get<1>(p1) );
 
         ReturnType result(0);
@@ -665,7 +665,7 @@ public:
                                    PPStrategy const& pp_strategy,
                                    PSStrategy const& ps_strategy)
     {
-        BOOST_ASSERT( geometry::less<SegmentPoint>()(p0, p1) );
+        BOOST_GEOMETRY_ASSERT( geometry::less<SegmentPoint>()(p0, p1) );
 
         if (geometry::get<0>(p0) < geometry::get<0>(p1)
             && geometry::get<1>(p0) > geometry::get<1>(p1))

--- a/include/boost/geometry/algorithms/detail/envelope/linestring.hpp
+++ b/include/boost/geometry/algorithms/detail/envelope/linestring.hpp
@@ -22,9 +22,8 @@
 #include <iterator>
 #include <vector>
 
-#include <boost/assert.hpp>
-
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/coordinate_system.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/cs.hpp>
@@ -65,8 +64,8 @@ struct envelope_linear_on_spheroid
                 Longitude, Units
             > constants;
 
-        BOOST_ASSERT(! math::larger(lon1, lon2));
-        BOOST_ASSERT(! math::larger(lon1, constants::max_longitude()));
+        BOOST_GEOMETRY_ASSERT(! math::larger(lon1, lon2));
+        BOOST_GEOMETRY_ASSERT(! math::larger(lon1, constants::max_longitude()));
 
         if (math::larger(lon2, constants::max_longitude()))
         {
@@ -92,7 +91,7 @@ struct envelope_linear_on_spheroid
                 Linear const
             > iterator_type;
 
-        BOOST_ASSERT(! geometry::is_empty(linear));
+        BOOST_GEOMETRY_ASSERT(! geometry::is_empty(linear));
 
         std::vector<interval_type> longitude_intervals;
         std::back_insert_iterator

--- a/include/boost/geometry/algorithms/detail/envelope/multipoint.hpp
+++ b/include/boost/geometry/algorithms/detail/envelope/multipoint.hpp
@@ -18,6 +18,7 @@
 #include <boost/range.hpp>
 
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/coordinate_system.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/tags.hpp>
@@ -275,7 +276,7 @@ public:
         else if (points.empty())
         {
             // all points are pole points
-            BOOST_ASSERT(has_south_pole || has_north_pole);
+            BOOST_GEOMETRY_ASSERT(has_south_pole || has_north_pole);
             lon_min = coordinate_type(0);
             lon_max = coordinate_type(0);
             lat_min = has_south_pole

--- a/include/boost/geometry/algorithms/detail/envelope/range_of_boxes.hpp
+++ b/include/boost/geometry/algorithms/detail/envelope/range_of_boxes.hpp
@@ -15,10 +15,10 @@
 #include <algorithm>
 #include <vector>
 
-#include <boost/assert.hpp>
 #include <boost/range.hpp>
 
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/coordinate_system.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
 
@@ -117,13 +117,13 @@ struct envelope_range_of_longitudes
                                                           max_gap_left,
                                                           max_gap_right);
 
-                BOOST_ASSERT(! math::larger(lon_min, lon_max));
-                BOOST_ASSERT(! math::larger(lon_max, max_longitude));
-                BOOST_ASSERT(! math::smaller(lon_min, min_longitude));
+                BOOST_GEOMETRY_ASSERT(! math::larger(lon_min, lon_max));
+                BOOST_GEOMETRY_ASSERT(! math::larger(lon_max, max_longitude));
+                BOOST_GEOMETRY_ASSERT(! math::smaller(lon_min, min_longitude));
 
-                BOOST_ASSERT(! math::larger(max_gap_left, max_gap_right));
-                BOOST_ASSERT(! math::larger(max_gap_right, max_longitude));
-                BOOST_ASSERT(! math::smaller(max_gap_left, min_longitude));
+                BOOST_GEOMETRY_ASSERT(! math::larger(max_gap_left, max_gap_right));
+                BOOST_GEOMETRY_ASSERT(! math::larger(max_gap_right, max_longitude));
+                BOOST_GEOMETRY_ASSERT(! math::smaller(max_gap_left, min_longitude));
 
                 if (math::larger(max_gap, zero))
                 {
@@ -174,7 +174,7 @@ struct envelope_range_of_boxes
         typedef longitude_interval<coordinate_type> interval_type;
         typedef std::vector<interval_type> interval_range_type;
 
-        BOOST_ASSERT(! boost::empty(range_of_boxes));
+        BOOST_GEOMETRY_ASSERT(! boost::empty(range_of_boxes));
 
         iterator_type it_min = std::min_element(boost::begin(range_of_boxes),
                                                 boost::end(range_of_boxes),

--- a/include/boost/geometry/algorithms/detail/envelope/segment.hpp
+++ b/include/boost/geometry/algorithms/detail/envelope/segment.hpp
@@ -21,10 +21,9 @@
 
 #include <utility>
 
-#include <boost/assert.hpp>
-
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/coordinate_system.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/cs.hpp>
@@ -76,7 +75,7 @@ private:
                                 CalculationType& a1,
                                 CalculationType& a2)
     {
-        BOOST_ASSERT(math::smaller(lon1, lon2));
+        BOOST_GEOMETRY_ASSERT(math::smaller(lon1, lon2));
 
         CalculationType dlon = lon2 - lon1;
         CalculationType sin_dlon = sin(dlon);
@@ -109,7 +108,7 @@ private:
                                         CalculationType const& a2)
     {
         // azimuths a1 and a2 are assumed to be in radians
-        BOOST_ASSERT(! math::equals(a1, a2));
+        BOOST_GEOMETRY_ASSERT(! math::equals(a1, a2));
 
         static CalculationType const pi_half = math::half_pi<CalculationType>();
 
@@ -142,13 +141,13 @@ private:
                                            CalculationType const& a2)
     {
         // coordinates are assumed to be in radians
-        BOOST_ASSERT(! math::larger(lon1, lon2));
+        BOOST_GEOMETRY_ASSERT(! math::larger(lon1, lon2));
 
         if (math::equals(a1, a2))
         {
             // the segment must lie on the equator; nothing to do
-            BOOST_ASSERT(math::equals(lat1, CalculationType(0)));
-            BOOST_ASSERT(math::equals(lat2, CalculationType(0)));
+            BOOST_GEOMETRY_ASSERT(math::equals(lat1, CalculationType(0)));
+            BOOST_GEOMETRY_ASSERT(math::equals(lat2, CalculationType(0)));
             return;
         }
 
@@ -198,7 +197,7 @@ private:
         {
             // both points are poles; nothing more to do:
             // longitudes are already normalized to 0
-            BOOST_ASSERT(lon1 == CalculationType(0)
+            BOOST_GEOMETRY_ASSERT(lon1 == CalculationType(0)
                          &&
                          lon2 == CalculationType(0));
         }
@@ -227,7 +226,7 @@ private:
             return;
         }
 
-        BOOST_ASSERT(!is_pole1 && !is_pole2);
+        BOOST_GEOMETRY_ASSERT(!is_pole1 && !is_pole2);
 
         if (math::larger(lon1, lon2))
         {

--- a/include/boost/geometry/algorithms/detail/get_left_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/get_left_turns.hpp
@@ -9,6 +9,8 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_GET_LEFT_TURNS_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_GET_LEFT_TURNS_HPP
 
+#include <boost/geometry/core/assert.hpp>
+
 #include <boost/geometry/arithmetic/arithmetic.hpp>
 #include <boost/geometry/algorithms/detail/overlay/segment_identifier.hpp>
 #include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>
@@ -195,7 +197,7 @@ template <typename Point, typename AngleCollection>
 inline std::size_t assign_cluster_indices(AngleCollection& sorted, Point const& origin)
 {
     // Assign same cluster_index for all turns in same direction
-    BOOST_ASSERT(boost::size(sorted) >= 4u);
+    BOOST_GEOMETRY_ASSERT(boost::size(sorted) >= 4u);
 
     angle_equal_to<Point> comparator(origin);
     typename boost::range_iterator<AngleCollection>::type it = sorted.begin();
@@ -218,7 +220,7 @@ inline std::size_t assign_cluster_indices(AngleCollection& sorted, Point const& 
 template <typename AngleCollection>
 inline void block_turns(AngleCollection& sorted, std::size_t cluster_size)
 {
-    BOOST_ASSERT(boost::size(sorted) >= 4u && cluster_size > 0);
+    BOOST_GEOMETRY_ASSERT(boost::size(sorted) >= 4u && cluster_size > 0);
 
     std::vector<std::pair<bool, bool> > directions;
     for (std::size_t i = 0; i < cluster_size; i++)

--- a/include/boost/geometry/algorithms/detail/is_simple/linear.hpp
+++ b/include/boost/geometry/algorithms/detail/is_simple/linear.hpp
@@ -13,9 +13,9 @@
 #include <algorithm>
 #include <deque>
 
-#include <boost/assert.hpp>
 #include <boost/range.hpp>
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/closure.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/point_type.hpp>
@@ -89,7 +89,7 @@ public:
     template <typename Turn>
     inline bool apply(Turn const& turn) const
     {
-        BOOST_ASSERT(boost::size(m_linestring) > 1);
+        BOOST_GEOMETRY_ASSERT(boost::size(m_linestring) > 1);
         return m_is_closed
             && turn.method == overlay::method_none
             && check_segment_indices(turn, boost::size(m_linestring) - 2)
@@ -112,7 +112,7 @@ private:
     static inline bool is_boundary_point_of(Point const& point,
                                             Linestring const& linestring)
     {
-        BOOST_ASSERT(boost::size(linestring) > 1);
+        BOOST_GEOMETRY_ASSERT(boost::size(linestring) > 1);
         return
             ! geometry::equals(range::front(linestring),
                                range::back(linestring))
@@ -125,7 +125,7 @@ private:
     static inline bool is_closing_point_of(Turn const& turn,
                                            Linestring const& linestring)
     {
-        BOOST_ASSERT(boost::size(linestring) > 1);
+        BOOST_GEOMETRY_ASSERT(boost::size(linestring) > 1);
         return
             turn.method == overlay::method_none
             &&

--- a/include/boost/geometry/algorithms/detail/is_valid/complement_graph.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/complement_graph.hpp
@@ -17,9 +17,9 @@
 #include <utility>
 #include <vector>
 
-#include <boost/assert.hpp>
 #include <boost/core/addressof.hpp>
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/policies/compare.hpp>
 
 
@@ -197,8 +197,8 @@ public:
 
     inline void add_edge(vertex_handle v1, vertex_handle v2)
     {
-        BOOST_ASSERT( v1 != m_vertices.end() );
-        BOOST_ASSERT( v2 != m_vertices.end() );
+        BOOST_GEOMETRY_ASSERT( v1 != m_vertices.end() );
+        BOOST_GEOMETRY_ASSERT( v2 != m_vertices.end() );
         m_neighbors[v1->id()].insert(v2);
         m_neighbors[v2->id()].insert(v1);
     }

--- a/include/boost/geometry/algorithms/detail/is_valid/has_valid_self_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/has_valid_self_turns.hpp
@@ -12,9 +12,9 @@
 
 #include <vector>
 
-#include <boost/assert.hpp>
 #include <boost/range.hpp>
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/point_type.hpp>
 
 #include <boost/geometry/policies/predicate_based_interrupt_policy.hpp>
@@ -88,7 +88,7 @@ public:
 
         if (interrupt_policy.has_intersections)
         {
-            BOOST_ASSERT(! boost::empty(turns));
+            BOOST_GEOMETRY_ASSERT(! boost::empty(turns));
             return visitor.template apply<failure_self_intersections>(turns);
         }
         else

--- a/include/boost/geometry/algorithms/detail/is_valid/polygon.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/polygon.hpp
@@ -18,9 +18,9 @@
 #include <set>
 #include <vector>
 
-#include <boost/assert.hpp>
 #include <boost/range.hpp>
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/exterior_ring.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
 #include <boost/geometry/core/ring_type.hpp>
@@ -192,12 +192,12 @@ protected:
         {
             if (tit->operations[0].seg_id.ring_index == -1)
             {
-                BOOST_ASSERT(tit->operations[1].seg_id.ring_index != -1);
+                BOOST_GEOMETRY_ASSERT(tit->operations[1].seg_id.ring_index != -1);
                 ring_indices.insert(tit->operations[1].seg_id.ring_index);
             }
             else if (tit->operations[1].seg_id.ring_index == -1)
             {
-                BOOST_ASSERT(tit->operations[0].seg_id.ring_index != -1);
+                BOOST_GEOMETRY_ASSERT(tit->operations[0].seg_id.ring_index != -1);
                 ring_indices.insert(tit->operations[0].seg_id.ring_index);
             }
         }

--- a/include/boost/geometry/algorithms/detail/max_interval_gap.hpp
+++ b/include/boost/geometry/algorithms/detail/max_interval_gap.hpp
@@ -15,12 +15,12 @@
 #include <utility>
 #include <vector>
 
-#include <boost/assert.hpp>
 #include <boost/core/ref.hpp>
 #include <boost/range.hpp>
 #include <boost/type_traits/remove_const.hpp>
 #include <boost/type_traits/remove_reference.hpp>
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/util/math.hpp>
 #include <boost/geometry/algorithms/detail/sweep.hpp>
 
@@ -102,7 +102,7 @@ struct initialization_visitor
                              PriorityQueue& queue,
                              EventVisitor&)
     {
-        BOOST_ASSERT(queue.empty());
+        BOOST_GEOMETRY_ASSERT(queue.empty());
 
         // it is faster to build the queue directly from the entire
         // range, rather than insert elements one after the other
@@ -148,7 +148,7 @@ public:
             if (m_overlap_count == 0 && ! queue.empty())
             {
                 // we may have a gap
-                BOOST_ASSERT(queue.top().is_start_event());
+                BOOST_GEOMETRY_ASSERT(queue.top().is_start_event());
 
                 event_time_type next_event_time
                     = queue.top().interval().template get<0>();

--- a/include/boost/geometry/algorithms/detail/occupation_info.hpp
+++ b/include/boost/geometry/algorithms/detail/occupation_info.hpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <boost/range.hpp>
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/point_type.hpp>
 
@@ -127,9 +128,9 @@ private :
 template<typename Pieces>
 inline void move_index(Pieces const& pieces, int& index, int& piece_index, int direction)
 {
-    BOOST_ASSERT(direction == 1 || direction == -1);
-    BOOST_ASSERT(piece_index >= 0 && piece_index < static_cast<int>(boost::size(pieces)) );
-    BOOST_ASSERT(index >= 0 && index < static_cast<int>(boost::size(pieces[piece_index].robust_ring)));
+    BOOST_GEOMETRY_ASSERT(direction == 1 || direction == -1);
+    BOOST_GEOMETRY_ASSERT(piece_index >= 0 && piece_index < static_cast<int>(boost::size(pieces)) );
+    BOOST_GEOMETRY_ASSERT(index >= 0 && index < static_cast<int>(boost::size(pieces[piece_index].robust_ring)));
 
     index += direction;
     if (direction == -1 && index < 0)

--- a/include/boost/geometry/algorithms/detail/overlay/check_enrich.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/check_enrich.hpp
@@ -12,11 +12,7 @@
 
 #include <cstddef>
 
-
-#include <boost/assert.hpp>
 #include <boost/range.hpp>
-
-
 
 #include <boost/geometry/algorithms/detail/ring_identifier.hpp>
 

--- a/include/boost/geometry/algorithms/detail/overlay/copy_segment_point.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/copy_segment_point.hpp
@@ -11,10 +11,10 @@
 
 
 #include <boost/array.hpp>
-#include <boost/assert.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/range.hpp>
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/ring_type.hpp>
 #include <boost/geometry/core/exterior_ring.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
@@ -54,7 +54,7 @@ struct copy_segment_point_range
             }
         }
 
-        BOOST_ASSERT(index >= 0 && index < n);
+        BOOST_GEOMETRY_ASSERT(index >= 0 && index < n);
 
         geometry::convert(*(boost::begin(view) + index), point);
         return true;
@@ -123,7 +123,7 @@ struct copy_segment_point_multi
                              PointOut& point)
     {
 
-        BOOST_ASSERT
+        BOOST_GEOMETRY_ASSERT
             (
                 seg_id.multi_index >= 0
                 && seg_id.multi_index < int(boost::size(multi))
@@ -306,7 +306,7 @@ inline bool copy_segment_point(Geometry1 const& geometry1, Geometry2 const& geom
     concept::check<Geometry1 const>();
     concept::check<Geometry2 const>();
 
-    BOOST_ASSERT(seg_id.source_index == 0 || seg_id.source_index == 1);
+    BOOST_GEOMETRY_ASSERT(seg_id.source_index == 0 || seg_id.source_index == 1);
 
     if (seg_id.source_index == 0)
     {

--- a/include/boost/geometry/algorithms/detail/overlay/copy_segments.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/copy_segments.hpp
@@ -19,14 +19,11 @@
 #include <vector>
 
 #include <boost/array.hpp>
-#include <boost/assert.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/range.hpp>
 #include <boost/type_traits/integral_constant.hpp>
 
-#include <boost/geometry/core/tags.hpp>
-
-#include <boost/geometry/core/ring_type.hpp>
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/exterior_ring.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
 #include <boost/geometry/core/ring_type.hpp>
@@ -96,7 +93,7 @@ struct copy_segments_ring
         signed_index_type const from_index = seg_id.segment_index + 1;
 
         // Sanity check
-        BOOST_ASSERT(from_index < static_cast<signed_index_type>(boost::size(view)));
+        BOOST_GEOMETRY_ASSERT(from_index < static_cast<signed_index_type>(boost::size(view)));
 
         ec_iterator it(boost::begin(view), boost::end(view),
                     boost::begin(view) + from_index);
@@ -225,7 +222,7 @@ struct copy_segments_box
             RangeOut& current_output)
     {
         signed_index_type index = seg_id.segment_index + 1;
-        BOOST_ASSERT(index < 5);
+        BOOST_GEOMETRY_ASSERT(index < 5);
 
         signed_index_type const count = index <= to_index
             ? to_index - index + 1
@@ -265,7 +262,7 @@ struct copy_segments_multi
             RangeOut& current_output)
     {
 
-        BOOST_ASSERT
+        BOOST_GEOMETRY_ASSERT
             (
                 seg_id.multi_index >= 0
                 && seg_id.multi_index < int(boost::size(multi_geometry))

--- a/include/boost/geometry/algorithms/detail/overlay/enrich_intersection_points.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/enrich_intersection_points.hpp
@@ -22,7 +22,6 @@
 #  define BOOST_GEOMETRY_DEBUG_IDENTIFIER
 #endif
 
-#include <boost/assert.hpp>
 #include <boost/range.hpp>
 
 #include <boost/geometry/algorithms/detail/ring_identifier.hpp>

--- a/include/boost/geometry/algorithms/detail/overlay/follow_linear_linear.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/follow_linear_linear.hpp
@@ -14,9 +14,9 @@
 #include <algorithm>
 #include <iterator>
 
-#include <boost/assert.hpp>
 #include <boost/range.hpp>
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tags.hpp>
 
@@ -142,7 +142,7 @@ static inline bool is_isolated_point(Turn const& turn,
 
     if ( turn.method == method_none )
     {
-        BOOST_ASSERT( operation.operation == operation_continue );
+        BOOST_GEOMETRY_ASSERT( operation.operation == operation_continue );
         return true;
     }
 
@@ -327,7 +327,7 @@ public:
             throw inconsistent_turns_exception();
         }
 #else
-        BOOST_ASSERT(enter_count == 0);
+        BOOST_GEOMETRY_ASSERT(enter_count == 0);
 #endif
 
         return process_end(entered, linestring,
@@ -433,7 +433,7 @@ public:
           TurnIterator first, TurnIterator beyond,
           OutputIterator oit)
     {
-        BOOST_ASSERT( first != beyond );
+        BOOST_GEOMETRY_ASSERT( first != beyond );
 
         typedef copy_linestrings_in_range
             <

--- a/include/boost/geometry/algorithms/detail/overlay/get_ring.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_ring.hpp
@@ -10,9 +10,9 @@
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_RING_HPP
 
 
-#include <boost/assert.hpp>
 #include <boost/range.hpp>
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/exterior_ring.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
 #include <boost/geometry/core/ring_type.hpp>
@@ -82,7 +82,7 @@ struct get_ring<polygon_tag>
                 ring_identifier const& id,
                 Polygon const& polygon)
     {
-        BOOST_ASSERT
+        BOOST_GEOMETRY_ASSERT
             (
                 id.ring_index >= -1
                 && id.ring_index < int(boost::size(interior_rings(polygon)))
@@ -102,7 +102,7 @@ struct get_ring<multi_polygon_tag>
                 ring_identifier const& id,
                 MultiPolygon const& multi_polygon)
     {
-        BOOST_ASSERT
+        BOOST_GEOMETRY_ASSERT
             (
                 id.multi_index >= 0
                 && id.multi_index < int(boost::size(multi_polygon))

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -15,10 +15,10 @@
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_TURN_INFO_HPP
 
 
-#include <boost/assert.hpp>
 #include <boost/core/ignore_unused.hpp>
 
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/strategies/intersection.hpp>
 
 #include <boost/geometry/algorithms/convert.hpp>
@@ -115,7 +115,7 @@ struct base_turn_handler
     {
         ti.method = method;
 
-        BOOST_ASSERT(index < info.count);
+        BOOST_GEOMETRY_ASSERT(index < info.count);
 
         geometry::convert(info.intersections[index], ti.point);
         ti.operations[0].fraction = info.fractions[index].robust_ra;
@@ -597,7 +597,7 @@ struct collinear : public base_turn_handler
 
         int const arrival = dir_info.arrival[0];
         // Should not be 0, this is checked before
-        BOOST_ASSERT(arrival != 0);
+        BOOST_GEOMETRY_ASSERT(arrival != 0);
 
         int const side_p = side.pk_wrt_p1();
         int const side_q = side.qk_wrt_q1();

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
@@ -14,6 +14,7 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_TURN_INFO_FOR_ENDPOINT_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_TURN_INFO_FOR_ENDPOINT_HPP
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/algorithms/detail/overlay/get_turn_info.hpp>
 #include <boost/geometry/policies/robustness/no_rescale_policy.hpp>
 
@@ -153,7 +154,7 @@ public:
             }
             else
             {
-                BOOST_ASSERT(result.template get<0>().count == 1);
+                BOOST_GEOMETRY_ASSERT(result.template get<0>().count == 1);
                 ips[0].p_operation = union_or_blocked_same_dirs(arrival_a, is_p_last);
                 ips[0].q_operation = union_or_blocked_same_dirs(arrival_b, is_q_last);
 
@@ -297,10 +298,10 @@ struct get_turn_info_for_endpoint
         // may this give false positives for INTs?
         typename IntersectionResult::point_type const&
             inters_pt = result.template get<0>().intersections[ip_index];
-        BOOST_ASSERT(ip_info.is_pi == equals::equals_point_point(pi, inters_pt));
-        BOOST_ASSERT(ip_info.is_qi == equals::equals_point_point(qi, inters_pt));
-        BOOST_ASSERT(ip_info.is_pj == equals::equals_point_point(pj, inters_pt));
-        BOOST_ASSERT(ip_info.is_qj == equals::equals_point_point(qj, inters_pt));
+        BOOST_GEOMETRY_ASSERT(ip_info.is_pi == equals::equals_point_point(pi, inters_pt));
+        BOOST_GEOMETRY_ASSERT(ip_info.is_qi == equals::equals_point_point(qi, inters_pt));
+        BOOST_GEOMETRY_ASSERT(ip_info.is_pj == equals::equals_point_point(pj, inters_pt));
+        BOOST_GEOMETRY_ASSERT(ip_info.is_qj == equals::equals_point_point(qj, inters_pt));
 #endif
 
         // TODO - calculate first/last only if needed
@@ -412,8 +413,8 @@ struct get_turn_info_for_endpoint
                 // may this give false positives for INTs?
                 typename IntersectionResult::point_type const&
                     inters_pt = inters.i_info().intersections[ip_index];
-                BOOST_ASSERT(ip_i2 == equals::equals_point_point(i2, inters_pt));
-                BOOST_ASSERT(ip_j2 == equals::equals_point_point(j2, inters_pt));
+                BOOST_GEOMETRY_ASSERT(ip_i2 == equals::equals_point_point(i2, inters_pt));
+                BOOST_GEOMETRY_ASSERT(ip_j2 == equals::equals_point_point(j2, inters_pt));
 #endif
                 if ( ip_i2 )
                 {
@@ -448,7 +449,7 @@ struct get_turn_info_for_endpoint
                     }
                     else
                     {
-                        BOOST_ASSERT(operations_combination(operations, operation_intersection, operation_union));
+                        BOOST_GEOMETRY_ASSERT(operations_combination(operations, operation_intersection, operation_union));
                         //op1 = operation_union;
                         //op2 = operation_union;
                     }
@@ -463,8 +464,8 @@ struct get_turn_info_for_endpoint
                 // may this give false positives for INTs?
                 typename IntersectionResult::point_type const&
                     inters_pt = inters.i_info().intersections[ip_index];
-                BOOST_ASSERT(ip_i2 == equals::equals_point_point(i2, inters_pt));
-                BOOST_ASSERT(ip_j2 == equals::equals_point_point(j2, inters_pt));
+                BOOST_GEOMETRY_ASSERT(ip_i2 == equals::equals_point_point(i2, inters_pt));
+                BOOST_GEOMETRY_ASSERT(ip_j2 == equals::equals_point_point(j2, inters_pt));
 #endif
                 if ( ip_i2 )
                 {
@@ -499,7 +500,7 @@ struct get_turn_info_for_endpoint
                     }
                     else
                     {
-                        BOOST_ASSERT(operations_combination(operations, operation_intersection, operation_union));
+                        BOOST_GEOMETRY_ASSERT(operations_combination(operations, operation_intersection, operation_union));
                         //op1 = operation_blocked;
                         //op2 = operation_union;
                     }
@@ -560,7 +561,7 @@ struct get_turn_info_for_endpoint
             // NOTE: is_collinear is NOT set for the first endpoint
             // for which there is no preceding segment
 
-            //BOOST_ASSERT( result.template get<1>().dir_a == 0 && result.template get<1>().dir_b == 0 );
+            //BOOST_GEOMETRY_ASSERT( result.template get<1>().dir_a == 0 && result.template get<1>().dir_b == 0 );
             if ( ! is_p_first_ip )
             {
                 tp.operations[0].is_collinear = op0 != operation_intersection

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -14,6 +14,8 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_TURN_INFO_LA_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_TURN_INFO_LA_HPP
 
+#include <boost/geometry/core/assert.hpp>
+
 #include <boost/geometry/util/condition.hpp>
 
 #include <boost/geometry/algorithms/detail/overlay/get_turn_info.hpp>
@@ -569,7 +571,7 @@ struct get_turn_info_linear_areal
                     tp.operations[0].is_collinear = true;
                     //tp.operations[1].is_collinear = false;
 
-                    BOOST_ASSERT(inters.i_info().count > 1);
+                    BOOST_GEOMETRY_ASSERT(inters.i_info().count > 1);
                     base_turn_handler::assign_point(tp, method_touch_interior, inters.i_info(), 1);
 
                     AssignPolicy::apply(tp, inters.pi(), inters.qi(), inters);
@@ -816,7 +818,7 @@ struct get_turn_info_linear_areal
             
             if ( inters.i_info().count > 1 )
             {
-                //BOOST_ASSERT( result.template get<1>().dir_a == 0 && result.template get<1>().dir_b == 0 );
+                //BOOST_GEOMETRY_ASSERT( result.template get<1>().dir_a == 0 && result.template get<1>().dir_b == 0 );
                 tp.operations[0].is_collinear = true;
                 tp.operations[1].operation = opposite ? operation_continue : operation_union;
             }

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
@@ -14,6 +14,8 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_TURN_INFO_LL_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_TURN_INFO_LL_HPP
 
+#include <boost/geometry/core/assert.hpp>
+
 #include <boost/geometry/algorithms/detail/overlay/get_turn_info.hpp>
 #include <boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp>
 
@@ -579,7 +581,7 @@ struct get_turn_info_linear_linear
                 tp.operations[0].is_collinear = true;
                 tp.operations[1].is_collinear = false;
                 
-                BOOST_ASSERT(inters.i_info().count > 1);
+                BOOST_GEOMETRY_ASSERT(inters.i_info().count > 1);
                 
                 base_turn_handler::assign_point(tp, method_touch_interior,
                                                 inters.i_info(), 1);
@@ -612,7 +614,7 @@ struct get_turn_info_linear_linear
                 tp.operations[0].is_collinear = false;
                 tp.operations[1].is_collinear = true;
                 
-                BOOST_ASSERT(inters.i_info().count > 0);
+                BOOST_GEOMETRY_ASSERT(inters.i_info().count > 0);
 
                 base_turn_handler::assign_point(tp, method_touch_interior, inters.i_info(), 0);
 
@@ -686,7 +688,7 @@ struct get_turn_info_linear_linear
             operation_type & op0 = turn.operations[0].operation;
             operation_type & op1 = turn.operations[1].operation;
 
-            BOOST_ASSERT(op0 != operation_blocked || op1 != operation_blocked );
+            BOOST_GEOMETRY_ASSERT(op0 != operation_blocked || op1 != operation_blocked );
 
             if ( op0 == operation_blocked )
             {

--- a/include/boost/geometry/algorithms/detail/overlay/pointlike_linear.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/pointlike_linear.hpp
@@ -14,7 +14,6 @@
 #include <iterator>
 #include <vector>
 
-#include <boost/assert.hpp>
 #include <boost/range.hpp>
 
 #include <boost/geometry/core/tags.hpp>

--- a/include/boost/geometry/algorithms/detail/overlay/pointlike_pointlike.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/pointlike_pointlike.hpp
@@ -14,9 +14,9 @@
 #include <algorithm>
 #include <vector>
 
-#include <boost/assert.hpp>
 #include <boost/range.hpp>
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/point_type.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tags.hpp>
@@ -182,7 +182,7 @@ struct multipoint_point_point
                                        OutputIterator oit,
                                        Strategy const&)
     {
-        BOOST_ASSERT( OverlayType == overlay_difference );
+        BOOST_GEOMETRY_ASSERT( OverlayType == overlay_difference );
 
         for (typename boost::range_iterator<MultiPoint const>::type
                  it = boost::begin(multipoint);

--- a/include/boost/geometry/algorithms/detail/overlay/traverse.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/traverse.hpp
@@ -18,6 +18,7 @@
 #include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>
 #include <boost/geometry/algorithms/num_points.hpp>
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/closure.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/geometries/concepts/check.hpp>
@@ -116,8 +117,8 @@ inline bool assign_next_ip(G1 const& g1, G2 const& g2,
             return false;
         }
 
-        BOOST_ASSERT(info.enriched.travels_to_vertex_index >= 0);
-        BOOST_ASSERT(info.enriched.travels_to_ip_index >= 0);
+        BOOST_GEOMETRY_ASSERT(info.enriched.travels_to_vertex_index >= 0);
+        BOOST_GEOMETRY_ASSERT(info.enriched.travels_to_ip_index >= 0);
 
         if (info.seg_id.source_index == 0)
         {

--- a/include/boost/geometry/algorithms/detail/relate/areal_areal.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/areal_areal.hpp
@@ -88,7 +88,7 @@ public:
         // TODO: This is O(N)
         // Run in a loop O(NM) - optimize!
         int const pig = detail::within::point_in_geometry(pt, m_other_areal);
-        //BOOST_ASSERT( pig != 0 );
+        //BOOST_GEOMETRY_ASSERT( pig != 0 );
         
         // inside
         if ( pig > 0 )
@@ -405,7 +405,7 @@ struct areal_areal
                   typename TurnIt>
         void apply(Result & result, TurnIt it)
         {
-            //BOOST_ASSERT( it != last );
+            //BOOST_GEOMETRY_ASSERT( it != last );
 
             overlay::operation_type const op = it->operations[op_id].operation;
 
@@ -498,7 +498,7 @@ struct areal_areal
         template <typename Result>
         void apply(Result & result)
         {
-            //BOOST_ASSERT( first != last );
+            //BOOST_GEOMETRY_ASSERT( first != last );
 
             if ( m_exit_detected /*m_previous_operation == overlay::operation_union*/ )
             {
@@ -618,7 +618,7 @@ struct areal_areal
             // O(N) - running it in a loop gives O(NM)
             int const pig = detail::within::point_in_geometry(range::front(range_ref), other_geometry);
 
-            //BOOST_ASSERT(pig != 0);
+            //BOOST_GEOMETRY_ASSERT(pig != 0);
             if ( pig > 0 )
             {
                 update<interior, interior, '2', transpose_result>(m_result);

--- a/include/boost/geometry/algorithms/detail/relate/boundary_checker.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/boundary_checker.hpp
@@ -47,7 +47,7 @@ public:
         boost::ignore_unused_variable_warning(pt);
 #ifdef BOOST_GEOMETRY_DEBUG_RELATE_BOUNDARY_CHECKER
         // may give false positives for INT
-        BOOST_ASSERT( (BoundaryQuery == boundary_front || BoundaryQuery == boundary_any)
+        BOOST_GEOMETRY_ASSERT( (BoundaryQuery == boundary_front || BoundaryQuery == boundary_any)
                    && detail::equals::equals_point_point(pt, range::front(geometry))
                    || (BoundaryQuery == boundary_back || BoundaryQuery == boundary_any)
                    && detail::equals::equals_point_point(pt, range::back(geometry)) );

--- a/include/boost/geometry/algorithms/detail/relate/follow_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/follow_helpers.hpp
@@ -14,6 +14,8 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_RELATE_FOLLOW_HELPERS_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_RELATE_FOLLOW_HELPERS_HPP
 
+#include <boost/geometry/core/assert.hpp>
+
 #include <boost/geometry/util/condition.hpp>
 #include <boost/geometry/util/range.hpp>
 //#include <boost/geometry/algorithms/detail/sub_range.hpp>
@@ -89,7 +91,7 @@ struct for_each_disjoint_geometry_if<OpId, Geometry, Tag, true>
                                  Geometry const& geometry,
                                  Pred & pred)
     {
-        BOOST_ASSERT(first != last);
+        BOOST_GEOMETRY_ASSERT(first != last);
 
         const std::size_t count = boost::size(geometry);
         boost::ignore_unused_variable_warning(count);
@@ -100,9 +102,9 @@ struct for_each_disjoint_geometry_if<OpId, Geometry, Tag, true>
         for ( TurnIt it = first ; it != last ; ++it )
         {
             signed_index_type multi_index = it->operations[OpId].seg_id.multi_index;
-            BOOST_ASSERT(multi_index >= 0);
+            BOOST_GEOMETRY_ASSERT(multi_index >= 0);
             std::size_t const index = static_cast<std::size_t>(multi_index);
-            BOOST_ASSERT(index < count);
+            BOOST_GEOMETRY_ASSERT(index < count);
             detected_intersections[index] = true;
         }
 
@@ -141,12 +143,12 @@ public:
     {}
     segment_identifier const& seg_id() const
     {
-        BOOST_ASSERT(sid_ptr);
+        BOOST_GEOMETRY_ASSERT(sid_ptr);
         return *sid_ptr;
     }
     Point const& point() const
     {
-        BOOST_ASSERT(pt_ptr);
+        BOOST_GEOMETRY_ASSERT(pt_ptr);
         return *pt_ptr;
     }
 
@@ -300,15 +302,15 @@ public:
 
     point_type const& get_exit_point() const
     {
-        BOOST_ASSERT(m_exit_operation != overlay::operation_none);
-        BOOST_ASSERT(m_exit_turn_ptr);
+        BOOST_GEOMETRY_ASSERT(m_exit_operation != overlay::operation_none);
+        BOOST_GEOMETRY_ASSERT(m_exit_turn_ptr);
         return m_exit_turn_ptr->point;
     }
 
     TurnInfo const& get_exit_turn() const
     {
-        BOOST_ASSERT(m_exit_operation != overlay::operation_none);
-        BOOST_ASSERT(m_exit_turn_ptr);
+        BOOST_GEOMETRY_ASSERT(m_exit_operation != overlay::operation_none);
+        BOOST_GEOMETRY_ASSERT(m_exit_turn_ptr);
         return *m_exit_turn_ptr;
     }
 

--- a/include/boost/geometry/algorithms/detail/relate/linear_areal.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/linear_areal.hpp
@@ -17,6 +17,7 @@
 #include <boost/core/ignore_unused.hpp>
 #include <boost/range/size.hpp>
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/topological_dimension.hpp>
 
 #include <boost/geometry/util/condition.hpp>
@@ -98,7 +99,7 @@ public:
         }
 
         int const pig = detail::within::point_in_geometry(range::front(linestring), m_geometry2);
-        //BOOST_ASSERT_MSG(pig != 0, "There should be no IPs");
+        //BOOST_GEOMETRY_ASSERT_MSG(pig != 0, "There should be no IPs");
 
         if ( pig > 0 )
         {
@@ -325,7 +326,7 @@ struct linear_areal
                     if ( prev_seg_id_ptr != NULL )
                     {
                         signed_index_type const next_ring_index = prev_seg_id_ptr->ring_index + 1;
-                        BOOST_ASSERT(next_ring_index >= 0);
+                        BOOST_GEOMETRY_ASSERT(next_ring_index >= 0);
                         
                         // if one of the last rings of previous single geometry was ommited
                         if ( static_cast<std::size_t>(next_ring_index)
@@ -396,7 +397,7 @@ struct linear_areal
             if ( prev_seg_id_ptr != NULL )
             {
                 signed_index_type const next_ring_index = prev_seg_id_ptr->ring_index + 1;
-                BOOST_ASSERT(next_ring_index >= 0);
+                BOOST_GEOMETRY_ASSERT(next_ring_index >= 0);
 
                 // if one of the last rings of previous single geometry was ommited
                 if ( static_cast<std::size_t>(next_ring_index)
@@ -457,7 +458,7 @@ struct linear_areal
         template <typename TurnIt>
         void operator()(TurnIt first, TurnIt last) const
         {
-            BOOST_ASSERT(first != last);
+            BOOST_GEOMETRY_ASSERT(first != last);
             static OpToPriority op_to_priority;
             // find the operation with the least priority
             int least_priority = op_to_priority(first->operations[0]);
@@ -1003,7 +1004,7 @@ struct linear_areal
                                       /*&& ( op == overlay::operation_blocked
                                         || op == overlay::operation_union )*/ ) // if we're here it's u or x
                                     {
-                                        BOOST_ASSERT(m_first_from_unknown);
+                                        BOOST_GEOMETRY_ASSERT(m_first_from_unknown);
                                         m_first_from_unknown_boundary_detected = true;
                                     }
                                     else
@@ -1044,7 +1045,7 @@ struct linear_areal
                    BoundaryChecker const& boundary_checker)
         {
             boost::ignore_unused(first, last);
-            //BOOST_ASSERT( first != last );
+            //BOOST_GEOMETRY_ASSERT( first != last );
 
             // For MultiPolygon many x/u operations may be generated as a first IP
             // if for all turns x/u was generated and any of the Polygons doesn't contain the LineString
@@ -1072,8 +1073,8 @@ struct linear_areal
                 // for sure
                 update<interior, exterior, '1', TransposeResult>(res);
 
-                BOOST_ASSERT(first != last);
-                BOOST_ASSERT(m_previous_turn_ptr);
+                BOOST_GEOMETRY_ASSERT(first != last);
+                BOOST_GEOMETRY_ASSERT(m_previous_turn_ptr);
 
                 segment_identifier const& prev_seg_id = m_previous_turn_ptr->operations[op_id].seg_id;
 
@@ -1095,8 +1096,8 @@ struct linear_areal
                 update<interior, interior, '1', TransposeResult>(res);
                 m_interior_detected = false;
 
-                BOOST_ASSERT(first != last);
-                BOOST_ASSERT(m_previous_turn_ptr);
+                BOOST_GEOMETRY_ASSERT(first != last);
+                BOOST_GEOMETRY_ASSERT(m_previous_turn_ptr);
 
                 segment_identifier const& prev_seg_id = m_previous_turn_ptr->operations[op_id].seg_id;
 
@@ -1113,7 +1114,7 @@ struct linear_areal
 
             // This condition may be false if the Linestring is lying on the Polygon's collinear spike
             // if Polygon's spikes are not handled in get_turns() or relate() (they currently aren't)
-            //BOOST_ASSERT_MSG(m_previous_operation != overlay::operation_continue,
+            //BOOST_GEOMETRY_ASSERT_MSG(m_previous_operation != overlay::operation_continue,
             //                    "Unexpected operation! Probably the error in get_turns(L,A) or relate(L,A)");
             // Currently one c/c turn is generated for the exit
             //   when a Linestring is going out on a collinear spike
@@ -1161,16 +1162,16 @@ struct linear_areal
             typedef typename boost::range_iterator<range2_type>::type range2_iterator;
             range2_type range2(sub_range(geometry2, turn.operations[other_op_id].seg_id));
             
-            BOOST_ASSERT(boost::size(range1));
+            BOOST_GEOMETRY_ASSERT(boost::size(range1));
             std::size_t const s2 = boost::size(range2);
-            BOOST_ASSERT(s2 > 2);
+            BOOST_GEOMETRY_ASSERT(s2 > 2);
             std::size_t const seg_count2 = s2 - 1;
 
             std::size_t const p_seg_ij = static_cast<std::size_t>(turn.operations[op_id].seg_id.segment_index);
             std::size_t const q_seg_ij = static_cast<std::size_t>(turn.operations[other_op_id].seg_id.segment_index);
 
-            BOOST_ASSERT(p_seg_ij + 1 < boost::size(range1));
-            BOOST_ASSERT(q_seg_ij + 1 < s2);
+            BOOST_GEOMETRY_ASSERT(p_seg_ij + 1 < boost::size(range1));
+            BOOST_GEOMETRY_ASSERT(q_seg_ij + 1 < s2);
 
             point1_type const& pi = range::at(range1, p_seg_ij);
             point2_type const& qi = range::at(range2, q_seg_ij);
@@ -1179,8 +1180,8 @@ struct linear_areal
             geometry::convert(qi, qi_conv);
             bool const is_ip_qj = equals::equals_point_point(turn.point, qj);
 // TODO: test this!
-//            BOOST_ASSERT(!equals::equals_point_point(turn.point, pi));
-//            BOOST_ASSERT(!equals::equals_point_point(turn.point, qi));
+//            BOOST_GEOMETRY_ASSERT(!equals::equals_point_point(turn.point, pi));
+//            BOOST_GEOMETRY_ASSERT(!equals::equals_point_point(turn.point, qi));
             point1_type new_pj;
             geometry::convert(turn.point, new_pj);
 
@@ -1212,7 +1213,7 @@ struct linear_areal
         template <typename It>
         static inline It find_next_non_duplicated(It first, It current, It last)
         {
-            BOOST_ASSERT( current != last );
+            BOOST_GEOMETRY_ASSERT( current != last );
 
             It it = current;
 
@@ -1380,7 +1381,7 @@ struct linear_areal
 
                 if ( is_union_detected )
                 {
-                    BOOST_ASSERT(m_previous_turn_ptr != NULL);
+                    BOOST_GEOMETRY_ASSERT(m_previous_turn_ptr != NULL);
                     if ( !detail::equals::equals_point_point(it->point, m_previous_turn_ptr->point) )
                     {
                         // break

--- a/include/boost/geometry/algorithms/detail/relate/linear_linear.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/linear_linear.hpp
@@ -19,6 +19,8 @@
 #include <boost/core/ignore_unused.hpp>
 #include <boost/range/size.hpp>
 
+#include <boost/geometry/core/assert.hpp>
+
 #include <boost/geometry/util/condition.hpp>
 #include <boost/geometry/util/range.hpp>
 
@@ -580,7 +582,7 @@ struct linear_linear
                    OtherBoundaryChecker const& /*other_boundary_checker*/)
         {
             boost::ignore_unused(first, last);
-            //BOOST_ASSERT( first != last );
+            //BOOST_GEOMETRY_ASSERT( first != last );
 
             // here, the possible exit is the real one
             // we know that we entered and now we exit
@@ -590,7 +592,7 @@ struct linear_linear
             {
                 update<interior, exterior, '1', transpose_result>(res);
 
-                BOOST_ASSERT(first != last);
+                BOOST_GEOMETRY_ASSERT(first != last);
 
                 const TurnInfo * turn_ptr = NULL;
                 if ( m_degenerated_turn_ptr )
@@ -602,7 +604,7 @@ struct linear_linear
                 {
                     segment_identifier const& prev_seg_id = turn_ptr->operations[op_id].seg_id;
 
-                    //BOOST_ASSERT(!boost::empty(sub_range(geometry, prev_seg_id)));
+                    //BOOST_GEOMETRY_ASSERT(!boost::empty(sub_range(geometry, prev_seg_id)));
                     bool const prev_back_b = is_endpoint_on_boundary<boundary_back>(
                                                 range::back(sub_range(geometry, prev_seg_id)),
                                                 boundary_checker);
@@ -692,7 +694,7 @@ struct linear_linear
 
                     if ( first_in_range )
                     {
-                        //BOOST_ASSERT(!boost::empty(ls1_ref));
+                        //BOOST_GEOMETRY_ASSERT(!boost::empty(ls1_ref));
                         bool const front_b = is_endpoint_on_boundary<boundary_front>(
                                                 range::front(ls1_ref), boundary_checker);
                         if ( front_b )
@@ -721,7 +723,7 @@ struct linear_linear
 
                     if ( first_in_range )
                     {
-                        //BOOST_ASSERT(!boost::empty(ls1_ref));
+                        //BOOST_GEOMETRY_ASSERT(!boost::empty(ls1_ref));
                         bool const front_b = is_endpoint_on_boundary<boundary_front>(
                                                 range::front(ls1_ref), boundary_checker);
                         if ( front_b )

--- a/include/boost/geometry/algorithms/detail/relate/result.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/result.hpp
@@ -16,7 +16,6 @@
 
 #include <cstddef>
 
-#include <boost/assert.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/mpl/at.hpp>
 #include <boost/mpl/begin.hpp>
@@ -28,6 +27,7 @@
 #include <boost/tuple/tuple.hpp>
 #include <boost/type_traits/integral_constant.hpp>
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/exception.hpp>
 #include <boost/geometry/util/condition.hpp>
@@ -87,7 +87,7 @@ public:
 
     inline char operator[](std::size_t index) const
     {
-        BOOST_ASSERT(index < static_size);
+        BOOST_GEOMETRY_ASSERT(index < static_size);
         return m_array[index];
     }
 

--- a/include/boost/geometry/algorithms/detail/sections/range_by_section.hpp
+++ b/include/boost/geometry/algorithms/detail/sections/range_by_section.hpp
@@ -19,11 +19,11 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_SECTIONS_RANGE_BY_SECTION_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_SECTIONS_RANGE_BY_SECTION_HPP
 
-#include <boost/assert.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/range.hpp>
 
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/closure.hpp>
 #include <boost/geometry/core/exterior_ring.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
@@ -77,7 +77,7 @@ struct full_section_multi
     {
         typedef typename boost::range_size<MultiGeometry>::type size_type;
 
-        BOOST_ASSERT
+        BOOST_GEOMETRY_ASSERT
             (
                 section.ring_id.multi_index >= 0
                 && size_type(section.ring_id.multi_index) < boost::size(multi)

--- a/include/boost/geometry/algorithms/detail/single_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/single_geometry.hpp
@@ -15,8 +15,9 @@
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_SINGLE_GEOMETRY_HPP
 
 #include <boost/mpl/if.hpp>
-
 #include <boost/type_traits/is_base_of.hpp>
+
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/util/range.hpp>
 
@@ -51,7 +52,7 @@ struct single_geometry<Geometry, true>
     template <typename Id>
     static inline return_type apply(Geometry & g, Id const& id)
     {
-        BOOST_ASSERT(id.multi_index >= 0);
+        BOOST_GEOMETRY_ASSERT(id.multi_index >= 0);
         typedef typename boost::range_size<Geometry>::type size_type;
         return range::at(g, static_cast<size_type>(id.multi_index));
     }

--- a/include/boost/geometry/algorithms/detail/sub_range.hpp
+++ b/include/boost/geometry/algorithms/detail/sub_range.hpp
@@ -16,6 +16,7 @@
 
 #include <boost/mpl/if.hpp>
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/util/range.hpp>
 
 namespace boost { namespace geometry {
@@ -86,7 +87,7 @@ struct sub_range<Geometry, Tag, true>
     template <typename Id> static inline
     return_type apply(Geometry & geometry, Id const& id)
     {
-        BOOST_ASSERT(0 <= id.multi_index);
+        BOOST_GEOMETRY_ASSERT(0 <= id.multi_index);
         typedef typename boost::range_size<Geometry>::type size_type;
         size_type const mi = static_cast<size_type>(id.multi_index);
         return sub_sub_range::apply(range::at(geometry, mi), id);

--- a/include/boost/geometry/algorithms/detail/within/point_in_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/within/point_in_geometry.hpp
@@ -20,12 +20,14 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_WITHIN_POINT_IN_GEOMETRY_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_WITHIN_POINT_IN_GEOMETRY_HPP
 
-#include <boost/assert.hpp>
+
 #include <boost/core/ignore_unused.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/range.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/remove_reference.hpp>
+
+#include <boost/geometry/core/assert.hpp>
 
 #include <boost/geometry/algorithms/detail/equals/point_point.hpp>
 #include <boost/geometry/algorithms/detail/interior_iterator.hpp>
@@ -53,7 +55,7 @@ inline int check_result_type(int result)
 template <typename T>
 inline T check_result_type(T result)
 {
-    BOOST_ASSERT(false);
+    BOOST_GEOMETRY_ASSERT(false);
     return result;
 }
 
@@ -291,7 +293,7 @@ struct point_in_geometry<Geometry, multi_point_tag>
         {
             int pip = point_in_geometry<point_type>::apply(point, *it, strategy);
 
-            //BOOST_ASSERT(pip != 0);
+            //BOOST_GEOMETRY_ASSERT(pip != 0);
             if ( pip > 0 ) // inside
                 return 1;
         }

--- a/include/boost/geometry/algorithms/touches.hpp
+++ b/include/boost/geometry/algorithms/touches.hpp
@@ -68,7 +68,7 @@ struct box_box_loop
         coordinate_type2 const& max2 = get<max_corner, Dimension>(b2);
 
         // TODO assert or exception?
-        //BOOST_ASSERT(min1 <= max1 && min2 <= max2);
+        //BOOST_GEOMETRY_ASSERT(min1 <= max1 && min2 <= max2);
 
         if ( max1 < min2 || max2 < min1 )
         {

--- a/include/boost/geometry/core/assert.hpp
+++ b/include/boost/geometry/core/assert.hpp
@@ -1,0 +1,43 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2001, 2002 Peter Dimov and Multi Media Ltd.
+// Copyright (c) 2007, 2014 Peter Dimov
+// Copyright (c) Beman Dawes 2011
+// Copyright (c) 2015 Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_CORE_ASSERT_HPP
+#define BOOST_GEOMETRY_CORE_ASSERT_HPP
+
+#include <boost/assert.hpp>
+
+#undef BOOST_GEOMETRY_ASSERT
+#undef BOOST_GEOMETRY_ASSERT_MSG
+
+#if defined(BOOST_GEOMETRY_ENABLE_ASSERT_HANDLER) || ( defined(BOOST_GEOMETRY_ENABLE_ASSERT_DEBUG_HANDLER) && !defined(NDEBUG) )
+
+#include <boost/config.hpp> // for BOOST_LIKELY
+#include <boost/current_function.hpp>
+
+namespace boost { namespace geometry
+{
+    void assertion_failed(char const * expr, char const * function, char const * file, long line); // user defined
+    void assertion_failed_msg(char const * expr, char const * msg, char const * function, char const * file, long line); // user defined
+}} // namespace boost::geometry
+
+#define BOOST_GEOMETRY_ASSERT(expr) (BOOST_LIKELY(!!(expr))? ((void)0): ::boost::geometry::assertion_failed(#expr, BOOST_CURRENT_FUNCTION, __FILE__, __LINE__))
+#define BOOST_GEOMETRY_ASSERT_MSG(expr, msg) (BOOST_LIKELY(!!(expr))? ((void)0): ::boost::geometry::assertion_failed_msg(#expr, msg, BOOST_CURRENT_FUNCTION, __FILE__, __LINE__))
+
+#else
+
+#define BOOST_GEOMETRY_ASSERT(expr) BOOST_ASSERT(expr)
+#define BOOST_GEOMETRY_ASSERT_MSG(expr, msg) BOOST_ASSERT_MSG(expr, msg)
+
+#endif
+
+#endif // BOOST_GEOMETRY_CORE_EXCEPTION_HPP

--- a/include/boost/geometry/extensions/gis/io/wkb/detail/parser.hpp
+++ b/include/boost/geometry/extensions/gis/io/wkb/detail/parser.hpp
@@ -15,7 +15,6 @@
 #include <iterator>
 #include <limits>
 
-#include <boost/assert.hpp>
 #include <boost/concept_check.hpp>
 #include <boost/cstdint.hpp>
 #include <boost/type_traits/is_integral.hpp>
@@ -23,6 +22,7 @@
 #include <boost/static_assert.hpp>
 
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/exterior_ring.hpp>
@@ -193,7 +193,7 @@ struct point_container_parser
         }
 
         typedef typename std::iterator_traits<Iterator>::difference_type size_type;
-        BOOST_ASSERT(num_points <= boost::uint32_t( (std::numeric_limits<size_type>::max)() ) );
+        BOOST_GEOMETRY_ASSERT(num_points <= boost::uint32_t( (std::numeric_limits<size_type>::max)() ) );
 
         size_type const container_size = static_cast<size_type>(num_points);
         size_type const point_size = dimension<point_type>::value * sizeof(double);
@@ -237,7 +237,7 @@ struct linestring_parser
             return false;
         }
 
-        BOOST_ASSERT(it != end);
+        BOOST_GEOMETRY_ASSERT(it != end);
         return point_container_parser<L>::parse(it, end, linestring, order);
     }
 };

--- a/include/boost/geometry/extensions/gis/io/wkb/utility.hpp
+++ b/include/boost/geometry/extensions/gis/io/wkb/utility.hpp
@@ -15,6 +15,10 @@
 #include <string>
 
 #include <boost/cstdint.hpp>
+#include <boost/static_assert.hpp>
+#include <boost/type_traits/is_convertible.hpp>
+
+#include <boost/geometry/core/assert.hpp>
 
 namespace boost { namespace geometry
 {
@@ -85,7 +89,7 @@ bool wkb2hex(Iterator begin, Iterator end, std::string& hex)
     // because begin/end always are random access iterators.
     typename std::iterator_traits<Iterator>::difference_type
         diff = std::distance(begin, end);
-    BOOST_ASSERT(diff > 0);
+    BOOST_GEOMETRY_ASSERT(diff > 0);
     return hex.size() == 2 * std::string::size_type(diff);
 }
 

--- a/include/boost/geometry/extensions/gis/projections/impl/pj_auth.hpp
+++ b/include/boost/geometry/extensions/gis/projections/impl/pj_auth.hpp
@@ -38,7 +38,7 @@
 #include <cassert>
 #include <cmath>
 
-#include <boost/assert.hpp>
+#include <boost/geometry/core/assert.hpp>
 
 namespace boost { namespace geometry { namespace projections {
 
@@ -55,7 +55,7 @@ static const int APA_SIZE = 3;
 /* determine latitude from authalic latitude */
 inline bool pj_authset(double es, double* APA)
 {
-    BOOST_ASSERT(0 != APA);
+    BOOST_GEOMETRY_ASSERT(0 != APA);
 
     double t = 0;
 
@@ -75,7 +75,7 @@ inline bool pj_authset(double es, double* APA)
 
 inline double pj_authlat(double beta, const double* APA)
 {
-    BOOST_ASSERT(0 != APA);
+    BOOST_GEOMETRY_ASSERT(0 != APA);
 
     double const t = beta + beta;
 

--- a/include/boost/geometry/extensions/index/rtree/rtree.hpp
+++ b/include/boost/geometry/extensions/index/rtree/rtree.hpp
@@ -435,7 +435,7 @@ private:
 
         if (n->is_leaf())
         {
-            // TODO: mloskot - add assert(node.size() >= 2); or similar
+            // TODO: mloskot - add BOOST_GEOMETRY_ASSERT(node.size() >= 2); or similar
 
             typename rtree_leaf<Box, Value>::leaf_map nodes = n->get_leaves();
             unsigned int remaining = nodes.size() - 2;
@@ -510,7 +510,7 @@ private:
         }
         else
         {
-            // TODO: mloskot - add assert(node.size() >= 2); or similar
+            // TODO: mloskot - add BOOST_GEOMETRY_ASSERT(node.size() >= 2); or similar
 
             typename rtree_node<Box, Value>::node_map nodes = n->get_nodes();
             unsigned int remaining = nodes.size() - 2;

--- a/include/boost/geometry/extensions/iterators/segment_returning_iterator.hpp
+++ b/include/boost/geometry/extensions/iterators/segment_returning_iterator.hpp
@@ -18,10 +18,11 @@
 
 #include <iterator>
 
-#include <boost/assert.hpp>
 #include <boost/iterator.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 #include <boost/iterator/iterator_categories.hpp>
+
+#include <boost/geometry/core/assert.hpp>
 
 #include <boost/geometry/algorithms/equals.hpp>
 
@@ -60,14 +61,14 @@ struct segment_returning_iterator
     {
         if (m_it != m_end)
         {
-            BOOST_ASSERT(m_prev != m_end);
+            BOOST_GEOMETRY_ASSERT(m_prev != m_end);
             ++m_it;
         }
     }
 
     reference operator*()
     {
-        BOOST_ASSERT(m_it != m_end && m_prev != m_end);
+        BOOST_GEOMETRY_ASSERT(m_it != m_end && m_prev != m_end);
 
         p1 = *m_prev;
         p2 = *m_it;

--- a/include/boost/geometry/extensions/nsphere/index/detail/rtree/linear/redistribute_elements.hpp
+++ b/include/boost/geometry/extensions/nsphere/index/detail/rtree/linear/redistribute_elements.hpp
@@ -91,7 +91,7 @@ struct find_greatest_normalized_separation<Elements, Parameters, Translator, nsp
 
         // highest_low - lowest_high
         separation = difference<separation_type>(lowest_high, highest_low);
-        // BOOST_ASSERT(0 <= width);
+        // BOOST_GEOMETRY_INDEX_ASSERT(0 <= width);
         if ( std::numeric_limits<coordinate_type>::epsilon() < width )
             separation /= width;
 

--- a/include/boost/geometry/extensions/nsphere/strategies/cartesian/point_in_nsphere.hpp
+++ b/include/boost/geometry/extensions/nsphere/strategies/cartesian/point_in_nsphere.hpp
@@ -15,9 +15,8 @@
 #ifndef BOOST_GEOMETRY_EXTENSIONS_NSPHERE_STRATEGIES_CARTESIAN_POINT_IN_NSPHERE_HPP
 #define BOOST_GEOMETRY_EXTENSIONS_NSPHERE_STRATEGIES_CARTESIAN_POINT_IN_NSPHERE_HPP
 
-#include <cassert>
-
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/strategies/covered_by.hpp>
 #include <boost/geometry/strategies/within.hpp>
@@ -75,7 +74,7 @@ struct point_in_nsphere
 //    static bool apply(A const& a, B const& b)
 //    {
 //        // Assertion if called
-//        assert(false);
+//        BOOST_GEOMETRY_ASSERT(false);
 //        return false;
 //    }
 //};

--- a/include/boost/geometry/geometries/box.hpp
+++ b/include/boost/geometry/geometries/box.hpp
@@ -23,7 +23,7 @@
 #include <boost/geometry/geometries/concepts/point_concept.hpp>
 
 #if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
-#include <boost/assert.hpp>
+#include <boost/geometry/core/assert.hpp>
 #endif
 
 
@@ -93,14 +93,14 @@ public:
     inline Point const& min_corner() const
     {
 #if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
-        BOOST_ASSERT(m_created == 1);
+        BOOST_GEOMETRY_ASSERT(m_created == 1);
 #endif
         return m_min_corner;
     }
     inline Point const& max_corner() const
     {
 #if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
-        BOOST_ASSERT(m_created == 1);
+        BOOST_GEOMETRY_ASSERT(m_created == 1);
 #endif
         return m_max_corner;
     }
@@ -108,14 +108,14 @@ public:
     inline Point& min_corner()
     {
 #if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
-        BOOST_ASSERT(m_created == 1);
+        BOOST_GEOMETRY_ASSERT(m_created == 1);
 #endif
         return m_min_corner;
     }
     inline Point& max_corner()
     {
 #if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
-        BOOST_ASSERT(m_created == 1);
+        BOOST_GEOMETRY_ASSERT(m_created == 1);
 #endif
         return m_max_corner;
     }

--- a/include/boost/geometry/geometries/point.hpp
+++ b/include/boost/geometry/geometries/point.hpp
@@ -27,13 +27,14 @@
 #include <boost/mpl/int.hpp>
 
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/coordinate_system.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 
 #if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
 #include <algorithm>
-#include <boost/assert.hpp>
+#include <boost/geometry/core/assert.hpp>
 #endif
 
 namespace boost { namespace geometry
@@ -186,8 +187,8 @@ public:
     inline CoordinateType const& get() const
     {
 #if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
-        BOOST_ASSERT(m_created == 1);
-        BOOST_ASSERT(m_values_initialized[K] == 1);
+        BOOST_GEOMETRY_ASSERT(m_created == 1);
+        BOOST_GEOMETRY_ASSERT(m_values_initialized[K] == 1);
 #endif
         BOOST_STATIC_ASSERT(K < DimensionCount);
         return m_values[K];
@@ -200,7 +201,7 @@ public:
     inline void set(CoordinateType const& value)
     {
 #if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
-        BOOST_ASSERT(m_created == 1);
+        BOOST_GEOMETRY_ASSERT(m_created == 1);
         m_values_initialized[K] = 1;
 #endif
         BOOST_STATIC_ASSERT(K < DimensionCount);

--- a/include/boost/geometry/geometries/pointing_segment.hpp
+++ b/include/boost/geometry/geometries/pointing_segment.hpp
@@ -12,17 +12,16 @@
 
 #include <cstddef>
 
-#include <boost/assert.hpp>
 #include <boost/concept/assert.hpp>
 #include <boost/core/addressof.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/type_traits/is_const.hpp>
 
-#include <boost/geometry/geometries/concepts/point_concept.hpp>
-
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
 
+#include <boost/geometry/geometries/concepts/point_concept.hpp>
 
 namespace boost { namespace geometry
 {
@@ -99,13 +98,13 @@ struct indexed_access<model::pointing_segment<Point>, 0, Dimension>
 
     static inline coordinate_type get(segment_type const& s)
     {
-        BOOST_ASSERT( s.first != NULL );
+        BOOST_GEOMETRY_ASSERT( s.first != NULL );
         return geometry::get<Dimension>(*s.first);
     }
 
     static inline void set(segment_type& s, coordinate_type const& value)
     {
-        BOOST_ASSERT( s.first != NULL );
+        BOOST_GEOMETRY_ASSERT( s.first != NULL );
         geometry::set<Dimension>(*s.first, value);
     }
 };
@@ -122,13 +121,13 @@ struct indexed_access<model::pointing_segment<Point>, 1, Dimension>
 
     static inline coordinate_type get(segment_type const& s)
     {
-        BOOST_ASSERT( s.second != NULL );
+        BOOST_GEOMETRY_ASSERT( s.second != NULL );
         return geometry::get<Dimension>(*s.second);
     }
 
     static inline void set(segment_type& s, coordinate_type const& value)
     {
-        BOOST_ASSERT( s.second != NULL );
+        BOOST_GEOMETRY_ASSERT( s.second != NULL );
         geometry::set<Dimension>(*s.second, value);
     }
 };

--- a/include/boost/geometry/index/detail/assert.hpp
+++ b/include/boost/geometry/index/detail/assert.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry Index
 //
-// Copyright (c) 2011-2014 Adam Wulkiewicz, Lodz, Poland.
+// Copyright (c) 2011-2015 Adam Wulkiewicz, Lodz, Poland.
 //
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -9,12 +9,12 @@
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_ASSERT_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_ASSERT_HPP
 
-#include <boost/assert.hpp>
+#include <boost/geometry/core/assert.hpp>
 
 #ifndef BOOST_GEOMETRY_INDEX_ASSERT
 
 #define BOOST_GEOMETRY_INDEX_ASSERT(CONDITION, TEXT_MSG) \
-    BOOST_ASSERT_MSG(CONDITION, TEXT_MSG)
+    BOOST_GEOMETRY_ASSERT_MSG(CONDITION, TEXT_MSG)
 
 #endif // BOOST_GEOMETRY_INDEX_ASSERT
 

--- a/include/boost/geometry/iterators/concatenate_iterator.hpp
+++ b/include/boost/geometry/iterators/concatenate_iterator.hpp
@@ -10,7 +10,6 @@
 #ifndef BOOST_GEOMETRY_ITERATORS_CONCATENATE_ITERATOR_HPP
 #define BOOST_GEOMETRY_ITERATORS_CONCATENATE_ITERATOR_HPP
 
-#include <boost/assert.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 #include <boost/iterator.hpp>

--- a/include/boost/geometry/iterators/flatten_iterator.hpp
+++ b/include/boost/geometry/iterators/flatten_iterator.hpp
@@ -10,13 +10,13 @@
 #ifndef BOOST_GEOMETRY_ITERATORS_FLATTEN_ITERATOR_HPP
 #define BOOST_GEOMETRY_ITERATORS_FLATTEN_ITERATOR_HPP
 
-#include <boost/assert.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 #include <boost/iterator.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/iterator/iterator_categories.hpp>
 
+#include <boost/geometry/core/assert.hpp>
 
 namespace boost { namespace geometry
 {
@@ -154,8 +154,8 @@ private:
 
     inline Reference dereference() const
     {
-        BOOST_ASSERT( m_outer_it != m_outer_end );
-        BOOST_ASSERT( m_inner_it != AccessInnerEnd::apply(*m_outer_it) );
+        BOOST_GEOMETRY_ASSERT( m_outer_it != m_outer_end );
+        BOOST_GEOMETRY_ASSERT( m_inner_it != AccessInnerEnd::apply(*m_outer_it) );
         return *m_inner_it;
     }
 
@@ -194,8 +194,8 @@ private:
 
     inline void increment()
     {
-        BOOST_ASSERT( m_outer_it != m_outer_end );
-        BOOST_ASSERT( m_inner_it != AccessInnerEnd::apply(*m_outer_it) );
+        BOOST_GEOMETRY_ASSERT( m_outer_it != m_outer_end );
+        BOOST_GEOMETRY_ASSERT( m_inner_it != AccessInnerEnd::apply(*m_outer_it) );
 
         ++m_inner_it;
         if ( m_inner_it == AccessInnerEnd::apply(*m_outer_it) )

--- a/include/boost/geometry/iterators/point_iterator.hpp
+++ b/include/boost/geometry/iterators/point_iterator.hpp
@@ -10,7 +10,6 @@
 #ifndef BOOST_GEOMETRY_ITERATORS_POINT_ITERATOR_HPP
 #define BOOST_GEOMETRY_ITERATORS_POINT_ITERATOR_HPP
 
-#include <boost/assert.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/type_traits/is_convertible.hpp>

--- a/include/boost/geometry/policies/relate/intersection_points.hpp
+++ b/include/boost/geometry/policies/relate/intersection_points.hpp
@@ -18,6 +18,7 @@
 
 #include <boost/geometry/algorithms/detail/assign_indexed_point.hpp>
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/strategies/side_info.hpp>
 #include <boost/geometry/util/promote_integral.hpp>
 #include <boost/geometry/util/select_calculation_type.hpp>
@@ -60,7 +61,7 @@ struct segments_intersection_points
         // Up to now, division was postponed. Here we divide using numerator/
         // denominator. In case of integer this results in an integer
         // division.
-        BOOST_ASSERT(ratio.denominator() != 0);
+        BOOST_GEOMETRY_ASSERT(ratio.denominator() != 0);
 
         typedef typename promote_integral<coordinate_type>::type promoted_type;
 

--- a/include/boost/geometry/policies/robustness/get_rescale_policy.hpp
+++ b/include/boost/geometry/policies/robustness/get_rescale_policy.hpp
@@ -23,6 +23,7 @@
 #include <boost/type_traits.hpp>
 #include <boost/mpl/assert.hpp>
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/tag_cast.hpp>
 
 #include <boost/geometry/algorithms/envelope.hpp>
@@ -70,7 +71,7 @@ inline void scale_box_to_integer_range(Box const& box,
         : boost::numeric_cast<num_type>(
             boost::numeric_cast<boost::long_long_type>(half + range / diff));
 
-    BOOST_ASSERT(factor >= 1);
+    BOOST_GEOMETRY_ASSERT(factor >= 1);
 
     // Assign input/output minimal points
     detail::assign_point_from_index<0>(box, min_point);

--- a/include/boost/geometry/policies/robustness/segment_ratio.hpp
+++ b/include/boost/geometry/policies/robustness/segment_ratio.hpp
@@ -9,10 +9,10 @@
 #ifndef BOOST_GEOMETRY_POLICIES_ROBUSTNESS_SEGMENT_RATIO_HPP
 #define BOOST_GEOMETRY_POLICIES_ROBUSTNESS_SEGMENT_RATIO_HPP
 
-#include <boost/assert.hpp>
 #include <boost/config.hpp>
 #include <boost/rational.hpp>
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/util/math.hpp>
 #include <boost/geometry/util/promote_floating_point.hpp>
 
@@ -47,8 +47,8 @@ struct less<Type, false>
     template <typename Ratio>
     static inline bool apply(Ratio const& lhs, Ratio const& rhs)
     {
-        BOOST_ASSERT(lhs.denominator() != 0);
-        BOOST_ASSERT(rhs.denominator() != 0);
+        BOOST_GEOMETRY_ASSERT(lhs.denominator() != 0);
+        BOOST_GEOMETRY_ASSERT(rhs.denominator() != 0);
         return lhs.numerator() * rhs.denominator()
              < rhs.numerator() * lhs.denominator();
     }
@@ -78,8 +78,8 @@ struct equal<Type, false>
     template <typename Ratio>
     static inline bool apply(Ratio const& lhs, Ratio const& rhs)
     {
-        BOOST_ASSERT(lhs.denominator() != 0);
-        BOOST_ASSERT(rhs.denominator() != 0);
+        BOOST_GEOMETRY_ASSERT(lhs.denominator() != 0);
+        BOOST_GEOMETRY_ASSERT(rhs.denominator() != 0);
         return geometry::math::equals
             (
                 lhs.numerator() * rhs.denominator(),

--- a/include/boost/geometry/strategies/agnostic/hull_graham_andrew.hpp
+++ b/include/boost/geometry/strategies/agnostic/hull_graham_andrew.hpp
@@ -24,6 +24,7 @@
 
 #include <boost/range.hpp>
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/point_type.hpp>
 #include <boost/geometry/strategies/convex_hull.hpp>
@@ -354,7 +355,7 @@ private:
     {
         std::copy(boost::begin(first), boost::end(first), out);
 
-        BOOST_ASSERT(closed ? !boost::empty(second) : boost::size(second) > 1);
+        BOOST_GEOMETRY_ASSERT(closed ? !boost::empty(second) : boost::size(second) > 1);
         std::copy(++boost::rbegin(second), // skip the first Point
                   closed ? boost::rend(second) : --boost::rend(second), // skip the last Point if open
                   out);

--- a/include/boost/geometry/strategies/cartesian/buffer_join_miter.hpp
+++ b/include/boost/geometry/strategies/cartesian/buffer_join_miter.hpp
@@ -9,7 +9,7 @@
 #ifndef BOOST_GEOMETRY_STRATEGIES_CARTESIAN_BUFFER_JOIN_MITER_HPP
 #define BOOST_GEOMETRY_STRATEGIES_CARTESIAN_BUFFER_JOIN_MITER_HPP
 
-#include <boost/assert.hpp>
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/policies/compare.hpp>
 #include <boost/geometry/util/math.hpp>
@@ -99,7 +99,7 @@ public:
 
         if (distance > max_distance)
         {
-            BOOST_ASSERT(distance != 0.0);
+            BOOST_GEOMETRY_ASSERT(distance != 0.0);
 
             promoted_type const proportion = max_distance / distance;
             set<0>(p, get<0>(vertex) + dx * proportion);

--- a/include/boost/geometry/strategies/cartesian/buffer_join_round.hpp
+++ b/include/boost/geometry/strategies/cartesian/buffer_join_round.hpp
@@ -16,7 +16,6 @@
 
 #include <algorithm>
 
-#include <boost/assert.hpp>
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/policies/compare.hpp>
 #include <boost/geometry/strategies/buffer.hpp>

--- a/include/boost/geometry/strategies/cartesian/buffer_join_round_by_divide.hpp
+++ b/include/boost/geometry/strategies/cartesian/buffer_join_round_by_divide.hpp
@@ -9,7 +9,6 @@
 #ifndef BOOST_GEOMETRY_STRATEGIES_CARTESIAN_BUFFER_JOIN_ROUND_BY_DIVIDE_HPP
 #define BOOST_GEOMETRY_STRATEGIES_CARTESIAN_BUFFER_JOIN_ROUND_BY_DIVIDE_HPP
 
-#include <boost/assert.hpp>
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/policies/compare.hpp>
 #include <boost/geometry/strategies/buffer.hpp>

--- a/include/boost/geometry/strategies/cartesian/cart_intersect.hpp
+++ b/include/boost/geometry/strategies/cartesian/cart_intersect.hpp
@@ -264,7 +264,7 @@ private:
                               bool const a_is_point,
                               bool const b_is_point)
     {
-        //BOOST_ASSERT_MSG(!(a_is_point && b_is_point), "both segments shouldn't be degenerated");
+        //BOOST_GEOMETRY_ASSERT_MSG(!(a_is_point && b_is_point), "both segments shouldn't be degenerated");
 
         // for degenerated segments the second is always true because this function
         // shouldn't be called if both segments were degenerated

--- a/include/boost/geometry/strategies/cartesian/side_of_intersection.hpp
+++ b/include/boost/geometry/strategies/cartesian/side_of_intersection.hpp
@@ -23,6 +23,7 @@
 
 #include <boost/geometry/arithmetic/determinant.hpp>
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/algorithms/detail/assign_indexed_point.hpp>
 #include <boost/geometry/strategies/cartesian/side_by_triangle.hpp>
@@ -122,7 +123,7 @@ struct multiplicable_integral
     {
         unsigned_type b = base; // a workaround for MinGW - undefined reference base
         CmpVal val = CmpVal(m_sign) * (CmpVal(m_ms) * CmpVal(b) + CmpVal(m_ls));
-        BOOST_ASSERT(cmp_val == val);
+        BOOST_GEOMETRY_ASSERT(cmp_val == val);
     }
 };
 
@@ -176,7 +177,7 @@ private :
                     : lab < lcd ? -1
                     : 0
                     ;
-        BOOST_ASSERT(result == result2);
+        BOOST_GEOMETRY_ASSERT(result == result2);
 #endif
 
         return result;

--- a/include/boost/geometry/util/normalize_spheroidal_box_coordinates.hpp
+++ b/include/boost/geometry/util/normalize_spheroidal_box_coordinates.hpp
@@ -10,8 +10,7 @@
 #ifndef BOOST_GEOMETRY_UTIL_NORMALIZE_SPHEROIDAL_BOX_COORDINATES_HPP
 #define BOOST_GEOMETRY_UTIL_NORMALIZE_SPHEROIDAL_BOX_COORDINATES_HPP
 
-#include <boost/assert.hpp>
-
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/util/math.hpp>
 #include <boost/geometry/util/normalize_spheroidal_coordinates.hpp>
 
@@ -78,14 +77,14 @@ public:
         }
 
 #ifdef BOOST_GEOMETRY_NORMALIZE_LATITUDE
-        BOOST_ASSERT(! math::larger(latitude1, latitude2));
-        BOOST_ASSERT(! math::smaller(latitude1, constants::min_latitude()));
-        BOOST_ASSERT(! math::larger(latitude2, constants::max_latitude()));
+        BOOST_GEOMETRY_ASSERT(! math::larger(latitude1, latitude2));
+        BOOST_GEOMETRY_ASSERT(! math::smaller(latitude1, constants::min_latitude()));
+        BOOST_GEOMETRY_ASSERT(! math::larger(latitude2, constants::max_latitude()));
 #endif
 
-        BOOST_ASSERT(! math::larger(longitude1, longitude2));
-        BOOST_ASSERT(! math::smaller(longitude1, constants::min_longitude()));
-        BOOST_ASSERT
+        BOOST_GEOMETRY_ASSERT(! math::larger(longitude1, longitude2));
+        BOOST_GEOMETRY_ASSERT(! math::smaller(longitude1, constants::min_longitude()));
+        BOOST_GEOMETRY_ASSERT
             (! math::larger(longitude2 - longitude1, constants::period()));
     }
 

--- a/include/boost/geometry/util/normalize_spheroidal_coordinates.hpp
+++ b/include/boost/geometry/util/normalize_spheroidal_coordinates.hpp
@@ -10,8 +10,7 @@
 #ifndef BOOST_GEOMETRY_UTIL_NORMALIZE_SPHEROIDAL_COORDINATES_HPP
 #define BOOST_GEOMETRY_UTIL_NORMALIZE_SPHEROIDAL_COORDINATES_HPP
 
-#include <boost/assert.hpp>
-
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/util/math.hpp>
 
@@ -178,12 +177,12 @@ public:
         }
 
 #ifdef BOOST_GEOMETRY_NORMALIZE_LATITUDE
-        BOOST_ASSERT(! math::larger(constants::min_latitude(), latitude));
-        BOOST_ASSERT(! math::larger(latitude, constants::max_latitude()));
+        BOOST_GEOMETRY_ASSERT(! math::larger(constants::min_latitude(), latitude));
+        BOOST_GEOMETRY_ASSERT(! math::larger(latitude, constants::max_latitude()));
 #endif // BOOST_GEOMETRY_NORMALIZE_LATITUDE
 
-        BOOST_ASSERT(math::smaller(constants::min_longitude(), longitude));
-        BOOST_ASSERT(! math::larger(longitude, constants::max_longitude()));
+        BOOST_GEOMETRY_ASSERT(math::smaller(constants::min_longitude(), longitude));
+        BOOST_GEOMETRY_ASSERT(! math::larger(longitude, constants::max_longitude()));
     }
 };
 

--- a/include/boost/geometry/util/range.hpp
+++ b/include/boost/geometry/util/range.hpp
@@ -16,7 +16,6 @@
 
 #include <algorithm>
 
-#include <boost/assert.hpp>
 #include <boost/concept_check.hpp>
 #include <boost/config.hpp>
 #include <boost/range/concepts.hpp>
@@ -26,6 +25,7 @@
 #include <boost/range/size.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/mutable_range.hpp>
 
 namespace boost { namespace geometry { namespace range {
@@ -59,7 +59,7 @@ inline typename boost::range_iterator<RandomAccessRange const>::type
 pos(RandomAccessRange const& rng,
     typename boost::range_size<RandomAccessRange const>::type i)
 {
-    BOOST_ASSERT(i <= boost::size(rng));
+    BOOST_GEOMETRY_ASSERT(i <= boost::size(rng));
     return detail::pos<RandomAccessRange const>::apply(rng, i);
 }
 
@@ -72,7 +72,7 @@ inline typename boost::range_iterator<RandomAccessRange>::type
 pos(RandomAccessRange & rng,
     typename boost::range_size<RandomAccessRange>::type i)
 {
-    BOOST_ASSERT(i <= boost::size(rng));
+    BOOST_GEOMETRY_ASSERT(i <= boost::size(rng));
     return detail::pos<RandomAccessRange>::apply(rng, i);
 }
 
@@ -85,7 +85,7 @@ inline typename boost::range_reference<RandomAccessRange const>::type
 at(RandomAccessRange const& rng,
    typename boost::range_size<RandomAccessRange const>::type i)
 {
-    BOOST_ASSERT(i < boost::size(rng));
+    BOOST_GEOMETRY_ASSERT(i < boost::size(rng));
     return * detail::pos<RandomAccessRange const>::apply(rng, i);
 }
 
@@ -98,7 +98,7 @@ inline typename boost::range_reference<RandomAccessRange>::type
 at(RandomAccessRange & rng,
    typename boost::range_size<RandomAccessRange>::type i)
 {
-    BOOST_ASSERT(i < boost::size(rng));
+    BOOST_GEOMETRY_ASSERT(i < boost::size(rng));
     return * detail::pos<RandomAccessRange>::apply(rng, i);
 }
 
@@ -110,7 +110,7 @@ template <typename Range>
 inline typename boost::range_reference<Range const>::type
 front(Range const& rng)
 {
-    BOOST_ASSERT(!boost::empty(rng));
+    BOOST_GEOMETRY_ASSERT(!boost::empty(rng));
     return *boost::begin(rng);
 }
 
@@ -122,7 +122,7 @@ template <typename Range>
 inline typename boost::range_reference<Range>::type
 front(Range & rng)
 {
-    BOOST_ASSERT(!boost::empty(rng));
+    BOOST_GEOMETRY_ASSERT(!boost::empty(rng));
     return *boost::begin(rng);
 }
 
@@ -137,7 +137,7 @@ inline typename boost::range_reference<BidirectionalRange const>::type
 back(BidirectionalRange const& rng)
 {
     BOOST_RANGE_CONCEPT_ASSERT(( boost::BidirectionalRangeConcept<BidirectionalRange const> ));
-    BOOST_ASSERT(!boost::empty(rng));
+    BOOST_GEOMETRY_ASSERT(!boost::empty(rng));
     return *(boost::rbegin(rng));
 }
 
@@ -150,7 +150,7 @@ inline typename boost::range_reference<BidirectionalRange>::type
 back(BidirectionalRange & rng)
 {
     BOOST_RANGE_CONCEPT_ASSERT((boost::BidirectionalRangeConcept<BidirectionalRange>));
-    BOOST_ASSERT(!boost::empty(rng));
+    BOOST_GEOMETRY_ASSERT(!boost::empty(rng));
     return *(boost::rbegin(rng));
 }
 
@@ -200,7 +200,7 @@ inline void resize(Range & rng,
 template <typename Range>
 inline void pop_back(Range & rng)
 {
-    BOOST_ASSERT(!boost::empty(rng));
+    BOOST_GEOMETRY_ASSERT(!boost::empty(rng));
     range::resize(rng, boost::size(rng) - 1);
 }
 
@@ -260,8 +260,8 @@ inline typename boost::range_iterator<Range>::type
 erase(Range & rng,
       typename boost::range_iterator<Range>::type it)
 {
-    BOOST_ASSERT(!boost::empty(rng));
-    BOOST_ASSERT(it != boost::end(rng));
+    BOOST_GEOMETRY_ASSERT(!boost::empty(rng));
+    BOOST_GEOMETRY_ASSERT(it != boost::end(rng));
 
     typename boost::range_difference<Range>::type const
         d = std::distance(boost::begin(rng), it);
@@ -314,10 +314,10 @@ erase(Range & rng,
 {
     typename boost::range_difference<Range>::type const
         diff = std::distance(first, last);
-    BOOST_ASSERT(diff >= 0);
+    BOOST_GEOMETRY_ASSERT(diff >= 0);
 
     std::size_t const count = static_cast<std::size_t>(diff);
-    BOOST_ASSERT(count <= boost::size(rng));
+    BOOST_GEOMETRY_ASSERT(count <= boost::size(rng));
     
     if ( count > 0 )
     {

--- a/test/core/Jamfile.v2
+++ b/test/core/Jamfile.v2
@@ -12,6 +12,7 @@
 test-suite boost-geometry-core
     :
     [ run access.cpp                : : : : core_access ]
+    [ run assert.cpp                : : : : core_assert ]
     [ run coordinate_dimension.cpp  : : : : core_coordinate_dimension ]
     [ run coordinate_system.cpp     : : : : core_coordinate_system ]
     [ run coordinate_type.cpp       : : : : core_coordinate_type ]

--- a/test/core/assert.cpp
+++ b/test/core/assert.cpp
@@ -1,0 +1,64 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+// Unit Test
+
+// Copyright (c) 2015 Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+
+#include <geometry_test_common.hpp>
+
+#define BOOST_GEOMETRY_ENABLE_ASSERT_HANDLER
+#include <boost/geometry/core/assert.hpp>
+
+struct assert_failure_exception
+    : std::exception
+{
+    const char * what() const throw()
+    {
+        return "assertion failure";
+    }
+};
+
+namespace boost { namespace geometry {
+
+inline void assertion_failed(char const * expr, char const * function, char const * file, long line)
+{
+    throw assert_failure_exception();
+}
+
+inline void assertion_failed_msg(char const * expr, char const * msg, char const * function, char const * file, long line)
+{
+    throw assert_failure_exception();
+}
+
+}}
+
+void fun1(bool condition)
+{
+    BOOST_GEOMETRY_ASSERT(condition);
+}
+
+void fun2(bool condition, const char* msg = "")
+{
+    BOOST_GEOMETRY_ASSERT_MSG(condition, msg);
+}
+
+bool is_ok(assert_failure_exception const& ) { return true; }
+
+int test_main(int, char* [])
+{
+    int a = 10;
+    int b = 20;
+
+    fun1(a == a);
+    BOOST_CHECK_EXCEPTION(fun1(a == b), assert_failure_exception, is_ok);
+    fun2(a == a);
+    BOOST_CHECK_EXCEPTION(fun2(a == b), assert_failure_exception, is_ok);
+
+    return 0;
+}


### PR DESCRIPTION
This allows to implement user-defined assertion failure handling mechanism specifically for Boost.Geometry assertions, e.g. to replace it with exception throw and/or logging or custom terminate, etc. The implementation is similar to the one in Boost.Assert so interested users should be familiar with it.