### PR TITLE
[algorithms][centroid] Fix crash when multi-geometry contains empty geometry

### DIFF
--- a/include/boost/geometry/algorithms/centroid.hpp
+++ b/include/boost/geometry/algorithms/centroid.hpp
@@ -220,19 +220,22 @@ struct centroid_range_state
         iterator_type it = boost::begin(view);
         iterator_type end = boost::end(view);
 
-        typename PointTransformer::result_type
-            previous_pt = transformer.apply(*it);
-
-        for ( ++it ; it != end ; ++it)
+        if (it != end)
         {
             typename PointTransformer::result_type
-                pt = transformer.apply(*it);
+                previous_pt = transformer.apply(*it);
 
-            strategy.apply(static_cast<point_type const&>(previous_pt),
-                           static_cast<point_type const&>(pt),
-                           state);
-            
-            previous_pt = pt;
+            for ( ++it ; it != end ; ++it)
+            {
+                typename PointTransformer::result_type
+                    pt = transformer.apply(*it);
+
+                strategy.apply(static_cast<point_type const&>(previous_pt),
+                               static_cast<point_type const&>(pt),
+                               state);
+
+                previous_pt = pt;
+            }
         }
     }
 };

--- a/test/algorithms/centroid.cpp
+++ b/test/algorithms/centroid.cpp
@@ -175,6 +175,21 @@ void test_exceptions()
     test_centroid_exception<bg::model::linestring<P> >();
     test_centroid_exception<bg::model::polygon<P> >();
     test_centroid_exception<bg::model::ring<P> >();
+
+    // Empty exterior ring
+    test_centroid_exception<bg::model::polygon<P> >(
+        "POLYGON((), ())");
+    test_centroid_exception<bg::model::polygon<P> >(
+        "POLYGON((), (0 0, 1 0, 1 1, 0 1, 0 0))");
+}
+
+template <typename P>
+void test_empty()
+{
+    // Empty interior ring
+    test_centroid<bg::model::polygon<P> >(
+        "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0), ())",
+        0.5, 0.5);
 }
 
 void test_large_integers()
@@ -255,6 +270,7 @@ int test_main(int, char* [])
     test_large_doubles();
 
     test_exceptions<bg::model::d2::point_xy<double> >();
+    test_empty<bg::model::d2::point_xy<double> >();
 
     return 0;
 }

--- a/test/algorithms/centroid_multi.cpp
+++ b/test/algorithms/centroid_multi.cpp
@@ -72,6 +72,14 @@ void test_2d(bool is_integer = false)
         test_centroid<bg::model::multi_polygon<bg::model::polygon<P> > >(
             "MULTIPOLYGON(((1 1)))",
             1.0, 1.0);
+
+        test_centroid<bg::model::multi_linestring<bg::model::linestring<P> > >(
+            "MULTILINESTRING((0 0, 1 0), ())",
+            0.5, 0.0);
+
+        test_centroid<bg::model::multi_polygon<bg::model::polygon<P> > >(
+            "MULTIPOLYGON(((0 0, 1 0, 1 1, 0 1, 0 0)), (()))",
+            0.5, 0.5);
     }
 
 

--- a/test/algorithms/centroid_multi.cpp
+++ b/test/algorithms/centroid_multi.cpp
@@ -72,14 +72,6 @@ void test_2d(bool is_integer = false)
         test_centroid<bg::model::multi_polygon<bg::model::polygon<P> > >(
             "MULTIPOLYGON(((1 1)))",
             1.0, 1.0);
-
-        test_centroid<bg::model::multi_linestring<bg::model::linestring<P> > >(
-            "MULTILINESTRING((0 0, 1 0), ())",
-            0.5, 0.0);
-
-        test_centroid<bg::model::multi_polygon<bg::model::polygon<P> > >(
-            "MULTIPOLYGON(((0 0, 1 0, 1 1, 0 1, 0 0)), (()))",
-            0.5, 0.5);
     }
 
 
@@ -123,6 +115,58 @@ void test_2d(bool is_integer = false)
         424530.6059719588, 4527519.619367547);
 }
 
+template <typename P>
+void test_exceptions()
+{
+    using namespace bg::model;
+    typedef multi_polygon<polygon<P> > multi_polygon;
+    typedef multi_linestring<linestring<P> > multi_linestring;
+
+    // Empty multi-polygon
+    test_centroid_exception<multi_polygon>("MULTIPOLYGON()");
+    test_centroid_exception<multi_polygon>("MULTIPOLYGON(())");
+    test_centroid_exception<multi_polygon>("MULTIPOLYGON((), ())");
+    test_centroid_exception<multi_polygon>("MULTIPOLYGON((()), ())");
+    test_centroid_exception<multi_polygon>("MULTIPOLYGON(((), ()))");
+
+    // Empty multi-linestring
+    test_centroid_exception<multi_linestring>("MULTILINESTRING()");
+    test_centroid_exception<multi_linestring>("MULTILINESTRING(())");
+    test_centroid_exception<multi_linestring>("MULTILINESTRING((), ())");
+}
+
+template <typename P>
+void test_empty()
+{
+    using namespace bg::model;
+    typedef multi_polygon<polygon<P> > multi_polygon;
+    typedef multi_linestring<linestring<P> > multi_linestring;
+
+    // Multi-linestring with empty linestring
+    test_centroid<multi_linestring>(
+        "MULTILINESTRING((), (0 0))",
+        0.0, 0.0);
+    test_centroid<multi_linestring>(
+        "MULTILINESTRING((0 0, 1 0), ())",
+        0.5, 0.0);
+
+    // Multi-polygon with empty polygon
+    test_centroid<multi_polygon>(
+        "MULTIPOLYGON((()), ((0 0)))",
+        0.0, 0.0);
+    test_centroid<multi_polygon>(
+        "MULTIPOLYGON(((0 0, 1 0, 1 1, 0 1, 0 0)), (()))",
+        0.5, 0.5);
+
+    // Multi-polygon with empty interior ring
+    test_centroid<multi_polygon>(
+        "MULTIPOLYGON(((0 0, 1 0, 1 1, 0 1, 0 0), ()))",
+        0.5, 0.5);
+    test_centroid<multi_polygon>(
+        "MULTIPOLYGON((()), ((0 0, 1 0, 1 1, 0 1, 0 0), ()))",
+        0.5, 0.5);
+}
+
 
 
 int test_main(int, char* [])
@@ -136,6 +180,9 @@ int test_main(int, char* [])
 #ifdef HAVE_TTMATH
     test_2d<bg::model::d2::point_xy<ttmath_big> >();
 #endif
+
+    test_exceptions<bg::model::d2::point_xy<double> >();
+    test_empty<bg::model::d2::point_xy<double> >();
 
     return 0;
 }

--- a/test/algorithms/test_centroid.hpp
+++ b/test/algorithms/test_centroid.hpp
@@ -126,5 +126,21 @@ void test_centroid_exception()
     BOOST_CHECK_MESSAGE(false, "A centroid_exception should have been thrown" );
 }
 
+template <typename Geometry>
+void test_centroid_exception(std::string const& wkt)
+{
+    Geometry geometry;
+    bg::read_wkt(wkt, geometry);
+    try
+    {
+        typename bg::point_type<Geometry>::type c;
+        bg::centroid(geometry, c);
+    }
+    catch(bg::centroid_exception const& )
+    {
+        return;
+    }
+    BOOST_CHECK_MESSAGE(false, "A centroid_exception should have been thrown" );
+}
 
 #endif


### PR DESCRIPTION
Fixes seg-faulting of centroid algorithm on multi-geometries when sub-geometry is empty. Test case is included.