### PR TITLE
Fix andoyer

### DIFF
--- a/include/boost/geometry/algorithms/detail/andoyer_inverse.hpp
+++ b/include/boost/geometry/algorithms/detail/andoyer_inverse.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2015 Oracle and/or its affiliates.
+// Copyright (c) 2015-2016 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -49,23 +49,16 @@ struct andoyer_inverse
                                     T2 const& lat2,
                                     Spheroid const& spheroid)
     {
+        CT const c0 = CT(0);
+        CT const pi = math::pi<CT>();
+
         result_type result;
 
         // coordinates in radians
 
-        if ( math::equals(lon1, lon2)
-          && math::equals(lat1, lat2) )
+        if ( math::equals(lon1, lon2) && math::equals(lat1, lat2) )
         {
-            result.set(CT(0), CT(0));
-            return result;
-        }
-
-        CT const pi_half = math::pi<CT>() / CT(2);
-
-        if ( math::equals(math::abs(lat1), pi_half)
-          && math::equals(math::abs(lat2), pi_half) )
-        {
-            result.set(CT(0), CT(0));
+            result.set(c0, c0);
             return result;
         }
 
@@ -81,20 +74,8 @@ struct andoyer_inverse
         // lat1 == +-90 && lat2 == +-90
         // lat1 == lat2 && lon1 == lon2
         CT const cos_d = sin_lat1*sin_lat2 + cos_lat1*cos_lat2*cos_dlon;
-        CT const d = acos(cos_d);
-        CT const sin_d = sin(d);
-
-        // just in case since above lat1 and lat2 is checked
-        // the check below is equal to cos_d == 1 || cos_d == -1 || d == 0
-        if ( math::equals(sin_d, CT(0)) )
-        {
-            result.set(CT(0), CT(0));
-            return result;
-        }
-
-        // if the function returned before this place
-        // and endpoints were on the poles +-90 deg
-        // in this case the azimuth could either be 0 or +-pi
+        CT const d = acos(cos_d); // [0, pi]
+        CT const sin_d = sin(d);  // [-1, 1]
 
         CT const f = detail::flattening<CT>(spheroid);
 
@@ -103,11 +84,18 @@ struct andoyer_inverse
             CT const K = math::sqr(sin_lat1-sin_lat2);
             CT const L = math::sqr(sin_lat1+sin_lat2);
             CT const three_sin_d = CT(3) * sin_d;
-            // H or G = infinity if cos_d = 1 or cos_d = -1
-            CT const H = (d+three_sin_d)/(CT(1)-cos_d);
-            CT const G = (d-three_sin_d)/(CT(1)+cos_d);
 
-            // for e.g. lat1=-90 && lat2=90 here we have G*L=INF*0
+            CT const one_minus_cos_d = CT(1) - cos_d;
+            CT const one_plus_cos_d = CT(1) + cos_d;
+            // cos_d = 1 or cos_d = -1 means that the points are antipodal
+
+            CT const H = math::equals(one_minus_cos_d, c0) ?
+                            c0 :
+                            (d + three_sin_d) / one_minus_cos_d;
+            CT const G = math::equals(one_plus_cos_d, c0) ?
+                            c0 :
+                            (d - three_sin_d) / one_plus_cos_d;
+
             CT const dd = -(f/CT(4))*(H*K+G*L);
 
             CT const a = get_radius<0>(spheroid);
@@ -116,41 +104,91 @@ struct andoyer_inverse
         }
         else
         {
-            result.distance = CT(0);
+            result.distance = c0;
         }
 
         if ( BOOST_GEOMETRY_CONDITION(EnableAzimuth) )
         {
-            CT A = CT(0);
-            CT U = CT(0);
-            if ( ! math::equals(cos_lat2, CT(0)) )
+            // sin_d = 0 <=> antipodal points
+            if (math::equals(sin_d, c0))
             {
-                CT const tan_lat2 = sin_lat2/cos_lat2;
-                CT const M = cos_lat1*tan_lat2-sin_lat1*cos_dlon;
-                A = atan2(sin_dlon, M);
-                CT const sin_2A = sin(CT(2)*A);
-                U = (f/CT(2))*math::sqr(cos_lat1)*sin_2A;
+                // T = inf
+                // dA = inf
+                // azimuth = -inf
+                if (lat1 <= lat2)
+                    result.azimuth = c0;
+                else
+                {
+                    if (lon1 <= lon2)
+                        result.azimuth = pi;
+                    else
+                        result.azimuth = -pi;
+                }
             }
-
-            CT V = CT(0);
-            if ( ! math::equals(cos_lat1, CT(0)) )
+            else
             {
-                CT const tan_lat1 = sin_lat1/cos_lat1;
-                CT const N = cos_lat2*tan_lat1-sin_lat2*cos_dlon;
-                CT const B = atan2(sin_dlon, N);
-                CT const sin_2B = sin(CT(2)*B);
-                V = (f/CT(2))*math::sqr(cos_lat2)*sin_2B;
+                CT A = c0;
+                CT U = c0;
+                if ( ! math::equals(cos_lat2, c0) )
+                {
+                    CT const tan_lat2 = sin_lat2/cos_lat2;
+                    CT const M = cos_lat1*tan_lat2-sin_lat1*cos_dlon;
+                    A = atan2(sin_dlon, M);
+                    CT const sin_2A = sin(CT(2)*A);
+                    U = (f/CT(2))*math::sqr(cos_lat1)*sin_2A;
+                }
+
+                CT V = c0;
+                if ( ! math::equals(cos_lat1, c0) )
+                {
+                    CT const tan_lat1 = sin_lat1/cos_lat1;
+                    CT const N = cos_lat2*tan_lat1-sin_lat2*cos_dlon;
+                    CT const B = atan2(sin_dlon, N);
+                    CT const sin_2B = sin(CT(2)*B);
+                    V = (f/CT(2))*math::sqr(cos_lat2)*sin_2B;
+                }
+
+                CT const T = d / sin_d;
+                CT const dA = V*T-U;
+
+                result.azimuth = A - dA;
+
+                // even with sin_d == 0 checked above if the second point
+                // is somewhere in the antipodal area T may still be great
+                // therefore dA may be great and the resulting azimuth
+                // may be some more or less arbitrary angle
+                if (A >= c0) // A indicates Eastern hemisphere
+                {
+                    if (dA >= c0) // A altered towards 0
+                    {
+                        if (result.azimuth < c0)
+                            result.azimuth = c0;
+                    }
+                    else // dA < 0, A altered towards pi
+                    {
+                        if (result.azimuth > pi)
+                            result.azimuth = pi;
+                    }
+                }
+                else // A indicates Western hemisphere
+                {
+                    if (dA <= c0) // A altered towards 0
+                    {
+                        if (result.azimuth > c0)
+                            result.azimuth = c0;
+                    }
+                    else // dA > 0, A altered towards -pi
+                    {
+                        CT const minus_pi = -pi;
+                        if (result.azimuth < minus_pi)
+                            result.azimuth = minus_pi;
+                    }
+                }
             }
-
-            // infinity if sin_d = 0, so cos_d = 1 or cos_d = -1
-            CT const T = d / sin_d;
-            CT const dA = V*T-U;
-
-            result.azimuth = A - dA;
         }
         else
         {
-            result.azimuth = CT(0);
+            result.azimuth = c0;
         }
 
         return result;

