### PR TITLE
[transform][strategies] Don't clobber BOOST_UBLAS_TYPE_CHECK macro.

### DIFF
--- a/include/boost/geometry/strategies/transform/inverse_transformer.hpp
+++ b/include/boost/geometry/strategies/transform/inverse_transformer.hpp
@@ -16,6 +16,9 @@
 
 // Remove the ublas checking, otherwise the inverse might fail
 // (while nothing seems to be wrong)
+#ifdef BOOST_UBLAS_TYPE_CHECK
+#undef BOOST_UBLAS_TYPE_CHECK
+#endif
 #define BOOST_UBLAS_TYPE_CHECK 0
 
 #include <boost/numeric/ublas/lu.hpp>

--- a/include/boost/geometry/strategies/transform/matrix_transformers.hpp
+++ b/include/boost/geometry/strategies/transform/matrix_transformers.hpp
@@ -24,6 +24,9 @@
 
 // Remove the ublas checking, otherwise the inverse might fail
 // (while nothing seems to be wrong)
+#ifdef BOOST_UBLAS_TYPE_CHECK
+#undef BOOST_UBLAS_TYPE_CHECK
+#endif
 #define BOOST_UBLAS_TYPE_CHECK 0
 
 #include <boost/numeric/conversion/cast.hpp>


### PR DESCRIPTION
This macro is also defined in boost/numeric/ublas/detail/config.hpp.

I assume that this is the behaviour you want, rather than checking the previous value?
