### PR TITLE
Replace int with more suitable type (std::size_t, signed_size_type, template parameter).

### DIFF
--- a/include/boost/geometry/algorithms/detail/get_left_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/get_left_turns.hpp
@@ -156,8 +156,8 @@ template <typename AngleCollection, typename Turns>
 inline void get_left_turns(AngleCollection const& sorted_angles,
         Turns& turns)
 {
-    std::set<int> good_incoming;
-    std::set<int> good_outgoing;
+    std::set<std::size_t> good_incoming;
+    std::set<std::size_t> good_outgoing;
 
     for (typename boost::range_iterator<AngleCollection const>::type it =
         sorted_angles.begin(); it != sorted_angles.end(); ++it)
@@ -244,14 +244,14 @@ inline void block_turns(AngleCollection& sorted, std::size_t cluster_size)
     for (typename boost::range_iterator<AngleCollection>::type it = sorted.begin();
         it != sorted.end(); ++it)
     {
-        int cluster_index = it->cluster_index;
-        int previous_index = cluster_index - 1;
+        signed_size_type cluster_index = static_cast<signed_size_type>(it->cluster_index);
+        signed_size_type previous_index = cluster_index - 1;
         if (previous_index < 0)
         {
             previous_index = cluster_size - 1;
         }
-        int next_index = cluster_index + 1;
-        if (next_index >= static_cast<int>(cluster_size))
+        signed_size_type next_index = cluster_index + 1;
+        if (next_index >= static_cast<signed_size_type>(cluster_size))
         {
             next_index = 0;
         }

--- a/include/boost/geometry/algorithms/detail/occupation_info.hpp
+++ b/include/boost/geometry/algorithms/detail/occupation_info.hpp
@@ -37,7 +37,7 @@ struct angle_info
     typedef Point point_type;
 
     segment_identifier seg_id;
-    int turn_index;
+    std::size_t turn_index;
     int operation_index;
     std::size_t cluster_index;
     Point intersection_point;
@@ -58,7 +58,7 @@ class occupation_info
 public :
     typedef std::vector<AngleInfo> collection_type;
 
-    int count;
+    std::size_t count;
 
     inline occupation_info()
         : count(0)
@@ -68,7 +68,7 @@ public :
     inline void add(RobustPoint const& incoming_point,
                     RobustPoint const& outgoing_point,
                     RobustPoint const& intersection_point,
-                    int turn_index, int operation_index,
+                    std::size_t turn_index, int operation_index,
                     segment_identifier const& seg_id)
     {
         geometry::equal_to<RobustPoint> comparator;
@@ -126,11 +126,19 @@ private :
 };
 
 template<typename Pieces>
-inline void move_index(Pieces const& pieces, int& index, int& piece_index, int direction)
+inline void move_index(Pieces const& pieces, signed_size_type& index, signed_size_type& piece_index, int direction)
 {
     BOOST_GEOMETRY_ASSERT(direction == 1 || direction == -1);
-    BOOST_GEOMETRY_ASSERT(piece_index >= 0 && piece_index < static_cast<int>(boost::size(pieces)) );
-    BOOST_GEOMETRY_ASSERT(index >= 0 && index < static_cast<int>(boost::size(pieces[piece_index].robust_ring)));
+    BOOST_GEOMETRY_ASSERT(
+        piece_index >= 0
+        && piece_index < static_cast<signed_size_type>(boost::size(pieces)) );
+    BOOST_GEOMETRY_ASSERT(
+        index >= 0
+        && index < static_cast<signed_size_type>(boost::size(pieces[piece_index].robust_ring)));
+
+    // NOTE: both index and piece_index must be in valid range
+    // this means that then they could be of type std::size_t
+    // if the code below was refactored
 
     index += direction;
     if (direction == -1 && index < 0)
@@ -143,10 +151,10 @@ inline void move_index(Pieces const& pieces, int& index, int& piece_index, int d
         index = boost::size(pieces[piece_index].robust_ring) - 1;
     }
     if (direction == 1
-        && index >= static_cast<int>(boost::size(pieces[piece_index].robust_ring)))
+        && index >= static_cast<signed_size_type>(boost::size(pieces[piece_index].robust_ring)))
     {
         piece_index++;
-        if (piece_index >= static_cast<int>(boost::size(pieces)))
+        if (piece_index >= static_cast<signed_size_type>(boost::size(pieces)))
         {
             piece_index = 0;
         }
@@ -177,8 +185,8 @@ inline void add_incoming_and_outgoing_angles(
     RobustPoint direction_points[2];
     for (int i = 0; i < 2; i++)
     {
-        int index = turn.operations[operation_index].index_in_robust_ring;
-        int piece_index = turn.operations[operation_index].piece_index;
+        signed_size_type index = turn.operations[operation_index].index_in_robust_ring;
+        signed_size_type piece_index = turn.operations[operation_index].piece_index;
         while(comparator(pieces[piece_index].robust_ring[index], intersection_point))
         {
             move_index(pieces, index, piece_index, i == 0 ? -1 : 1);

--- a/include/boost/geometry/algorithms/detail/overlay/copy_segments.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/copy_segments.hpp
@@ -265,7 +265,7 @@ struct copy_segments_multi
         BOOST_GEOMETRY_ASSERT
             (
                 seg_id.multi_index >= 0
-                && seg_id.multi_index < int(boost::size(multi_geometry))
+                && static_cast<std::size_t>(seg_id.multi_index) < boost::size(multi_geometry)
             );
 
         // Call the single-version

--- a/include/boost/geometry/algorithms/detail/overlay/enrich_intersection_points.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/enrich_intersection_points.hpp
@@ -357,14 +357,14 @@ inline void enrich_assign(Container& operations,
                     = turn_points[it->turn_index].operations[it->operation_index];
 
             prev_op.enriched.travels_to_ip_index
-                    = static_cast<int>(it->turn_index);
+                    = static_cast<signed_size_type>(it->turn_index);
             prev_op.enriched.travels_to_vertex_index
                     = it->subject->seg_id.segment_index;
 
             if (! first
                 && prev_op.seg_id.segment_index == op.seg_id.segment_index)
             {
-                prev_op.enriched.next_ip_index = static_cast<int>(it->turn_index);
+                prev_op.enriched.next_ip_index = static_cast<signed_size_type>(it->turn_index);
             }
             first = false;
         }

--- a/include/boost/geometry/algorithms/detail/overlay/enrichment_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/enrichment_info.hpp
@@ -37,13 +37,13 @@ struct enrichment_info
     // vertex to which is free travel after this IP,
     // so from "segment_index+1" to "travels_to_vertex_index", without IP-s,
     // can be -1
-    signed_index_type travels_to_vertex_index;
+    signed_size_type travels_to_vertex_index;
 
     // same but now IP index, so "next IP index" but not on THIS segment
-    int travels_to_ip_index;
+    signed_size_type travels_to_ip_index;
 
     // index of next IP on this segment, -1 if there is no one
-    int next_ip_index;
+    signed_size_type next_ip_index;
 };
 
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
@@ -143,7 +143,7 @@ class get_turns_in_sections
 
     template <typename Geometry, typename Section>
     static inline bool neighbouring(Section const& section,
-            int index1, int index2)
+            signed_index_type index1, signed_index_type index2)
     {
         // About n-2:
         //   (square: range_count=5, indices 0,1,2,3
@@ -151,7 +151,7 @@ class get_turns_in_sections
         // Also tested for open polygons, and/or duplicates
         // About first condition: will be optimized by compiler (static)
         // It checks if it is areal (box,ring,(multi)polygon
-        int const n = int(section.range_count);
+        signed_index_type const n = static_cast<signed_index_type>(section.range_count);
 
         boost::ignore_unused_variable_warning(n);
         boost::ignore_unused_variable_warning(index1);
@@ -208,8 +208,8 @@ public :
 
         int const dir1 = sec1.directions[0];
         int const dir2 = sec2.directions[0];
-        int index1 = sec1.begin_index;
-        int ndi1 = sec1.non_duplicate_index;
+        signed_index_type index1 = sec1.begin_index;
+        signed_index_type ndi1 = sec1.non_duplicate_index;
 
         bool const same_source =
             source_id1 == source_id2
@@ -237,8 +237,8 @@ public :
                     begin_range_1, end_range_1, next1, true);
             advance_to_non_duplicate_next(nd_next1, it1, sec1, robust_policy);
 
-            int index2 = sec2.begin_index;
-            int ndi2 = sec2.non_duplicate_index;
+            signed_index_type index2 = sec2.begin_index;
+            signed_index_type ndi2 = sec2.non_duplicate_index;
 
             range2_iterator prev2, it2, end2;
 
@@ -360,7 +360,7 @@ private :
             typename boost::range_iterator<Range const>::type& it,
             typename boost::range_iterator<Range const>::type& prev,
             typename boost::range_iterator<Range const>::type& end,
-            int& index, int& ndi,
+            signed_index_type& index, signed_index_type& ndi,
             int dir, Box const& other_bounding_box, RobustPolicy const& robust_policy)
     {
         it = boost::begin(range) + section.begin_index;

--- a/include/boost/geometry/algorithms/detail/relate/areal_areal.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/areal_areal.hpp
@@ -104,9 +104,9 @@ public:
 
             // Check if any interior ring is outside
             ring_identifier ring_id(0, -1, 0);
-            int const irings_count = boost::numeric_cast<int>(
-                                        geometry::num_interior_rings(areal) );
-            for ( ; ring_id.ring_index < irings_count ; ++ring_id.ring_index )
+            std::size_t const irings_count = geometry::num_interior_rings(areal);
+            for ( ; static_cast<std::size_t>(ring_id.ring_index) < irings_count ;
+                    ++ring_id.ring_index )
             {
                 typename detail::sub_range_return_type<Areal const>::type
                     range_ref = detail::sub_range(areal, ring_id);
@@ -140,9 +140,9 @@ public:
 
             // Check if any interior ring is inside
             ring_identifier ring_id(0, -1, 0);
-            int const irings_count = boost::numeric_cast<int>(
-                                        geometry::num_interior_rings(areal) );
-            for ( ; ring_id.ring_index < irings_count ; ++ring_id.ring_index )
+            std::size_t const irings_count = geometry::num_interior_rings(areal);
+            for ( ; static_cast<std::size_t>(ring_id.ring_index) < irings_count ;
+                    ++ring_id.ring_index )
             {
                 typename detail::sub_range_return_type<Areal const>::type
                     range_ref = detail::sub_range(areal, ring_id);

--- a/include/boost/geometry/algorithms/detail/sections/sectionalize.hpp
+++ b/include/boost/geometry/algorithms/detail/sections/sectionalize.hpp
@@ -1,12 +1,12 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
-// Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
-// Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
-// Copyright (c) 2014 Adam Wulkiewicz, Lodz, Poland.
+// Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
+// Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
+// Copyright (c) 2014-2015 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2013, 2014.
-// Modifications copyright (c) 2013, 2014 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013, 2014, 2015.
+// Modifications copyright (c) 2013-2015 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
@@ -36,6 +36,7 @@
 #include <boost/geometry/algorithms/detail/interior_iterator.hpp>
 #include <boost/geometry/algorithms/detail/recalculate.hpp>
 #include <boost/geometry/algorithms/detail/ring_identifier.hpp>
+#include <boost/geometry/algorithms/detail/signed_index_type.hpp>
 
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/closure.hpp>
@@ -80,12 +81,14 @@ struct section
     ring_identifier ring_id;
     Box bounding_box;
 
-    int begin_index;
-    int end_index;
+    // NOTE: size_type could be passed as template parameter
+    // NOTE: these probably also could be of type std::size_t
+    signed_size_type begin_index;
+    signed_size_type end_index;
     std::size_t count;
     std::size_t range_count;
     bool duplicate;
-    int non_duplicate_index;
+    signed_size_type non_duplicate_index;
 
     bool is_non_duplicate_first;
     bool is_non_duplicate_last;
@@ -248,7 +251,7 @@ struct check_duplicate_loop<DimensionCount, DimensionCount>
 template <typename T, std::size_t Index, std::size_t Count>
 struct assign_loop
 {
-    static inline void apply(T dims[Count], int const value)
+    static inline void apply(T dims[Count], T const value)
     {
         dims[Index] = value;
         assign_loop<T, Index + 1, Count>::apply(dims, value);
@@ -258,7 +261,7 @@ struct assign_loop
 template <typename T, std::size_t Count>
 struct assign_loop<T, Count, Count>
 {
-    static inline void apply(T [Count], int const)
+    static inline void apply(T [Count], T const)
     {
     }
 };
@@ -291,8 +294,8 @@ struct sectionalize_part
         typedef typename boost::range_value<Sections>::type section_type;
         BOOST_STATIC_ASSERT
             (
-                (static_cast<int>(section_type::dimension_count)
-                 == static_cast<int>(boost::mpl::size<DimensionVector>::value))
+                (static_cast<std::size_t>(section_type::dimension_count)
+                 == static_cast<std::size_t>(boost::mpl::size<DimensionVector>::value))
             );
 
         typedef typename geometry::robust_point_type
@@ -307,8 +310,8 @@ struct sectionalize_part
             return;
         }
 
-        int index = 0;
-        int ndi = 0; // non duplicate index
+        signed_size_type index = 0;
+        signed_size_type ndi = 0; // non duplicate index
         section_type section;
 
         bool mark_first_non_duplicated = true;
@@ -762,7 +765,7 @@ template
 inline void sectionalize(Geometry const& geometry,
                 RobustPolicy const& robust_policy,
                 Sections& sections,
-                int source_index = 0,
+                signed_index_type source_index = 0,
                 std::size_t max_count = 10)
 {
     concept::check<Geometry const>();

--- a/include/boost/geometry/strategies/cartesian/buffer_join_round.hpp
+++ b/include/boost/geometry/strategies/cartesian/buffer_join_round.hpp
@@ -99,14 +99,14 @@ private :
         // - generates 1 point  in between for an angle of 125 based on 3 points
         // - generates 0 points in between for an angle of 90  based on 4 points
 
-        int const n = (std::max)(static_cast<int>(
-            ceil(m_points_per_circle * angle_diff / two_pi)), 1);
+        std::size_t const n = (std::max)(static_cast<std::size_t>(
+            ceil(m_points_per_circle * angle_diff / two_pi)), std::size_t(1));
 
         PromotedType const diff = angle_diff / static_cast<PromotedType>(n);
         PromotedType a = angle1 - diff;
 
         // Walk to n - 1 to avoid generating the last point
-        for (int i = 0; i < n - 1; i++, a -= diff)
+        for (std::size_t i = 0; i < n - 1; i++, a -= diff)
         {
             Point p;
             set<0>(p, get<0>(vertex) + buffer_distance * cos(a));


### PR DESCRIPTION
This affects buffer, overlay, relate and sectionalize.

Please for now treat `signed_index_type` and `signed_size_type` as one type. I still plan to replace the former with the latter consistently in the whole library. This is not the intention of this PR.