### PR TITLE
Debug print

### DIFF
--- a/include/boost/geometry/algorithms/detail/is_valid/debug_complement_graph.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/debug_complement_graph.hpp
@@ -55,11 +55,7 @@ debug_print_complement_graph(OutputStream& os,
     }
 }
 #else
-template <typename OutputStream, typename TurnPoint>
-inline void debug_print_complement_graph(OutputStream&,
-                                         complement_graph<TurnPoint> const&)
-{
-}
+#define debug_print_complement_graph(A, B)
 #endif
 
 


### PR DESCRIPTION
The use of `debug_print_complement_graph()` in `polygon.hpp`, even when debugging is turned off, requires `std::cout` and therefore `<iostream>` (which is not included). This how I have plugged the hole but I understand if you want to do it differently.
