### PR TITLE
Boost.Trac ticket 11711

### DIFF
--- a/include/boost/geometry/algorithms/detail/is_valid/box.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/box.hpp
@@ -20,6 +20,7 @@
 #include <boost/geometry/core/coordinate_dimension.hpp>
 
 #include <boost/geometry/algorithms/validity_failure_type.hpp>
+#include <boost/geometry/algorithms/detail/is_valid/has_invalid_coordinate.hpp>
 #include <boost/geometry/algorithms/dispatch/is_valid.hpp>
 
 
@@ -66,6 +67,20 @@ struct has_valid_corners<Box, 0>
     }
 };
 
+
+template <typename Box>
+struct is_valid_box
+{
+    template <typename VisitPolicy>
+    static inline bool apply(Box const& box, VisitPolicy& visitor)
+    {
+        return
+            ! has_invalid_coordinate<Box>::apply(box, visitor)
+            &&
+            has_valid_corners<Box, dimension<Box>::value>::apply(box, visitor);
+    }
+};
+
 }} // namespace detail::is_valid
 #endif // DOXYGEN_NO_DETAIL
 
@@ -85,7 +100,7 @@ namespace dispatch
 // Reference (for polygon validity): OGC 06-103r4 (6.1.11.1)
 template <typename Box>
 struct is_valid<Box, box_tag>
-    : detail::is_valid::has_valid_corners<Box, dimension<Box>::value>
+    : detail::is_valid::is_valid_box<Box>
 {};
 
 

