### PR TITLE
Enable rescale policy only in cartesian coordinate system.

### DIFF
--- a/include/boost/geometry/policies/robustness/get_rescale_policy.hpp
+++ b/include/boost/geometry/policies/robustness/get_rescale_policy.hpp
@@ -252,9 +252,15 @@ struct rescale_policy_type
         false
 #else
         boost::is_floating_point
-        <
-            typename geometry::coordinate_type<Point>::type
-        >::type::value
+            <
+                typename geometry::coordinate_type<Point>::type
+            >::type::value
+        &&
+        boost::is_same
+            <
+                typename geometry::coordinate_system<Point>::type,
+                geometry::cs::cartesian
+            >::value
 #endif
     >
 {

--- a/test/algorithms/set_operations/intersection/intersection_aa_sph.cpp
+++ b/test/algorithms/set_operations/intersection/intersection_aa_sph.cpp
@@ -1,0 +1,39 @@
+// Boost.Geometry
+// Unit Test
+
+// Copyright (c) 2016, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "test_intersection.hpp"
+
+template <typename P>
+void test_all()
+{
+    typedef bg::model::polygon<P> polygon;
+    
+    // https://svn.boost.org/trac/boost/ticket/11789
+    test_one<polygon, polygon, polygon>("poly_poly_se_ticket_11789",
+        "POLYGON((-4.5726431789237223 52.142932977753595, \
+                  -4.5743166242433153 52.143359442355219, \
+                  -4.5739141406075410 52.143957260988416, \
+                  -4.5722406991324354 52.143530796430468, \
+                  -4.5726431789237223 52.142932977753595))",
+        "POLYGON((-4.5714644516017975 52.143819810922480, \
+                  -4.5670821923630358 52.143819810922480, \
+                  -4.5670821923630358 52.143649055226163, \
+                  -4.5714644516017975 52.143649055226163, \
+                  -4.5714644516017975 52.143819810922480))",
+        0, 0, 0.0);
+}
+
+int test_main(int, char* [])
+{
+    test_all<bg::model::point<double, 2, bg::cs::spherical_equatorial<bg::degree> > >();
+
+    return 0;
+}


### PR DESCRIPTION
This PR fixes the regression reported here:
https://svn.boost.org/trac/boost/ticket/11789

An assertion fails in `expand()` called from `sectionalize()` for non-cartesian geometries. It's because it is called for Points containing very big integral coordinates. The reason is that currently, by default, floating-point coordinates are rescaled into integral coordinates internally in set operations and these integral coordinates are passed into expand() to calculate bounding boxes. This also means that since these coordinates are normalized, the result is not correct. 

After merging this PR rescaling will be enabled only for geometries in cartesian CS.