### PR TITLE
Fix: possible infinite loop in has_spikes

### DIFF
--- a/include/boost/geometry/algorithms/detail/is_valid/has_spikes.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/has_spikes.hpp
@@ -12,11 +12,11 @@
 
 #include <algorithm>
 
-#include <boost/assert.hpp>
 #include <boost/core/ignore_unused.hpp>
 #include <boost/range.hpp>
 #include <boost/type_traits/is_same.hpp>
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/point_type.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tags.hpp>
@@ -83,7 +83,7 @@ struct has_spikes
     {
         typedef not_equal_to<typename point_type<Range>::type> not_equal;
 
-        BOOST_ASSERT(first != last);
+        BOOST_GEOMETRY_ASSERT(first != last);
 
         Iterator second = first;
         ++second;

--- a/include/boost/geometry/algorithms/detail/is_valid/has_spikes.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/has_spikes.hpp
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 
+#include <boost/assert.hpp>
 #include <boost/core/ignore_unused.hpp>
 #include <boost/range.hpp>
 #include <boost/type_traits/is_same.hpp>
@@ -77,12 +78,22 @@ struct not_equal_to
 template <typename Range, closure_selector Closure>
 struct has_spikes
 {
+    template <typename Iterator>
+    static inline Iterator find_not_equal(Iterator first, Iterator last)
+    {
+        typedef not_equal_to<typename point_type<Range>::type> not_equal;
+
+        BOOST_ASSERT(first != last);
+
+        Iterator second = first;
+        ++second;
+        return std::find_if(second, last, not_equal(*first));
+    }
+
     template <typename VisitPolicy>
     static inline bool apply(Range const& range, VisitPolicy& visitor)
     {
         boost::ignore_unused(visitor);
-
-        typedef not_equal_to<typename point_type<Range>::type> not_equal;
 
         typedef typename closeable_view<Range const, Closure>::type view_type;
         typedef typename boost::range_iterator<view_type const>::type iterator; 
@@ -94,23 +105,23 @@ struct has_spikes
 
         iterator prev = boost::begin(view);
 
-        iterator cur = std::find_if(prev, boost::end(view), not_equal(*prev));
-        if ( cur == boost::end(view) )
+        iterator cur = find_not_equal(prev, boost::end(view));
+        if (cur == boost::end(view))
         {
             // the range has only one distinct point, so it
             // cannot have a spike
             return ! visitor.template apply<no_failure>();
         }
 
-        iterator next = std::find_if(cur, boost::end(view), not_equal(*cur));
-        if ( next == boost::end(view) )
+        iterator next = find_not_equal(cur, boost::end(view));
+        if (next == boost::end(view))
         {
             // the range has only two distinct points, so it
             // cannot have a spike
             return ! visitor.template apply<no_failure>();
         }
 
-        while ( next != boost::end(view) )
+        while (next != boost::end(view))
         {
             if ( geometry::detail::point_is_spike_or_equal(*prev,
                                                            *next,
@@ -121,20 +132,19 @@ struct has_spikes
             }
             prev = cur;
             cur = next;
-            next = std::find_if(cur, boost::end(view), not_equal(*cur));
+            next = find_not_equal(cur, boost::end(view));
         }
 
-        if ( geometry::equals(range::front(view), range::back(view)) )
+        if (geometry::equals(range::front(view), range::back(view)))
         {
             iterator cur = boost::begin(view);
             typename boost::range_reverse_iterator
                 <
                     view_type const
-                >::type prev = std::find_if(boost::rbegin(view),
-                                            boost::rend(view),
-                                            not_equal(range::back(view)));
-            iterator next =
-                std::find_if(cur, boost::end(view), not_equal(*cur));
+                >::type prev = find_not_equal(boost::rbegin(view),
+                                              boost::rend(view));
+
+            iterator next = find_not_equal(cur, boost::end(view));
             if (detail::point_is_spike_or_equal(*prev, *next, *cur))
             {
                 return

--- a/include/boost/geometry/algorithms/detail/is_valid/has_spikes.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/has_spikes.hpp
@@ -79,7 +79,8 @@ template <typename Range, closure_selector Closure>
 struct has_spikes
 {
     template <typename Iterator>
-    static inline Iterator find_not_equal(Iterator first, Iterator last)
+    static inline Iterator find_different_from_first(Iterator first,
+                                                     Iterator last)
     {
         typedef not_equal_to<typename point_type<Range>::type> not_equal;
 
@@ -105,7 +106,7 @@ struct has_spikes
 
         iterator prev = boost::begin(view);
 
-        iterator cur = find_not_equal(prev, boost::end(view));
+        iterator cur = find_different_from_first(prev, boost::end(view));
         if (cur == boost::end(view))
         {
             // the range has only one distinct point, so it
@@ -113,7 +114,7 @@ struct has_spikes
             return ! visitor.template apply<no_failure>();
         }
 
-        iterator next = find_not_equal(cur, boost::end(view));
+        iterator next = find_different_from_first(cur, boost::end(view));
         if (next == boost::end(view))
         {
             // the range has only two distinct points, so it
@@ -132,7 +133,7 @@ struct has_spikes
             }
             prev = cur;
             cur = next;
-            next = find_not_equal(cur, boost::end(view));
+            next = find_different_from_first(cur, boost::end(view));
         }
 
         if (geometry::equals(range::front(view), range::back(view)))
@@ -141,10 +142,10 @@ struct has_spikes
             typename boost::range_reverse_iterator
                 <
                     view_type const
-                >::type prev = find_not_equal(boost::rbegin(view),
-                                              boost::rend(view));
+                >::type prev = find_different_from_first(boost::rbegin(view),
+                                                         boost::rend(view));
 
-            iterator next = find_not_equal(cur, boost::end(view));
+            iterator next = find_different_from_first(cur, boost::end(view));
             if (detail::point_is_spike_or_equal(*prev, *next, *cur))
             {
                 return

--- a/test/algorithms/is_simple.cpp
+++ b/test/algorithms/is_simple.cpp
@@ -33,6 +33,7 @@
 
 #include <boost/geometry/io/wkt/wkt.hpp>
 
+#include <boost/geometry/algorithms/intersection.hpp>
 #include <boost/geometry/algorithms/is_valid.hpp>
 #include <boost/geometry/algorithms/is_simple.hpp>
 
@@ -294,6 +295,27 @@ BOOST_AUTO_TEST_CASE( test_is_simple_areal )
                 false);
     test_simple(from_wkt<mpl>("MULTIPOLYGON(((0 0,1 0,1 1,1 1)),((10 0,20 0,20 0,20 10,10 10)))"),
                 false);
+}
+
+BOOST_AUTO_TEST_CASE( test_geometry_with_NaN_coordinates )
+{
+#ifdef BOOST_GEOMETRY_TEST_DEBUG
+    std::cout << std::endl << std::endl;
+    std::cout << "************************************" << std::endl;
+    std::cout << " is_valid: geometry with NaN coordinates" << std::endl;
+    std::cout << "************************************" << std::endl;
+#endif
+
+    linestring_type ls1, ls2;
+    bg::read_wkt("LINESTRING(1 1,1.115235e+308 1.738137e+308)", ls1);
+    bg::read_wkt("LINESTRING(-1 1,1.115235e+308 1.738137e+308)", ls2);
+
+    // the intersection of the two linestrings is a new linestring
+    // (multilinestring with a single element) that has NaN coordinates
+    multi_linestring_type mls;
+    bg::intersection(ls1, ls2, mls);
+
+    test_simple(mls, true);
 }
 
 BOOST_AUTO_TEST_CASE( test_is_simple_variant )


### PR DESCRIPTION
If the range passed to `has_spikes` consists of points with `NaN` coordinates (this can happen if the range passed as been computed as the result, e.g., of a set operation), then `has_spikes` can enter an infinite loop.

If a point `p` has such `NaN` coordinates, then `p` is considered as not equal to itself, a property/feature assumed in the previous implementation of `has_spikes`), and the following calls (in the older version of `has_spikes`) to `std::find_if` never return:
```
std::find_if(prev, boost::end(view), not_equal(*prev));
```
and
```
std::find_if(cur, boost::end(view), not_equal(*cur));
```

The solution if to essentially call `std::find_if` as `std::find_if(second, first, last, not_equal(*first))`, which avoids the implicit assumption that the `bg::equals(*first, *first)` returns `true`.

***Note:*** the problem appears for geometries with `NaN` coordinates. The point addressed here is to have `has_spikes` return instead of entering an endless loop; the result returned, however, does not (and could not) have any geometric significance.