### PR TITLE
Fix/difference intersection linear areal

### DIFF
--- a/include/boost/geometry/algorithms/detail/overlay/intersection_insert.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/intersection_insert.hpp
@@ -208,11 +208,13 @@ struct intersection_of_linestring_with_areal
     class is_crossing_turn
     {
         // return true is the operation is intersection or blocked
-        template <std::size_t I, typename Turn>
+        template <std::size_t Index, typename Turn>
         static inline bool has_op_i_or_b(Turn const& t)
         {
-            return t.operations[I].operation == overlay::operation_intersection
-                || t.operations[I].operation == overlay::operation_blocked;
+            return
+                t.operations[Index].operation == overlay::operation_intersection
+                ||
+                t.operations[Index].operation == overlay::operation_blocked;
         }
 
         template <typename Turn>
@@ -238,7 +240,7 @@ struct intersection_of_linestring_with_areal
         }
 
         template <typename Turn>
-        static inline bool is_tab_or_mab(Turn const& t)
+        static inline bool has_i_or_b_ops(Turn const& t)
         {
             return
                 (t.method == overlay::method_touch
@@ -257,7 +259,7 @@ struct intersection_of_linestring_with_areal
         static inline bool apply(Turn const& t)
         {
             bool const is_crossing
-                = has_method_crosses(t) || is_cc(t) || is_tab_or_mab(t);
+                = has_method_crosses(t) || is_cc(t) || has_i_or_b_ops(t);
 #if defined(BOOST_GEOMETRY_DEBUG_FOLLOW)
             debug_turn(t, ! is_crossing);
 #endif

--- a/test/algorithms/set_operations/difference/difference.cpp
+++ b/test/algorithms/set_operations/difference/difference.cpp
@@ -86,6 +86,71 @@ void test_areal_linear()
     test_one_lp<LineString, LineString, Polygon>("case25", "LINESTRING(4 0,4 5,7 5)", poly_9, 2, 5, 5.0);
     test_one_lp<LineString, LineString, Polygon>("case26", "LINESTRING(4 0,4 3,4 5,7 5)", poly_9, 2, 5, 5.0);
     test_one_lp<LineString, LineString, Polygon>("case27", "LINESTRING(4 4,4 5,5 5)", poly_9, 1, 3, 2.0);
+
+    test_one_lp<LineString, LineString, Polygon>("case28",
+        "LINESTRING(-1.3 0,-15 0,-1.3 0)",
+        "POLYGON((2 3,-9 -7,12 -13,2 3))",
+         1, 3, 27.4);
+
+    test_one_lp<LineString, LineString, Polygon>("case29",
+        "LINESTRING(5 5,-10 5,5 5)",
+        "POLYGON((0 0,0 10,10 10,10 0,0 0))",
+         1, 3, 20);
+
+    test_one_lp<LineString, LineString, Polygon>("case29a",
+        "LINESTRING(1 1,5 5,-10 5,5 5,6 6)",
+        "POLYGON((0 0,0 10,10 10,10 0,0 0))",
+         1, 3, 20);
+
+    test_one_lp<LineString, LineString, Polygon>("case30",
+        "LINESTRING(-10 5,5 5,-10 5)",
+        "POLYGON((0 0,0 10,10 10,10 0,0 0))",
+         2, 4, 20);
+
+    test_one_lp<LineString, LineString, Polygon>("case30a",
+        "LINESTRING(-20 10,-10 5,5 5,-10 5,-20 -10)",
+        "POLYGON((0 0,0 10,10 10,10 0,0 0))",
+         2, 6, 49.208096);
+
+    test_one_lp<LineString, LineString, Polygon>("case31",
+        "LINESTRING(0 5,5 5,0 5)",
+        "POLYGON((0 0,0 10,10 10,10 0,0 0))",
+         0, 0, 0);
+
+    test_one_lp<LineString, LineString, Polygon>("case31",
+        "LINESTRING(0 5,5 5,1 1,9 1,5 5,0 5)",
+        "POLYGON((0 0,0 10,10 10,10 0,0 0))",
+         0, 0, 0);
+
+    test_one_lp<LineString, LineString, Polygon>("case32",
+        "LINESTRING(5 5,0 5,5 5)",
+        "POLYGON((0 0,0 10,10 10,10 0,0 0))",
+         0, 0, 0);
+
+    test_one_lp<LineString, LineString, Polygon>("case32a",
+        "LINESTRING(-10 10,5 5,0 5,5 5,20 10)",
+        "POLYGON((0 0,0 10,10 10,10 0,0 0))",
+         2, 4, 21.081851);
+
+    test_one_lp<LineString, LineString, Polygon>("case33",
+        "LINESTRING(-5 5,0 5,-5 5)",
+        "POLYGON((0 0,0 10,10 10,10 0,0 0))",
+         1, 3, 10);
+
+    test_one_lp<LineString, LineString, Polygon>("case33a",
+        "LINESTRING(-10 10,-5 5,0 5,-5 5,-10 -10)",
+        "POLYGON((0 0,0 10,10 10,10 0,0 0))",
+         1, 5, 32.882456);
+
+    test_one_lp<LineString, LineString, Polygon>("case34",
+        "LINESTRING(5 5,0 5,5 5,5 4,0 4,5 4)",
+        "POLYGON((0 0,0 10,10 10,10 0,0 0))",
+         0, 0, 0);
+
+    test_one_lp<LineString, LineString, Polygon>("case35",
+        "LINESTRING(5 5,0 5,5 5,5 4,0 4,5 3)",
+        "POLYGON((0 0,0 10,10 10,10 0,0 0))",
+         0, 0, 0);
 }
 
 template <typename CoordinateType>

--- a/test/algorithms/set_operations/difference/difference.cpp
+++ b/test/algorithms/set_operations/difference/difference.cpp
@@ -156,6 +156,11 @@ void test_areal_linear()
         "LINESTRING(5 5,0 5,5 5,5 4,0 4,5 3)",
         "POLYGON((0 0,0 10,10 10,10 0,0 0))",
          0, 0, 0);
+
+    test_one_lp<LineString, LineString, Polygon>("case36",
+        "LINESTRING(-1 -1,10 10)",
+        "POLYGON((5 5,15 15,15 5,5 5))",
+        1, 2, 6 * std::sqrt(2.0));
 }
 
 template <typename CoordinateType>

