### PR TITLE
Fix issue with use of std::cout only in debug mode

### DIFF
--- a/include/boost/geometry/algorithms/detail/is_valid/polygon.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/polygon.hpp
@@ -11,6 +11,9 @@
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_IS_VALID_POLYGON_HPP
 
 #include <cstddef>
+#ifdef BOOST_GEOMETRY_TEST_DEBUG
+#include <iostream>
+#endif // BOOST_GEOMETRY_TEST_DEBUG
 
 #include <algorithm>
 #include <deque>
@@ -327,7 +330,9 @@ protected:
                 g.add_edge(v2, vip);
             }
 
+#ifdef BOOST_GEOMETRY_TEST_DEBUG
             debug_print_complement_graph(std::cout, g);
+#endif // BOOST_GEOMETRY_TEST_DEBUG
 
             if (g.has_cycles())
             {


### PR DESCRIPTION
This is a follow up of PR #326 proposed by @jeremy-murphy.
The problem is that when `debug_print_complement_graph()` is called, `std::cout` needs to be defined
which requires the inclusion of `<iostream>` even in non-debug mode.

With this PR the call to `debug_print_complement_graph()` is guarded by the appropriate
macro and the use inclusion of `<iostream>` is no longer needed in non-debug mode.