### PR TITLE
[algorithms][intersection] Fixes liang_barsky for integral data

### DIFF
--- a/include/boost/geometry/algorithms/detail/overlay/clip_linestring.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/clip_linestring.hpp
@@ -51,14 +51,14 @@ class liang_barsky
 private:
     typedef model::referring_segment<Point> segment_type;
 
-    template <typename T>
-    inline bool check_edge(T const& p, T const& q, T& t1, T& t2) const
+    template <typename PointType, typename CalcType>
+    inline bool check_edge(PointType const& p, PointType const& q, CalcType& t1, CalcType& t2) const
     {
         bool visible = true;
 
         if(p < 0)
         {
-            T const r = q / p;
+            CalcType const r = static_cast<CalcType>(q) / p;
             if (r > t2)
                 visible = false;
             else if (r > t1)
@@ -66,7 +66,7 @@ private:
         }
         else if(p > 0)
         {
-            T const r = q / p;
+            CalcType const r = static_cast<CalcType>(q) / p;
             if (r < t1)
                 visible = false;
             else if (r < t2)
@@ -86,9 +86,10 @@ public:
     inline bool clip_segment(Box const& b, segment_type& s, bool& sp1_clipped, bool& sp2_clipped) const
     {
         typedef typename select_coordinate_type<Box, Point>::type coordinate_type;
+        typedef double calc_type;
 
-        coordinate_type t1 = 0;
-        coordinate_type t2 = 1;
+        calc_type t1 = 0;
+        calc_type t2 = 1;
 
         coordinate_type const dx = get<1, 0>(s) - get<0, 0>(s);
         coordinate_type const dy = get<1, 1>(s) - get<0, 1>(s);

--- a/include/boost/geometry/algorithms/detail/overlay/clip_linestring.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/clip_linestring.hpp
@@ -51,8 +51,8 @@ class liang_barsky
 private:
     typedef model::referring_segment<Point> segment_type;
 
-    template <typename PointType, typename CalcType>
-    inline bool check_edge(PointType const& p, PointType const& q, CalcType& t1, CalcType& t2) const
+    template <typename CoordinateType, typename CalcType>
+    inline bool check_edge(CoordinateType const& p, CoordinateType const& q, CalcType& t1, CalcType& t2) const
     {
         bool visible = true;
 
@@ -86,7 +86,7 @@ public:
     inline bool clip_segment(Box const& b, segment_type& s, bool& sp1_clipped, bool& sp2_clipped) const
     {
         typedef typename select_coordinate_type<Box, Point>::type coordinate_type;
-        typedef double calc_type;
+        typedef typename select_most_precise<coordinate_type, double>::type calc_type;
 
         calc_type t1 = 0;
         calc_type t2 = 1;


### PR DESCRIPTION
I've noticed that `bg::intersection` fails to produce correct results when the input geometry and clipping box use integral types for coordinates.

The reduced testcase at https://github.com/springmeyer/boost-geometry-line-clipping-testcase/blob/master/bg-testcase.cpp produces this result with current boost geometry:

```
LINESTRING(-10 0,10 0)
LINESTRING(-20 0)
```

And produces the correct results (they should be the same) with the fix:

```
LINESTRING(-10 0,10 0)
LINESTRING(-10 0,10 0)
```

Per https://github.com/mapbox/mapnik-vector-tile/pull/102 I found and have been using a workaround for this problem: using `linear_ring` as the clipping shape which invokes a different code path entirely.

This is my first time contributing to `boost::geometry` so let me know if you'd like this report somewhere else or any other things I can do to help. I presume that clipping a polygon with a `box` instead of a `linear_ring` will be slightly faster?