### PR TITLE
Support for reading and writing Multi-geometries

### DIFF
--- a/extensions/test/gis/io/wkb/write_wkb.cpp
+++ b/extensions/test/gis/io/wkb/write_wkb.cpp
@@ -27,8 +27,16 @@
 
 #include <boost/geometry/io/wkt/wkt.hpp>
 
+#include <boost/geometry/multi/algorithms/equals.hpp>
+#include <boost/geometry/multi/geometries/multi_geometries.hpp> 
+#include <boost/geometry/multi/io/wkt/wkt.hpp> 
+
+#include <boost/geometry/extensions/multi/gis/io/wkb/write_wkb.hpp>
+
 #include <boost/range/algorithm_ext/push_back.hpp>
 #include <boost/assign/list_of.hpp>
+
+#include <boost/algorithm/string.hpp>
 
 namespace bg = boost::geometry;
 
@@ -42,10 +50,11 @@ void test_geometry_equals(Geometry const& geometry, std::string const& wkbhex)
 
     std::string hex_out;
     BOOST_CHECK( bg::wkb2hex(wkb_out.begin(), wkb_out.end(), hex_out) );
-
+    
+    boost::algorithm::to_lower(hex_out);
+    
     BOOST_CHECK_EQUAL( wkbhex, hex_out);
 }
-
 } // namespace anonymous
 
 int test_main(int, char* [])
@@ -67,7 +76,7 @@ int test_main(int, char* [])
         test_geometry_equals<point_type, true>
             (
             point,
-            "0101000000000000000000F03F0000000000000040"
+            "0101000000000000000000f03f0000000000000040"
             );
     }
 
@@ -77,7 +86,7 @@ int test_main(int, char* [])
         test_geometry_equals<point3d_type, true>
             (
             point,
-            "01E9030000000000000000F03F00000000000000400000000000000840"
+            "01e9030000000000000000f03f00000000000000400000000000000840"
             );
     }
 
@@ -98,7 +107,7 @@ int test_main(int, char* [])
         test_geometry_equals<linestring_type, true>
             (
             linestring,
-            "010200000003000000000000000000F03F00000000000000400000000000000040000000000000084000000000000010400000000000001440"
+            "010200000003000000000000000000f03f00000000000000400000000000000040000000000000084000000000000010400000000000001440"
             );
     }
 
@@ -115,7 +124,7 @@ int test_main(int, char* [])
         test_geometry_equals<linestring3d_type, true>
             (
             linestring,
-            "01EA03000003000000000000000000F03F00000000000000400000000000000840000000000000004000000000000008400000000000001040000000000000104000000000000014400000000000001840"
+            "01ea03000003000000000000000000f03f00000000000000400000000000000840000000000000004000000000000008400000000000001040000000000000104000000000000014400000000000001840"
             );
     }
 
@@ -157,7 +166,7 @@ int test_main(int, char* [])
         test_geometry_equals<polygon3d_type, true>
             (
             polygon,
-            "01EB0300000100000005000000000000000000494000000000000049400000000000001440000000000000494000000000000059400000000000002440000000000000594000000000000059400000000000001440000000000000594000000000000049400000000000002440000000000000494000000000000049400000000000001440"
+            "01eb0300000100000005000000000000000000494000000000000049400000000000001440000000000000494000000000000059400000000000002440000000000000594000000000000059400000000000001440000000000000594000000000000049400000000000002440000000000000494000000000000049400000000000001440"
             );
     }
 
@@ -187,9 +196,161 @@ int test_main(int, char* [])
         test_geometry_equals<polygon_type, true>
             (
             polygon,
-            "0103000000020000000500000000000000008041400000000000002440000000000080464000000000008046400000000000002E40000000000000444000000000000024400000000000003440000000000080414000000000000024400400000000000000000034400000000000003E40000000000080414000000000008041400000000000003E40000000000000344000000000000034400000000000003E40"
+            "0103000000020000000500000000000000008041400000000000002440000000000080464000000000008046400000000000002e40000000000000444000000000000024400000000000003440000000000080414000000000000024400400000000000000000034400000000000003e40000000000080414000000000008041400000000000003e40000000000000344000000000000034400000000000003e40"
             );
     }
 