--- a/include/boost/geometry/strategies/geographic/distance_andoyer.hpp
+++ b/include/boost/geometry/strategies/geographic/distance_andoyer.hpp
@@ -1,9 +1,9 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2007-2016 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2014.
-// Modifications copyright (c) 2014 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014, 2016.
+// Modifications copyright (c) 2014-2016 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -20,6 +20,7 @@
 #include <boost/geometry/core/radius.hpp>
 #include <boost/geometry/core/srs.hpp>
 
+#include <boost/geometry/algorithms/detail/andoyer_inverse.hpp>
 #include <boost/geometry/algorithms/detail/flattening.hpp>
 
 #include <boost/geometry/strategies/distance.hpp>
@@ -50,6 +51,8 @@ are about the same as Vincenty. In my (Barend's) testcases the results didn't di
 \see http://www.codeguru.com/Cpp/Cpp/algorithms/article.php/c5115 (implementation)
 \see http://futureboy.homeip.net/frinksamp/navigation.frink (implementation)
 \see http://www.voidware.com/earthdist.htm (implementation)
+\see http://www.dtic.mil/docs/citations/AD0627893
+\see http://www.dtic.mil/docs/citations/AD703541
 */
 template
 <
@@ -82,16 +85,17 @@ public :
         : m_spheroid(spheroid)
     {}
 
-
     template <typename Point1, typename Point2>
     inline typename calculation_type<Point1, Point2>::type
     apply(Point1 const& point1, Point2 const& point2) const
     {
-        return calc<typename calculation_type<Point1, Point2>::type>
-            (
-                get_as_radian<0>(point1), get_as_radian<1>(point1),
-                get_as_radian<0>(point2), get_as_radian<1>(point2)
-            );
+        return geometry::detail::andoyer_inverse
+            <
+                typename calculation_type<Point1, Point2>::type,
+                true, false
+            >::apply(get_as_radian<0>(point1), get_as_radian<1>(point1),
+                     get_as_radian<0>(point2), get_as_radian<1>(point2),
+                     m_spheroid).distance;
     }
 
     inline Spheroid const& model() const
@@ -100,55 +104,6 @@ public :
     }
 
 private :
