### PR TITLE
Boost.Trac tickets 11709 and 11710

### DIFF
--- a/include/boost/geometry/algorithms/detail/is_simple/areal.hpp
+++ b/include/boost/geometry/algorithms/detail/is_simple/areal.hpp
@@ -40,11 +40,11 @@ struct is_simple_ring
     static inline bool apply(Ring const& ring)
     {
         simplicity_failure_policy policy;
-        return
-            !detail::is_valid::has_duplicates
-                <
-                    Ring, geometry::closure<Ring>::value
-                >::apply(ring, policy);
+        return ! boost::empty(ring)
+            && ! detail::is_valid::has_duplicates
+                    <
+                        Ring, geometry::closure<Ring>::value
+                    >::apply(ring, policy);
     }
 };
 
@@ -128,7 +128,7 @@ struct is_simple<MultiPolygon, multi_polygon_tag>
                         <
                             typename boost::range_value<MultiPolygon>::type
                         >,
-                    false // do not allow empty multi-polygon
+                    true // allow empty multi-polygon
                 >::apply(boost::begin(multipolygon), boost::end(multipolygon));
     }
 };

--- a/include/boost/geometry/algorithms/detail/is_simple/linear.hpp
+++ b/include/boost/geometry/algorithms/detail/is_simple/linear.hpp
@@ -235,7 +235,8 @@ struct is_simple_linestring
     static inline bool apply(Linestring const& linestring)
     {
         simplicity_failure_policy policy;
-        return ! detail::is_valid::has_duplicates
+        return ! boost::empty(linestring)
+            && ! detail::is_valid::has_duplicates
                     <
                         Linestring, closed
                     >::apply(linestring, policy)
@@ -263,7 +264,7 @@ struct is_simple_multilinestring
                              typename boost::range_value<MultiLinestring>::type,
                              false // do not compute self-intersections
                          >,
-                     false // do not allow empty multilinestring
+                     true // allow empty multilinestring
                  >::apply(boost::begin(multilinestring),
                           boost::end(multilinestring))
              )

--- a/include/boost/geometry/algorithms/detail/is_simple/multipoint.hpp
+++ b/include/boost/geometry/algorithms/detail/is_simple/multipoint.hpp
@@ -40,9 +40,9 @@ struct is_simple_multipoint
 {
     static inline bool apply(MultiPoint const& multipoint)
     {
-        if ( boost::size(multipoint) == 0 )
+        if (boost::empty(multipoint))
         {
-            return false;
+            return true;
         }
 
         MultiPoint mp(multipoint);

--- a/test/algorithms/is_simple.cpp
+++ b/test/algorithms/is_simple.cpp
@@ -64,14 +64,15 @@ typedef bg::model::box<point_type>                      box_type;
 
 
 template <typename Geometry>
-void test_simple(Geometry const& geometry, bool expected_result)
+void test_simple(Geometry const& geometry, bool expected_result,
+                 bool check_validity = true)
 {
 #ifdef BOOST_GEOMETRY_TEST_DEBUG
     std::cout << "=======" << std::endl;
 #endif
 
     bool simple = bg::is_simple(geometry);
-    BOOST_ASSERT( bg::is_valid(geometry) );
+    BOOST_ASSERT( ! check_validity || bg::is_valid(geometry) );
     BOOST_CHECK_MESSAGE( simple == expected_result,
         "Expected: " << expected_result
         << " detected: " << simple
@@ -122,6 +123,9 @@ BOOST_AUTO_TEST_CASE( test_is_simple_multipoint )
     test_simple(from_wkt<G>("MULTIPOINT(0 0)"), true);
     test_simple(from_wkt<G>("MULTIPOINT(0 0,1 0,1 1,0 1)"), true);
     test_simple(from_wkt<G>("MULTIPOINT(0 0,1 0,1 1,1 0,0 1)"), false);
+
+    // empty multipoint
+    test_simple(from_wkt<G>("MULTIPOINT()"), true);
 }
 
 BOOST_AUTO_TEST_CASE( test_is_simple_segment )
@@ -191,6 +195,11 @@ BOOST_AUTO_TEST_CASE( test_is_simple_linestring )
                 false);
     test_simple(from_wkt<G>("LINESTRING(10 3,10 5,4 1,4 6,10 8,4 1)"),
                 false);
+
+    // empty linestring
+    // the simplicity result is irrelevant since an empty linestring
+    // is considered as invalid
+    test_simple(from_wkt<G>("LINESTRING()"), false, false);
 }
 
 BOOST_AUTO_TEST_CASE( test_is_simple_multilinestring )
@@ -271,6 +280,9 @@ BOOST_AUTO_TEST_CASE( test_is_simple_multilinestring )
                 false);
     test_simple(from_wkt<G>("MULTILINESTRING((10 3,10 5,4 1,4 6,10 8,4 1))"),
                 false);
+
+    // empty multilinestring
+    test_simple(from_wkt<G>("MULTILINESTRING()"), true);
 }
 
 BOOST_AUTO_TEST_CASE( test_is_simple_areal )
@@ -295,6 +307,14 @@ BOOST_AUTO_TEST_CASE( test_is_simple_areal )
                 false);
     test_simple(from_wkt<mpl>("MULTIPOLYGON(((0 0,1 0,1 1,1 1)),((10 0,20 0,20 0,20 10,10 10)))"),
                 false);
+
+    // empty polygon
+    // the simplicity result is irrelevant since an empty polygon
+    // is considered as invalid
+    test_simple(from_wkt<o_ccw_p>("POLYGON(())"), false, false);
+
+    // empty multipolygon
+    test_simple(from_wkt<mpl>("MULTIPOLYGON()"), true);
 }
 
 BOOST_AUTO_TEST_CASE( test_geometry_with_NaN_coordinates )
@@ -315,7 +335,7 @@ BOOST_AUTO_TEST_CASE( test_geometry_with_NaN_coordinates )
     multi_linestring_type mls;
     bg::intersection(ls1, ls2, mls);
 
-    test_simple(mls, true);
+    test_simple(mls, true, false);
 }
 
 BOOST_AUTO_TEST_CASE( test_is_simple_variant )


### PR DESCRIPTION
This PR addresses two Boost.Trac tickets: [11709](https://svn.boost.org/trac/boost/ticket/11709) and [11710](https://svn.boost.org/trac/boost/ticket/11710).

###### Ticket [11709](https://svn.boost.org/trac/boost/ticket/11709)
`bg::is_simple()` segfaults if given an empty linestring. In this PR the linestring is first checked for emptiness (before any further computations are performed) and `false` is returned is the linestring is found to be empty. Notice that the actual return value does not really matter, as empty linestrings are considered invalid, which means that the behavior of `bg::is_simple()` is undefined for them (the same holds actually for any BG algorithm operating on invalid input).

###### Ticket [11710](https://svn.boost.org/trac/boost/ticket/11710)

`bg::is_simple()` used to return `false` for empty multi-geometries. This was inconsistent with the behavior of `bg::is_valid()` which accepts empty multi-geometries as valid. In this PR we change this behavior and `bg::is_simple()` returns `true` for empty multi-geometries.