+    //
+    // Multi Geometries
+    //
+    
+    typedef bg::model::multi_point<point_type> multipoint_type;
+    typedef bg::model::multi_linestring<linestring_type> multilinestring_type;
+    typedef bg::model::multi_polygon<polygon_type> multipolygon_type;
+
+    //
+    // MultiPoint
+    //
+    
+    {
+        multipoint_type multipoint;
+        
+        bg::append(multipoint, 
+            boost::assign::list_of
+            (point_type(1.234, 5.678))
+            );
+
+        test_geometry_equals<multipoint_type, true>
+            (
+            multipoint, 
+            "01040000000100000001010000005839b4c876bef33f83c0caa145b61640"
+            );
+    }
+    
+    {
+        multipoint_type multipoint;
+        
+        bg::append(multipoint, 
+            boost::assign::list_of
+            (point_type(1.234, 5.678))
+            (point_type(10.1112, 13.1415))
+            );
+
+        test_geometry_equals<multipoint_type, true>
+            (
+            multipoint, 
+            "01040000000200000001010000005839b4c876bef33f83c0caa145b61640010100000062a1d634ef3824409cc420b072482a40"
+            );
+    }
+    
+    //
+    // MultiLineString
+    //
+    
+    {
+        multilinestring_type multilinestring;
+        
+        // Create linestrings (append does not do this automatically)
+        multilinestring.resize(1);
+        
+        bg::append(multilinestring[0], 
+            boost::assign::list_of
+            (point_type(1.234, 5.678))
+            (point_type(9.1011, 10.1112))
+            (point_type(13.1415, 16.1718))
+            );
+
+        test_geometry_equals<multilinestring_type, true>
+            (
+            multilinestring, 
+            "0105000000010000000102000000030000005839b4c876bef33f83c0caa145b616404f401361c333224062a1d634ef3824409cc420b072482a40eb73b515fb2b3040"
+            );
+    }
+    
+    {
+        multilinestring_type multilinestring;
+        
+        // Create linestrings (append does not do this automatically)
+        multilinestring.resize(2);
+        
+        bg::append(multilinestring[0], 
+            boost::assign::list_of
+            (point_type(1.234, 5.678))
+            (point_type(9.1011, 10.1112))
+            (point_type(13.1415, 16.1718))
+            );
+            
+        bg::append(multilinestring[1], 
+            boost::assign::list_of
+            (point_type(19.2, 21.22))
+            (point_type(23.24, 25.26))
+            );
+
+        test_geometry_equals<multilinestring_type, true>
+            (
+            multilinestring, 
+"0105000000020000000102000000030000005839b4c876bef33f83c0caa145b616404f401361c333224062a1d634ef3824409cc420b072482a40eb73b515fb2b30400102000000020000003333333333333340b81e85eb513835403d0ad7a3703d3740c3f5285c8f423940"
+            );
+    }
+    
+    //
+    // MultiPolygon
+    //
+    
+    {
+        multipolygon_type multipolygon;
+        
+        // Create polygons (append does not do this automatically)
+        multipolygon.resize(1);
+        
+        bg::append(multipolygon[0], 
+            boost::assign::list_of
+            (point_type(100, 200))
+            (point_type(200, 200))
+            (point_type(200, 400))
+            (point_type(100, 400))
+            (point_type(100, 200))
+            );
+
+        test_geometry_equals<multipolygon_type, true>
+            (
+            multipolygon, 
+"010600000001000000010300000001000000050000000000000000005940000000000000694000000000000069400000000000006940000000000000694000000000000079400000000000005940000000000000794000000000000059400000000000006940"
+            );
+    }
+    
+    {
+        multipolygon_type multipolygon;
+        
+        // Create polygons (append does not do this automatically)
+        multipolygon.resize(1);
+        // Create an interior ring (append does not do this automatically)
+        multipolygon[0].inners().resize(1);
+        
+        bg::append(multipolygon[0], 
+            boost::assign::list_of
+            (point_type(35, 10))
+            (point_type(10, 20))
+            (point_type(15, 40))
+            (point_type(45, 45))
+            (point_type(35, 10))
+            );
+
+        bg::append(multipolygon[0], 
+            boost::assign::list_of
+            (point_type(20, 30))
+            (point_type(35, 35))
+            (point_type(30, 20))
+            (point_type(20, 30)),
+            0
+            );
+        
+        test_geometry_equals<multipolygon_type, true>
+            (
+            multipolygon, 
+"0106000000010000000103000000020000000500000000000000008041400000000000002440000000000000244000000000000034400000000000002e40000000000000444000000000008046400000000000804640000000000080414000000000000024400400000000000000000034400000000000003e40000000000080414000000000008041400000000000003e40000000000000344000000000000034400000000000003e40"
+            );
+    }
+    
     return 0;
 }

