### PR TITLE
[get_turns][strategies] Optimize get_turns().

### DIFF
--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
@@ -217,7 +217,9 @@ public:
         : base_t(pi, pj, pk, qi, qj, qk, robust_policy)
         , m_result(strategy::apply(segment_type1(pi, pj),
                                    segment_type2(qi, qj),
-                                   robust_policy))
+                                   robust_policy,
+                                   base_t::rpi(), base_t::rpj(),
+                                   base_t::rqi(), base_t::rqj()))
         , m_robust_policy(robust_policy)
     {}
 

--- a/include/boost/geometry/strategies/cartesian/cart_intersect.hpp
+++ b/include/boost/geometry/strategies/cartesian/cart_intersect.hpp
@@ -119,14 +119,9 @@ struct relate_cartesian_segments
 
         boost::ignore_unused_variable_warning(robust_policy);
 
-        typedef typename select_calculation_type
-            <Segment1, Segment2, CalculationType>::type coordinate_type;
-
         using geometry::detail::equals::equals_point_point;
         bool const a_is_point = equals_point_point(robust_a1, robust_a2);
         bool const b_is_point = equals_point_point(robust_b1, robust_b2);
-
-        typedef side::side_by_triangle<coordinate_type> side;
 
         if(a_is_point && b_is_point)
         {
@@ -136,19 +131,31 @@ struct relate_cartesian_segments
                 ;
         }
 
+        typedef typename select_calculation_type
+            <Segment1, Segment2, CalculationType>::type coordinate_type;
+
+        typedef side::side_by_triangle<coordinate_type> side;
+
         side_info sides;
         sides.set<0>(side::apply(robust_b1, robust_b2, robust_a1),
                      side::apply(robust_b1, robust_b2, robust_a2));
-        sides.set<1>(side::apply(robust_a1, robust_a2, robust_b1),
-                     side::apply(robust_a1, robust_a2, robust_b2));
 
-        bool collinear = sides.collinear();
-
-        if (sides.same<0>() || sides.same<1>())
+        if (sides.same<0>())
         {
             // Both points are at same side of other segment, we can leave
             return Policy::disjoint();
         }
+
+        sides.set<1>(side::apply(robust_a1, robust_a2, robust_b1),
+                     side::apply(robust_a1, robust_a2, robust_b2));
+        
+        if (sides.same<1>())
+        {
+            // Both points are at same side of other segment, we can leave
+            return Policy::disjoint();
+        }
+
+        bool collinear = sides.collinear();
 
         typedef typename select_most_precise
             <


### PR DESCRIPTION
The optimization is based on the fact that in the most cases the segments
handled in the `TurnInfoPolicy` are disjoint. For disjoint segments first
the points are rescaled, then the test for disjoint is run, next the
`TurnInfoPolicy` just returns and the next pair of segments is handled.
Therefore to optimze the `get_turns()` this commit changes two things:
1. the `cart_intersect` strategy may return just after the calculation of sides
   for the first segment (2 sides calculation instead of 4),
2. the points are rescaled only one time in the intersection_helper,
   already rescaled points are passed into the intersection strategy

I tested it using the MultiPoint `buffer()`. For only some fraction of the tests (all basic tests and 2 first tests from the `test_many_points_per_circle`, because I was initially testing it like this to not wait too much) the stats of the segments relations are:

    disjoint segments: 15260208
    crossing segments: 1857
    collinear segments: 670

so you can see how important is it to have an optimized version of the disjoint segments handling, performing as small number of operations as possible for them. Though have in mind that those test cases are very specific and typically the number of disjoint segments should be smaller in relation to the other ones.

I tested the performance with MSVC10 release O2, NDEBUG. The "release" MultiPoint buffer test (so with `test_many_points_per_circle` but without `BOOST_GEOMETRY_BUFFER_INCLUDE_SLOW_TESTS`) took 88 sec. After applying the optimization 1 the time decreased to 80 sec., after applying the optimization 2 it decreased further to 55 sec. It seems that the rescaling adds the major factor for disjoint segments.

I see one more optimization possibility. Currently all 6 points are always rescaled before the segments disjoint test. But for this test only 4 points are needed. So we could even further optimize it by postponing the rescaling of `pk` and `qk`.