--- a/include/boost/geometry/algorithms/detail/is_valid/has_invalid_coordinate.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/has_invalid_coordinate.hpp
@@ -1,0 +1,154 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2014-2015, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+#ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_IS_VALID_HAS_INVALID_COORDINATE_HPP
+#define BOOST_GEOMETRY_ALGORITHMS_DETAIL_IS_VALID_HAS_INVALID_COORDINATE_HPP
+
+#include <cstddef>
+
+#include <boost/type_traits/is_floating_point.hpp>
+
+#include <boost/geometry/core/coordinate_type.hpp>
+#include <boost/geometry/core/point_type.hpp>
+
+#include <boost/geometry/util/has_nan_coordinate.hpp>
+#include <boost/geometry/util/has_infinite_coordinate.hpp>
+
+#include <boost/geometry/iterators/point_iterator.hpp>
+#include <boost/geometry/views/detail/indexed_point_view.hpp>
+#include <boost/geometry/algorithms/detail/check_iterator_range.hpp>
+
+
+namespace boost { namespace geometry
+{
+    
+#ifndef DOXYGEN_NO_DETAIL
+namespace detail { namespace is_valid
+{
+
+struct always_valid
+{
+    template <typename Geometry, typename VisitPolicy>
+    static inline bool apply(Geometry const&, VisitPolicy& visitor)
+    {
+        return ! visitor.template apply<no_failure>();
+    }
+};
+
+struct point_has_invalid_coordinate
+{
+    template <typename Point, typename VisitPolicy>
+    static inline bool apply(Point const& point, VisitPolicy& visitor)
+    {
+        boost::ignore_unused(visitor);
+
+        return
+            (geometry::has_nan_coordinate(point)
+             || geometry::has_infinite_coordinate(point))
+            ?
+            (! visitor.template apply<failure_invalid_coordinate>())
+            :
+            (! visitor.template apply<no_failure>());
+    }
+
+    template <typename Point>
+    static inline bool apply(Point const& point)
+    {
+        return geometry::has_nan_coordinate(point)
+            || geometry::has_infinite_coordinate(point);
+    }
+};
+
+struct indexed_has_invalid_coordinate
+{
+    template <typename Geometry, typename VisitPolicy>
+    static inline bool apply(Geometry const& geometry, VisitPolicy& visitor)
+    {
+        geometry::detail::indexed_point_view<Geometry const, 0> p0(geometry);
+        geometry::detail::indexed_point_view<Geometry const, 1> p1(geometry);
+
+        return point_has_invalid_coordinate::apply(p0, visitor)
+            || point_has_invalid_coordinate::apply(p1, visitor);
+    }
+};
+
+
+struct range_has_invalid_coordinate
+{
+    struct point_has_valid_coordinates
+    {
+        template <typename Point>
+        static inline bool apply(Point const& point)
+        {
+            return ! point_has_invalid_coordinate::apply(point);
+        }
+    };
+
+    template <typename Geometry, typename VisitPolicy>
+    static inline bool apply(Geometry const& geometry, VisitPolicy& visitor)
+    {
+        boost::ignore_unused(visitor);
+
+        bool const has_valid_coordinates = detail::check_iterator_range
+            <
+                point_has_valid_coordinates,
+                true // do not consider an empty range as problematic
+            >::apply(geometry::points_begin(geometry),
+                     geometry::points_end(geometry));
+
+        return has_valid_coordinates
+            ?
+            (! visitor.template apply<no_failure>())
+            :
+            (! visitor.template apply<failure_invalid_coordinate>());
+    }
+};
+
+
+template
+<
+    typename Geometry,
+    typename Tag = typename tag<Geometry>::type,
+    bool HasFloatingPointCoordinates = boost::is_floating_point
+        <
+            typename coordinate_type<Geometry>::type
+        >::value
+>
+struct has_invalid_coordinate
+    : range_has_invalid_coordinate
+{};
+
+template <typename Geometry, typename Tag>
+struct has_invalid_coordinate<Geometry, Tag, false>
+    : always_valid
+{};
+
+template <typename Point>
+struct has_invalid_coordinate<Point, point_tag, true>
+    : point_has_invalid_coordinate
+{};
+
+template <typename Segment>
+struct has_invalid_coordinate<Segment, segment_tag, true>
+    : indexed_has_invalid_coordinate
+{};
+
+template <typename Box>
+struct has_invalid_coordinate<Box, box_tag, true>
+    : indexed_has_invalid_coordinate
+{};
+
+
+}} // namespace detail::is_valid
+#endif // DOXYGEN_NO_DETAIL
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_IS_VALID_HAS_INVALID_COORDINATE_HPP

--- a/include/boost/geometry/algorithms/detail/is_valid/has_invalid_coordinate.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/has_invalid_coordinate.hpp
@@ -18,8 +18,7 @@
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/point_type.hpp>
 
-#include <boost/geometry/util/has_nan_coordinate.hpp>
-#include <boost/geometry/util/has_infinite_coordinate.hpp>
+#include <boost/geometry/util/has_non_finite_coordinate.hpp>
 
 #include <boost/geometry/iterators/point_iterator.hpp>
 #include <boost/geometry/views/detail/indexed_point_view.hpp>
@@ -50,8 +49,7 @@ struct point_has_invalid_coordinate
         boost::ignore_unused(visitor);
 
         return
-            (geometry::has_nan_coordinate(point)
-             || geometry::has_infinite_coordinate(point))
+            geometry::has_non_finite_coordinate(point)
             ?
             (! visitor.template apply<failure_invalid_coordinate>())
             :
@@ -61,8 +59,7 @@ struct point_has_invalid_coordinate
     template <typename Point>
     static inline bool apply(Point const& point)
     {
-        return geometry::has_nan_coordinate(point)
-            || geometry::has_infinite_coordinate(point);
+        return geometry::has_non_finite_coordinate(point);
     }
 };
 

--- a/include/boost/geometry/algorithms/detail/is_valid/linear.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/linear.hpp
@@ -25,6 +25,7 @@
 #include <boost/geometry/algorithms/equals.hpp>
 #include <boost/geometry/algorithms/validity_failure_type.hpp>
 #include <boost/geometry/algorithms/detail/check_iterator_range.hpp>
+#include <boost/geometry/algorithms/detail/is_valid/has_invalid_coordinate.hpp>
 #include <boost/geometry/algorithms/detail/is_valid/has_spikes.hpp>
 #include <boost/geometry/algorithms/detail/num_distinct_consecutive_points.hpp>
 
@@ -46,6 +47,11 @@ struct is_valid_linestring
     static inline bool apply(Linestring const& linestring,
                              VisitPolicy& visitor)
     {
+        if (has_invalid_coordinate<Linestring>::apply(linestring, visitor))
+        {
+            return false;
+        }
+
         if (boost::size(linestring) < 2)
         {
             return visitor.template apply<failure_few_points>();

--- a/include/boost/geometry/algorithms/detail/is_valid/pointlike.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/pointlike.hpp
@@ -17,6 +17,7 @@
 #include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/algorithms/validity_failure_type.hpp>
+#include <boost/geometry/algorithms/detail/is_valid/has_invalid_coordinate.hpp>
 #include <boost/geometry/algorithms/dispatch/is_valid.hpp>
 
 #include <boost/geometry/util/condition.hpp>
@@ -36,10 +37,13 @@ template <typename Point>
 struct is_valid<Point, point_tag>
 {
     template <typename VisitPolicy>
-    static inline bool apply(Point const&, VisitPolicy& visitor)
+    static inline bool apply(Point const& point, VisitPolicy& visitor)
     {
         boost::ignore_unused(visitor);
-        return visitor.template apply<no_failure>();
+        return ! detail::is_valid::has_invalid_coordinate
+            <
+                Point
+            >::apply(point, visitor);
     }
 };
 
@@ -63,7 +67,10 @@ struct is_valid<MultiPoint, multi_point_tag, AllowEmptyMultiGeometries>
         {
             // we allow empty multi-geometries, so an empty multipoint
             // is considered valid
-            return visitor.template apply<no_failure>();
+            return ! detail::is_valid::has_invalid_coordinate
+                <
+                    MultiPoint
+                >::apply(multipoint, visitor);
         }
         else
         {

--- a/include/boost/geometry/algorithms/detail/is_valid/ring.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/ring.hpp
@@ -30,8 +30,9 @@
 #include <boost/geometry/algorithms/intersects.hpp>
 #include <boost/geometry/algorithms/validity_failure_type.hpp>
 #include <boost/geometry/algorithms/detail/num_distinct_consecutive_points.hpp>
-#include <boost/geometry/algorithms/detail/is_valid/has_spikes.hpp>
 #include <boost/geometry/algorithms/detail/is_valid/has_duplicates.hpp>
+#include <boost/geometry/algorithms/detail/is_valid/has_invalid_coordinate.hpp>
+#include <boost/geometry/algorithms/detail/is_valid/has_spikes.hpp>
 #include <boost/geometry/algorithms/detail/is_valid/has_valid_self_turns.hpp>
 
 #include <boost/geometry/strategies/area.hpp>
@@ -153,17 +154,23 @@ struct is_valid_ring
     static inline bool apply(Ring const& ring, VisitPolicy& visitor)
     {
         // return invalid if any of the following condition holds:
-        // (a) the ring's size is below the minimal one
-        // (b) the ring consists of at most two distinct points
-        // (c) the ring is not topologically closed
-        // (d) the ring has spikes
-        // (e) the ring has duplicate points (if AllowDuplicates is false)
-        // (f) the boundary of the ring has self-intersections
-        // (g) the order of the points is inconsistent with the defined order
+        // (a) the ring's point coordinates are not invalid (e.g., NaN)
+        // (b) the ring's size is below the minimal one
+        // (c) the ring consists of at most two distinct points
+        // (d) the ring is not topologically closed
+        // (e) the ring has spikes
+        // (f) the ring has duplicate points (if AllowDuplicates is false)
+        // (g) the boundary of the ring has self-intersections
+        // (h) the order of the points is inconsistent with the defined order
         //
         // Note: no need to check if the area is zero. If this is the
         // case, then the ring must have at least two spikes, which is
-        // checked by condition (c).
+        // checked by condition (d).
+
+        if (has_invalid_coordinate<Ring>::apply(ring, visitor))
+        {
+            return false;
+        }
 
         closure_selector const closure = geometry::closure<Ring>::value;
         typedef typename closeable_view<Ring const, closure>::type view_type;

--- a/include/boost/geometry/algorithms/detail/is_valid/segment.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/segment.hpp
@@ -19,7 +19,7 @@
 #include <boost/geometry/algorithms/assign.hpp>
 #include <boost/geometry/algorithms/equals.hpp>
 #include <boost/geometry/algorithms/validity_failure_type.hpp>
-
+#include <boost/geometry/algorithms/detail/is_valid/has_invalid_coordinate.hpp>
 #include <boost/geometry/algorithms/dispatch/is_valid.hpp>
 
 
@@ -53,7 +53,14 @@ struct is_valid<Segment, segment_tag>
         detail::assign_point_from_index<0>(segment, p[0]);
         detail::assign_point_from_index<1>(segment, p[1]);
 
-        if(! geometry::equals(p[0], p[1]))
+        if (detail::is_valid::has_invalid_coordinate
+                <
+                    Segment
+                >::apply(segment, visitor))
+        {
+            return false;
+        }
+        else if (! geometry::equals(p[0], p[1]))
         {
             return visitor.template apply<no_failure>();
         }

--- a/include/boost/geometry/algorithms/validity_failure_type.hpp
+++ b/include/boost/geometry/algorithms/validity_failure_type.hpp
@@ -78,7 +78,10 @@ enum validity_failure_type
     /// The top-right corner of the box is lexicographically smaller
     /// than its bottom-left corner
     /// (applies to boxes only)
-    failure_wrong_corner_order = 50 // for boxes
+    failure_wrong_corner_order = 50, // for boxes
+    /// The geometry has at least one point with an invalid coordinate
+    /// (for example, the coordinate is a NaN)
+    failure_invalid_coordinate = 60
 };
 
 

--- a/include/boost/geometry/policies/is_valid/failing_reason_policy.hpp
+++ b/include/boost/geometry/policies/is_valid/failing_reason_policy.hpp
@@ -54,6 +54,8 @@ inline char const* validity_failure_type_message(validity_failure_type failure)
         return "Geometry has duplicate (consecutive) points";
     case failure_wrong_corner_order:
         return "Box has corners in wrong order";
+    case failure_invalid_coordinate:
+        return "Geometry has point(s) with invalid coordinate(s)";
     default: // to avoid -Wreturn-type warning
         return "";
     }

--- a/include/boost/geometry/util/has_infinite_coordinate.hpp
+++ b/include/boost/geometry/util/has_infinite_coordinate.hpp
@@ -1,0 +1,53 @@
+// Boost.Geometry
+
+// Copyright (c) 2015 Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_UTIL_HAS_INFINITE_COORDINATE_HPP
+#define BOOST_GEOMETRY_UTIL_HAS_INFINITE_COORDINATE_HPP
+
+#include <boost/type_traits/is_floating_point.hpp>
+
+#include <boost/geometry/core/coordinate_type.hpp>
+#include <boost/geometry/util/has_nan_coordinate.hpp>
+#include <boost/math/special_functions/fpclassify.hpp>
+
+namespace boost { namespace geometry {
+    
+#ifndef DOXYGEN_NO_DETAIL
+namespace detail {
+
+struct isinf
+{
+    template <typename T>
+    static inline bool apply(T const& t)
+    {
+        return boost::math::isinf(t);
+    }
+};
+
+} // namespace detail
+#endif // DOXYGEN_NO_DETAIL
+
+template <typename Point>
+bool has_infinite_coordinate(Point const& point)
+{
+    return detail::has_coordinate_with_property
+        <
+            Point,
+            detail::isinf,
+            boost::is_floating_point
+                <
+                    typename coordinate_type<Point>::type
+                >::value
+        >::apply(point);
+}
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_UTIL_HAS_INFINITE_COORDINATE_HPP

--- a/include/boost/geometry/util/has_infinite_coordinate.hpp
+++ b/include/boost/geometry/util/has_infinite_coordinate.hpp
@@ -17,10 +17,12 @@
 #include <boost/geometry/util/has_nan_coordinate.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 
-namespace boost { namespace geometry {
+namespace boost { namespace geometry
+{
     
 #ifndef DOXYGEN_NO_DETAIL
-namespace detail {
+namespace detail
+{
 
 struct isinf
 {

--- a/include/boost/geometry/util/has_nan_coordinate.hpp
+++ b/include/boost/geometry/util/has_nan_coordinate.hpp
@@ -23,10 +23,12 @@
 #include <boost/math/special_functions/fpclassify.hpp>
 
 
-namespace boost { namespace geometry {
+namespace boost { namespace geometry
+{
     
 #ifndef DOXYGEN_NO_DETAIL
-namespace detail {
+namespace detail
+{
 
 struct isnan
 {

--- a/include/boost/geometry/util/has_nan_coordinate.hpp
+++ b/include/boost/geometry/util/has_nan_coordinate.hpp
@@ -3,6 +3,7 @@
 // Copyright (c) 2015 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -13,8 +14,11 @@
 
 #include <cstddef>
 
+#include <boost/type_traits/is_floating_point.hpp>
+
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
+#include <boost/geometry/core/coordinate_type.hpp>
 
 #include <boost/math/special_functions/fpclassify.hpp>
 
@@ -24,20 +28,46 @@ namespace boost { namespace geometry {
 #ifndef DOXYGEN_NO_DETAIL
 namespace detail {
 
-template <typename Point,
-          std::size_t I = 0,
-          std::size_t N = geometry::dimension<Point>::value>
-struct has_nan_coordinate
+struct isnan
 {
-    static bool apply(Point const& point)
+    template <typename T>
+    static inline bool apply(T const& t)
     {
-        return boost::math::isnan(geometry::get<I>(point))
-            || has_nan_coordinate<Point, I+1, N>::apply(point);
+        return boost::math::isnan(t);
     }
 };
 
-template <typename Point, std::size_t N>
-struct has_nan_coordinate<Point, N, N>
+template
+<
+    typename Point,
+    typename Predicate,
+    bool Enable,
+    std::size_t I = 0,
+    std::size_t N = geometry::dimension<Point>::value
+>
+struct has_coordinate_with_property
+{
+    static bool apply(Point const& point)
+    {
+        return Predicate::apply(geometry::get<I>(point))
+            || has_coordinate_with_property
+                <
+                    Point, Predicate, Enable, I+1, N
+                >::apply(point);
+    }
+};
+
+template <typename Point, typename Predicate, std::size_t I, std::size_t N>
+struct has_coordinate_with_property<Point, Predicate, false, I, N>
+{
+    static inline bool apply(Point const&)
+    {
+        return false;
+    }
+};
+
+template <typename Point, typename Predicate, std::size_t N>
+struct has_coordinate_with_property<Point, Predicate, true, N, N>
 {
     static bool apply(Point const& )
     {
@@ -51,7 +81,15 @@ struct has_nan_coordinate<Point, N, N>
 template <typename Point>
 bool has_nan_coordinate(Point const& point)
 {
-    return detail::has_nan_coordinate<Point>::apply(point);
+    return detail::has_coordinate_with_property
+        <
+            Point,
+            detail::isnan,
+            boost::is_floating_point
+                <
+                    typename coordinate_type<Point>::type
+                >::value
+        >::apply(point);
 }
 
 }} // namespace boost::geometry

--- a/include/boost/geometry/util/has_non_finite_coordinate.hpp
+++ b/include/boost/geometry/util/has_non_finite_coordinate.hpp
@@ -1,0 +1,55 @@
+// Boost.Geometry
+
+// Copyright (c) 2015 Oracle and/or its affiliates.
+
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_UTIL_HAS_NON_FINITE_COORDINATE_HPP
+#define BOOST_GEOMETRY_UTIL_HAS_NON_FINITE_COORDINATE_HPP
+
+#include <boost/type_traits/is_floating_point.hpp>
+
+#include <boost/geometry/core/coordinate_type.hpp>
+#include <boost/geometry/util/has_nan_coordinate.hpp>
+#include <boost/math/special_functions/fpclassify.hpp>
+
+namespace boost { namespace geometry
+{
+    
+#ifndef DOXYGEN_NO_DETAIL
+namespace detail
+{
+
+struct is_not_finite
+{
+    template <typename T>
+    static inline bool apply(T const& t)
+    {
+        return ! boost::math::isfinite(t);
+    }
+};
+
+} // namespace detail
+#endif // DOXYGEN_NO_DETAIL
+
+template <typename Point>
+bool has_non_finite_coordinate(Point const& point)
+{
+    return detail::has_coordinate_with_property
+        <
+            Point,
+            detail::is_not_finite,
+            boost::is_floating_point
+                <
+                    typename coordinate_type<Point>::type
+                >::value
+        >::apply(point);
+}
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_UTIL_HAS_NON_FINITE_COORDINATE_HPP


### PR DESCRIPTION
This PR partially addresses Boost.Trac ticket [11711](https://svn.boost.org/trac/boost/ticket/11711): "is_simple and is_valid - Points that are NaN or Infinity".

**Problem:** The problem with the existing `bg::is_valid()` implementation is that it may not handle properly geometries that have invalid floating-point coordinates, namely coordinates that are NaN or infinite. For such geometries `bg::is_valid()` may return `true`, which should not be the case.

**Fix:** In this PR the coordinates of a geometry whose coordinate type is a fundamental floating-point number are checked. If at least one coordinate is found to be NaN or infinite, the geometry is considered as invalid.
Note that for non-fundamental number types or fundamental non-floating-point types the check is essentially deactivated: fundamental non-floating-point types cannot have NaN or infinite values, whereas for non-fundamental number types a mechanism similar to `std::numeric_limits<>` needs to be present to perform similar checks (and such a mechanism is not present currently).

**is_simple:** The Boost.Trac ticket asks for `bg::is_simple()` to return `false` for geometries that have invalid coordinates. This is not implemented in this PR. As it is the case with almost all BG algorithms (the only exception is `bg::is_valid()`) the geometric input is assumed to be valid, and validity of the input is not checked internally in the algorithm. According to this rule, `bg::is_simple()` should not check for invalid coordinates as suggested in the Boost.Trac ticket; when called with an invalid geometry as input (as it is the case in the ticket) the behavior of `bg::is_simple()` is simply undefined.