--- a/include/boost/geometry/algorithms/equals.hpp
+++ b/include/boost/geometry/algorithms/equals.hpp
@@ -242,6 +242,20 @@ struct equals<P1, P2, point_tag, point_tag, DimensionCount, Reverse>
         >
 {};
 
+template <typename MultiPoint1, typename MultiPoint2, std::size_t DimensionCount, bool Reverse>
+struct equals<MultiPoint1, MultiPoint2, multi_point_tag, multi_point_tag, DimensionCount, Reverse>
+    : detail::equals::equals_by_relate<MultiPoint1, MultiPoint2>
+{};
+
+template <typename MultiPoint, typename Point, std::size_t DimensionCount, bool Reverse>
+struct equals<MultiPoint, Point, multi_point_tag, point_tag, DimensionCount, Reverse>
+    : detail::equals::equals_by_relate<MultiPoint, Point>
+{};
+
+template <typename MultiPoint, typename Point, std::size_t DimensionCount, bool Reverse>
+struct equals<Point, MultiPoint, point_tag, multi_point_tag, DimensionCount, Reverse>
+    : detail::equals::equals_by_relate<Point, MultiPoint>
+{};
 
 template <typename Box1, typename Box2, std::size_t DimensionCount, bool Reverse>
 struct equals<Box1, Box2, box_tag, box_tag, DimensionCount, Reverse>
@@ -285,7 +299,6 @@ struct equals<Segment1, Segment2, segment_tag, segment_tag, DimensionCount, Reve
 
 template <typename LineString1, typename LineString2, bool Reverse>
 struct equals<LineString1, LineString2, linestring_tag, linestring_tag, 2, Reverse>
-    //: detail::equals::equals_by_collection<detail::equals::length_check>
     : detail::equals::equals_by_relate<LineString1, LineString2>
 {};
 

--- a/include/boost/geometry/extensions/gis/io/wkb/detail/ogc.hpp
+++ b/include/boost/geometry/extensions/gis/io/wkb/detail/ogc.hpp
@@ -68,12 +68,10 @@ struct geometry_type_ogc
     {
         point      = 1,
         linestring = 2,
-        polygon    = 3
-
-        // TODO: Not implemented
-        //multipoint = 4,
-        //multilinestring = 5,
-        //multipolygon = 6,
+        polygon    = 3,
+        multipoint = 4,
+        multilinestring = 5,
+        multipolygon = 6,
         //collection = 7
     };
 };
@@ -167,6 +165,21 @@ struct geometry_type<Geometry, CheckPolicy, linestring_tag>
 template <typename Geometry, typename CheckPolicy>
 struct geometry_type<Geometry, CheckPolicy, polygon_tag>
     : geometry_type_impl<Geometry, geometry_type_ogc::polygon>
+{};
+
+template <typename Geometry, typename CheckPolicy>
+struct geometry_type<Geometry, CheckPolicy, multi_point_tag>
+    : geometry_type_impl<Geometry, geometry_type_ogc::multipoint>
+{};
+
+template <typename Geometry, typename CheckPolicy>
+struct geometry_type<Geometry, CheckPolicy, multi_linestring_tag>
+    : geometry_type_impl<Geometry, geometry_type_ogc::multilinestring>
+{};
+
+template <typename Geometry, typename CheckPolicy>
+struct geometry_type<Geometry, CheckPolicy, multi_polygon_tag>
+    : geometry_type_impl<Geometry, geometry_type_ogc::multipolygon>
 {};
 
 }} // namespace detail::wkb

--- a/include/boost/geometry/extensions/gis/io/wkb/read_wkb.hpp
+++ b/include/boost/geometry/extensions/gis/io/wkb/read_wkb.hpp
@@ -27,38 +27,38 @@ namespace dispatch
 template <typename Tag, typename G>
 struct read_wkb {};
 
