### PR TITLE
Fix/centroid multipolygon empty exterior ring

### DIFF
--- a/include/boost/geometry/algorithms/centroid.hpp
+++ b/include/boost/geometry/algorithms/centroid.hpp
@@ -283,9 +283,26 @@ struct centroid_polygon_state
                              typename Strategy::state_type& state)
     {
         typedef typename ring_type<Polygon>::type ring_type;
-        typedef centroid_range_state<geometry::closure<ring_type>::value> per_ring;
+        typedef centroid_range_state
+            <
+                geometry::closure<ring_type>::value
+            > per_ring;
 
-        per_ring::apply(exterior_ring(poly), transformer, strategy, state);
+        typename ring_return_type
+            <
+                Polygon const
+            >::type e_ring = exterior_ring(poly);
+
+        if (boost::empty(e_ring) && ! geometry::is_empty(poly))
+        {
+#if ! defined(BOOST_GEOMETRY_CENTROID_NO_THROW)
+            throw centroid_exception();
+#else
+            return;
+#endif
+        }
+
+        per_ring::apply(e_ring, transformer, strategy, state);
 
         typename interior_return_type<Polygon const>::type
             rings = interior_rings(poly);

--- a/test/algorithms/centroid_multi.cpp
+++ b/test/algorithms/centroid_multi.cpp
@@ -133,6 +133,10 @@ void test_exceptions()
     test_centroid_exception<multi_linestring>("MULTILINESTRING()");
     test_centroid_exception<multi_linestring>("MULTILINESTRING(())");
     test_centroid_exception<multi_linestring>("MULTILINESTRING((), ())");
+
+    // Multi-polygon containing polygon with empty exterior ring
+    test_centroid_exception<multi_polygon>
+        ("MULTIPOLYGON(((4 1,4 3,8 3,8 1,4 1)),((),(0 0,1 0,1 1,0 1,0 0)))");
 }
 
 template <typename P>


### PR DESCRIPTION
This PR is a follow up on PR #336. It PR addresses the behavior of the `centroid` algorithms for certain kinds of multi-polygons.

The multi-polygons of interest are (invalid) multi-polygons that contains one of more polygons whose exterior ring is empty and at the same time have one or more non-empty interior rings. For such multi-polygons an exception should be thrown. See also related discussion in PR #336. This PR fixes the behavior of the `centroid` algorithm by triggering an exception when multi-polygons (like the ones described above) are given as input to `centroid`.