--- a/test/algorithms/set_operations/difference/difference.cpp
+++ b/test/algorithms/set_operations/difference/difference.cpp
@@ -142,6 +142,11 @@ void test_areal_linear()
         "POLYGON((0 0,0 10,10 10,10 0,0 0))",
          1, 5, 32.882456);
 
+    test_one_lp<LineString, LineString, Polygon>("case33b",
+        "LINESTRING(0 5,-5 5,0 5)",
+        "POLYGON((0 0,0 10,10 10,10 0,0 0))",
+         1, 3, 10);
+
     test_one_lp<LineString, LineString, Polygon>("case34",
         "LINESTRING(5 5,0 5,5 5,5 4,0 4,5 4)",
         "POLYGON((0 0,0 10,10 10,10 0,0 0))",

--- a/test/algorithms/set_operations/intersection/intersection.cpp
+++ b/test/algorithms/set_operations/intersection/intersection.cpp
@@ -447,6 +447,82 @@ void test_areal_linear()
     test_one_lp<LineString, Polygon, LineString>("case19", poly_9, "LINESTRING(1 2,1 3,0 3)", 1, 2, 1.0);
     test_one_lp<LineString, Polygon, LineString>("case20", poly_9, "LINESTRING(1 2,1 3,2 3)", 1, 3, 2.0);
 
+    test_one_lp<LineString, Polygon, LineString>("case21",
+        "POLYGON((2 3,-9 -7,12 -13,2 3))",
+        "LINESTRING(-1.3 0,-15 0,-1.3 0)",
+         0, 0, 0);
+
+    test_one_lp<LineString, Polygon, LineString>("case22",
+        "POLYGON((0 0,0 10,10 10,10 0,0 0))",
+        "LINESTRING(5 5,-10 5,5 5)",
+         2, 4, 10);
+
+    test_one_lp<LineString, Polygon, LineString>("case22a",
+        "POLYGON((0 0,0 10,10 10,10 0,0 0))",
+        "LINESTRING(1 1,5 5,-10 5,5 5,6 6)",
+         2, 6, 17.071068);
+
+    test_one_lp<LineString, Polygon, LineString>("case23",
+        "POLYGON((0 0,0 10,10 10,10 0,0 0))",
+        "LINESTRING(-10 5,5 5,-10 5)",
+         1, 3, 10);
+
+    test_one_lp<LineString, Polygon, LineString>("case23a",
+        "POLYGON((0 0,0 10,10 10,10 0,0 0))",
+        "LINESTRING(-20 10,-10 5,5 5,-10 5,-20 -10)",
+         1, 3, 10);
+
+    test_one_lp<LineString, Polygon, LineString>("case24",
+        "POLYGON((0 0,0 10,10 10,10 0,0 0))",
+        "LINESTRING(0 5,5 5,0 5)",
+         1, 3, 10);
+
+    test_one_lp<LineString, Polygon, LineString>("case24",
+        "POLYGON((0 0,0 10,10 10,10 0,0 0))",
+        "LINESTRING(0 5,5 5,1 1,9 1,5 5,0 5)",
+         1, 6, 29.313708);
+
+    test_one_lp<LineString, Polygon, LineString>("case25",
+        "POLYGON((0 0,0 10,10 10,10 0,0 0))",
+        "LINESTRING(5 5,0 5,5 5)",
+         1, 3, 10);
+
+    test_one_lp<LineString, Polygon, LineString>("case25a",
+        "POLYGON((0 0,0 10,10 10,10 0,0 0))",
+        "LINESTRING(-10 10,5 5,0 5,5 5,20 10)",
+         1, 4, 20.540925);
+
+    test_one_lp<LineString, Polygon, LineString>("case25b",
+        "POLYGON((0 0,0 10,10 10,10 0,0 0))",
+        "LINESTRING(-10 10,5 5,1 5,5 5,20 10)",
+         1, 4, 18.540925);
+
+    test_one_lp<LineString, Polygon, LineString>("case25c",
+        "POLYGON((0 0,0 10,10 10,10 0,0 0))",
+        "LINESTRING(-10 10,5 5,-1 5,5 5,20 10)",
+         2, 6, 20.540925);
+
+    test_one_lp<LineString, Polygon, LineString>("case26",
+        "POLYGON((0 0,0 10,10 10,10 0,0 0))",
+        "LINESTRING(-5 5,0 5,-5 5)",
+         0, 0, 0);
+
+    test_one_lp<LineString, Polygon, LineString>("case26a",
+        "POLYGON((0 0,0 10,10 10,10 0,0 0))",
+        "LINESTRING(-10 10,-5 5,0 5,-5 5,-10 -10)",
+         0, 0, 0);
+
+    test_one_lp<LineString, Polygon, LineString>("case27",
+        "POLYGON((0 0,0 10,10 10,10 0,0 0))",
+        "LINESTRING(5 5,0 5,5 5,5 4,0 4,5 4)",
+         1, 6, 21.0);
+
+    test_one_lp<LineString, Polygon, LineString>("case28",
+        "POLYGON((0 0,0 10,10 10,10 0,0 0))",
+        "LINESTRING(5 5,0 5,5 5,5 4,0 4,5 3)",
+         1, 6, 21.099019);
+
+
     // PROPERTIES CHANGED BY switch_to_integer
     // TODO test_one_lp<LineString, Polygon, LineString>("case21", poly_9, "LINESTRING(1 2,1 4,4 4,4 1,2 1,2 2)", 1, 6, 11.0);
 

--- a/test/algorithms/set_operations/intersection/intersection.cpp
+++ b/test/algorithms/set_operations/intersection/intersection.cpp
@@ -522,6 +522,10 @@ void test_areal_linear()
         "LINESTRING(5 5,0 5,5 5,5 4,0 4,5 3)",
          1, 6, 21.099019);
 
