### PR TITLE
Fix winding strategy for spherical and geographic system.

### DIFF
--- a/include/boost/geometry/algorithms/detail/buffer/buffered_piece_collection.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/buffered_piece_collection.hpp
@@ -2,6 +2,10 @@
 
 // Copyright (c) 2012-2014 Barend Gehrels, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2016.
+// Modifications copyright (c) 2016 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -255,8 +259,11 @@ struct buffered_piece_collection
         {
             geometry::envelope(m_ring, m_box);
 
-            // create monotonic sections in y-dimension
-            typedef boost::mpl::vector_c<std::size_t, 1> dimensions;
+            // create monotonic sections in x-dimension
+            // The dimension is critical because the direction is later used
+            // in the optimization for within checks using winding strategy
+            // and this strategy is scanning in x direction.
+            typedef boost::mpl::vector_c<std::size_t, 0> dimensions;
             geometry::sectionalize<false, dimensions>(m_ring,
                     detail::no_rescale_policy(), m_sections);
         }

--- a/include/boost/geometry/algorithms/detail/buffer/turn_in_original_visitor.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/turn_in_original_visitor.hpp
@@ -2,6 +2,10 @@
 
 // Copyright (c) 2014 Barend Gehrels, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2016.
+// Modifications copyright (c) 2016 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -103,32 +107,32 @@ template
     typename Iterator
 >
 inline bool point_in_section(Strategy& strategy, State& state,
-        Point const& point, CoordinateType const& point_y,
+        Point const& point, CoordinateType const& point_x,
         Iterator begin, Iterator end,
         int direction)
 {
     if (direction == 0)
     {
-        // Not a monotonic section, or no change in Y-direction
+        // Not a monotonic section, or no change in X-direction
         return point_in_range(strategy, state, point, begin, end);
     }
 
-    // We're in a monotonic section in y-direction
+    // We're in a monotonic section in x-direction
     Iterator it = begin;
 
     for (Iterator previous = it++; it != end; ++previous, ++it)
     {
         // Depending on sections.direction we can quit for this section
-        CoordinateType const previous_y = geometry::get<1>(*previous);
+        CoordinateType const previous_x = geometry::get<0>(*previous);
 
-        if (direction == 1 && point_y < previous_y)
+        if (direction == 1 && point_x < previous_x)
         {
-            // Section goes upwards, y increases, point is is below section
+            // Section goes upwards, x increases, point is is below section
             return true;
         }
-        else if (direction == -1 && point_y > previous_y)
+        else if (direction == -1 && point_x > previous_x)
         {
-            // Section goes downwards, y decreases, point is above section
+            // Section goes downwards, x decreases, point is above section
             return true;
         }
 
@@ -145,6 +149,9 @@ inline bool point_in_section(Strategy& strategy, State& state,
 template <typename Point, typename Original>
 inline int point_in_original(Point const& point, Original const& original)
 {
+    // The winding strategy is scanning in x direction
+    // therefore it's critical to pass direction calculated
+    // for x dimension below.
     typedef strategy::within::winding<Point> strategy_type;
 
     typename strategy_type::state_type state;
@@ -166,7 +173,7 @@ inline int point_in_original(Point const& point, Original const& original)
     typedef typename boost::range_value<sections_type const>::type section_type;
     typedef typename geometry::coordinate_type<Point>::type coordinate_type;
 
-    coordinate_type const point_y = geometry::get<1>(point);
+    coordinate_type const point_x = geometry::get<0>(point);
 
     // Walk through all monotonic sections of this original
     for (iterator_type it = boost::begin(original.m_sections);
@@ -177,11 +184,11 @@ inline int point_in_original(Point const& point, Original const& original)
 
         if (! section.duplicate
             && section.begin_index < section.end_index
-            && point_y >= geometry::get<min_corner, 1>(section.bounding_box)
-            && point_y <= geometry::get<max_corner, 1>(section.bounding_box))
+            && point_x >= geometry::get<min_corner, 0>(section.bounding_box)
+            && point_x <= geometry::get<max_corner, 0>(section.bounding_box))
         {
-            // y-coordinate of point overlaps with section
-            if (! point_in_section(strategy, state, point, point_y,
+            // x-coordinate of point overlaps with section
+            if (! point_in_section(strategy, state, point, point_x,
                     boost::begin(original.m_ring) + section.begin_index,
                     boost::begin(original.m_ring) + section.end_index + 1,
                     section.directions[0]))

--- a/include/boost/geometry/algorithms/detail/buffer/turn_in_piece_visitor.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/turn_in_piece_visitor.hpp
@@ -2,6 +2,10 @@
 
 // Copyright (c) 2012-2014 Barend Gehrels, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2016.
+// Modifications copyright (c) 2016 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -218,16 +222,16 @@ public :
 
         BOOST_GEOMETRY_ASSERT(! piece.sections.empty());
 
-        coordinate_type const point_y = geometry::get<1>(turn.robust_point);
+        coordinate_type const point_x = geometry::get<0>(turn.robust_point);
 
         for (std::size_t s = 0; s < piece.sections.size(); s++)
         {
             section_type const& section = piece.sections[s];
-            // If point within vertical range of monotonic section:
+            // If point within horizontal range of monotonic section:
             if (! section.duplicate
                 && section.begin_index < section.end_index
-                && point_y >= geometry::get<min_corner, 1>(section.bounding_box) - 1
-                && point_y <= geometry::get<max_corner, 1>(section.bounding_box) + 1)
+                && point_x >= geometry::get<min_corner, 0>(section.bounding_box) - 1
+                && point_x <= geometry::get<max_corner, 0>(section.bounding_box) + 1)
             {
                 for (signed_size_type i = section.begin_index + 1; i <= section.end_index; i++)
                 {
@@ -239,21 +243,21 @@ public :
                     // First check if it is in range - if it is not, the
                     // expensive side_of_intersection does not need to be
                     // applied
-                    coordinate_type y1 = geometry::get<1>(previous);
-                    coordinate_type y2 = geometry::get<1>(current);
+                    coordinate_type x1 = geometry::get<0>(previous);
+                    coordinate_type x2 = geometry::get<0>(current);
 
-                    if (y1 > y2)
+                    if (x1 > x2)
                     {
-                        std::swap(y1, y2);
+                        std::swap(x1, x2);
                     }
 
-                    if (point_y >= y1 - 1 && point_y <= y2 + 1)
+                    if (point_x >= x1 - 1 && point_x <= x2 + 1)
                     {
                         segment_type const r(previous, current);
                         int const side = strategy::side::side_of_intersection::apply(p, q, r,
                                     turn.robust_point);
 
-                        // Sections are monotonic in y-dimension
+                        // Sections are monotonic in x-dimension
                         if (side == 1)
                         {
                             // Left on segment

--- a/include/boost/geometry/strategies/agnostic/point_in_poly_winding.hpp
+++ b/include/boost/geometry/strategies/agnostic/point_in_poly_winding.hpp
@@ -3,8 +3,9 @@
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2013 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2013, 2014.
-// Modifications copyright (c) 2013, 2014 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013, 2014, 2016.
+// Modifications copyright (c) 2013-2016 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
@@ -12,8 +13,6 @@
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
-
-// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 #ifndef BOOST_GEOMETRY_STRATEGY_AGNOSTIC_POINT_IN_POLY_WINDING_HPP
 #define BOOST_GEOMETRY_STRATEGY_AGNOSTIC_POINT_IN_POLY_WINDING_HPP
@@ -35,15 +34,49 @@ namespace boost { namespace geometry
 namespace strategy { namespace within
 {
 
+template <typename Point,
+          typename CalculationType = typename coordinate_type<Point>::type>
+struct winding_normalize_lon
+{
+    typedef typename coordinate_system<Point>::type cs_t;
+
+    static inline void apply(CalculationType & lon)
+    {
+        // TODO: get rid of the dummy parameter
+        CalculationType lat = 0;
+        math::normalize_spheroidal_coordinates
+            <typename cs_t::units, CalculationType>(lon, lat);
+    }
+};
+
+// 1 deg or pi/180 rad
+template <typename Point,
+          typename CalculationType = typename coordinate_type<Point>::type>
+struct winding_small_angle
+{
+    typedef typename coordinate_system<Point>::type cs_t;
+    typedef math::detail::constants_on_spheroid
+        <
+            CalculationType,
+            typename cs_t::units
+        > constants;
+
+    static inline CalculationType apply()
+    {
+        return constants::half_period() / CalculationType(180);
+    }
+};
+
 
 // Fix for https://svn.boost.org/trac/boost/ticket/9628
-// For floating point coordinates, the <1> coordinate of a point is compared
+// For floating point coordinates, the <D> coordinate of a point is compared
 // with the segment's points using some EPS. If the coordinates are "equal"
 // the sides are calculated. Therefore we can treat a segment as a long areal
 // geometry having some width. There is a small ~triangular area somewhere
 // between the segment's effective area and a segment's line used in sides
 // calculation where the segment is on the one side of the line but on the
 // other side of a segment (due to the width).
+// Below picture assuming D = 1, if D = 0 horiz<->vert, E<->N, RIGHT<->UP.
 // For the s1 of a segment going NE the real side is RIGHT but the point may
 // be detected as LEFT, like this:
 //                     RIGHT
@@ -54,6 +87,9 @@ namespace strategy { namespace within
 //             _____7
 //       _____/
 // _____/
+// In the code below actually D = 0, so segments are nearly-vertical
+// Called when the point is on the same level as one of the segment's points
+// but the point is not aligned with a vertical segment
 template <typename CSTag>
 struct winding_side_equal
 {
@@ -62,122 +98,107 @@ struct winding_side_equal
             CSTag
         >::type strategy_side_type;
 
-    template <size_t D, typename Point, typename PointOfSegment>
+    template <typename Point, typename PointOfSegment>
     static inline int apply(Point const& point,
                             PointOfSegment const& se,
                             int count)
     {
-        // Create a vertical segment intersecting the original segment's endpoint
-        // equal to the point, with the derived direction (UP/DOWN).
-        // Set only the 2 first coordinates, the other ones are ignored
+        typedef typename coordinate_type<PointOfSegment>::type scoord_t;
+        typedef typename coordinate_system<PointOfSegment>::type scs_t;
+
+        if (math::equals(get<1>(point), get<1>(se)))
+            return 0;
+
+        // Create a horizontal segment intersecting the original segment's endpoint
+        // equal to the point, with the derived direction (E/W).
         PointOfSegment ss1, ss2;
-        set<1-D>(ss1, get<1-D>(se));
-        set<1-D>(ss2, get<1-D>(se));
-        if (count > 0) // UP
+        set<1>(ss1, get<1>(se));
+        set<0>(ss1, get<0>(se));
+        set<1>(ss2, get<1>(se));
+        scoord_t ss20 = get<0>(se);
+        if (count > 0)
         {
-            set<D>(ss1, 0);
-            set<D>(ss2, 1);
+            // TODO: should it be normalized?
+            ss20 += winding_small_angle<PointOfSegment>::apply();
         }
-        else // DOWN
+        else
         {
-            set<D>(ss1, 1);
-            set<D>(ss2, 0);
+            // TODO: should it be normalized?
+            ss20 -= winding_small_angle<PointOfSegment>::apply();
         }
+        winding_normalize_lon<PointOfSegment>::apply(ss20);
+        set<0>(ss2, ss20);
+
         // Check the side using this vertical segment
         return strategy_side_type::apply(ss1, ss2, point);
     }
 };
-
 // The optimization for cartesian
 template <>
 struct winding_side_equal<cartesian_tag>
 {
-    template <size_t D, typename Point, typename PointOfSegment>
+    template <typename Point, typename PointOfSegment>
     static inline int apply(Point const& point,
                             PointOfSegment const& se,
                             int count)
     {
-        return math::equals(get<1-D>(point), get<1-D>(se)) ?
+        // NOTE: for D=0 the signs would be reversed
+        return math::equals(get<1>(point), get<1>(se)) ?
                 0 :
-                get<1-D>(point) < get<1-D>(se) ?
+                get<1>(point) < get<1>(se) ?
                     // assuming count is equal to 1 or -1
-                    count : // ( count > 0 ? 1 : -1) :
-                    -count; // ( count > 0 ? -1 : 1) ;
+                    -count : // ( count > 0 ? -1 : 1) :
+                    count;   // ( count > 0 ? 1 : -1) ;
     }
 };
 
 
-template <typename CSTag>
-struct winding_side_between
+// Called if point is not aligned with a vertical segment
+template <typename Point,
+          typename CalculationType,
+          typename CSTag = typename cs_tag<Point>::type>
+struct winding_calculate_count
 {
-    typedef typename strategy::side::services::default_strategy
-        <
-            CSTag
-        >::type strategy_side_type;
+    typedef CalculationType calc_t;
+    typedef typename coordinate_system<Point>::type cs_t;
 
-    template <size_t D, typename Point, typename PointOfSegment>
-    static inline int apply(Point const& point,
-                            PointOfSegment const& s1, PointOfSegment const& s2,
-                            int count)
+    static inline bool greater(calc_t const& l, calc_t const& r)
     {
-        // Create a vertical segment intersecting the original segment's endpoint
-        // equal to the point, with the derived direction (UP/DOWN).
-        // Set only the 2 first coordinates, the other ones are ignored
-        PointOfSegment ss1, ss2;
-        set<1-D>(ss1, get<1-D>(s1));
-        set<1-D>(ss2, get<1-D>(s1));
+        calc_t diff = l - r;
+        winding_normalize_lon<Point, calc_t>::apply(diff);
+        return diff > calc_t(0);
+    }
 
-        if (count > 0) // UP
-        {
-            set<D>(ss1, 0);
-            set<D>(ss2, 1);
-        }
-        else // DOWN
-        {
-            set<D>(ss1, 1);
-            set<D>(ss2, 0);
-        }
-
-        int const seg_side = strategy_side_type::apply(ss1, ss2, s2);
-
-        if (seg_side != 0) // segment not vertical
-        {
-            if (strategy_side_type::apply(ss1, ss2, point) == -seg_side) // point on the opposite side than s2
-            {
-                return -seg_side;
-            }
-            else
-            {
-                set<1-D>(ss1, get<1-D>(s2));
-                set<1-D>(ss2, get<1-D>(s2));
-
-                if (strategy_side_type::apply(ss1, ss2, point) == seg_side) // point behind s2
-                {
-                    return seg_side;
-                }
-            }
-        }
-
-        // segment is vertical or point is between p1 and p2
-        return strategy_side_type::apply(s1, s2, point);
+    static inline int apply(calc_t const& p,
+                            calc_t const& s1, calc_t const& s2,
+                            bool eq1, bool eq2)
+    {
+        // Probably could be optimized by avoiding normalization for some comparisons
+        // e.g. s1 > p could be calculated from p > s1
+        return
+              eq1 ? (greater(s2, p) ?  1 : -1)      // Point on level s1, E/W depending on s2
+            : eq2 ? (greater(s1, p) ? -1 :  1)      // idem
+            : greater(p, s1) && greater(s2, p) ?  2 // Point between s1 -> s2 --> E
+            : greater(p, s2) && greater(s1, p) ? -2 // Point between s2 -> s1 --> W
+            : 0;
     }
 };
-
-// The specialization for cartesian
-template <>
-struct winding_side_between<cartesian_tag>
+// The optimization for cartesian
+template <typename Point, typename CalculationType>
+struct winding_calculate_count<Point, CalculationType, cartesian_tag>
 {
-    typedef strategy::side::services::default_strategy
-        <
-            cartesian_tag
-        >::type strategy_side_type;
-
-    template <size_t D, typename Point, typename PointOfSegment>
-    static inline int apply(Point const& point,
-                            PointOfSegment const& s1, PointOfSegment const& s2,
-                            int /*count*/)
+    typedef CalculationType calc_t;
+    
+    static inline int apply(calc_t const& p,
+                            calc_t const& s1, calc_t const& s2,
+                            bool eq1, bool eq2)
     {
-        return strategy_side_type::apply(s1, s2, point);
+        return
+              eq1 ? (s2 > p ?  1 : -1)  // Point on level s1, E/W depending on s2
+            : eq2 ? (s1 > p ? -1 :  1)  // idem
+            : s1 < p && s2 > p ?  2     // Point between s1 -> s2 --> E
+            : s2 < p && s1 > p ? -2     // Point between s2 -> s1 --> W
+            : 0;
     }
 };
 
@@ -242,14 +263,14 @@ class winding
     };
 
 
-    template <size_t D>
+    // This function may give wrong results if a segment is going through a pole
     static inline int check_touch(Point const& point,
                 PointOfSegment const& seg1, PointOfSegment const& seg2,
                 counter& state)
     {
-        calculation_type const p = get<D>(point);
-        calculation_type const s1 = get<D>(seg1);
-        calculation_type const s2 = get<D>(seg2);
+        calculation_type const p = get<1>(point);
+        calculation_type const s1 = get<1>(seg1);
+        calculation_type const s2 = get<1>(seg2);
         if ((s1 <= p && s2 >= p) || (s2 <= p && s1 >= p))
         {
             state.m_touches = true;
@@ -258,32 +279,29 @@ class winding
     }
 
 
-    template <size_t D>
     static inline int check_segment(Point const& point,
                 PointOfSegment const& seg1, PointOfSegment const& seg2,
                 counter& state, bool& eq1, bool& eq2)
     {
-        calculation_type const p = get<D>(point);
-        calculation_type const s1 = get<D>(seg1);
-        calculation_type const s2 = get<D>(seg2);
+        calculation_type const p = get<0>(point);
+        calculation_type const s1 = get<0>(seg1);
+        calculation_type const s2 = get<0>(seg2);
 
-        // Check if one of segment endpoints is at same level of point
+        // Check if one of segment endpoints is at the same level of point
+        // TODO: For segment going through pole and point touching it
+        //       eq1 or eq2 will be true, but not both
         eq1 = math::equals(s1, p);
         eq2 = math::equals(s2, p);
 
         if (eq1 && eq2)
         {
-            // Both equal p -> segment is horizontal (or vertical for D=0)
+            // Both equal p -> segment vertical
             // The only thing which has to be done is check if point is ON segment
-            return check_touch<1 - D>(point, seg1, seg2, state);
+            return check_touch(point, seg1, seg2, state);
         }
 
-        return
-              eq1 ? (s2 > p ?  1 : -1)  // Point on level s1, UP/DOWN depending on s2
-            : eq2 ? (s1 > p ? -1 :  1)  // idem
-            : s1 < p && s2 > p ?  2     // Point between s1 -> s2 --> UP
-            : s2 < p && s1 > p ? -2     // Point between s2 -> s1 --> DOWN
-            : 0;
+        return winding_calculate_count<Point, calculation_type>
+                    ::apply(p, s1, s2, eq1, eq2);
     }
 
 
@@ -304,19 +322,18 @@ public :
         bool eq2 = false;
         boost::ignore_unused(eq2);
 
-        int count = check_segment<1>(point, s1, s2, state, eq1, eq2);
+        int count = check_segment(point, s1, s2, state, eq1, eq2);
         if (count != 0)
         {
             int side = 0;
             if (count == 1 || count == -1)
             {
-                side = winding_side_equal<cs_t>
-                            ::template apply<1>(point, eq1 ? s1 : s2, count);
+                side = winding_side_equal<cs_t>::apply(point, eq1 ? s1 : s2, count);
             }
             else // count == 2 || count == -2
             {
-                side = winding_side_between<cs_t>
-                            ::template apply<1>(point, s1, s2, count);
+                // 1 left, -1 right
+                side = strategy_side_type::apply(s1, s2, point);
             }
             
             if (side == 0)

--- a/test/algorithms/relational_operations/within/within_pointlike_geometry.cpp
+++ b/test/algorithms/relational_operations/within/within_pointlike_geometry.cpp
@@ -205,18 +205,34 @@ void test_spherical()
         BOOST_CHECK_EQUAL(bg::within(pt_n23, poly_n), false);
         BOOST_CHECK_EQUAL(bg::within(pt_n24, poly_n), false);
     }
+
     // segment going through pole
-    // Move to covered_by tests
-#ifdef BOOST_GEOMETRY_TEST_ENABLE_FAILING
+    // TODO: Move to covered_by tests
     {
         bg::model::polygon<Point> poly_n;
         bg::read_wkt("POLYGON((-90 80,90 80,90 70,-90 70, -90 80))", poly_n);
+        // Points on segment
         Point pt_n1(-90, 85);
         Point pt_n2(90, 85);
         BOOST_CHECK_EQUAL(bg::covered_by(pt_n1, poly_n), true);
         BOOST_CHECK_EQUAL(bg::covered_by(pt_n2, poly_n), true);
+        // Points on pole
+        Point pt_np1(90, 90);
+        Point pt_np2(0, 90);
+        Point pt_np3(45, 90);
+        BOOST_CHECK_EQUAL(bg::covered_by(pt_np1, poly_n), true);
+        BOOST_CHECK_EQUAL(bg::covered_by(pt_np2, poly_n), true);
+        BOOST_CHECK_EQUAL(bg::covered_by(pt_np3, poly_n), true);
     }
-#endif
+    // Segment endpoints on pole with arbitrary longitudes
+    {
+        bg::model::polygon<Point> poly_n;
+        bg::read_wkt("POLYGON((45 90,45 80,0 80,45 90))", poly_n);
+        Point pt_n1(0, 85);
+        Point pt_n2(45, 85);
+        BOOST_CHECK_EQUAL(bg::covered_by(pt_n1, poly_n), true);
+        BOOST_CHECK_EQUAL(bg::covered_by(pt_n2, poly_n), true);
+    }
 }
 
 void test_large_integers()

--- a/test/strategies/winding.cpp
+++ b/test/strategies/winding.cpp
@@ -3,9 +3,8 @@
 
 // Copyright (c) 2010-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2014.
-// Modifications copyright (c) 2014 Oracle and/or its affiliates.
-
+// This file was modified by Oracle on 2014, 2016.
+// Modifications copyright (c) 2014-2016 Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -90,8 +89,6 @@ void test_spherical()
         s,
         false);
 
-#ifdef BOOST_GEOMETRY_TEST_STRATEGIES_WINDING_ENABLE_FAILING_TESTS
-
     test_geometry<point, polygon>(
         "sph1N",
         "POINT(0 10.001)",
@@ -145,8 +142,6 @@ void test_spherical()
               point(0, (T)-10.001)) == -1 // right side
       /*true*/);
 
-#endif // BOOST_GEOMETRY_TEST_STRATEGIES_WINDING_ENABLE_FAILING_TESTS
-
     test_geometry<point, polygon>(
         "sphEq1",
         "POINT(179 10)",
@@ -159,7 +154,7 @@ void test_spherical()
         "POINT(179 10)",
         "POLYGON((170 20, -170 20, -170 10, 170 10, 170 20))",
         s,
-        true,
+        false,
         false);
     test_geometry<point, polygon>(
         "sphEq3",
@@ -173,10 +168,8 @@ void test_spherical()
         "POINT(-179 10)",
         "POLYGON((170 20, -170 20, -170 10, 170 10, 170 20))",
         s,
-        true,
+        false,
         false);
-
-#ifdef BOOST_GEOMETRY_TEST_STRATEGIES_WINDING_ENABLE_FAILING_TESTS
 
     test_geometry<point, polygon>(
         "sphEq5",
@@ -206,8 +199,6 @@ void test_spherical()
         s,
         false,
         false);
-
-#endif // BOOST_GEOMETRY_TEST_STRATEGIES_WINDING_ENABLE_FAILING_TESTS
 }
 
 int test_main(int, char* [])


### PR DESCRIPTION
In spherical and geographic CS if a point has the same latitude as both points of a segment it doesn't mean that it lies on the segment. This PR fixes this case by scanning dimension 0 (X) instead of dimension 1 (Y). In spherical and geographic it's guaranteed that if longitude is the same a point lies on a segment.

Furthermore special checks are added for points lying on poles and segments going through poles.

IMPORTANT: The change of dimensions mentioned above influences buffer implementation which uses winding strategy directly and assume that this strategy scans in a specific dimension.