### PR TITLE
Add range::back_inserter() and use it in algorithms when needed.

### DIFF
--- a/include/boost/geometry/algorithms/buffer.hpp
+++ b/include/boost/geometry/algorithms/buffer.hpp
@@ -277,7 +277,7 @@ inline void buffer(GeometryIn const& geometry_in,
     rescale_policy_type rescale_policy
             = boost::geometry::get_rescale_policy<rescale_policy_type>(box);
 
-    detail::buffer::buffer_inserter<polygon_type>(geometry_in, std::back_inserter(geometry_out),
+    detail::buffer::buffer_inserter<polygon_type>(geometry_in, range::back_inserter(geometry_out),
                 distance_strategy,
                 side_strategy,
                 join_strategy,

--- a/include/boost/geometry/algorithms/convex_hull.hpp
+++ b/include/boost/geometry/algorithms/convex_hull.hpp
@@ -83,7 +83,7 @@ struct hull_to_geometry
                 geometry::point_order<OutputGeometry>::value,
                 geometry::closure<OutputGeometry>::value
             >::apply(geometry,
-                std::back_inserter(
+                range::back_inserter(
                     // Handle linestring, ring and polygon the same:
                     detail::as_range
                         <

--- a/include/boost/geometry/algorithms/detail/intersection/interface.hpp
+++ b/include/boost/geometry/algorithms/detail/intersection/interface.hpp
@@ -54,7 +54,7 @@ struct intersection
         <
             Geometry1, Geometry2, OneOut,
             overlay_intersection
-        >::apply(geometry1, geometry2, robust_policy, std::back_inserter(geometry_out), strategy);
+        >::apply(geometry1, geometry2, robust_policy, range::back_inserter(geometry_out), strategy);
 
         return true;
     }

--- a/include/boost/geometry/algorithms/difference.hpp
+++ b/include/boost/geometry/algorithms/difference.hpp
@@ -159,7 +159,7 @@ inline void difference(Geometry1 const& geometry1,
 
     detail::difference::difference_insert<geometry_out>(
             geometry1, geometry2, robust_policy,
-            std::back_inserter(output_collection));
+            range::back_inserter(output_collection));
 }
 
 

--- a/include/boost/geometry/algorithms/remove_spikes.hpp
+++ b/include/boost/geometry/algorithms/remove_spikes.hpp
@@ -139,7 +139,7 @@ struct range_remove_spikes
 
         // Copy output
         geometry::clear(range);
-        std::copy(cleaned.begin(), cleaned.end(), std::back_inserter(range));
+        std::copy(cleaned.begin(), cleaned.end(), range::back_inserter(range));
     }
 };
 

--- a/include/boost/geometry/algorithms/simplify.hpp
+++ b/include/boost/geometry/algorithms/simplify.hpp
@@ -77,7 +77,7 @@ struct simplify_copy
     {
         std::copy
             (
-                boost::begin(range), boost::end(range), std::back_inserter(out)
+                boost::begin(range), boost::end(range), geometry::range::back_inserter(out)
             );
     }
 };
@@ -113,7 +113,7 @@ struct simplify_range
         {
             simplify_range_insert::apply
                 (
-                    range, std::back_inserter(out), max_distance, strategy
+                    range, geometry::range::back_inserter(out), max_distance, strategy
                 );
         }
     }

--- a/include/boost/geometry/algorithms/sym_difference.hpp
+++ b/include/boost/geometry/algorithms/sym_difference.hpp
@@ -332,7 +332,7 @@ inline void sym_difference(Geometry1 const& geometry1,
 
     detail::sym_difference::sym_difference_insert<geometry_out>(
             geometry1, geometry2, robust_policy,
-            std::back_inserter(output_collection));
+            range::back_inserter(output_collection));
 }
 
 

