### PR TITLE
Fix special case of intersects(Segment, Box)

### DIFF
--- a/include/boost/geometry/algorithms/detail/disjoint/segment_box.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/segment_box.hpp
@@ -128,7 +128,9 @@ struct disjoint_segment_box_impl
                   && t_min.first > ti_max)
                  ||
                  (geometry::math::equals(t_max.second, 0)
-                  && t_max.first < ti_min) )
+                  && t_max.first < ti_min)
+                 ||
+                 (math::sign(ti_min) * math::sign(ti_max) > 0) )
             {
                 return true;
             }
@@ -197,6 +199,11 @@ struct disjoint_segment_box_impl
         {
             if ( geometry::math::equals(t_min.first, 0) ) { t_min.first = -1; }
             if ( geometry::math::equals(t_max.first, 0) ) { t_max.first = 1; }
+
+            if (math::sign(t_min.first) * math::sign(t_max.first) > 0)
+            {
+                return true;
+            }
         }
 
         if ( t_min.first > diff || t_max.first < 0 )

--- a/test/algorithms/relational_operations/intersects/intersects_box_geometry.cpp
+++ b/test/algorithms/relational_operations/intersects/intersects_box_geometry.cpp
@@ -83,9 +83,16 @@ void test_additional()
 
     // http://stackoverflow.com/questions/32457920/boost-rtree-of-box-gives-wrong-intersection-with-segment
     // http://lists.boost.org/geometry/2015/09/3476.php
-    // For now disabled by default even though it works properly on MSVC14
-    // it's probable that the result depends on the compiler
-#ifdef BOOST_GEOMETRY_ENABLE_FAILING_TESTS
+    typedef bg::model::point<typename bg::coordinate_type<P>::type, 3, bg::cs::cartesian> point3d_t;
+    test_geometry<bg::model::segment<point3d_t>, bg::model::box<point3d_t> >(
+        "SEGMENT(2 1 0,2 1 10)",
+        "BOX(0 0 0,10 0 10)",
+        false);
+    test_geometry<bg::model::segment<point3d_t>, bg::model::box<point3d_t> >(
+        "SEGMENT(2 1 0,2 1 10)",
+        "BOX(0 -5 0,10 0 10)",
+        false);
+    // and derived from the cases above
     test_geometry<bg::model::segment<P>, bg::model::box<P> >(
         "SEGMENT(12 0,20 10)",
         "BOX(0 0,10 10)",
@@ -98,12 +105,46 @@ void test_additional()
         "SEGMENT(2 0,18 8)",
         "BOX(0 0,10 10)",
         true);
-    typedef bg::model::point<typename bg::coordinate_type<P>::type, 3, bg::cs::cartesian> point3d_t;
-    test_geometry<bg::model::segment<point3d_t>, bg::model::box<point3d_t> >(
-        "SEGMENT(2 1 0,2 1 10)",
-        "BOX(0 0 0,10 0 10)",
+    test_geometry<bg::model::segment<P>, bg::model::box<P> >(
+        "SEGMENT(1 0,1 10)",
+        "BOX(0 0,0 10)",
         false);
-#endif
+    test_geometry<bg::model::segment<P>, bg::model::box<P> >(
+        "SEGMENT(-1 0,-1 10)",
+        "BOX(0 0,0 10)",
+        false);
+    test_geometry<bg::model::segment<P>, bg::model::box<P> >(
+        "SEGMENT(2 1,2 1)",
+        "BOX(0 0,10 0)",
+        false);
+    test_geometry<bg::model::segment<P>, bg::model::box<P> >(
+        "SEGMENT(2 3,2 3)",
+        "BOX(0 0,10 0)",
+        false);
+    test_geometry<bg::model::segment<P>, bg::model::box<P> >(
+        "SEGMENT(0 0,10 0)",
+        "BOX(0 0,10 0)",
+        true);
+    test_geometry<bg::model::segment<P>, bg::model::box<P> >(
+        "SEGMENT(10 0,10 0)",
+        "BOX(0 0,10 0)",
+        true);
+    test_geometry<bg::model::segment<P>, bg::model::box<P> >(
+        "SEGMENT(1 0,1 0)",
+        "BOX(0 0,10 0)",
+        true);
+    test_geometry<bg::model::segment<P>, bg::model::box<P> >(
+        "SEGMENT(0 0,0 10)",
+        "BOX(0 0,0 10)",
+        true);
+    test_geometry<bg::model::segment<P>, bg::model::box<P> >(
+        "SEGMENT(0 10,0 10)",
+        "BOX(0 0,0 10)",
+        true);
+    test_geometry<bg::model::segment<P>, bg::model::box<P> >(
+        "SEGMENT(0 1,0 1)",
+        "BOX(0 0,0 10)",
+        true);
 }
 
 


### PR DESCRIPTION
In a special case when the difference between points' coordinates of a Segment is 0 and the Segment is disjoint the functio returns wrong result. E.g. for:

    SEGMENT(2 1 0,2 1 10)
    BOX(0 0 0,10 0 10)

See also:
http://stackoverflow.com/questions/32457920/boost-rtree-of-box-gives-wrong-intersection-with-segment