-template <typename G>
-struct read_wkb<point_tag, G>
+template <typename Geometry>
+struct read_wkb<point_tag, Geometry>
 {
     template <typename Iterator>
-    static inline bool parse(Iterator& it, Iterator end, G& geometry,
+    static inline bool parse(Iterator& it, Iterator end, Geometry& geometry,
         detail::wkb::byte_order_type::enum_t order)
     {
-        return detail::wkb::point_parser<G>::parse(it, end, geometry, order);
+        return detail::wkb::point_parser<Geometry>::parse(it, end, geometry, order);
     }
 };
 
-template <typename G>
-struct read_wkb<linestring_tag, G>
+template <typename Geometry>
+struct read_wkb<linestring_tag, Geometry>
 {
     template <typename Iterator>
-    static inline bool parse(Iterator& it, Iterator end, G& geometry,
+    static inline bool parse(Iterator& it, Iterator end, Geometry& geometry,
         detail::wkb::byte_order_type::enum_t order)
     {
         geometry::clear(geometry);
-        return detail::wkb::linestring_parser<G>::parse(it, end, geometry, order);
+        return detail::wkb::linestring_parser<Geometry>::parse(it, end, geometry, order);
     }
 };
 
-template <typename G>
-struct read_wkb<polygon_tag, G>
+template <typename Geometry>
+struct read_wkb<polygon_tag, Geometry>
 {
     template <typename Iterator>
-    static inline bool parse(Iterator& it, Iterator end, G& geometry,
+    static inline bool parse(Iterator& it, Iterator end, Geometry& geometry,
         detail::wkb::byte_order_type::enum_t order)
     {
         geometry::clear(geometry);
-        return detail::wkb::polygon_parser<G>::parse(it, end, geometry, order);
+        return detail::wkb::polygon_parser<Geometry>::parse(it, end, geometry, order);
     }
 };
 
@@ -66,8 +66,8 @@ struct read_wkb<polygon_tag, G>
 #endif // DOXYGEN_NO_DISPATCH
 
 
-template <typename Iterator, typename G>
-inline bool read_wkb(Iterator begin, Iterator end, G& geometry)
+template <typename Iterator, typename Geometry>
+inline bool read_wkb(Iterator begin, Iterator end, Geometry& geometry)
 {
     // Stream of bytes can only be parsed using random access iterator.
     BOOST_STATIC_ASSERT((
@@ -82,16 +82,16 @@ inline bool read_wkb(Iterator begin, Iterator end, G& geometry)
     {
         return dispatch::read_wkb
             <
-            typename tag<G>::type,
-            G
+            typename tag<Geometry>::type,
+            Geometry
             >::parse(begin, end, geometry, byte_order);
     }
 
     return false;
 }
 
-template <typename ByteType, typename G>
-inline bool read_wkb(ByteType const* bytes, std::size_t length, G& geometry)
+template <typename ByteType, typename Geometry>
+inline bool read_wkb(ByteType const* bytes, std::size_t length, Geometry& geometry)
 {
     BOOST_STATIC_ASSERT((boost::is_integral<ByteType>::value));
     BOOST_STATIC_ASSERT((sizeof(boost::uint8_t) == sizeof(ByteType)));

--- a/include/boost/geometry/extensions/multi/gis/io/wkb/detail/parser.hpp
+++ b/include/boost/geometry/extensions/multi/gis/io/wkb/detail/parser.hpp
@@ -1,0 +1,248 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_MULTI_IO_WKB_DETAIL_PARSER_HPP
+#define BOOST_GEOMETRY_MULTI_IO_WKB_DETAIL_PARSER_HPP
+
+#include <cstddef>
+#include <iterator>
+#include <limits>
+
+#include <boost/geometry/core/exception.hpp>
+
+#include <boost/geometry/extensions/gis/io/wkb/detail/endian.hpp>
+#include <boost/geometry/extensions/gis/io/wkb/detail/parser.hpp>
+#include <boost/geometry/extensions/gis/io/wkb/detail/ogc.hpp>
+
+
+#include <boost/geometry/multi/core/point_type.hpp>
+#include <boost/geometry/multi/core/ring_type.hpp>
+#include <boost/geometry/core/exterior_ring.hpp>
+
+#include <boost/geometry/multi/core/interior_rings.hpp>
+
+namespace boost { namespace geometry
+{
+
+#ifndef DOXYGEN_NO_DETAIL
+namespace detail { namespace wkb
+{
+
+template <typename MultiPoint>
+struct multipoint_parser
+{
+    template <typename Iterator>
+    static bool parse(Iterator& it, Iterator end, MultiPoint& multipoint, byte_order_type::enum_t order)
+    {
+        if (!geometry_type_parser<MultiPoint>::parse(it, end, order))
+        {
+            return false;
+        }
+        
+        boost::uint32_t num_points(0);
+        if (!value_parser<boost::uint32_t>::parse(it, end, num_points, order))
+        {
+            return false;
+        }
+        
+        // Check that the number of double values in the stream is equal
+        // or greater than the number of expected values in the multipoint
+        
+        typedef typename std::iterator_traits<Iterator>::difference_type size_type;
+        
+        typedef typename point_type<MultiPoint>::type point_type;
+        
+        size_type const container_byte_size = dimension<point_type>::value * num_points * sizeof(double)
+                                            + num_points * sizeof(boost::uint8_t)
+                                            + num_points * sizeof(boost::uint32_t);
+        
+        size_type const stream_byte_size = std::distance(it,end);
+        
+        if(stream_byte_size < container_byte_size)
+        {
+            throw boost::geometry::read_wkb_exception();
+        }
+        
+        point_type point_buffer;
+        std::back_insert_iterator<MultiPoint> output(std::back_inserter(multipoint));
+        
+        typedef typename std::iterator_traits<Iterator>::difference_type size_type;
+        if(num_points > (std::numeric_limits<boost::uint32_t>::max)() )
+        {
+            throw boost::geometry::read_wkb_exception();
+        }
+        
+        size_type points_parsed = 0;
+        while (points_parsed < num_points && it != end)
+        {
+            detail::wkb::byte_order_type::enum_t point_byte_order;
+            if (!detail::wkb::byte_order_parser::parse(it, end, point_byte_order))
+            {
+                return false;
+            }
+            
+            if (!geometry_type_parser<point_type>::parse(it, end, point_byte_order))
+            {
+                return false;
+            }
+            
+            parsing_assigner<point_type, 0, dimension<point_type>::value>::run(it, end, point_buffer, point_byte_order);
+            
+            output = point_buffer;
+            
+            ++output;
+            ++points_parsed;
+        }
+        return true;
+    }
+};
+
+template <typename MultiLinestring>
+struct multilinestring_parser
+{
+    template <typename Iterator>
+    static bool parse(Iterator& it, Iterator end, MultiLinestring& multilinestring, byte_order_type::enum_t order)
+    {
+        typedef typename MultiLinestring::value_type linestring_type;
+        typedef typename point_type<MultiLinestring>::type point_type;
+        
+        if (!geometry_type_parser<MultiLinestring>::parse(it, end, order))
+        {
+            return false;
+        }
+        
+        boost::uint32_t num_linestrings(0);
+        if (!value_parser<boost::uint32_t>::parse(it, end, num_linestrings, order))
+        {
+            return false;
+        }
+        
+        std::back_insert_iterator<MultiLinestring> output(std::back_inserter(multilinestring));
+        
+        typedef typename std::iterator_traits<Iterator>::difference_type size_type;
+        if(num_linestrings > (std::numeric_limits<boost::uint32_t>::max)() )
+        {
+            throw boost::geometry::read_wkb_exception();
+        }
+        
+        size_type linestrings_parsed = 0;
+        while (linestrings_parsed < num_linestrings && it != end)
+        {
+            linestring_type linestring_buffer;
+            
+            detail::wkb::byte_order_type::enum_t linestring_byte_order;
+            if (!detail::wkb::byte_order_parser::parse(it, end, linestring_byte_order))
+            {
+                return false;
+            }
+            
+            if (!geometry_type_parser<linestring_type>::parse(it, end, order))
+            {
+                return false;
+            }
+            
+            if(!point_container_parser<linestring_type>::parse(it, end, linestring_buffer, linestring_byte_order))
+            {
+                return false;
+            }
+            
+            output = linestring_buffer;
+            
+            ++output;
+            ++linestrings_parsed;
+        }
+        return true;
+    }
+};
+
+template <typename MultiPolygon>
+struct multipolygon_parser
+{
+    template <typename Iterator>
+    static bool parse(Iterator& it, Iterator end, MultiPolygon& multipolygon, byte_order_type::enum_t order)
+    {
+        typedef typename boost::range_value<MultiPolygon>::type polygon_type;
+        
+        if (!geometry_type_parser<MultiPolygon>::parse(it, end, order))
+        {
+            return false;
+        }
+        
+        boost::uint32_t num_polygons(0);
+        if (!value_parser<boost::uint32_t>::parse(it, end, num_polygons, order))
+        {
+            return false;
+        }
+        
+        std::back_insert_iterator<MultiPolygon> output(std::back_inserter(multipolygon));
+        
+        std::size_t polygons_parsed = 0;
+        while(polygons_parsed < num_polygons && it != end)
+        {
+            polygon_type polygon_buffer;
+            
+            detail::wkb::byte_order_type::enum_t polygon_byte_order;
+            if (!detail::wkb::byte_order_parser::parse(it, end, polygon_byte_order))
+            {
+                return false;
+            }
+            
+            if (!geometry_type_parser<polygon_type>::parse(it, end, order))
+            {
+                return false;
+            }
+            
+            boost::uint32_t num_rings(0);
+            if (!value_parser<boost::uint32_t>::parse(it, end, num_rings, polygon_byte_order))
+            {
+                return false;
+            }
+            
+            std::size_t rings_parsed = 0;
+            
+            while (rings_parsed < num_rings && it != end)
+            {
+                typedef typename boost::geometry::ring_return_type<polygon_type>::type ring_type;
+
+                if (0 == rings_parsed)
+                {
+                    ring_type ring0 = exterior_ring(polygon_buffer);
+                    
+                    if (!point_container_parser<ring_type>::parse(it, end, ring0, polygon_byte_order))
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    boost::geometry::range::resize(interior_rings(polygon_buffer), rings_parsed);
+                    ring_type ringN = boost::geometry::range::back(interior_rings(polygon_buffer));
+                    
+                    if (!point_container_parser<ring_type>::parse(it, end, ringN, polygon_byte_order))
+                    {
+                        return false;
+                    }
+                }
+                ++rings_parsed;
+            }
+            
+            output = polygon_buffer;
+            ++output;
+        }
+        
+        return true;
+    }
+};
+
+}} // namespace detail::wkb
+#endif // DOXYGEN_NO_IMPL
+
+}} // namespace boost::geometry
+
+
+#endif // BOOST_GEOMETRY_MULTI_IO_WKB_DETAIL_PARSER_HPP

--- a/include/boost/geometry/extensions/multi/gis/io/wkb/detail/writer.hpp
+++ b/include/boost/geometry/extensions/multi/gis/io/wkb/detail/writer.hpp
@@ -1,0 +1,145 @@
+// Boost.Geometry
+//
+// Copyright (c) 2015 Mats Taraldsvik.
+//
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_MULTI_IO_WKB_DETAIL_WRITER_HPP
+#define BOOST_GEOMETRY_MULTI_IO_WKB_DETAIL_WRITER_HPP
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <limits>
+
+#include <boost/concept_check.hpp>
+#include <boost/cstdint.hpp>
+#include <boost/range.hpp>
+#include <boost/static_assert.hpp>
+#include <boost/type_traits/is_integral.hpp>
+#include <boost/type_traits/is_same.hpp>
+
+#include <boost/geometry/extensions/gis/io/wkb/detail/writer.hpp>
+
+#include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/coordinate_dimension.hpp>
+#include <boost/geometry/core/coordinate_type.hpp>
+#include <boost/geometry/core/exterior_ring.hpp>
+#include <boost/geometry/core/interior_rings.hpp>
+#include <boost/geometry/extensions/gis/io/wkb/detail/endian.hpp>
+#include <boost/geometry/extensions/gis/io/wkb/detail/ogc.hpp>
+
+#include <iostream>
+
+namespace boost { namespace geometry
+{
+
+#ifndef DOXYGEN_NO_DETAIL
+namespace detail { namespace wkb
+{
+    template <typename MultiPoint>
+    struct multipoint_writer
+    {
+        template <typename OutputIterator>
+        static bool write(MultiPoint const& multipoint,
+                          OutputIterator& iter,
+                          byte_order_type::enum_t byte_order)
+        {
+            // write endian type
+            value_writer<uint8_t>::write(byte_order, iter, byte_order);
+
+            // write geometry type
+            uint32_t type = geometry_type<MultiPoint>::get();
+            value_writer<uint32_t>::write(type, iter, byte_order);
+
+            // write num points
+            uint32_t num_points = boost::size(multipoint);
+            value_writer<uint32_t>::write(num_points, iter, byte_order);
+            
+            typedef typename point_type<MultiPoint>::type point_type;
+            
+            for(typename boost::range_iterator<MultiPoint const>::type
+                    point_iter = boost::begin(multipoint);
+                point_iter != boost::end(multipoint);
+                ++point_iter)
+            {
+                detail::wkb::point_writer<point_type>::write(*point_iter, iter, byte_order);
+            }
+
+            return true;
+        }
+    };
+
+    template <typename MultiLinestring>
+    struct multilinestring_writer
+    {
+        template <typename OutputIterator>
+        static bool write(MultiLinestring const& multilinestring,
+                          OutputIterator& iter,
+                          byte_order_type::enum_t byte_order)
+        {
+            // write endian type
+            value_writer<uint8_t>::write(byte_order, iter, byte_order);
+
+            // write geometry type
+            uint32_t type = geometry_type<MultiLinestring>::get();
+            value_writer<uint32_t>::write(type, iter, byte_order);
+
+            // write num linestrings
+            uint32_t num_linestrings = boost::size(multilinestring);
+            value_writer<uint32_t>::write(num_linestrings, iter, byte_order);
+            
+            typedef typename boost::range_value<MultiLinestring>::type linestring_type;
+            
+            for(typename boost::range_iterator<MultiLinestring const>::type
+                    linestring_iter = boost::begin(multilinestring);
+                linestring_iter != boost::end(multilinestring);
+                ++linestring_iter)
+            {
+                detail::wkb::linestring_writer<linestring_type>::write(*linestring_iter, iter, byte_order);
+            }
+
+            return true;
+        }
+    };
+
+    template <typename MultiPolygon>
+    struct multipolygon_writer
+    {
+        template <typename OutputIterator>
+        static bool write(MultiPolygon const& multipolygon,
+                          OutputIterator& iter,
+                          byte_order_type::enum_t byte_order)
+        {
+            // write endian type
+            value_writer<uint8_t>::write(byte_order, iter, byte_order);
+
+            // write geometry type
+            uint32_t type = geometry_type<MultiPolygon>::get();
+            value_writer<uint32_t>::write(type, iter, byte_order);
+
+            // write num polygons
+            uint32_t num_polygons = boost::size(multipolygon);
+            value_writer<uint32_t>::write(num_polygons, iter, byte_order);
+            
+            typedef typename boost::range_value<MultiPolygon>::type polygon_type;
+            
+            for(typename boost::range_iterator<MultiPolygon const>::type
+                    polygon_iter = boost::begin(multipolygon);
+                polygon_iter != boost::end(multipolygon);
+                ++polygon_iter)
+            {
+                detail::wkb::polygon_writer<polygon_type>::write(*polygon_iter, iter, byte_order);
+            }
+
+            return true;
+        }
+    };
+
+}} // namespace detail::wkb
+#endif // DOXYGEN_NO_IMPL
+
+}} // namespace boost::geometry
+#endif // BOOST_GEOMETRY_MULTI_IO_WKB_DETAIL_WRITER_HPP

--- a/include/boost/geometry/extensions/multi/gis/io/wkb/read_wkb.hpp
+++ b/include/boost/geometry/extensions/multi/gis/io/wkb/read_wkb.hpp
@@ -1,0 +1,62 @@
+// Boost.Geometry
+
+// Copyright (c) 2015 Mats Taraldsvik
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_MULTI_IO_WKB_READ_WKB_HPP
+#define BOOST_GEOMETRY_MULTI_IO_WKB_READ_WKB_HPP
+
+#include <iterator>
+
+#include <boost/geometry/extensions/multi/gis/io/wkb/detail/parser.hpp>
+#include <boost/geometry/extensions/gis/io/wkb/read_wkb.hpp>
+
+namespace boost { namespace geometry
+{
+
+#ifndef DOXYGEN_NO_DISPATCH
+namespace dispatch
+{
+
+template <typename Geometry>
+struct read_wkb<multi_point_tag, Geometry>
+{
+    template <typename Iterator>
+    static inline bool parse(Iterator& it, Iterator end, Geometry& geometry,
+        detail::wkb::byte_order_type::enum_t order)
+    {
+        return detail::wkb::multipoint_parser<Geometry>::parse(it, end, geometry, order);
+    }
+};
+
+template <typename Geometry>
+struct read_wkb<multi_linestring_tag, Geometry>
+{
+    template <typename Iterator>
+    static inline bool parse(Iterator& it, Iterator end, Geometry& geometry,
+        detail::wkb::byte_order_type::enum_t order)
+    {
+        return detail::wkb::multilinestring_parser<Geometry>::parse(it, end, geometry, order);
+    }
+};
+
+template <typename Geometry>
+struct read_wkb<multi_polygon_tag, Geometry>
+{
+    template <typename Iterator>
+    static inline bool parse(Iterator& it, Iterator end, Geometry& geometry,
+        detail::wkb::byte_order_type::enum_t order)
+    {
+        return detail::wkb::multipolygon_parser<Geometry>::parse(it, end, geometry, order);
+    }
+};
+
+} // namespace dispatch
+#endif // DOXYGEN_NO_DISPATCH
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_MULTI_IO_WKB_READ_WKB_HPP

--- a/include/boost/geometry/extensions/multi/gis/io/wkb/write_wkb.hpp
+++ b/include/boost/geometry/extensions/multi/gis/io/wkb/write_wkb.hpp
@@ -1,0 +1,66 @@
+// Boost.Geometry
+//
+// Copyright (c) 2015 Mats Taraldsvik.
+//
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_MULTI_IO_WKB_WRITE_WKB_HPP
+#define BOOST_GEOMETRY_MULTI_IO_WKB_WRITE_WKB_HPP
+
+#include <iterator>
+
+#include <boost/type_traits/is_convertible.hpp>
+#include <boost/static_assert.hpp>
+
+#include <boost/geometry/core/tags.hpp>
+
+#include <boost/geometry/extensions/multi/gis/io/wkb/detail/writer.hpp>
+#include <boost/geometry/extensions/gis/io/wkb/write_wkb.hpp>
+
+namespace boost { namespace geometry
+{
+
+#ifndef DOXYGEN_NO_DISPATCH
+namespace dispatch
+{
+
+template <typename Geometry>
+struct write_wkb<multi_point_tag, Geometry>
+{
+    template <typename OutputIterator>
+    static inline bool write(const Geometry& geometry, OutputIterator iter,
+                       detail::wkb::byte_order_type::enum_t byte_order)
+    {
+        return detail::wkb::multipoint_writer<Geometry>::write(geometry, iter, byte_order);
+    }
+};
+
+template <typename Geometry>
+struct write_wkb<multi_linestring_tag, Geometry>
+{
+    template <typename OutputIterator>
+    static inline bool write(const Geometry& geometry, OutputIterator iter,
+                       detail::wkb::byte_order_type::enum_t byte_order)
+    {
+        return detail::wkb::multilinestring_writer<Geometry>::write(geometry, iter, byte_order);
+    }
+};
+
+template <typename Geometry>
+struct write_wkb<multi_polygon_tag, Geometry>
+{
+    template <typename OutputIterator>
+    static inline bool write(const Geometry& geometry, OutputIterator iter,
+                       detail::wkb::byte_order_type::enum_t byte_order)
+    {
+        return detail::wkb::multipolygon_writer<Geometry>::write(geometry, iter, byte_order);
+    }
+};
+
+} // namespace dispatch
+#endif // DOXYGEN_NO_DISPATCH
+
+}} // namespace boost::geometry
+#endif // BOOST_GEOMETRY_MULTI_IO_WKB_WRITE_WKB_HPP


### PR DESCRIPTION
Adds support for Multi-geometries in the WKB data format.

This is the first draft, and a (better) version of the svn patches for Multi-geometry WKB support. I need help with the equals-algorithm used for the tests, as they currently only check the number of geometries (in the multi-geometry).

@mloskot 