-    template <typename CT, typename T>
-    inline CT calc(T const& lon1,
-                T const& lat1,
-                T const& lon2,
-                T const& lat2) const
-    {
-        CT const G = (lat1 - lat2) / 2.0;
-        CT const lambda = (lon1 - lon2) / 2.0;
-
-        if (geometry::math::equals(lambda, 0.0)
-            && geometry::math::equals(G, 0.0))
-        {
-            return 0.0;
-        }
-
-        CT const F = (lat1 + lat2) / 2.0;
-
-        CT const sinG2 = math::sqr(sin(G));
-        CT const cosG2 = math::sqr(cos(G));
-        CT const sinF2 = math::sqr(sin(F));
-        CT const cosF2 = math::sqr(cos(F));
-        CT const sinL2 = math::sqr(sin(lambda));
-        CT const cosL2 = math::sqr(cos(lambda));
-
-        CT const S = sinG2 * cosL2 + cosF2 * sinL2;
-        CT const C = cosG2 * cosL2 + sinF2 * sinL2;
-
-        CT const c0 = 0;
-        CT const c1 = 1;
-        CT const c2 = 2;
-        CT const c3 = 3;
-
-        if (geometry::math::equals(S, c0) || geometry::math::equals(C, c0))
-        {
-            return c0;
-        }
-
-        CT const radius_a = CT(get_radius<0>(m_spheroid));
-        CT const flattening = geometry::detail::flattening<CT>(m_spheroid);
-
-        CT const omega = atan(math::sqrt(S / C));
-        CT const r3 = c3 * math::sqrt(S * C) / omega; // not sure if this is r or greek nu
-        CT const D = c2 * omega * radius_a;
-        CT const H1 = (r3 - c1) / (c2 * C);
-        CT const H2 = (r3 + c1) / (c2 * S);
-
-        return D * (c1 + flattening * (H1 * sinF2 * cosG2 - H2 * cosF2 * sinG2) );
-    }
-
     Spheroid m_spheroid;
 };
 

--- a/test/strategies/andoyer.cpp
+++ b/test/strategies/andoyer.cpp
@@ -196,29 +196,29 @@ void test_all()
     // polar
     test_distazi<P1, P2>(0, 90, 1, 80,
                          1116.814237, 179);
+    
     // no point difference
     test_distazi<P1, P2>(4, 52, 4, 52,
                          0.0, 0.0);
