### PR TITLE
[strategies][distance][cross track] expose the radius type as a typedef

### DIFF
--- a/include/boost/geometry/strategies/spherical/distance_cross_track.hpp
+++ b/include/boost/geometry/strategies/spherical/distance_cross_track.hpp
@@ -340,6 +340,8 @@ public :
           >
     {};
 
+    typedef typename Strategy::radius_type radius_type;
+
     inline cross_track()
     {}
 
@@ -491,6 +493,8 @@ public :
                   >::type
           >
     {};
+
+    typedef typename Strategy::radius_type radius_type;
 
     inline cross_track()
     {}


### PR DESCRIPTION
(same as for projected_point distance strategy)