+    test_one_lp<LineString, Polygon, LineString>("case29",
+        "POLYGON((5 5,15 15,15 5,5 5))",
+        "LINESTRING(0 0,10 10)",
+        1, 2, 5 * std::sqrt(2.0));
 
     // PROPERTIES CHANGED BY switch_to_integer
     // TODO test_one_lp<LineString, Polygon, LineString>("case21", poly_9, "LINESTRING(1 2,1 4,4 4,4 1,2 1,2 2)", 1, 6, 11.0);

--- a/test/algorithms/set_operations/intersection/test_intersection.hpp
+++ b/test/algorithms/set_operations/intersection/test_intersection.hpp
@@ -257,6 +257,9 @@ void test_one_lp(std::string const& caseid,
         double percentage = 0.0001,
         bool debug1 = false, bool debug2 = false)
 {
+#ifdef BOOST_GEOMETRY_TEST_DEBUG
+    std::cout << caseid << " -- start" << std::endl;
+#endif
     Areal areal;
     bg::read_wkt(wkt_areal, areal);
     bg::correct(areal);
@@ -274,6 +277,9 @@ void test_one_lp(std::string const& caseid,
     test_intersection<OutputType, void>(caseid + "_rev", areal, linear,
         expected_count, expected_point_count,
         expected_length, percentage, debug2);
+#ifdef BOOST_GEOMETRY_TEST_DEBUG
+    std::cout << caseid << " -- end" << std::endl;
+#endif
 }
 
 template <typename Geometry1, typename Geometry2>


### PR DESCRIPTION
The existing `bg::intersection(L, A)` and bg::difference(L, A)` algorithm discard spikes present in the linear geometry passed to the algorithm. This is not only inconsistent with the fact that Boost.Geometry considers linear geometries with spikes as valid, but can also produce invalid output.

To give an example of one such case where the output can be invalid, consider the linestring `LINESTRING(0 5,-5 5,0 5)` and the polygon `POLYGON((0 0,0 10,10 10,10 0,0 0))`. The existing code returns as output of `bg::difference()` the linestring `LINESTRING(0 5,0 5)` which is invalid (it is 0-dimensional instead of 1-dimensional).

Another interesting case is the test case where we have the linestring `LINESTRING(0 5,5 5,0 5)` and the polygon `POLYGON((0 0,0 10,10 10,10 0,0 0))`. The expected output is the empty multilinestring, but instead the linestring `LINESTRING(0 5,0 5)` is again reported.

As far as spikes are concerned, this is handled by specifying the last template parameter of `bg::detail::overlay::follow<>` to be `false` instead of `true` (the default value is `true` and signifies that spikes should be discarded).

As far as the second case is concerned, it is handled now by performing an initial scan of the turns computed, to determine is there are any turns that are considered as *crossing* turns, i.e., correspond to intersection points at which the linestring leaves the closure of the areal geometry and goes towards the free space, or vice versa. If no such turns are found, then the algorithm determines if the entire linear geometry lies inside the areal geometry or not, in exactly the same way as if no turns where found.