-    // normal case
+
+    // normal cases
     test_distazi<P1, P2>(4, 52, 3, 40,
                          1336.039890, -176.3086);
     test_distazi<P1, P2>(3, 52, 4, 40,
                          1336.039890, 176.3086);
-
     test_distazi<P1, P2>(make_deg(17, 19, 43.28),
                          make_deg(40, 30, 31.151),
                          18, 40,
                          80.323245,
                          make_deg(134, 27, 50.05));
 
-#ifdef BOOST_GEOMETRY_TEST_ENABLE_FAILING
+    // antipodal
     // ok? in those cases shorter path would pass through a pole
     // but 90 or -90 would be consistent with distance?
     test_distazi<P1, P2>(0, 0,  180, 0, 20037.5, 0.0);
     test_distazi<P1, P2>(0, 0, -180, 0, 20037.5, 0.0);
     test_distazi<P1, P2>(-90, 0, 90, 0, 20037.5, 0.0);
     test_distazi<P1, P2>(90, 0, -90, 0, 20037.5, 0.0);
-#endif
 
     // 0, 45, 90 ...
     for (int i = 0 ; i < 360 ; i += 45)
@@ -241,9 +241,8 @@ void test_all()
         test_distazi_symmNS<P1, P2>(l, -89.9, l, 89.9, 19981.6, 0.0);
         test_distazi_symmNS<P1, P2>(l, -89.99, l, 89.99, 20001.7, 0.0);
         test_distazi_symmNS<P1, P2>(l, -89.999, l, 89.999, 20003.7, 0.0);
-#ifdef BOOST_GEOMETRY_TEST_ENABLE_FAILING
+        // antipodal
         test_distazi_symmNS<P1, P2>(l, -90, l, 90, 20003.9, 0.0);
-#endif
 
         test_distazi_symm<P1, P2>(normlized_deg(l-10.0), -10.0, normlized_deg(l+135), 45, 14892.1, 34.1802);
         test_distazi_symm<P1, P2>(normlized_deg(l-30.0), -30.0, normlized_deg(l+135), 45, 17890.7, 33.7002);
@@ -260,13 +259,13 @@ void test_all()
         test_distazi_symm<P1, P2>(normlized_deg(l-44.6), -44.6, normlized_deg(l+135), 45, 19955.0, 18.6438);
         test_distazi_symm<P1, P2>(normlized_deg(l-44.7), -44.7, normlized_deg(l+135), 45, 19968.6, 13.1096);
         test_distazi_symm<P1, P2>(normlized_deg(l-44.8), -44.8, normlized_deg(l+135), 45, 19982.3, 2.0300);
+        // nearly antipodal
         test_distazi_symm<P1, P2>(normlized_deg(l-44.9), -44.9, normlized_deg(l+135), 45, 19995.9, 0.0);
         test_distazi_symm<P1, P2>(normlized_deg(l-44.95), -44.95, normlized_deg(l+135), 45, 20002.7, 0.0);
         test_distazi_symm<P1, P2>(normlized_deg(l-44.99), -44.99, normlized_deg(l+135), 45, 20008.1, 0.0);
         test_distazi_symm<P1, P2>(normlized_deg(l-44.999), -44.999, normlized_deg(l+135), 45, 20009.4, 0.0);
-#ifdef BOOST_GEOMETRY_TEST_ENABLE_FAILING
+        // antipodal
         test_distazi_symm<P1, P2>(normlized_deg(l-45), -45, normlized_deg(l+135), 45, 20020.7, 0.0);
-#endif
     }
 
     /* SQL Server gives:


### PR DESCRIPTION
This PR is related to #338

It fixes `andoyer_inverse` formula for points in antipodal areas. This formula can be used to calculate distances and azimuths between points using first order Andoyer-Lambert-Forsyth type approximation. Besides fixed distances the azimuths for points in the vincinity of antipodal point are convergent to the azimuth calculated for antipodal point.

This formula may be used in the Andoyer strategy which currently uses separate, older implementation.
