### PR TITLE
Different approach for handling Boxes WRT machine epsilon

### DIFF
--- a/include/boost/geometry/algorithms/detail/disjoint/box_box.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/box_box.hpp
@@ -28,7 +28,6 @@
 
 #include <boost/geometry/algorithms/dispatch/disjoint.hpp>
 
-#include <boost/geometry/util/math.hpp>
 
 namespace boost { namespace geometry
 {
@@ -36,7 +35,6 @@ namespace boost { namespace geometry
 #ifndef DOXYGEN_NO_DETAIL
 namespace detail { namespace disjoint
 {
-
 
 template
 <
@@ -47,11 +45,11 @@ struct box_box
 {
     static inline bool apply(Box1 const& box1, Box2 const& box2)
     {
-        if (math::smaller(get<max_corner, Dimension>(box1), get<min_corner, Dimension>(box2)))
+        if (get<max_corner, Dimension>(box1) < get<min_corner, Dimension>(box2))
         {
             return true;
         }
-        if (math::larger(get<min_corner, Dimension>(box1), get<max_corner, Dimension>(box2)))
+        if (get<min_corner, Dimension>(box1) > get<max_corner, Dimension>(box2))
         {
             return true;
         }

--- a/include/boost/geometry/algorithms/detail/disjoint/point_box.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/point_box.hpp
@@ -29,8 +29,6 @@
 
 #include <boost/geometry/algorithms/dispatch/disjoint.hpp>
 
-#include <boost/geometry/util/math.hpp>
-
 namespace boost { namespace geometry
 {
 
@@ -48,8 +46,8 @@ struct point_box
 {
     static inline bool apply(Point const& point, Box const& box)
     {
-        if ( math::smaller(get<Dimension>(point), get<min_corner, Dimension>(box))
-          || math::larger(get<Dimension>(point), get<max_corner, Dimension>(box)) )
+        if (get<Dimension>(point) < get<min_corner, Dimension>(box)
+            || get<Dimension>(point) > get<max_corner, Dimension>(box))
         {
             return true;
         }

--- a/include/boost/geometry/algorithms/detail/expand_by_epsilon.hpp
+++ b/include/boost/geometry/algorithms/detail/expand_by_epsilon.hpp
@@ -1,0 +1,113 @@
+// Boost.Geometry
+
+// Copyright (c) 2015, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_EXPAND_EXPAND_BY_EPSILON_HPP
+#define BOOST_GEOMETRY_ALGORITHMS_DETAIL_EXPAND_EXPAND_BY_EPSILON_HPP
+
+#include <cstddef>
+#include <algorithm>
+
+#include <boost/type_traits/is_floating_point.hpp>
+
+#include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/coordinate_dimension.hpp>
+#include <boost/geometry/core/coordinate_type.hpp>
+
+#include <boost/geometry/util/math.hpp>
+
+#include <boost/geometry/views/detail/indexed_point_view.hpp>
+
+namespace boost { namespace geometry
+{
+
+#ifndef DOXYGEN_NO_DETAIL
+namespace detail { namespace expand
+{
+
+template
+<
+    typename Point,
+    template <typename> class PlusOrMinus,
+    std::size_t I = 0,
+    std::size_t D = dimension<Point>::value,
+    bool Enable = boost::is_floating_point
+                    <
+                        typename coordinate_type<Point>::type
+                    >::value
+>
+struct corner_by_epsilon
+{
+    static inline void apply(Point & point)
+    {
+        typedef typename coordinate_type<Point>::type coord_type;
+        coord_type const coord = get<I>(point);
+        coord_type const eps = math::scaled_epsilon(coord);
+        
+        set<I>(point, PlusOrMinus<coord_type>()(coord, eps));
+
+        corner_by_epsilon<Point, PlusOrMinus, I+1>::apply(point);
+    }
+};
+
+template
+<
+    typename Point,
+    template <typename> class PlusOrMinus,
+    std::size_t I,
+    std::size_t D
+>
+struct corner_by_epsilon<Point, PlusOrMinus, I, D, false>
+{
+    static inline void apply(Point const&) {}
+};
+
+template
+<
+    typename Point,
+    template <typename> class PlusOrMinus,
+    std::size_t D,
+    bool Enable
+>
+struct corner_by_epsilon<Point, PlusOrMinus, D, D, Enable>
+{
+    static inline void apply(Point const&) {}
+};
+
+template
+<
+    typename Point,
+    template <typename> class PlusOrMinus,
+    std::size_t D
+>
+struct corner_by_epsilon<Point, PlusOrMinus, D, D, false>
+{
+    static inline void apply(Point const&) {}
+};
+
+} // namespace expand
+
+template <typename Box>
+inline void expand_by_epsilon(Box & box)
+{
+    typedef detail::indexed_point_view<Box, min_corner> min_type;
+    min_type min_point(box);
+    expand::corner_by_epsilon<min_type, std::minus>::apply(min_point);
+
+    typedef detail::indexed_point_view<Box, max_corner> max_type;
+    max_type max_point(box);
+    expand::corner_by_epsilon<max_type, std::plus>::apply(max_point);
+}
+
+} // namespace detail
+#endif // DOXYGEN_NO_DETAIL
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_EXPAND_EXPAND_BY_EPSILON_HPP

--- a/include/boost/geometry/algorithms/detail/overlay/intersection_box_box.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/intersection_box_box.hpp
@@ -17,7 +17,7 @@
 
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
-#include <boost/geometry/util/math.hpp>
+
 
 namespace boost { namespace geometry
 {
@@ -44,35 +44,26 @@ struct intersection_box_box
     {
         typedef typename coordinate_type<BoxOut>::type ct;
 
-        ct min1 = get<min_corner, Dimension>(box1);
-        ct min2 = get<min_corner, Dimension>(box2);
         ct max1 = get<max_corner, Dimension>(box1);
-        ct max2 = get<max_corner, Dimension>(box2);
+        ct min2 = get<min_corner, Dimension>(box2);
 
-        if (math::smaller(max1, min2) || math::smaller(max2, min1))
+        if (max1 < min2)
         {
             return false;
         }
-        
-        ct const res_min = min1 < min2 ? min2 : min1;
-        ct const res_max = max1 > max2 ? max2 : max1;
+
+        ct max2 = get<max_corner, Dimension>(box2);
+        ct min1 = get<min_corner, Dimension>(box1);
+
+        if (max2 < min1)
+        {
+            return false;
+        }
 
         // Set dimensions of output coordinate
-        // This condition is needed because math::smaller() compares values WRT
-        // machine epsilon, so max may be lesser than min when compared with
-        // raw operator<
-        if (res_min <= res_max)
-        {
-            set<min_corner, Dimension>(box_out, res_min);
-            set<max_corner, Dimension>(box_out, res_max);
-        }
-        else
-        {
-            set<min_corner, Dimension>(box_out, res_max);
-            set<max_corner, Dimension>(box_out, res_min);
-        }
+        set<min_corner, Dimension>(box_out, min1 < min2 ? min2 : min1);
+        set<max_corner, Dimension>(box_out, max1 > max2 ? max2 : max1);
         
-
         return intersection_box_box<Dimension + 1, DimensionCount>
                ::apply(box1, box2, robust_policy, box_out, strategy);
     }

--- a/include/boost/geometry/algorithms/detail/sections/section_functions.hpp
+++ b/include/boost/geometry/algorithms/detail/sections/section_functions.hpp
@@ -18,7 +18,7 @@
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/algorithms/detail/recalculate.hpp>
 #include <boost/geometry/policies/robustness/robust_point_type.hpp>
-#include <boost/geometry/util/math.hpp>
+
 
 namespace boost { namespace geometry
 {
@@ -40,8 +40,8 @@ static inline bool preceding(int dir, Point const& point,
 {
     typename geometry::robust_point_type<Point, RobustPolicy>::type robust_point;
     geometry::recalculate(robust_point, point, robust_policy);
-    return (dir == 1  && math::smaller(get<Dimension>(robust_point), get<min_corner, Dimension>(robust_box)))
-        || (dir == -1 && math::larger(get<Dimension>(robust_point), get<max_corner, Dimension>(robust_box)));
+    return (dir == 1  && get<Dimension>(robust_point) < get<min_corner, Dimension>(robust_box))
+        || (dir == -1 && get<Dimension>(robust_point) > get<max_corner, Dimension>(robust_box));
 }
 
 template
@@ -57,8 +57,8 @@ static inline bool exceeding(int dir, Point const& point,
 {
     typename geometry::robust_point_type<Point, RobustPolicy>::type robust_point;
     geometry::recalculate(robust_point, point, robust_policy);
-    return (dir == 1  && math::larger(get<Dimension>(robust_point), get<max_corner, Dimension>(robust_box)))
-        || (dir == -1 && math::smaller(get<Dimension>(robust_point), get<min_corner, Dimension>(robust_box)));
+    return (dir == 1  && get<Dimension>(robust_point) > get<max_corner, Dimension>(robust_box))
+        || (dir == -1 && get<Dimension>(robust_point) < get<min_corner, Dimension>(robust_box));
 }
 
 

--- a/include/boost/geometry/algorithms/overlaps.hpp
+++ b/include/boost/geometry/algorithms/overlaps.hpp
@@ -31,7 +31,6 @@
 #include <boost/geometry/algorithms/relate.hpp>
 #include <boost/geometry/algorithms/detail/relate/relate_impl.hpp>
 
-#include <boost/geometry/util/math.hpp>
 
 namespace boost { namespace geometry
 {
@@ -68,8 +67,7 @@ struct box_box_loop
         // B1: |-------|
         // B2:           |------|
         // in any dimension -> no overlap
-        if (math::smaller_or_equals(max1, min2)
-         || math::larger_or_equals(min1, max2))
+        if (max1 <= min2 || min1 >= max2)
         {
             overlaps = false;
             return;
@@ -82,29 +80,15 @@ struct box_box_loop
         // B1: |--------------------|
         // B2: |-------------|
         // this is "within-touch" -> then no overlap. So use < and >
-
-        if (! math::equals(min1, min2))
+        if (min1 < min2 || max1 > max2)
         {
-            if (min1 < min2)
-            {
-                one_in_two = false;
-            }
-            else // Same other way round - min2 < min1
-            {
-                two_in_one = false;
-            }
+            one_in_two = false;
         }
 
-        if (! math::equals(max1, max2))
+        // Same other way round
+        if (min2 < min1 || max2 > max1)
         {
-            if (max1 > max2)
-            {
-                one_in_two = false;
-            }
-            else // Same other way round - max2 > max1
-            {
-                two_in_one = false;
-            }
+            two_in_one = false;
         }
 
         box_box_loop

--- a/include/boost/geometry/algorithms/touches.hpp
+++ b/include/boost/geometry/algorithms/touches.hpp
@@ -40,8 +40,6 @@
 #include <boost/geometry/algorithms/relate.hpp>
 #include <boost/geometry/algorithms/detail/relate/relate_impl.hpp>
 
-#include <boost/geometry/util/math.hpp>
-
 
 namespace boost { namespace geometry
 {
@@ -73,22 +71,14 @@ struct box_box_loop
         // TODO assert or exception?
         //BOOST_GEOMETRY_ASSERT(min1 <= max1 && min2 <= max2);
 
-        if (math::equals(max1, min2))
-        {
-            touch = true;
-        }
-        else if (max1 < min2)
+        if (max1 < min2 || max2 < min1)
         {
             return false;
         }
 
-        if (math::equals(max2, min1))
+        if (max1 == min2 || max2 == min1)
         {
             touch = true;
-        }
-        else if (max2 < min1)
-        {
-            return false;
         }
         
         return box_box_loop

--- a/include/boost/geometry/extensions/iterators/section_iterators.hpp
+++ b/include/boost/geometry/extensions/iterators/section_iterators.hpp
@@ -41,15 +41,15 @@ namespace detail
     template <size_t D, typename P, typename B>
     inline bool exceeding(short int dir, P const& point, B const& box)
     {
-        return (dir == 1  && math::larger(get<D>(point), get<1, D>(box)))
-            || (dir == -1 && math::smaller(get<D>(point), get<0, D>(box)));
+        return (dir == 1  && get<D>(point) > get<1, D>(box))
+            || (dir == -1 && get<D>(point) < get<0, D>(box));
     }
 
     template <size_t D, typename P, typename B>
     inline bool preceding(short int dir, P const& point, B const& box)
     {
-        return (dir == 1  && math::smaller(get<D>(point), get<0, D>(box)))
-            || (dir == -1 && math::larger(get<D>(point), get<1, D>(box)));
+        return (dir == 1  && get<D>(point) < get<0, D>(box))
+            || (dir == -1 && get<D>(point) > get<0, D>(box));
     }
 }
 

--- a/include/boost/geometry/extensions/nsphere/algorithms/disjoint.hpp
+++ b/include/boost/geometry/extensions/nsphere/algorithms/disjoint.hpp
@@ -23,8 +23,6 @@
 
 #include <boost/geometry/extensions/nsphere/views/center_view.hpp>
 
-#include <boost/geometry/util/math.hpp>
-
 namespace boost { namespace geometry
 {
 
@@ -107,8 +105,7 @@ struct disjoint<Point, NSphere, DimensionCount, point_tag, nsphere_tag, Reverse>
         typename radius_type<NSphere>::type const r = get_radius<0>(s);
         center_view<const NSphere> const c(s);
 
-        return math::smaller(r * r,
-                             geometry::comparable_distance(p, c));
+        return r * r < geometry::comparable_distance(p, c);
     }
 };
 
@@ -127,11 +124,10 @@ struct disjoint<NSphere, Box, DimensionCount, nsphere_tag, box_tag, Reverse>
 
         typename radius_type<NSphere>::type const r = get_radius<0>(s);
 
-        return math::smaller(r * r,
-                             geometry::detail::disjoint::box_nsphere_comparable_distance_cartesian
-                                <
-                                    Box, NSphere, 0, DimensionCount
-                                >::apply(b, s));
+        return r * r < geometry::detail::disjoint::box_nsphere_comparable_distance_cartesian
+                           <
+                               Box, NSphere, 0, DimensionCount
+                           >::apply(b, s);
     }
 };
 
@@ -156,8 +152,8 @@ struct disjoint<NSphere1, NSphere2, DimensionCount, nsphere_tag, nsphere_tag, Re
         center_view<NSphere1 const> const c1(s1);
         center_view<NSphere2 const> const c2(s2);
 
-        return math::smaller(r1 * r1 + 2 * r1 * r2 + r2 * r2,
-                             geometry::comparable_distance(c1, c2));
+        return r1 * r1 + 2 * r1 * r2 + r2 * r2
+                < geometry::comparable_distance(c1, c2);
     }
 };
 

--- a/include/boost/geometry/extensions/nsphere/algorithms/within.hpp
+++ b/include/boost/geometry/extensions/nsphere/algorithms/within.hpp
@@ -28,8 +28,6 @@
 #include <boost/geometry/extensions/nsphere/core/tags.hpp>
 #include <boost/geometry/extensions/nsphere/algorithms/assign.hpp>
 
-#include <boost/geometry/util/math.hpp>
-
 
 namespace boost { namespace geometry
 {
@@ -68,7 +66,7 @@ inline bool point_in_circle(P const& p, C const& c)
             strategy_type, P, point_type
         >::apply(strategy, get_radius<0>(c));
 
-    return math::smaller(r, rad);
+    return r < rad;
 }
 /// 2D version
 template<typename T, typename C>

--- a/include/boost/geometry/extensions/nsphere/strategies/cartesian/nsphere_in_box.hpp
+++ b/include/boost/geometry/extensions/nsphere/strategies/cartesian/nsphere_in_box.hpp
@@ -20,7 +20,6 @@
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/strategies/covered_by.hpp>
 #include <boost/geometry/strategies/within.hpp>
-#include <boost/geometry/util/math.hpp>
 
 
 namespace boost { namespace geometry { namespace strategy
@@ -37,8 +36,7 @@ struct nsphere_within_range
                            , ContainingValue const& ing_min
                            , ContainingValue const& ing_max)
     {
-        return math::smaller(ing_min, ed_min)
-            && math::smaller(ed_max, ing_max);
+        return ing_min < ed_min && ed_max < ing_max;
     }
 };
 
@@ -51,8 +49,7 @@ struct nsphere_covered_by_range
                            , ContainingValue const& ing_min
                            , ContainingValue const& ing_max)
     {
-        return math::smaller_or_equals(ing_min, ed_min)
-            && math::smaller_or_equals(ed_max, ing_max);
+        return ing_min <= ed_min && ed_max <= ing_max;
     }
 };
 

--- a/include/boost/geometry/extensions/nsphere/strategies/cartesian/point_in_nsphere.hpp
+++ b/include/boost/geometry/extensions/nsphere/strategies/cartesian/point_in_nsphere.hpp
@@ -37,7 +37,7 @@ struct point_nsphere_within_comparable_distance
     static inline bool apply(ComparableDistance const& ed_comp_dist,
                              Radius const& ing_radius)
     {
-        return math::smaller(ed_comp_dist, ing_radius * ing_radius);
+        return ed_comp_dist < ing_radius * ing_radius;
     }
 };
 
@@ -48,7 +48,7 @@ struct point_nsphere_covered_by_comparable_distance
     static inline bool apply(ComparableDistance const& ed_comp_dist,
                              Radius const& ing_radius)
     {
-        return math::smaller_or_equals(ed_comp_dist, ing_radius * ing_radius);
+        return ed_comp_dist <= ing_radius * ing_radius;
     }
 };
 

--- a/include/boost/geometry/strategies/cartesian/box_in_box.hpp
+++ b/include/boost/geometry/strategies/cartesian/box_in_box.hpp
@@ -25,7 +25,6 @@
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/strategies/covered_by.hpp>
 #include <boost/geometry/strategies/within.hpp>
-#include <boost/geometry/util/math.hpp>
 
 
 namespace boost { namespace geometry { namespace strategy
@@ -43,9 +42,8 @@ struct box_within_range
                              BoxContainingValue const& bing_min,
                              BoxContainingValue const& bing_max)
     {
-        return math::smaller_or_equals(bing_min, bed_min) // contained in containing
-            && math::smaller_or_equals(bed_max, bing_max) // contd.
-            && math::smaller(bed_min, bed_max);           // interiors overlap
+        return bing_min <= bed_min && bed_max <= bing_max // contained in containing
+            && bed_min < bed_max;                         // interiors overlap
     }
 };
 
@@ -58,8 +56,7 @@ struct box_covered_by_range
                              BoxContainingValue const& bing_min,
                              BoxContainingValue const& bing_max)
     {
-        return math::larger_or_equals(bed_min, bing_min)
-            && math::smaller_or_equals(bed_max, bing_max);
+        return bed_min >= bing_min && bed_max <= bing_max;
     }
 };
 

--- a/include/boost/geometry/strategies/cartesian/point_in_box.hpp
+++ b/include/boost/geometry/strategies/cartesian/point_in_box.hpp
@@ -24,7 +24,6 @@
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/strategies/covered_by.hpp>
 #include <boost/geometry/strategies/within.hpp>
-#include <boost/geometry/util/math.hpp>
 
 
 namespace boost { namespace geometry { namespace strategy
@@ -39,8 +38,7 @@ struct within_range
     template <typename Value1, typename Value2>
     static inline bool apply(Value1 const& value, Value2 const& min_value, Value2 const& max_value)
     {
-        return math::larger(value, min_value)
-            && math::smaller(value, max_value);
+        return value > min_value && value < max_value;
     }
 };
 
@@ -50,8 +48,7 @@ struct covered_by_range
     template <typename Value1, typename Value2>
     static inline bool apply(Value1 const& value, Value2 const& min_value, Value2 const& max_value)
     {
-        return math::larger_or_equals(value, min_value)
-            && math::smaller_or_equals(value, max_value);
+        return value >= min_value && value <= max_value;
     }
 };
 

--- a/include/boost/geometry/util/math.hpp
+++ b/include/boost/geometry/util/math.hpp
@@ -442,7 +442,7 @@ struct scaled_epsilon
 {
     static inline T apply(T const& val)
     {
-        return (std::max)(math::abs(val), T(1))
+        return (std::max)(abs<T>::apply(val), T(1))
                     * std::numeric_limits<T>::epsilon();
     }
 };

--- a/include/boost/geometry/util/math.hpp
+++ b/include/boost/geometry/util/math.hpp
@@ -201,11 +201,12 @@ struct smaller<Type, true>
 {
     static inline bool apply(Type const& a, Type const& b)
     {
-        if (equals<Type, true>::apply(a, b, equals_default_policy()))
+        if (!(a < b)) // a >= b
         {
             return false;
         }
-        return a < b;
+        
+        return ! equals<Type, true>::apply(b, a, equals_default_policy());
     }
 };
 
@@ -224,8 +225,12 @@ struct smaller_or_equals<Type, true>
 {
     static inline bool apply(Type const& a, Type const& b)
     {
-        return a <= b
-            || equals<Type, true>::apply(a, b, equals_default_policy());
+        if (a <= b)
+        {
+            return true;
+        }
+
+        return equals<Type, true>::apply(a, b, equals_default_policy());
     }
 };
 
@@ -427,6 +432,30 @@ struct relaxed_epsilon
     }
 };
 
+// This must be consistent with math::equals.
+// By default math::equals() scales the error by epsilon using the greater of
+// compared values but here is only one value, though it should work the same way.
+// (a-a) <= max(a, a) * EPS       -> 0 <= a*EPS
+// (a+da-a) <= max(a+da, a) * EPS -> da <= (a+da)*EPS
+template <typename T, bool IsFloat = boost::is_floating_point<T>::value>
+struct scaled_epsilon
+{
+    static inline T apply(T const& val)
+    {
+        return (std::max)(math::abs(val), T(1))
+                    * std::numeric_limits<T>::epsilon();
+    }
+};
+
+template <typename T>
+struct scaled_epsilon<T, false>
+{
+    static inline T apply(T const& val)
+    {
+        return T(0);
+    }
+};
+
 // ItoF ItoI FtoF
 template <typename Result, typename Source,
           bool ResultIsInteger = std::numeric_limits<Result>::is_integer,
@@ -478,6 +507,12 @@ template <typename T>
 inline T relaxed_epsilon(T const& factor)
 {
     return detail::relaxed_epsilon<T>::apply(factor);
+}
+
+template <typename T>
+inline T scaled_epsilon(T const& value)
+{
+    return detail::scaled_epsilon<T>::apply(value);
 }
 
 

--- a/test/algorithms/relational_operations/covered_by.cpp
+++ b/test/algorithms/relational_operations/covered_by.cpp
@@ -137,31 +137,10 @@ void test_mixed()
 }
 
 
-template <typename P>
-void test_eps()
-{
-    typedef typename bg::coordinate_type<P>::type coord_type;
-    coord_type const eps = std::numeric_limits<coord_type>::epsilon();
-
-    P p1(-eps/2, -eps/2);
-    bg::model::box<P> b1(P(-eps/2, -eps/2), P(0, 0));
-    bg::model::box<P> b2(P(0, 0), P(1, 1));
-
-    check_geometry(p1, b2,
-                   "point(-eps/2, -eps/2)", "box(P(0, 0), P(1, 1))",
-                   true);
-
-    check_geometry(b1, b2,
-                   "box(P(-eps/2, -eps/2), P(0, 0))", "box(P(0, 0), P(1, 1))",
-                   true);
-}
-
-
 int test_main( int , char* [] )
 {
     test_all<bg::model::d2::point_xy<int> >();
     test_all<bg::model::d2::point_xy<double> >();
-    test_eps<bg::model::d2::point_xy<double> >();
 
     //test_spherical<bg::model::point<double, 2, bg::cs::spherical_equatorial<bg::degree> > >();
 

--- a/test/algorithms/relational_operations/disjoint/disjoint_point_box_geometry.cpp
+++ b/test/algorithms/relational_operations/disjoint/disjoint_point_box_geometry.cpp
@@ -111,52 +111,15 @@ void test_3d()
 
 }
 
-template <typename P>
-void test_eps()
-{
-    typedef typename bg::coordinate_type<P>::type coord_type;
-    coord_type const eps = std::numeric_limits<coord_type>::epsilon();
-    
-    P p_1(-1, -1);
-    P p0(0, 0);
-    P p1(eps/2, 0);
-    P p2(0, eps/2);
-    P p3(-1-eps/2, -1);
-    P p4(-1, -1-eps/2);
-
-    bg::model::box<P> b0(p_1, p0);
-    bg::model::box<P> b1(p1, P(1, 1));
-    bg::model::box<P> b2(p2, P(1, 1));
-    bg::model::box<P> b3(P(-2, -2), p3);
-    bg::model::box<P> b4(P(-2, -2), p4);
-
-    check_disjoint("eps_p0_p1", p0, p1, false);
-    check_disjoint("eps_p0_p2", p0, p2, false);
-    check_disjoint("eps_p_1_p3", p_1, p3, false);
-    check_disjoint("eps_p_1_p4", p_1, p4, false);
-
-    check_disjoint("eps_b0_b1", b0, b1, false);
-    check_disjoint("eps_b0_b2", b0, b2, false);
-    check_disjoint("eps_b0_b3", b0, b3, false);
-    check_disjoint("eps_b0_b4", b0, b4, false);
-
-    check_disjoint("eps_b0_p1", b0, p1, false);
-    check_disjoint("eps_b0_p2", b0, p2, false);
-    check_disjoint("eps_b0_p3", b0, p3, false);
-    check_disjoint("eps_b0_p4", b0, p4, false);
-}
 
 int test_main(int, char* [])
 {
     test_all<bg::model::d2::point_xy<float> >();
-    test_eps<bg::model::d2::point_xy<float> >();
     
     test_all<bg::model::d2::point_xy<double> >();
-    test_eps<bg::model::d2::point_xy<double> >();
 
 #ifdef HAVE_TTMATH
     test_all<bg::model::d2::point_xy<ttmath_big> >();
-    test_eps<bg::model::d2::point_xy<ttmath_big> >();
 #endif
 
     test_3d<bg::model::point<double, 3, bg::cs::cartesian> >();

--- a/test/algorithms/relational_operations/overlaps/overlaps_box.cpp
+++ b/test/algorithms/relational_operations/overlaps/overlaps_box.cpp
@@ -43,19 +43,6 @@ void test_3d()
     test_geometry<bg::model::box<P>, bg::model::box<P> >("BOX(1 1 1, 3 3 3)", "BOX(4 4 4,6 6 6)", false);
 }
 
-template <typename P>
-void test_eps()
-{
-    typedef typename bg::coordinate_type<P>::type coord_type;
-    coord_type const eps = std::numeric_limits<coord_type>::epsilon();
-    
-    bg::model::box<P> b1(P(0, 0), P(1, 1));
-    bg::model::box<P> b2(P(-1, -1), P(eps/2, eps/2));
-
-    test_geometry(b1, b2,
-                  "box(P(0, 0), P(1, 1))", "box(P(-1, -1), P(eps/2, eps/2))",
-                  false);
-}
 
 template <typename P>
 void test_2d()
@@ -67,11 +54,9 @@ int test_main( int , char* [] )
 {
     test_2d<bg::model::d2::point_xy<int> >();
     test_2d<bg::model::d2::point_xy<double> >();
-    test_eps<bg::model::d2::point_xy<double> >();
 
 #if defined(HAVE_TTMATH)
     test_2d<bg::model::d2::point_xy<ttmath_big> >();
-    test_eps<bg::model::d2::point_xy<ttmath_big> >();
 #endif
 
    //test_3d<bg::model::point<double, 3, bg::cs::cartesian> >();

--- a/test/algorithms/relational_operations/touches/touches_box.cpp
+++ b/test/algorithms/relational_operations/touches/touches_box.cpp
@@ -42,29 +42,14 @@ void test_box_3d()
                             true);
 }
 
-template <typename P>
-void test_eps()
-{
-    typedef typename bg::coordinate_type<P>::type coord_type;
-    coord_type const eps = std::numeric_limits<coord_type>::epsilon();
-
-    bg::model::box<P> b1(P(0, 0), P(1, 1));
-    bg::model::box<P> b2(P(-1, -1), P(eps/2, eps/2));
-
-    check_touches(b1, b2,
-                  "box(P(0, 0), P(1, 1))", "box(P(-1, -1), P(eps/2, eps/2))",
-                  true);
-}
 
 int test_main( int , char* [] )
 {
     test_all<bg::model::d2::point_xy<double> >();
-    test_eps<bg::model::d2::point_xy<double> >();
     test_box_3d<bg::model::point<double, 3, bg::cs::cartesian> >();
 
 #if defined(HAVE_TTMATH)
     test_all<bg::model::d2::point_xy<ttmath_big> >();
-    test_eps<bg::model::d2::point_xy<ttmath_big> >();
 #endif
 
     return 0;

--- a/test/algorithms/relational_operations/within/within.cpp
+++ b/test/algorithms/relational_operations/within/within.cpp
@@ -170,25 +170,6 @@ void test_strategy()
     BOOST_CHECK_EQUAL(r, true);
 }
 
-template <typename P>
-void test_eps()
-{
-    typedef typename bg::coordinate_type<P>::type coord_type;
-    coord_type const eps = std::numeric_limits<coord_type>::epsilon();
-
-    P p1(eps/2, eps/2);
-    bg::model::box<P> b1(P(0, 0), P(eps/2, eps/2));
-    bg::model::box<P> b2(P(0, 0), P(1, 1));
-
-    check_geometry(p1, b2,
-                   "point(eps/2, eps/2)", "box(P(0, 0), P(1, 1))",
-                   false);
-
-    check_geometry(b1, b2,
-                   "box(P(0, 0), P(eps/2, eps/2))", "box(P(0, 0), P(1, 1))",
-                   false);
-}
-
 
 int test_main( int , char* [] )
 {
@@ -196,8 +177,6 @@ int test_main( int , char* [] )
     test_all<bg::model::d2::point_xy<double> >();
 
     test_spherical<bg::model::point<double, 2, bg::cs::spherical_equatorial<bg::degree> > >();
-
-    test_eps<bg::model::d2::point_xy<double> >();
 
     test_mixed();
     test_3d();
@@ -207,7 +186,6 @@ int test_main( int , char* [] )
 #if defined(HAVE_TTMATH)
     test_all<bg::model::d2::point_xy<ttmath_big> >();
     test_spherical<bg::model::point<ttmath_big, 2, bg::cs::spherical_equatorial<bg::degree> > >();
-    test_eps<bg::model::d2::point_xy<ttmath_big> >();
 #endif
 
     return 0;

--- a/test/algorithms/set_operations/intersection/intersection.cpp
+++ b/test/algorithms/set_operations/intersection/intersection.cpp
@@ -682,38 +682,6 @@ void test_boxes_nd()
     test_boxes_per_d(p3(0,0,0), p3(5,5,5), p3(3,3,3), p3(6,6,6), true);
 }
 
-template <typename P>
-void test_boxes_eps()
-{
-    typedef bg::model::box<P> box;
-
-    typedef typename bg::coordinate_type<P>::type coord_type;
-    coord_type const eps = std::numeric_limits<coord_type>::epsilon();
-
-    P p_eps(-eps/2, -eps/2);
-    box b1(P(-1, -1), p_eps);
-    box b2(P(0, 0), P(1, 1));
-
-    box box_out;
-    bool detected = bg::intersection(b1, b2, box_out);
-
-    BOOST_CHECK_EQUAL(detected, true);
-    if ( detected )
-    {
-        BOOST_CHECK( bg::equals(box_out, box(p_eps, P(0, 0))) );
-    }
-
-    /*
-    P p_out;
-    detected = bg::intersection(p_eps, b2, p_out);
-
-    BOOST_CHECK_EQUAL(detected, true);
-    if ( detected )
-    {
-        BOOST_CHECK( bg::equals(p_out, p_eps) );
-    }
-    */
-}
 
 template <typename CoordinateType>
 void test_ticket_10868(std::string const& wkt_out)
@@ -763,7 +731,6 @@ int test_main(int, char* [])
 #endif
 
     test_boxes_nd<double>();
-    test_boxes_eps<bg::model::d2::point_xy<double> >();
 
 #ifdef BOOST_GEOMETRY_TEST_INCLUDE_FAILING_TESTS
     // ticket #10868 still fails for 32-bit integers


### PR DESCRIPTION
This PR reverts the changes done by PR https://github.com/boostorg/geometry/pull/318 and addresses the `sectionalize`/`partition` problem in a different way.

Spatial relations between Boxes and other Geometries must be checked as fast as possible (see the other PR for more info). This is why raw comparison operators gives the advantage here. Other Geometries are spatially-compared taking machine epsilon into account, so using functions like `math::equals()`. This is clearly an inconsistency, but I propose to keep it. Instead of making the checks consistent this PR enlarges the Boxes WRT epsilon in `sectionalize()` in a way that should be consistent with `math::equal()` checks performed for other Geometries.

I modified and used a function that was already there: `enlarge_sections()`. It wasn't used but in there (2D) sections was enlarged by `relaxed_epsilon(10)`. This could work in some cases but I think not in all of them because in `math::equals()` the epsilon is scaled WRT the greatest absolute value by default. I saw a comment there which mentions some robustness issues related to one of the union tests. The new approach doesn't break this test. What was the exact problem related to this code?