### PR TITLE
Fix/sym difference areal

### DIFF
--- a/include/boost/geometry/algorithms/sym_difference.hpp
+++ b/include/boost/geometry/algorithms/sym_difference.hpp
@@ -1,6 +1,11 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
+
+// This file was modified by Oracle on 2015.
+// Modifications copyright (c) 2015 Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -10,13 +15,203 @@
 #define BOOST_GEOMETRY_ALGORITHMS_SYM_DIFFERENCE_HPP
 
 #include <algorithm>
-
+#include <iterator>
+#include <vector>
 
 #include <boost/geometry/algorithms/intersection.hpp>
+#include <boost/geometry/algorithms/union.hpp>
+#include <boost/geometry/geometries/multi_polygon.hpp>
 
 
 namespace boost { namespace geometry
 {
+
+#ifndef DOXYGEN_NO_DETAIL
+namespace detail { namespace sym_difference
+{
+
+
+template <typename GeometryOut, typename Geometry1, typename Geometry2>
+struct sym_difference_generic
+{
+    template
+    <
+        typename RobustPolicy,
+        typename OutputIterator,
+        typename Strategy
+    >
+    static inline OutputIterator apply(Geometry1 const& geometry1,
+                                       Geometry2 const& geometry2,
+                                       RobustPolicy const& robust_policy,
+                                       OutputIterator out,
+                                       Strategy const& strategy)
+    {
+        out = geometry::dispatch::intersection_insert
+            <
+                Geometry1,
+                Geometry2,
+                GeometryOut,
+                overlay_difference,
+                geometry::detail::overlay::do_reverse
+                    <
+                        geometry::point_order<Geometry1>::value
+                    >::value,
+                geometry::detail::overlay::do_reverse
+                    <
+                        geometry::point_order<Geometry2>::value, true
+                    >::value
+            >::apply(geometry1, geometry2, robust_policy, out, strategy);
+
+        out = geometry::dispatch::intersection_insert
+            <
+                Geometry2,
+                Geometry1,
+                GeometryOut,
+                overlay_difference,
+                geometry::detail::overlay::do_reverse
+                    <
+                        geometry::point_order<Geometry2>::value
+                    >::value,
+                geometry::detail::overlay::do_reverse
+                    <
+                        geometry::point_order<Geometry1>::value, true
+                    >::value,
+                geometry::detail::overlay::do_reverse
+                    <
+                        geometry::point_order<GeometryOut>::value
+                    >::value
+            >::apply(geometry2, geometry1, robust_policy, out, strategy);
+
+        return out;
+    }
+};
+
+template <typename GeometryOut, typename Areal1, typename Areal2>
+struct sym_difference_areal_areal
+{
+    template
+    <
+        typename RobustPolicy,
+        typename OutputIterator,
+        typename Strategy
+    >
+    static inline OutputIterator apply(Areal1 const& areal1,
+                                       Areal2 const& areal2,
+                                       RobustPolicy const& robust_policy,
+                                       OutputIterator out,
+                                       Strategy const& strategy)
+    {
+        typedef geometry::model::multi_polygon
+            <
+                GeometryOut
+            > helper_geometry_type;
+
+        helper_geometry_type diff12, diff21;
+
+        std::back_insert_iterator<helper_geometry_type> oit12(diff12);
+        std::back_insert_iterator<helper_geometry_type> oit21(diff21);
+
+        geometry::dispatch::intersection_insert
+            <
+                Areal1,
+                Areal2,
+                GeometryOut,
+                overlay_difference,
+                geometry::detail::overlay::do_reverse
+                    <
+                        geometry::point_order<Areal1>::value
+                    >::value,
+                geometry::detail::overlay::do_reverse
+                    <
+                        geometry::point_order<Areal2>::value, true
+                    >::value
+            >::apply(areal1, areal2, robust_policy, oit12, strategy);
+
+        geometry::dispatch::intersection_insert
+            <
+                Areal2,
+                Areal1,
+                GeometryOut,
+                overlay_difference,
+                geometry::detail::overlay::do_reverse
+                    <
+                        geometry::point_order<Areal2>::value
+                    >::value,
+                geometry::detail::overlay::do_reverse
+                    <
+                        geometry::point_order<Areal1>::value, true
+                    >::value,
+                geometry::detail::overlay::do_reverse
+                    <
+                        geometry::point_order<GeometryOut>::value
+                    >::value
+            >::apply(areal2, areal1, robust_policy, oit21, strategy);
+
+        return geometry::dispatch::union_insert
+            <
+                helper_geometry_type,
+                helper_geometry_type,
+                GeometryOut
+            >::apply(diff12, diff21, robust_policy, out, strategy);
+    }
+};
+
+
+}} // namespace detail::sym_difference
+#endif // DOXYGEN_NO_DETAIL
+
+
+
+#ifndef DOXYGEN_NO_DISPATCH
+namespace dispatch
+{
+
+
+template
+<
+    typename Geometry1,
+    typename Geometry2,
+    typename GeometryOut,
+    typename TagIn1 = typename geometry::tag_cast
+        <
+            typename tag<Geometry1>::type, areal_tag
+        >::type,
+    typename TagIn2 = typename geometry::tag_cast
+        <
+            typename tag<Geometry2>::type, areal_tag
+        >::type,
+    typename TagOut = typename geometry::tag<GeometryOut>::type
+>
+struct sym_difference_insert
+    : detail::sym_difference::sym_difference_generic
+        <
+            GeometryOut, Geometry1, Geometry2
+        >
+{};
+
+
+template
+<
+    typename Areal1,
+    typename Areal2,
+    typename GeometryOut,
+    typename TagOut
+>
+struct sym_difference_insert
+    <
+        Areal1, Areal2, GeometryOut,
+        areal_tag, areal_tag, TagOut
+    > : detail::sym_difference::sym_difference_areal_areal
+        <
+            GeometryOut, Areal1, Areal2
+        >
+{};
+
+
+} // namespace dispatch
+#endif // DOXYGEN_NO_DISPATCH
+
+
 
 #ifndef DOXYGEN_NO_DETAIL
 namespace detail { namespace sym_difference
@@ -60,24 +255,10 @@ inline OutputIterator sym_difference_insert(Geometry1 const& geometry1,
     concept::check<Geometry2 const>();
     concept::check<GeometryOut>();
 
-    out = geometry::dispatch::intersection_insert
+    return dispatch::sym_difference_insert
         <
-            Geometry1, Geometry2,
-            GeometryOut,
-            overlay_difference,
-            geometry::detail::overlay::do_reverse<geometry::point_order<Geometry1>::value>::value,
-            geometry::detail::overlay::do_reverse<geometry::point_order<Geometry2>::value, true>::value
+            Geometry1, Geometry2, GeometryOut
         >::apply(geometry1, geometry2, robust_policy, out, strategy);
-    out = geometry::dispatch::intersection_insert
-        <
-            Geometry2, Geometry1,
-            GeometryOut,
-            overlay_difference,
-            geometry::detail::overlay::do_reverse<geometry::point_order<Geometry2>::value>::value,
-            geometry::detail::overlay::do_reverse<geometry::point_order<Geometry1>::value, true>::value,
-            geometry::detail::overlay::do_reverse<geometry::point_order<GeometryOut>::value>::value
-        >::apply(geometry2, geometry1, robust_policy, out, strategy);
-    return out;
 }
 
 

--- a/include/boost/geometry/algorithms/sym_difference.hpp
+++ b/include/boost/geometry/algorithms/sym_difference.hpp
@@ -31,6 +31,43 @@ namespace detail { namespace sym_difference
 {
 
 
+template <typename GeometryOut>
+struct compute_difference
+{
+    template
+    <
+        typename Geometry1,
+        typename Geometry2,
+        typename RobustPolicy,
+        typename OutputIterator,
+        typename Strategy
+    >
+    static inline OutputIterator apply(Geometry1 const& geometry1,
+                                       Geometry2 const& geometry2,
+                                       RobustPolicy const& robust_policy,
+                                       OutputIterator out,
+                                       Strategy const& strategy)
+    {
+        return geometry::dispatch::intersection_insert
+            <
+                Geometry1,
+                Geometry2,
+                GeometryOut,
+                overlay_difference,
+                geometry::detail::overlay::do_reverse
+                    <
+                        geometry::point_order<Geometry1>::value
+                    >::value,
+                geometry::detail::overlay::do_reverse
+                    <
+                        geometry::point_order<Geometry2>::value, true
+                    >::value
+            >::apply(geometry1, geometry2, robust_policy, out, strategy);
+    }
+};
+
+
+
 template <typename GeometryOut, typename Geometry1, typename Geometry2>
 struct sym_difference_generic
 {
@@ -46,45 +83,18 @@ struct sym_difference_generic
                                        OutputIterator out,
                                        Strategy const& strategy)
     {
-        out = geometry::dispatch::intersection_insert
+        out = compute_difference
             <
-                Geometry1,
-                Geometry2,
-                GeometryOut,
-                overlay_difference,
-                geometry::detail::overlay::do_reverse
-                    <
-                        geometry::point_order<Geometry1>::value
-                    >::value,
-                geometry::detail::overlay::do_reverse
-                    <
-                        geometry::point_order<Geometry2>::value, true
-                    >::value
+                GeometryOut
             >::apply(geometry1, geometry2, robust_policy, out, strategy);
 
-        out = geometry::dispatch::intersection_insert
+        return compute_difference
             <
-                Geometry2,
-                Geometry1,
-                GeometryOut,
-                overlay_difference,
-                geometry::detail::overlay::do_reverse
-                    <
-                        geometry::point_order<Geometry2>::value
-                    >::value,
-                geometry::detail::overlay::do_reverse
-                    <
-                        geometry::point_order<Geometry1>::value, true
-                    >::value,
-                geometry::detail::overlay::do_reverse
-                    <
-                        geometry::point_order<GeometryOut>::value
-                    >::value
+                GeometryOut
             >::apply(geometry2, geometry1, robust_policy, out, strategy);
-
-        return out;
     }
 };
+
 
 template <typename GeometryOut, typename Areal1, typename Areal2>
 struct sym_difference_areal_areal
@@ -111,40 +121,14 @@ struct sym_difference_areal_areal
         std::back_insert_iterator<helper_geometry_type> oit12(diff12);
         std::back_insert_iterator<helper_geometry_type> oit21(diff21);
 
-        geometry::dispatch::intersection_insert
+        compute_difference
             <
-                Areal1,
-                Areal2,
-                GeometryOut,
-                overlay_difference,
-                geometry::detail::overlay::do_reverse
-                    <
-                        geometry::point_order<Areal1>::value
-                    >::value,
-                geometry::detail::overlay::do_reverse
-                    <
-                        geometry::point_order<Areal2>::value, true
-                    >::value
+                GeometryOut
             >::apply(areal1, areal2, robust_policy, oit12, strategy);
 
-        geometry::dispatch::intersection_insert
+        compute_difference
             <
-                Areal2,
-                Areal1,
-                GeometryOut,
-                overlay_difference,
-                geometry::detail::overlay::do_reverse
-                    <
-                        geometry::point_order<Areal2>::value
-                    >::value,
-                geometry::detail::overlay::do_reverse
-                    <
-                        geometry::point_order<Areal1>::value, true
-                    >::value,
-                geometry::detail::overlay::do_reverse
-                    <
-                        geometry::point_order<GeometryOut>::value
-                    >::value
+                GeometryOut
             >::apply(areal2, areal1, robust_policy, oit21, strategy);
 
         return geometry::dispatch::union_insert

--- a/test/algorithms/set_operations/difference/difference.cpp
+++ b/test/algorithms/set_operations/difference/difference.cpp
@@ -254,7 +254,8 @@ void test_all()
     test_one<polygon, polygon, polygon>("fitting",
         fitting[0], fitting[1],
         1, 9, 21.0,
-        1, 4, 4.0);
+        1, 4, 4.0,
+        1, 5, 25.0);
 
     test_one<polygon, polygon, polygon>("identical",
         identical[0], identical[1],
@@ -319,7 +320,8 @@ void test_all()
     test_one<polygon, polygon, polygon>("side_side",
         side_side[0], side_side[1],
         1, 5, 1,
-        1, 5, 1);
+        1, 5, 1,
+        1, 7, 2);
 
 #if ! defined(BOOST_GEOMETRY_NO_ROBUSTNESS)
     test_one<polygon, polygon, polygon>("buffer_mp1",
@@ -382,7 +384,8 @@ void test_all()
     test_one<polygon, polygon, polygon>("geos_3",
         geos_3[0], geos_3[1],
         1, -1, 16211128.5,
-        1, -1, 13180420.0);
+        1, -1, 13180420.0,
+        1, -1, 16211128.5 + 13180420.0);
 
     test_one<polygon, polygon, polygon>("geos_4",
         geos_4[0], geos_4[1],
@@ -392,7 +395,8 @@ void test_all()
     test_one<polygon, polygon, polygon>("ggl_list_20110306_javier",
         ggl_list_20110306_javier[0], ggl_list_20110306_javier[1],
         1, -1, 71495.3331,
-        2, -1, 8960.49049);
+        2, -1, 8960.49049,
+        2, -1, 71495.3331 + 8960.49049);
 
     test_one<polygon, polygon, polygon>("ggl_list_20110307_javier",
         ggl_list_20110307_javier[0], ggl_list_20110307_javier[1],
@@ -405,8 +409,8 @@ void test_all()
         test_one<polygon, polygon, polygon>("ggl_list_20110716_enrico",
             ggl_list_20110716_enrico[0], ggl_list_20110716_enrico[1],
             3, -1, 35723.8506317139,
-            1, -1, 58456.4964294434
-            );
+            1, -1, 58456.4964294434,
+            1, -1, 35723.8506317139 + 58456.4964294434);
     }
 
     test_one<polygon, polygon, polygon>("ggl_list_20110820_christophe",
@@ -637,7 +641,9 @@ void test_specific()
     test_one<polygon, polygon, polygon>("ggl_list_20120717_volker",
         ggl_list_20120717_volker[0], ggl_list_20120717_volker[1],
         1, 11, 3371540,
-        1, 4, 385, 0.001);
+        1, 4, 385,
+        1, 16, 3371540 + 385,
+        0.001);
 
     test_one<polygon, polygon, polygon>("ticket_10658",
         ticket_10658[0], ticket_10658[1],

--- a/test/algorithms/set_operations/difference/difference_multi.cpp
+++ b/test/algorithms/set_operations/difference/difference_multi.cpp
@@ -58,14 +58,14 @@ void test_areal()
     test_one<Polygon, Ring, MultiPolygon>("simplex_multi_r_mp",
             case_single_simplex, case_multi_simplex[0],
             4, 17, 2.58, 5, 21, 5.58);
-    test_one<Ring, MultiPolygon, Polygon>("simplex_multi_mp_r",
+    test_one<Polygon, MultiPolygon, Ring>("simplex_multi_mp_r",
             case_multi_simplex[0], case_single_simplex,
             5, 21, 5.58, 4, 17, 2.58);
 
     // Constructed cases for multi/touch/equal/etc
     test_one<Polygon, MultiPolygon, MultiPolygon>("case_61_multi",
             case_61_multi[0], case_61_multi[1],
-            2, 10, 2, 2, 10, 2);
+            2, 10, 2, 2, 10, 2, 1, 10, 4);
     test_one<Polygon, MultiPolygon, MultiPolygon>("case_62_multi",
             case_62_multi[0], case_62_multi[1],
             0, 0, 0, 1, 5, 1);
@@ -74,7 +74,7 @@ void test_areal()
             0, 0, 0, 1, 5, 1);
     test_one<Polygon, MultiPolygon, MultiPolygon>("case_64_multi",
         case_64_multi[0], case_64_multi[1],
-            1, 5, 1, 1, 5, 1);
+        1, 5, 1, 1, 5, 1, 1, 7, 2);
     test_one<Polygon, MultiPolygon, MultiPolygon>("case_65_multi",
         case_65_multi[0], case_65_multi[1],
             0, 0, 0, 2, 10, 3);
@@ -142,6 +142,7 @@ void test_areal()
     test_one<Polygon, MultiPolygon, MultiPolygon>("ticket_9081",
         ticket_9081[0], ticket_9081[1],
             2, 28, 0.0907392476356186, 4, 25, 0.126018011439877,
+            4, 42, 0.0907392476356186 + 0.126018011439877,
             0.001);
 
     /* TODO: fix

--- a/test/algorithms/set_operations/difference/difference_multi_spike.cpp
+++ b/test/algorithms/set_operations/difference/difference_multi_spike.cpp
@@ -43,7 +43,10 @@ void test_spikes_in_ticket_8364()
         if_typed<ct, int>(2775595.5, 2775256.487954), // SQL Server: 2775256.47588724
         3,
         -1, // don't check point-count
-        if_typed<ct, int>(7893.0, 7810.487954)); // SQL Server: 7810.48711165739
+        if_typed<ct, int>(7893.0, 7810.487954), // SQL Server: 7810.48711165739
+        if_typed<ct, int>(1, 5),
+        -1,
+        if_typed<ct, int>(2783349.5, 2775256.487954 + 7810.487954));
 
     test_one<polygon, multi_polygon, multi_polygon>("ticket_8364_step4",
         "MULTIPOLYGON(((2567 2688,2136 2790,2052 2712,1032 2130,1032 1764,1032 1458,1032 1212,2136 2328,3232 2220,3232 1056,1031 1056,1031 2856,3232 2856,3232 2580,2567 2688)))",
@@ -53,7 +56,10 @@ void test_spikes_in_ticket_8364()
         if_typed<ct, int>(2615783.5, 2616029.559567), // SQL Server: 2616029.55616044
         1,
         if_typed<ct, int>(9, 11),
-        if_typed<ct, int>(161133.5, 161054.559567)); // SQL Server: 161054.560110092
+        if_typed<ct, int>(161133.5, 161054.559567), // SQL Server: 161054.560110092
+        if_typed<ct, int>(1, 2),
+        if_typed<ct, int>(25, 31),
+        if_typed<ct, int>(2776875.5, 2616029.559567 + 161054.559567));
 }
 
 template <typename P, bool ClockWise, bool Closed>
@@ -74,7 +80,10 @@ void test_spikes_in_ticket_8365()
         if_typed<ct, int>(7975092.5, 7975207.6047877), // SQL Server:
         2,
         -1,
-        if_typed<ct, int>(196.5, 197.1047877)); // SQL Server:
+        if_typed<ct, int>(196.5, 197.1047877), // SQL Server:
+        if_typed<ct, int>(3, 4),
+        -1,
+        if_typed<ct, int>(7975092.5 + 196.5, 7975207.6047877 + 197.1047877));
 }
 
 

--- a/test/algorithms/set_operations/difference/test_difference.hpp
+++ b/test/algorithms/set_operations/difference/test_difference.hpp
@@ -195,11 +195,12 @@ void test_one(std::string const& caseid,
         int expected_count1,
         int expected_point_count1,
         double expected_area1,
-
         int expected_count2,
         int expected_point_count2,
         double expected_area2,
-
+        int expected_count_s,
+        int expected_point_count_s,
+        double expected_area_s,
         double percentage = 0.0001)
 {
 #ifdef BOOST_GEOMETRY_CHECK_WITH_SQLSERVER
@@ -234,10 +235,9 @@ void test_one(std::string const& caseid,
         expected_count2, expected_point_count2,
         expected_area2, percentage);
     test_difference<OutputType>(caseid + "_s", g1, g2,
-        expected_count1 + expected_count2,
-        expected_point_count1 >= 0 && expected_point_count2 >= 0
-            ? (expected_point_count1 + expected_point_count2) : -1,
-        expected_area1 + expected_area2,
+        expected_count_s,
+        expected_point_count_s,
+        expected_area_s,
         percentage, true);
 
 
@@ -273,6 +273,27 @@ void test_one(std::string const& caseid,
         << std::endl;
 #endif
 
+}
+
+template <typename OutputType, typename G1, typename G2>
+void test_one(std::string const& caseid,
+        std::string const& wkt1, std::string const& wkt2,
+        int expected_count1,
+        int expected_point_count1,
+        double expected_area1,
+        int expected_count2,
+        int expected_point_count2,
+        double expected_area2,
+        double percentage = 0.0001)
+{
+    test_one<OutputType, G1, G2>(caseid, wkt1, wkt2,
+        expected_count1, expected_point_count1, expected_area1,
+        expected_count2, expected_point_count2, expected_area2,
+        expected_count1 + expected_count2,
+        expected_point_count1 >= 0 && expected_point_count2 >= 0
+            ? (expected_point_count1 + expected_point_count2) : -1,
+        expected_area1 + expected_area2,
+        percentage);
 }
 
 template <typename OutputType, typename G1, typename G2>

--- a/test/algorithms/set_operations/sym_difference/Jamfile.v2
+++ b/test/algorithms/set_operations/sym_difference/Jamfile.v2
@@ -16,5 +16,6 @@
 
 test-suite boost-geometry-algorithms-sym_difference
     :
+    [ run sym_difference_areal_areal.cpp : : : : algorithms_sym_difference_areal_areal ]
     [ run sym_difference_linear_linear.cpp : : : : algorithms_sym_difference_linear_linear ]
     ;

--- a/test/algorithms/set_operations/sym_difference/sym_difference_areal_areal.cpp
+++ b/test/algorithms/set_operations/sym_difference/sym_difference_areal_areal.cpp
@@ -1,0 +1,137 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2014-2015 Oracle and/or its affiliates.
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+
+#include <iostream>
+
+#ifndef BOOST_TEST_MODULE
+#define BOOST_TEST_MODULE test_sym_difference_areal_areal
+#endif
+
+#ifdef BOOST_GEOMETRY_TEST_DEBUG
+#define BOOST_GEOMETRY_DEBUG_TURNS
+#define BOOST_GEOMETRY_DEBUG_SEGMENT_IDENTIFIER
+#endif
+
+#include <boost/test/included/unit_test.hpp>
+
+#include <boost/geometry/geometries/linestring.hpp>
+#include <boost/geometry/geometries/multi_linestring.hpp>
+#include <boost/geometry/algorithms/sym_difference.hpp>
+
+#include "../difference/test_difference.hpp"
+#include <from_wkt.hpp>
+
+typedef bg::model::point<double,2,bg::cs::cartesian>  point_type;
+typedef bg::model::ring<point_type> ring_type; // ccw, closed
+typedef bg::model::polygon<point_type> polygon_type; // ccw, closed
+typedef bg::model::multi_polygon<polygon_type> multi_polygon_type;
+
+double const default_tolerance = 0.0001;
+
+template
+<
+    typename Areal1, typename Areal2, typename PolygonOut
+>
+struct test_sym_difference_of_areal_geometries
+{
+    static inline void apply(std::string const& case_id,
+                             Areal1 const& areal1,
+                             Areal2 const& areal2,
+                             int expected_polygon_count,
+                             int expected_point_count,
+                             double expected_area,
+                             double tolerance = default_tolerance)
+    {
+#ifdef BOOST_GEOMETRY_TEST_DEBUG
+        bg::model::multi_polygon<PolygonOut> sdf;
+
+        bg::sym_difference(areal1, areal2, sdf);
+
+        std::cout << "Case ID: " << case_id << std::endl;
+        std::cout << "Geometry #1: " << bg::wkt(areal1) << std::endl;
+        std::cout << "Geometry #2: " << bg::wkt(areal2) << std::endl;
+        std::cout << "Sym diff: " << bg::wkt(sdf) << std::endl;
+        std::cout << "Polygon count: expected: "
+                  << expected_polygon_count
+                  << "; detected: " << sdf.size() << std::endl;
+        std::cout << "Point count: expected: "
+                  << expected_point_count
+                  << "; detected: " << bg::num_points(sdf) << std::endl;
+        std::cout << "Area: expected: "
+                  << expected_area
+                  << "; detected: " << bg::area(sdf) << std::endl;
+#endif
+        test_difference
+            <
+                PolygonOut
+            >(case_id, areal1, areal2,
+              expected_polygon_count, expected_point_count, expected_area,
+              tolerance, true);
+    }
+};
+
+
+//===========================================================================
+//===========================================================================
+//===========================================================================
+
+
+BOOST_AUTO_TEST_CASE( test_sym_difference_ring_ring )
+{
+#ifdef BOOST_GEOMETRY_TEST_DEBUG
+    std::cout << std::endl << std::endl << std::endl;
+    std::cout << "*** RING / RING SYMMETRIC DIFFERENCE ***" << std::endl;
+    std::cout << std::endl;
+#endif
+
+    typedef ring_type R;
+    typedef polygon_type PG;
+
+    typedef test_sym_difference_of_areal_geometries<R, R, PG> tester;
+
+    tester::apply("r-r-sdf00",
+                  from_wkt<R>("POLYGON((0 0,0 10,10 10,10 0,0 0))"),
+                  from_wkt<R>("POLYGON((10 0,10 20,20 20,20 0,10 0))"),
+                  1,
+                  8,
+                  300);
+
+    tester::apply("r-r-sdf01",
+                  from_wkt<R>("POLYGON((0 0,0 10,10 10,10 0,0 0))"),
+                  from_wkt<R>("POLYGON((9 0,9 20,20 20,20 0,9 0))"),
+                  2,
+                  12,
+                  300);
+}
+
+
+BOOST_AUTO_TEST_CASE( test_sym_difference_polygon_multipolygon )
+{
+#ifdef BOOST_GEOMETRY_TEST_DEBUG
+    std::cout << std::endl << std::endl << std::endl;
+    std::cout << "*** POLYGON / MULTIPOLYGON SYMMETRIC DIFFERENCE ***"
+              << std::endl;
+    std::cout << std::endl;
+#endif
+
+    typedef polygon_type PG;
+    typedef multi_polygon_type MPG;
+
+    typedef test_sym_difference_of_areal_geometries<PG, MPG, PG> tester;
+
+    tester::apply
+        ("pg-mpg-sdf00",
+         from_wkt<PG>("POLYGON((10 0,10 10,20 10,20 0,10 0))"),
+         from_wkt<MPG>("MULTIPOLYGON(((0 0,0 10,10 10,10 0,0 0)),\
+                       ((20 0,20 10,30 10,30 0,20 0)))"),
+         1,
+         9,
+         300);
+}
+


### PR DESCRIPTION
This PR fixes the symmetric difference algorithm for areal geometries.

The problem with the previous algorithm is that it could generate invalid multipolygons (this could happen when the input to the symmetric difference algorithm was two areal geometries with disjoint interiors and touching boundaries).

The fix proposed in this PR is to compute the differences of the first and second, and second and first geometries, and then return their union (instead of concatenating the two results).

For non-areal geometries the behavior of the algorithm remains unchanged.