--- a/include/boost/geometry/algorithms/transform.hpp
+++ b/include/boost/geometry/algorithms/transform.hpp
@@ -162,7 +162,7 @@ struct transform_polygon
         geometry::clear(poly2);
 
         if (!transform_range_out<point2_type>(geometry::exterior_ring(poly1),
-                    std::back_inserter(geometry::exterior_ring(poly2)), strategy))
+                    range::back_inserter(geometry::exterior_ring(poly2)), strategy))
         {
             return false;
         }
@@ -189,7 +189,7 @@ struct transform_polygon
         for ( ; it1 != boost::end(rings1); ++it1, ++it2)
         {
             if ( ! transform_range_out<point2_type>(*it1,
-                                                    std::back_inserter(*it2),
+                                                    range::back_inserter(*it2),
                                                     strategy) )
             {
                 return false;
@@ -228,7 +228,7 @@ struct transform_range
         // Should NOT be done here!
         // geometry::clear(range2);
         return transform_range_out<point_type>(range1,
-                std::back_inserter(range2), strategy);
+                range::back_inserter(range2), strategy);
     }
 };
 

--- a/include/boost/geometry/algorithms/union.hpp
+++ b/include/boost/geometry/algorithms/union.hpp
@@ -271,7 +271,7 @@ inline void union_(Geometry1 const& geometry1,
     concept::check<geometry_out>();
 
     detail::union_::union_insert<geometry_out>(geometry1, geometry2,
-                std::back_inserter(output_collection));
+                range::back_inserter(output_collection));
 }
 
 

--- a/include/boost/geometry/util/range.hpp
+++ b/include/boost/geometry/util/range.hpp
@@ -2,8 +2,8 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2013, 2014, 2015.
-// Modifications copyright (c) 2013-2015 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013, 2014, 2015, 2016.
+// Modifications copyright (c) 2013-2016 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -15,6 +15,7 @@
 #define BOOST_GEOMETRY_UTIL_RANGE_HPP
 
 #include <algorithm>
+#include <iterator>
 
 #include <boost/concept_check.hpp>
 #include <boost/config.hpp>
@@ -360,6 +361,50 @@ erase(Range & rng,
                     + std::distance(boost::const_begin(rng), clast);
 
     return erase(rng, first, last);
+}
+
+// back_inserter
+
+template <class Container>
+class back_insert_iterator
+    : public std::iterator<std::output_iterator_tag, void, void, void, void>
+{
+public:
+    typedef Container container_type;
+
+    explicit back_insert_iterator(Container & c)
+        : container(boost::addressof(c))
+    {}
+
+    back_insert_iterator & operator=(typename Container::value_type const& value)
+    {
+        range::push_back(*container, value);
+        return *this;
+    }
+
+    back_insert_iterator & operator* ()
+    {
+        return *this;
+    }
+
+    back_insert_iterator & operator++ ()
+    {
+        return *this;
+    }
+
+    back_insert_iterator operator++(int)
+    {
+        return *this;
+    }
+
+private:
+    Container * container;
+};
+
+template <typename Range>
+inline back_insert_iterator<Range> back_inserter(Range & rng)
+{
+    return back_insert_iterator<Range>(rng);
 }
 
 }}} // namespace boost::geometry::range

--- a/test/util/range.cpp
+++ b/test/util/range.cpp
@@ -108,6 +108,12 @@ void test_all()
         BOOST_CHECK(bgr::at(v, i) == i);
     }
 
+    {
+        std::vector<T> w;
+        std::copy(v.begin(), v.end(), bgr::back_inserter(w));
+        BOOST_CHECK(v.size() == w.size() && std::equal(v.begin(), v.end(), w.begin()));
+    }
+
     BOOST_CHECK(bgr::front(v) == 0);
     BOOST_CHECK(bgr::back(v) == 19);
 


### PR DESCRIPTION
This PR adds `range::back_insert_iterator` calling using Boost.Geometry version of push_back() specialized in traits and replaces the `std::back_inserter()` with `range::back_inserter()` in places where points are added to geometries.