### PR TITLE
Fix assertion failure in distance(Pt, Box) for NaN coordinates

### DIFF
--- a/include/boost/geometry/algorithms/detail/distance/segment_to_box.hpp
+++ b/include/boost/geometry/algorithms/detail/distance/segment_to_box.hpp
@@ -562,11 +562,12 @@ private:
 
         // assert that the segment has non-negative slope
         BOOST_GEOMETRY_ASSERT( ( math::equals(geometry::get<0>(p0), geometry::get<0>(p1))
-                        && geometry::get<1>(p0) < geometry::get<1>(p1))
-                      ||
-                      ( geometry::get<0>(p0) < geometry::get<0>(p1)
-                        && geometry::get<1>(p0) <= geometry::get<1>(p1) )
-                      );
+                              && geometry::get<1>(p0) < geometry::get<1>(p1))
+                            ||
+                               ( geometry::get<0>(p0) < geometry::get<0>(p1)
+                              && geometry::get<1>(p0) <= geometry::get<1>(p1) )
+                            || geometry::has_nan_coordinate(p0)
+                            || geometry::has_nan_coordinate(p1));
 
         ReturnType result(0);
 
@@ -617,8 +618,10 @@ private:
         typedef compare_less_equal<ReturnType, false> greater_equal;
 
         // assert that the segment has negative slope
-        BOOST_GEOMETRY_ASSERT( geometry::get<0>(p0) < geometry::get<0>(p1)
-                      && geometry::get<1>(p0) > geometry::get<1>(p1) );
+        BOOST_GEOMETRY_ASSERT( ( geometry::get<0>(p0) < geometry::get<0>(p1)
+                              && geometry::get<1>(p0) > geometry::get<1>(p1) )
+                            || geometry::has_nan_coordinate(p0)
+                            || geometry::has_nan_coordinate(p1) );
 
         ReturnType result(0);
 
@@ -665,7 +668,9 @@ public:
                                    PPStrategy const& pp_strategy,
                                    PSStrategy const& ps_strategy)
     {
-        BOOST_GEOMETRY_ASSERT( geometry::less<SegmentPoint>()(p0, p1) );
+        BOOST_GEOMETRY_ASSERT( geometry::less<SegmentPoint>()(p0, p1)
+                            || geometry::has_nan_coordinate(p0)
+                            || geometry::has_nan_coordinate(p1) );
 
         if (geometry::get<0>(p0) < geometry::get<0>(p1)
             && geometry::get<1>(p0) > geometry::get<1>(p1))

--- a/test/algorithms/distance/distance_pointlike_linear.cpp
+++ b/test/algorithms/distance/distance_pointlike_linear.cpp
@@ -226,6 +226,19 @@ void test_distance_multipoint_multilinestring(Strategy const& strategy)
     tester::apply("multipoint(0 0,1 0,0 1,1 1)",
                   "multilinestring((4 4,5 5),(),(3 3))",
                   sqrt(8.0), 8, strategy);
+
+	// 21890717 - assertion failure in distance(Pt, Box)
+	{
+		multi_point_type mpt;
+		bg::read_wkt("multipoint(1 1,1 1,1 1,1 1,1 1,1 1,1 1,1 1,1 1)", mpt);
+		multi_linestring_type mls;
+		linestring_type ls;
+		point_type pt(std::numeric_limits<double>::quiet_NaN(), 1.0);
+		ls.push_back(pt);
+		ls.push_back(pt);
+		mls.push_back(ls);
+		bg::distance(mpt, mls);
+	}
 }
 
 //===========================================================================


### PR DESCRIPTION
If there are NaN coordinates the assertions in distance(Pt, Box) cannot be reasonably checked, therefore this PR changes the conditions so if the original condition isn't met an additional check is performed if NaN coordinates were not involved. This is consistent with the general policy WRT invalid geometries, the algorithm doesn't fail but may generate invalid result.