### PR TITLE
[io] Support all geometries in svg() and use it in svg_mapper.

### DIFF
--- a/include/boost/geometry/io/svg/write_svg.hpp
+++ b/include/boost/geometry/io/svg/write_svg.hpp
@@ -3,6 +3,11 @@
 // Copyright (c) 2009-2012 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2014 Adam Wulkiewicz, Lodz, Poland.
 
+// This file was modified by Oracle on 2016.
+// Modifications copyright (c) 2016, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -77,6 +82,24 @@ struct svg_box
     }
 };
 
+template <typename Segment>
+struct svg_segment
+{
+    template <typename Char, typename Traits>
+    static inline void apply(std::basic_ostream<Char, Traits>& os,
+        Segment const& segment, std::string const& style, int)
+    {
+        typedef typename coordinate_type<Segment>::type ct;
+        ct x1 = geometry::get<0, 0>(segment);
+        ct y1 = geometry::get<0, 1>(segment);
+        ct x2 = geometry::get<1, 0>(segment);
+        ct y2 = geometry::get<1, 1>(segment);
+        
+        os << "<line x1=\"" << x1 << "\" y1=\"" << y1
+            << "\" x2=\"" << x2 << "\" y2=\"" << y2
+            << "\" style=\"" << style << "\"/>";
+    }
+};
 
 /*!
 \brief Stream ranges as SVG
@@ -203,6 +226,9 @@ struct svg
 
 template <typename Point>
 struct svg<point_tag, Point> : detail::svg::svg_point<Point> {};
+
+template <typename Segment>
+struct svg<segment_tag, Segment> : detail::svg::svg_segment<Segment> {};
 
 template <typename Box>
 struct svg<box_tag, Box> : detail::svg::svg_box<Box> {};

--- a/include/boost/geometry/io/svg/write_svg_multi.hpp
+++ b/include/boost/geometry/io/svg/write_svg_multi.hpp
@@ -2,6 +2,11 @@
 
 // Copyright (c) 2009-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2016.
+// Modifications copyright (c) 2016, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -53,6 +58,32 @@ struct svg_multi
 namespace dispatch
 {
 
+template <typename MultiPoint>
+struct svg<multi_point_tag, MultiPoint>
+    : detail::svg::svg_multi
+        <
+            MultiPoint,
+            detail::svg::svg_point
+                <
+                    typename boost::range_value<MultiPoint>::type
+                >
+
+        >
+{};
+
+template <typename MultiLinestring>
+struct svg<multi_linestring_tag, MultiLinestring>
+    : detail::svg::svg_multi
+        <
+            MultiLinestring,
+            detail::svg::svg_range
+                <
+                    typename boost::range_value<MultiLinestring>::type,
+                    detail::svg::prefix_linestring
+                >
+
+        >
+{};
 
 template <typename MultiPolygon>
 struct svg<multi_polygon_tag, MultiPolygon>

--- a/test/io/Jamfile.v2
+++ b/test/io/Jamfile.v2
@@ -4,8 +4,14 @@
 # Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 # Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 #
+# This file was modified by Oracle on 2016.
+# Modifications copyright (c) 2016 Oracle and/or its affiliates.
+#
+# Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+#
 # Use, modification and distribution is subject to the Boost Software License,
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
 build-project wkt ; 
+build-project svg ;

--- a/test/io/svg/Jamfile.v2
+++ b/test/io/svg/Jamfile.v2
@@ -1,0 +1,15 @@
+# Boost.Geometry
+#
+# Copyright (c) 2016 Oracle and/or its affiliates.
+#
+# Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+#
+# Use, modification and distribution is subject to the Boost Software License,
+# Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+test-suite boost-geometry-io-svg
+    :
+    [ run svg.cpp       : : : : io_svg ]
+    ;
+

--- a/test/io/svg/svg.cpp
+++ b/test/io/svg/svg.cpp
@@ -1,0 +1,146 @@
+// Boost.Geometry
+// Unit Test
+
+// Copyright (c) 2016 Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifdef TEST_WITH_SVG
+#include <fstream>
+#endif
+
+#include <sstream>
+#include <string>
+
+#include <geometry_test_common.hpp>
+
+#include <boost/geometry/algorithms/area.hpp>
+#include <boost/geometry/algorithms/correct.hpp>
+
+#include <boost/geometry/geometries/geometries.hpp>
+#include <boost/geometry/geometries/point_xy.hpp>
+
+#include <boost/geometry/io/svg/svg_mapper.hpp>
+#include <boost/geometry/io/svg/write_svg.hpp>
+#include <boost/geometry/io/svg/write_svg_multi.hpp>
+
+#include <boost/geometry/strategies/cartesian/area_surveyor.hpp>
+
+template <typename R, typename T>
+inline void push_back_square(R & rng, T const& mi, T const& ma)
+{
+    typedef typename bg::point_type<R>::type P;
+    rng.push_back(P(mi, mi));
+    rng.push_back(P(mi, ma));
+    rng.push_back(P(ma, ma));
+    rng.push_back(P(ma, mi));
+    rng.push_back(P(mi, mi));
+}
+
+template <typename P>
+void test_all()
+{
+    typedef bg::model::box<P> box;
+    typedef bg::model::segment<P> segment;
+    typedef bg::model::linestring<P> linestring;
+    typedef bg::model::ring<P> ring;
+    typedef bg::model::polygon<P> polygon;
+
+    typedef bg::model::multi_point<P> multi_point;
+    typedef bg::model::multi_linestring<linestring> multi_linestring;
+    typedef bg::model::multi_polygon<polygon> multi_polygon;
+    
+    P pt(0, 0);
+    box b(P(10, 10), P(20, 20));
+    segment s(P(30, 30), P(40, 40));
+    
+    linestring ls;
+    push_back_square(ls, 50, 60);
+    
+    ring r;
+    push_back_square(r, 70, 80);
+
+    polygon po;
+    push_back_square(po.outer(), 90, 120);
+    po.inners().resize(1);
+    push_back_square(po.inners()[0], 100, 110);
+    bg::correct(po);
+
+    multi_point m_pt;
+    m_pt.push_back(pt);
+
+    multi_linestring m_ls;
+    m_ls.push_back(ls);
+
+    multi_polygon m_po;
+    m_po.push_back(po);
+
+    std::string style = "fill-opacity:0.5;fill:rgb(200,0,0);stroke:rgb(200,0,0);stroke-width:3";
+    std::string m_style = "fill-opacity:0.5;fill:rgb(0,200,0);stroke:rgb(0,200,0);stroke-width:1";
+
+    {
+#ifdef TEST_WITH_SVG
+        std::ofstream os("test1.svg", std::ios::trunc);
+#else
+        std::stringstream os;
+#endif
+        os << "<?xml version=\"1.0\" standalone=\"no\"?>"
+           << "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">"
+           << "<svg height=\"200\" width=\"200\" version=\"1.1\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">";
+
+        os << bg::svg(pt, style);
+        os << bg::svg(b, style);
+        os << bg::svg(s, style);
+        os << bg::svg(ls, style);
+        os << bg::svg(r, style);
+        os << bg::svg(po, style);
+        os << bg::svg(m_pt, m_style);
+        os << bg::svg(m_ls, m_style);
+        os << bg::svg(m_po, m_style);
+
+        os << "</svg>";
+    }
+
+    {
+#ifdef TEST_WITH_SVG
+        std::ofstream os("test2.svg", std::ios::trunc);
+#else
+        std::stringstream os;
+#endif
+        bg::svg_mapper<P> mapper(os, 500, 500);
+        mapper.add(pt);
+        mapper.add(b);
+        mapper.add(s);
+        mapper.add(ls);
+        mapper.add(r);
+        mapper.add(po);
+        mapper.add(m_pt);
+        mapper.add(m_ls);
+        mapper.add(m_po);
+        mapper.map(pt, style);
+        mapper.map(b, style);
+        mapper.map(s, style);
+        mapper.map(ls, style);
+        mapper.map(r, style);
+        mapper.map(po, style);
+        mapper.map(m_pt, m_style);
+        mapper.map(m_ls, m_style);
+        mapper.map(m_po, m_style);
+    }
+}
+
+int test_main(int, char* [])
+{
+    test_all< boost::geometry::model::d2::point_xy<double> >();
+    test_all< boost::geometry::model::d2::point_xy<int> >();
+
+#if defined(HAVE_TTMATH)
+    test_all< boost::geometry::model::d2::point_xy<ttmath_big> >();
+#endif
+
+    return 0;
+}


### PR DESCRIPTION
SVG tag for Segment in `svg()` is `<line>`. This function is called by `svg_mapper`. The implementation of `svg_map` previously used only for Box is now used for Segment as well. Previously it was a separate implementation transforming Segments into Linestrings. This means that `svg_mapper` now outputs Segments as SVG Lines (`<line>`) instead of PolyLines (`<polyline>`).
