### PR TITLE
Point/Box and Box/Box spatial relations in non-cartesian coordinate systems.

### DIFF
--- a/include/boost/geometry/algorithms/detail/disjoint/box_box.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/box_box.hpp
@@ -104,16 +104,10 @@ struct box_box<Box1, Box2, 0, DimensionCount, spherical_tag>
         calc_t const diff2 = b2_max - b2_min;
 
         // check the intersection if neither box cover the whole globe
-        if (math::smaller(diff1, constants::period())
-         && math::smaller(diff2, constants::period()) ) // < period
+        if (diff1 < constants::period() && diff2 < constants::period())
         {
             // calculate positive longitude translation with b1_min as origin
-            calc_t const c0 = 0;
-            calc_t diff_min = b2_min - b1_min;
-            math::normalize_longitude<units_t, calc_t>(diff_min);
-            if (diff_min < c0) // [-180, 180] -> [0, 360]
-                diff_min += constants::period();
-        
+            calc_t const diff_min = math::longitude_distance_unsigned<units_t>(b1_min, b2_min);
             calc_t const b2_min_transl = b1_min + diff_min; // always right of b1_min
 
             if (b2_min_transl > b1_max                                // b2_min right of b1_max

--- a/include/boost/geometry/algorithms/detail/disjoint/box_box.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/box_box.hpp
@@ -5,8 +5,8 @@
 // Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 // Copyright (c) 2013-2015 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2013-2015.
-// Modifications copyright (c) 2013-2015, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013-2016.
+// Modifications copyright (c) 2013-2016, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
@@ -28,6 +28,9 @@
 
 #include <boost/geometry/algorithms/dispatch/disjoint.hpp>
 
+#include <boost/geometry/util/normalize_spheroidal_coordinates.hpp>
+#include <boost/geometry/util/select_most_precise.hpp>
+
 
 namespace boost { namespace geometry
 {
@@ -39,7 +42,13 @@ namespace detail { namespace disjoint
 template
 <
     typename Box1, typename Box2,
-    std::size_t Dimension, std::size_t DimensionCount
+    std::size_t Dimension = 0,
+    std::size_t DimensionCount = dimension<Box1>::value,
+    typename CSTag = typename tag_cast
+                        <
+                            typename cs_tag<Box1>::type,
+                            spherical_tag
+                        >::type
 >
 struct box_box
 {
@@ -62,12 +71,63 @@ struct box_box
 };
 
 
-template <typename Box1, typename Box2, std::size_t DimensionCount>
-struct box_box<Box1, Box2, DimensionCount, DimensionCount>
+template <typename Box1, typename Box2, std::size_t DimensionCount, typename CSTag>
+struct box_box<Box1, Box2, DimensionCount, DimensionCount, CSTag>
 {
     static inline bool apply(Box1 const& , Box2 const& )
     {
         return false;
+    }
+};
+
+
+template <typename Box1, typename Box2, std::size_t DimensionCount>
+struct box_box<Box1, Box2, 0, DimensionCount, spherical_tag>
+{
+    static inline bool apply(Box1 const& box1, Box2 const& box2)
+    {
+        typedef typename geometry::select_most_precise
+            <
+                typename coordinate_type<Box1>::type,
+                typename coordinate_type<Box2>::type
+            >::type calc_t;
+        typedef typename coordinate_system<Box1>::type::units units_t;
+        typedef math::detail::constants_on_spheroid<calc_t, units_t> constants;
+
+        calc_t const b1_min = get<min_corner, 0>(box1);
+        calc_t const b1_max = get<max_corner, 0>(box1);
+        calc_t const b2_min = get<min_corner, 0>(box2);
+        calc_t const b2_max = get<max_corner, 0>(box2);
+
+        // min <= max <=> diff >= 0
+        calc_t const diff1 = b1_max - b1_min;
+        calc_t const diff2 = b2_max - b2_min;
+
+        // check the intersection if neither box cover the whole globe
+        if (math::smaller(diff1, constants::period())
+         && math::smaller(diff2, constants::period()) ) // < period
+        {
+            // calculate positive longitude translation with b1_min as origin
+            calc_t const c0 = 0;
+            calc_t diff_min = b2_min - b1_min;
+            math::normalize_longitude<units_t, calc_t>(diff_min);
+            if (diff_min < c0) // [-180, 180] -> [0, 360]
+                diff_min += constants::period();
+        
+            calc_t const b2_min_transl = b1_min + diff_min; // always right of b1_min
+
+            if (b2_min_transl > b1_max                                // b2_min right of b1_max
+             && b2_min_transl - constants::period() + diff2 < b1_min) // b2_max left of b1_min
+            {
+                return true;
+            }
+        }
+
+        return box_box
+            <
+                Box1, Box2,
+                1, DimensionCount
+            >::apply(box1, box2);
     }
 };
 
@@ -80,11 +140,7 @@ struct box_box<Box1, Box2, DimensionCount, DimensionCount>
 template <typename Box1, typename Box2>
 inline bool disjoint_box_box(Box1 const& box1, Box2 const& box2)
 {
-    return box_box
-        <
-            Box1, Box2,
-            0, dimension<Box1>::type::value
-        >::apply(box1, box2);
+    return box_box<Box1, Box2>::apply(box1, box2);
 }
 
 

--- a/include/boost/geometry/strategies/agnostic/point_in_box_by_side.hpp
+++ b/include/boost/geometry/strategies/agnostic/point_in_box_by_side.hpp
@@ -55,6 +55,10 @@ struct decide_covered_by
 };
 
 
+// WARNING
+// This strategy is not suitable for boxes in non-cartesian CSes having edges
+// longer than 180deg because e.g. the SSF formula picks the side of the closer
+// longitude, so for long edges the side is the opposite.
 template <typename Point, typename Box, typename Decide = decide_within>
 struct point_in_box_by_side
 {
@@ -91,58 +95,6 @@ struct point_in_box_by_side
 
 
 } // namespace within
-
-
-#ifndef DOXYGEN_NO_STRATEGY_SPECIALIZATIONS
-
-
-namespace within { namespace services
-{
-
-template <typename Point, typename Box>
-struct default_strategy
-    <
-        point_tag, box_tag,
-        point_tag, areal_tag,
-        spherical_tag, spherical_tag,
-        Point, Box
-    >
-{
-    typedef within::point_in_box_by_side
-                <
-                    Point, Box, within::decide_within
-                > type;
-};
-
-
-
-}} // namespace within::services
-
-
-namespace covered_by { namespace services
-{
-
-
-template <typename Point, typename Box>
-struct default_strategy
-    <
-        point_tag, box_tag,
-        point_tag, areal_tag,
-        spherical_tag, spherical_tag,
-        Point, Box
-    >
-{
-    typedef within::point_in_box_by_side
-                <
-                    Point, Box, within::decide_covered_by
-                > type;
-};
-
-
-}} // namespace covered_by::services
-
-
-#endif // DOXYGEN_NO_STRATEGY_SPECIALIZATIONS
 
 
 }}} // namespace boost::geometry::strategy

--- a/include/boost/geometry/strategies/cartesian/box_in_box.hpp
+++ b/include/boost/geometry/strategies/cartesian/box_in_box.hpp
@@ -25,6 +25,7 @@
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/strategies/covered_by.hpp>
 #include <boost/geometry/strategies/within.hpp>
+#include <boost/geometry/util/normalize_spheroidal_coordinates.hpp>
 
 
 namespace boost { namespace geometry { namespace strategy
@@ -34,6 +35,8 @@ namespace boost { namespace geometry { namespace strategy
 namespace within
 {
 
+
+template <typename Geometry, std::size_t Dimension, typename CSTag>
 struct box_within_range
 {
     template <typename BoxContainedValue, typename BoxContainingValue>
@@ -48,6 +51,7 @@ struct box_within_range
 };
 
 
+template <typename Geometry, std::size_t Dimension, typename CSTag>
 struct box_covered_by_range
 {
     template <typename BoxContainedValue, typename BoxContainingValue>
@@ -61,9 +65,103 @@ struct box_covered_by_range
 };
 
 
+// spherical_equatorial_tag and spherical_polar_tag is casted to spherical_tag
+template <typename Geometry>
+struct box_within_range<Geometry, 0, spherical_tag>
+{
+    template <typename BoxContainedValue, typename BoxContainingValue>
+    static inline bool apply(BoxContainedValue const& bed_min,
+                             BoxContainedValue const& bed_max,
+                             BoxContainingValue const& bing_min,
+                             BoxContainingValue const& bing_max)
+    {
+        typedef typename select_most_precise
+            <
+                BoxContainedValue,
+                BoxContainingValue
+            >::type calc_t;
+        typedef typename coordinate_system<Geometry>::type::units units_t;
+        typedef math::detail::constants_on_spheroid<calc_t, units_t> constants;
+
+        // min <= max <=> diff >= 0
+        calc_t diff_ed = bed_max - bed_min;
+        calc_t diff_ing = bing_max - bing_min;
+        // if containing is smaller it cannot contain
+        // or interiors doesn't overlap (no interior in contained)
+        if (diff_ing < diff_ed || diff_ed == 0)
+            return false;
+
+        // if containing covers the whole globe it contains all
+        if (!math::smaller(diff_ing, constants::period())) // >= period
+            return true;
+
+        // calculate positive longitude translation with bing_min as origin
+        calc_t const c0 = 0;
+        calc_t diff_min = bed_min - bing_min;
+        math::normalize_longitude<units_t, calc_t>(diff_min);
+        if (diff_min < c0) // [-180, 180] -> [0, 360]
+            diff_min += constants::period();
+
+        return bing_min + diff_min + diff_ed <= bing_max;
+    }
+};
+
+
+template <typename Geometry>
+struct box_covered_by_range<Geometry, 0, spherical_tag>
+{
+    template <typename BoxContainedValue, typename BoxContainingValue>
+    static inline bool apply(BoxContainedValue const& bed_min,
+                             BoxContainedValue const& bed_max,
+                             BoxContainingValue const& bing_min,
+                             BoxContainingValue const& bing_max)
+    {
+        typedef typename select_most_precise
+            <
+                BoxContainedValue,
+                BoxContainingValue
+            >::type calc_t;
+        typedef typename coordinate_system<Geometry>::type::units units_t;
+        typedef math::detail::constants_on_spheroid<calc_t, units_t> constants;
+
+        // min <= max <=> diff >= 0
+        calc_t diff_ed = bed_max - bed_min;
+        calc_t diff_ing = bing_max - bing_min;
+        // if containing is smaller it cannot contain
+        if (diff_ing < diff_ed)
+            return false;
+
+        // if containing covers the whole globe it contains all
+        if (!math::smaller(diff_ing, constants::period())) // >= period
+            return true;
+
+        // calculate positive longitude translation with bing_min as origin
+        calc_t const c0 = 0;
+        calc_t diff_min = bed_min - bing_min;
+        math::normalize_longitude<units_t, calc_t>(diff_min);
+        if (diff_min < c0) // [-180, 180] -> [0, 360]
+            diff_min += constants::period();
+
+        return bing_min + diff_min + diff_ed <= bing_max;
+    }
+};
+
+
+template <typename Geometry>
+struct box_within_range<Geometry, 0, geographic_tag>
+    : box_within_range<Geometry, 0, spherical_tag>
+{};
+
+
+template <typename Geometry>
+struct box_covered_by_range<Geometry, 0, geographic_tag>
+    : box_covered_by_range<Geometry, 0, spherical_tag>
+{};
+
+
 template
 <
-    typename SubStrategy,
+    template <typename, std::size_t, typename> class SubStrategy,
     typename Box1,
     typename Box2,
     std::size_t Dimension,
@@ -74,8 +172,9 @@ struct relate_box_box_loop
     static inline bool apply(Box1 const& b_contained, Box2 const& b_containing)
     {
         assert_dimension_equal<Box1, Box2>();
+        typedef typename tag_cast<typename cs_tag<Box1>::type, spherical_tag>::type cs_tag_t;
 
-        if (! SubStrategy::apply(
+        if (! SubStrategy<Box1, Dimension, cs_tag_t>::apply(
                     get<min_corner, Dimension>(b_contained),
                     get<max_corner, Dimension>(b_contained),
                     get<min_corner, Dimension>(b_containing),
@@ -97,7 +196,7 @@ struct relate_box_box_loop
 
 template
 <
-    typename SubStrategy,
+    template <typename, std::size_t, typename> class SubStrategy,
     typename Box1,
     typename Box2,
     std::size_t DimensionCount
@@ -114,7 +213,7 @@ template
 <
     typename Box1,
     typename Box2,
-    typename SubStrategy = box_within_range
+    template <typename, std::size_t, typename> class SubStrategy = box_within_range
 >
 struct box_in_box
 {
@@ -150,6 +249,30 @@ struct default_strategy
     typedef within::box_in_box<BoxContained, BoxContaining> type;
 };
 
+template <typename BoxContained, typename BoxContaining>
+struct default_strategy
+    <
+        box_tag, box_tag,
+        box_tag, areal_tag,
+        spherical_tag, spherical_tag,
+        BoxContained, BoxContaining
+    >
+{
+    typedef within::box_in_box<BoxContained, BoxContaining> type;
+};
+
+template <typename BoxContained, typename BoxContaining>
+struct default_strategy
+    <
+        box_tag, box_tag,
+        box_tag, areal_tag,
+        geographic_tag, geographic_tag,
+        BoxContained, BoxContaining
+    >
+{
+    typedef within::box_in_box<BoxContained, BoxContaining> type;
+};
+
 
 }} // namespace within::services
 
@@ -162,6 +285,38 @@ struct default_strategy
         box_tag, box_tag,
         box_tag, areal_tag,
         cartesian_tag, cartesian_tag,
+        BoxContained, BoxContaining
+    >
+{
+    typedef within::box_in_box
+                <
+                    BoxContained, BoxContaining,
+                    within::box_covered_by_range
+                > type;
+};
+
+template <typename BoxContained, typename BoxContaining>
+struct default_strategy
+    <
+        box_tag, box_tag,
+        box_tag, areal_tag,
+        spherical_tag, spherical_tag,
+        BoxContained, BoxContaining
+    >
+{
+    typedef within::box_in_box
+                <
+                    BoxContained, BoxContaining,
+                    within::box_covered_by_range
+                > type;
+};
+
+template <typename BoxContained, typename BoxContaining>
+struct default_strategy
+    <
+        box_tag, box_tag,
+        box_tag, areal_tag,
+        geographic_tag, geographic_tag,
         BoxContained, BoxContaining
     >
 {

--- a/include/boost/geometry/strategies/cartesian/box_in_box.hpp
+++ b/include/boost/geometry/strategies/cartesian/box_in_box.hpp
@@ -5,8 +5,8 @@
 // Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 // Copyright (c) 2013-2015 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2015.
-// Modifications copyright (c) 2015, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2015, 2016.
+// Modifications copyright (c) 2016, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -84,8 +84,8 @@ struct box_within_range<Geometry, 0, spherical_tag>
         typedef math::detail::constants_on_spheroid<calc_t, units_t> constants;
 
         // min <= max <=> diff >= 0
-        calc_t diff_ed = bed_max - bed_min;
-        calc_t diff_ing = bing_max - bing_min;
+        calc_t const diff_ed = bed_max - bed_min;
+        calc_t const diff_ing = bing_max - bing_min;
         // if containing is smaller it cannot contain
         // or interiors doesn't overlap (no interior in contained)
         if (diff_ing < diff_ed || diff_ed == 0)
@@ -125,8 +125,8 @@ struct box_covered_by_range<Geometry, 0, spherical_tag>
         typedef math::detail::constants_on_spheroid<calc_t, units_t> constants;
 
         // min <= max <=> diff >= 0
-        calc_t diff_ed = bed_max - bed_min;
-        calc_t diff_ing = bing_max - bing_min;
+        calc_t const diff_ed = bed_max - bed_min;
+        calc_t const diff_ing = bing_max - bing_min;
         // if containing is smaller it cannot contain
         if (diff_ing < diff_ed)
             return false;
@@ -147,16 +147,7 @@ struct box_covered_by_range<Geometry, 0, spherical_tag>
 };
 
 
-template <typename Geometry>
-struct box_within_range<Geometry, 0, geographic_tag>
-    : box_within_range<Geometry, 0, spherical_tag>
-{};
-
-
-template <typename Geometry>
-struct box_covered_by_range<Geometry, 0, geographic_tag>
-    : box_covered_by_range<Geometry, 0, spherical_tag>
-{};
+// geographic_tag is casted to spherical_tag
 
 
 template
@@ -261,18 +252,7 @@ struct default_strategy
     typedef within::box_in_box<BoxContained, BoxContaining> type;
 };
 
-template <typename BoxContained, typename BoxContaining>
-struct default_strategy
-    <
-        box_tag, box_tag,
-        box_tag, areal_tag,
-        geographic_tag, geographic_tag,
-        BoxContained, BoxContaining
-    >
-{
-    typedef within::box_in_box<BoxContained, BoxContaining> type;
-};
-
+// geographic_tag is casted to spherical_tag
 
 }} // namespace within::services
 
@@ -311,21 +291,7 @@ struct default_strategy
                 > type;
 };
 
-template <typename BoxContained, typename BoxContaining>
-struct default_strategy
-    <
-        box_tag, box_tag,
-        box_tag, areal_tag,
-        geographic_tag, geographic_tag,
-        BoxContained, BoxContaining
-    >
-{
-    typedef within::box_in_box
-                <
-                    BoxContained, BoxContaining,
-                    within::box_covered_by_range
-                > type;
-};
+// geographic_tag is casted to spherical_tag
 
 }} // namespace covered_by::services
 

--- a/include/boost/geometry/strategies/cartesian/point_in_box.hpp
+++ b/include/boost/geometry/strategies/cartesian/point_in_box.hpp
@@ -4,8 +4,8 @@
 // Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2015.
-// Modifications copyright (c) 2015, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2015-2016.
+// Modifications copyright (c) 2015-2016, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -24,6 +24,7 @@
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/strategies/covered_by.hpp>
 #include <boost/geometry/strategies/within.hpp>
+#include <boost/geometry/util/normalize_spheroidal_coordinates.hpp>
 
 
 namespace boost { namespace geometry { namespace strategy
@@ -33,6 +34,7 @@ namespace within
 {
 
 
+template <typename Geometry, std::size_t Dimension, typename CSTag>
 struct within_range
 {
     template <typename Value1, typename Value2>
@@ -43,6 +45,7 @@ struct within_range
 };
 
 
+template <typename Geometry, std::size_t Dimension, typename CSTag>
 struct covered_by_range
 {
     template <typename Value1, typename Value2>
@@ -53,9 +56,75 @@ struct covered_by_range
 };
 
 
+template <typename Geometry>
+struct within_range<Geometry, 0, spherical_tag>
+{
+    template <typename Value1, typename Value2>
+    static inline bool apply(Value1 const& value, Value2 const& min_value, Value2 const& max_value)
+    {
+        typedef typename select_most_precise
+            <
+                Value1, Value2
+            >::type calc_t;
+        typedef typename coordinate_system<Geometry>::type::units units_t;
+        typedef math::detail::constants_on_spheroid<calc_t, units_t> constants;
+
+        // min <= max <=> diff >= 0
+        calc_t const diff_ing = max_value - min_value;
+
+        // if containing covers the whole globe it contains all
+        if (!math::smaller(diff_ing, constants::period())) // >= period
+            return true;
+
+        // calculate positive longitude translation with bing_min as origin
+        calc_t const c0 = 0;
+        calc_t diff_min = value - min_value;
+        math::normalize_longitude<units_t, calc_t>(diff_min);
+        if (diff_min < c0) // [-180, 180] -> [0, 360]
+            diff_min += constants::period();
+
+        return diff_min > c0 && min_value + diff_min < max_value;
+    }
+};
+
+
+template <typename Geometry>
+struct covered_by_range<Geometry, 0, spherical_tag>
+{
+    template <typename Value1, typename Value2>
+    static inline bool apply(Value1 const& value, Value2 const& min_value, Value2 const& max_value)
+    {
+        typedef typename select_most_precise
+            <
+                Value1, Value2
+            >::type calc_t;
+        typedef typename coordinate_system<Geometry>::type::units units_t;
+        typedef math::detail::constants_on_spheroid<calc_t, units_t> constants;
+
+        // min <= max <=> diff >= 0
+        calc_t const diff_ing = max_value - min_value;
+
+        // if containing covers the whole globe it contains all
+        if (!math::smaller(diff_ing, constants::period())) // >= period
+            return true;
+
+        // calculate positive longitude translation with min_value as origin
+        calc_t const c0 = 0;
+        calc_t diff_min = value - min_value;
+        math::normalize_longitude<units_t, calc_t>(diff_min);
+        if (diff_min < c0) // [-180, 180] -> [0, 360]
+            diff_min += constants::period();
+
+        return min_value + diff_min <= max_value;
+    }
+};
+
+// geographic_tag is casted to spherical_tag
+
+
 template
 <
-    typename SubStrategy,
+    template <typename, std::size_t, typename> class SubStrategy,
     typename Point,
     typename Box,
     std::size_t Dimension,
@@ -65,7 +134,9 @@ struct relate_point_box_loop
 {
     static inline bool apply(Point const& point, Box const& box)
     {
-        if (! SubStrategy::apply(get<Dimension>(point),
+        typedef typename tag_cast<typename cs_tag<Point>::type, spherical_tag>::type cs_tag_t;
+
+        if (! SubStrategy<Point, Dimension, cs_tag_t>::apply(get<Dimension>(point),
                     get<min_corner, Dimension>(box),
                     get<max_corner, Dimension>(box))
             )
@@ -85,7 +156,7 @@ struct relate_point_box_loop
 
 template
 <
-    typename SubStrategy,
+    template <typename, std::size_t, typename> class SubStrategy,
     typename Point,
     typename Box,
     std::size_t DimensionCount
@@ -103,7 +174,7 @@ template
 <
     typename Point,
     typename Box,
-    typename SubStrategy = within_range
+    template <typename, std::size_t, typename> class SubStrategy = within_range
 >
 struct point_in_box
 {
@@ -140,6 +211,20 @@ struct default_strategy
     typedef within::point_in_box<Point, Box> type;
 };
 
+template <typename Point, typename Box>
+struct default_strategy
+    <
+        point_tag, box_tag,
+        point_tag, areal_tag,
+        spherical_tag, spherical_tag,
+        Point, Box
+    >
+{
+    typedef within::point_in_box<Point, Box> type;
+};
+
+// geographic_tag is casted to spherical_tag
+
 
 }} // namespace within::services
 
@@ -163,6 +248,24 @@ struct default_strategy
                     within::covered_by_range
                 > type;
 };
+
+template <typename Point, typename Box>
+struct default_strategy
+    <
+        point_tag, box_tag,
+        point_tag, areal_tag,
+        spherical_tag, spherical_tag,
+        Point, Box
+    >
+{
+    typedef within::point_in_box
+                <
+                    Point, Box,
+                    within::covered_by_range
+                > type;
+};
+
+// geographic_tag is casted to spherical_tag
 
 
 }} // namespace covered_by::services

--- a/include/boost/geometry/strategies/spherical/ssf.hpp
+++ b/include/boost/geometry/strategies/spherical/ssf.hpp
@@ -2,6 +2,10 @@
 
 // Copyright (c) 2011-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2016.
+// Modifications copyright (c) 2016, Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -61,9 +65,9 @@ int spherical_side_formula(T const& lambda1, T const& delta1,
         + (c1x * c2y - c1y * c2x) * sin(delta);
 
     T zero = T();
-    return dist > zero ? 1
-        : dist < zero ? -1
-        : 0;
+    return math::equals(dist, zero) ? 0
+        : dist > zero ? 1
+        : -1; // dist < zero
 }
 
 }

--- a/include/boost/geometry/util/normalize_spheroidal_coordinates.hpp
+++ b/include/boost/geometry/util/normalize_spheroidal_coordinates.hpp
@@ -236,6 +236,52 @@ inline void normalize_longitude(CoordinateType& longitude)
 }
 
 
+/*!
+\brief Short utility to calculate difference between two longitudes
+       normalized in range (-180, 180].
+\tparam Units The units of the coordindate system in the spheroid
+\tparam CoordinateType The type of the coordinates
+\param longitude1 Longitude 1
+\param longitude2 Longitude 2
+\ingroup utility
+*/
+template <typename Units, typename CoordinateType>
+inline CoordinateType longitude_distance_signed(CoordinateType const& longitude1,
+                                                CoordinateType const& longitude2)
+{
+    CoordinateType diff = longitude2 - longitude1;
+    math::normalize_longitude<Units, CoordinateType>(diff);
+    return diff;
+}
+
+
+/*!
+\brief Short utility to calculate difference between two longitudes
+       normalized in range [0, 360).
+\tparam Units The units of the coordindate system in the spheroid
+\tparam CoordinateType The type of the coordinates
+\param longitude1 Longitude 1
+\param longitude2 Longitude 2
+\ingroup utility
+*/
+template <typename Units, typename CoordinateType>
+inline CoordinateType longitude_distance_unsigned(CoordinateType const& longitude1,
+                                                  CoordinateType const& longitude2)
+{
+    typedef math::detail::constants_on_spheroid
+        <
+            CoordinateType, Units
+        > constants;
+
+    CoordinateType const c0 = 0;
+    CoordinateType diff = longitude_distance_signed<Units>(longitude1, longitude2);
+    if (diff < c0) // (-180, 180] -> [0, 360)
+    {
+        diff += constants::period();
+    }
+    return diff;
+}
+
 } // namespace math
 
 

--- a/test/algorithms/relational_operations/Jamfile.v2
+++ b/test/algorithms/relational_operations/Jamfile.v2
@@ -4,8 +4,8 @@
 # Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
 # Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 #
-# This file was modified by Oracle on 2014, 2015.
-# Modifications copyright (c) 2014-2015, Oracle and/or its affiliates.
+# This file was modified by Oracle on 2014, 2015, 2016.
+# Modifications copyright (c) 2014-2016, Oracle and/or its affiliates.
 #
 # Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 # Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -18,6 +18,7 @@ test-suite boost-geometry-algorithms-relational
     :
     [ run covered_by.cpp         : : : : algorithms_covered_by ]
     [ run covered_by_multi.cpp   : : : : algorithms_covered_by_multi ]
+    [ run covered_by_sph_geo.cpp : : : : algorithms_covered_by_sph_geo ]
     [ run crosses.cpp            : : : : algorithms_crosses ]
     [ run equals.cpp             : : : : algorithms_equals ]
     [ run equals_multi.cpp       : : : : algorithms_equals_multi ]

--- a/test/algorithms/relational_operations/covered_by_sph_geo.cpp
+++ b/test/algorithms/relational_operations/covered_by_sph_geo.cpp
@@ -1,0 +1,79 @@
+// Boost.Geometry
+
+// Copyright (c) 2016 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "test_covered_by.hpp"
+
+
+#include <boost/geometry/geometries/geometries.hpp>
+
+
+template <typename P>
+void test_point_box()
+{
+    typedef bg::model::box<P> box_t;
+
+    test_geometry<P, box_t>("POINT(0 0)",    "BOX(0 0, 1 1)", true);
+    test_geometry<P, box_t>("POINT(1 1)",    "BOX(0 0, 2 2)", true);
+
+    test_geometry<P, box_t>("POINT(180 1)",  "BOX(170 0, 190 2)", true);
+    test_geometry<P, box_t>("POINT(-180 1)", "BOX(170 0, 190 2)", true);
+    test_geometry<P, box_t>("POINT(180 1)",  "BOX(170 0, 180 2)", true);
+    test_geometry<P, box_t>("POINT(-180 1)", "BOX(170 0, 180 2)", true);
+    test_geometry<P, box_t>("POINT(179 1)",  "BOX(170 0, 190 2)", true);
+    test_geometry<P, box_t>("POINT(-179 1)", "BOX(170 0, 190 2)", true);
+    test_geometry<P, box_t>("POINT(179 1)",  "BOX(170 0, 180 2)", true);
+    test_geometry<P, box_t>("POINT(-179 1)", "BOX(170 0, 180 2)", false);
+    test_geometry<P, box_t>("POINT(169 1)", "BOX(170 0, 180 2)", false);
+}
+
+template <typename P>
+void test_box_box()
+{
+    typedef bg::model::box<P> box_t;
+
+    test_geometry<box_t, box_t>("BOX(0 0, 1 1)", "BOX(0 0, 1 1)", true);
+
+    test_geometry<box_t, box_t>("BOX(-170 0,-160 1)", "BOX(-180 0, 180 1)", true);
+    test_geometry<box_t, box_t>("BOX(-170 0,-160 1)", "BOX(170 0, 200 1)",  true);
+    test_geometry<box_t, box_t>("BOX(-170 0,-150 1)", "BOX(170 0, 200 1)",  false);
+    test_geometry<box_t, box_t>("BOX(0 0,1 1)",       "BOX(170 0, 370 1)",  true);
+    test_geometry<box_t, box_t>("BOX(0 0,10 1)",      "BOX(170 0, 370 1)",  true);
+    test_geometry<box_t, box_t>("BOX(-180 0,10 1)",   "BOX(170 0, 370 1)",  true);
+    test_geometry<box_t, box_t>("BOX(-180 0,20 1)",   "BOX(170 0, 370 1)",  false);
+    test_geometry<box_t, box_t>("BOX(10 0,20 1)",     "BOX(170 0, 370 1)",  false);
+    test_geometry<box_t, box_t>("BOX(160 0,180 1)",   "BOX(170 0, 370 1)",  false);
+
+    test_geometry<box_t, box_t>("BOX(-180 0,-170 1)", "BOX(180 0, 190 1)",  true); // invalid?
+    test_geometry<box_t, box_t>("BOX(-180 0,-170 1)", "BOX(180 0, 191 1)",  true); // invalid?
+    test_geometry<box_t, box_t>("BOX(-180 0,-170 1)", "BOX(179 0, 190 1)",  true);
+    test_geometry<box_t, box_t>("BOX(-180 0,-170 1)", "BOX(181 0, 190 1)",  false); // invalid?
+    test_geometry<box_t, box_t>("BOX(-180 0,-170 1)", "BOX(180 0, 189 1)",  false); // invalid?
+}
+
+
+template <typename P>
+void test_cs()
+{
+    test_point_box<P>();
+    test_box_box<P>();
+}
+
+
+int test_main( int , char* [] )
+{
+    test_cs<bg::model::point<double, 2, bg::cs::spherical_equatorial<bg::degree> > >();
+    test_cs<bg::model::point<double, 2, bg::cs::geographic<bg::degree> > >();
+
+#if defined(HAVE_TTMATH)
+    test_cs<bg::model::point<ttmath_big, 2, bg::cs::spherical_equatorial<bg::degree> > >();
+    test_cs<bg::model::point<ttmath_big, 2, bg::cs::geographic<bg::degree> > >();;
+#endif
+
+    return 0;
+}

--- a/test/algorithms/relational_operations/intersects/Jamfile.v2
+++ b/test/algorithms/relational_operations/intersects/Jamfile.v2
@@ -4,8 +4,8 @@
 # Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
 # Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 #
-# This file was modified by Oracle on 2014, 2015.
-# Modifications copyright (c) 2014-2015, Oracle and/or its affiliates.
+# This file was modified by Oracle on 2014, 2015, 2016.
+# Modifications copyright (c) 2014-2016, Oracle and/or its affiliates.
 #
 # Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 # Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -20,5 +20,6 @@ test-suite boost-geometry-algorithms-relational-intersects
     [ run intersects_box_geometry.cpp : : : : algorithms_intersects_box_geometry ]
     [ run intersects_multi.cpp        : : : : algorithms_intersects_multi ]
     [ run intersects_self.cpp         : : : : algorithms_intersects_self ]
+    [ run intersects_sph_geo.cpp      : : : : algorithms_intersects_sph_geo ]
     ;
 

--- a/test/algorithms/relational_operations/intersects/intersects_sph_geo.cpp
+++ b/test/algorithms/relational_operations/intersects/intersects_sph_geo.cpp
@@ -1,0 +1,86 @@
+// Boost.Geometry
+
+// Copyright (c) 2016 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "test_intersects.hpp"
+
+
+#include <boost/geometry/geometries/geometries.hpp>
+
+
+template <typename P>
+void test_point_box()
+{
+    typedef bg::model::box<P> box_t;
+
+    test_geometry<P, box_t>("POINT(0 0)",    "BOX(0 0, 1 1)", true);
+    test_geometry<P, box_t>("POINT(1 1)",    "BOX(0 0, 2 2)", true);
+
+    test_geometry<P, box_t>("POINT(180 1)",  "BOX(170 0, 190 2)", true);
+    test_geometry<P, box_t>("POINT(-180 1)", "BOX(170 0, 190 2)", true);
+    test_geometry<P, box_t>("POINT(180 1)",  "BOX(170 0, 180 2)", true);
+    test_geometry<P, box_t>("POINT(-180 1)", "BOX(170 0, 180 2)", true);
+    test_geometry<P, box_t>("POINT(179 1)",  "BOX(170 0, 190 2)", true);
+    test_geometry<P, box_t>("POINT(-179 1)", "BOX(170 0, 190 2)", true);
+    test_geometry<P, box_t>("POINT(179 1)",  "BOX(170 0, 180 2)", true);
+    test_geometry<P, box_t>("POINT(-179 1)", "BOX(170 0, 180 2)", false);
+    test_geometry<P, box_t>("POINT(169 1)", "BOX(170 0, 180 2)", false);
+}
+
+template <typename P>
+void test_box_box()
+{
+    typedef bg::model::box<P> box_t;
+
+    test_geometry<box_t, box_t>("BOX(0 0, 1 1)", "BOX(0 0, 1 1)", true);
+
+    test_geometry<box_t, box_t>("BOX(-170 0,-160 1)", "BOX(-180 0, 180 1)", true);
+    test_geometry<box_t, box_t>("BOX(-170 0,-160 1)", "BOX(170 0, 200 1)",  true);
+    test_geometry<box_t, box_t>("BOX(-170 0,-150 1)", "BOX(170 0, 200 1)",  true);
+    test_geometry<box_t, box_t>("BOX(201 0,202 1)",   "BOX(170 0, 200 1)",  false); // invalid g1?
+    test_geometry<box_t, box_t>("BOX(-159 0,-158 1)", "BOX(170 0, 200 1)",  false);
+    test_geometry<box_t, box_t>("BOX(160 0,169 1)",   "BOX(170 0, 200 1)",  false);
+    test_geometry<box_t, box_t>("BOX(-159 0,169 1)",  "BOX(170 0, 200 1)",  false);
+    test_geometry<box_t, box_t>("BOX(0 0,1 1)",       "BOX(170 0, 370 1)",  true);
+    test_geometry<box_t, box_t>("BOX(0 0,10 1)",      "BOX(170 0, 370 1)",  true);
+    test_geometry<box_t, box_t>("BOX(-180 0,10 1)",   "BOX(170 0, 370 1)",  true);
+    test_geometry<box_t, box_t>("BOX(-180 0,20 1)",   "BOX(170 0, 370 1)",  true);
+    test_geometry<box_t, box_t>("BOX(10 0,20 1)",     "BOX(170 0, 370 1)",  true);
+    test_geometry<box_t, box_t>("BOX(160 0,180 1)",   "BOX(170 0, 370 1)",  true);
+    test_geometry<box_t, box_t>("BOX(160 0,165 1)",   "BOX(170 0, 370 1)",  false);
+    test_geometry<box_t, box_t>("BOX(15 0,20 1)",     "BOX(170 0, 370 1)",  false);
+    test_geometry<box_t, box_t>("BOX(375 0,380 1)",   "BOX(170 0, 370 1)",  false); // invalid g1?
+
+    test_geometry<box_t, box_t>("BOX(-180 0,-170 1)", "BOX(180 0, 190 1)",  true); // invalid?
+    test_geometry<box_t, box_t>("BOX(-180 0,-170 1)", "BOX(180 0, 191 1)",  true); // invalid?
+    test_geometry<box_t, box_t>("BOX(-180 0,-170 1)", "BOX(179 0, 190 1)",  true);
+    test_geometry<box_t, box_t>("BOX(-180 0,-170 1)", "BOX(181 0, 190 1)",  true); // invalid?
+    test_geometry<box_t, box_t>("BOX(-180 0,-170 1)", "BOX(180 0, 189 1)",  true); // invalid?
+}
+
+
+template <typename P>
+void test_cs()
+{
+    test_point_box<P>();
+    test_box_box<P>();
+}
+
+
+int test_main( int , char* [] )
+{
+    test_cs<bg::model::point<double, 2, bg::cs::spherical_equatorial<bg::degree> > >();
+    test_cs<bg::model::point<double, 2, bg::cs::geographic<bg::degree> > >();
+
+#if defined(HAVE_TTMATH)
+    test_cs<bg::model::point<ttmath_big, 2, bg::cs::spherical_equatorial<bg::degree> > >();
+    test_cs<bg::model::point<ttmath_big, 2, bg::cs::geographic<bg::degree> > >();;
+#endif
+
+    return 0;
+}

--- a/test/algorithms/relational_operations/within/Jamfile.v2
+++ b/test/algorithms/relational_operations/within/Jamfile.v2
@@ -4,8 +4,8 @@
 # Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
 # Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 #
-# This file was modified by Oracle on 2014, 2015.
-# Modifications copyright (c) 2014-2015, Oracle and/or its affiliates.
+# This file was modified by Oracle on 2014, 2015, 2016.
+# Modifications copyright (c) 2014-2016, Oracle and/or its affiliates.
 #
 # Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 # Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -22,4 +22,5 @@ test-suite boost-geometry-algorithms-within
     [ run within_linear_linear.cpp      : : : : algorithms_within_linear_linear ]
     [ run within_multi.cpp              : : : : algorithms_within_multi ]
     [ run within_pointlike_geometry.cpp : : : : algorithms_within_pointlike_geometry ]
+    [ run within_sph_geo.cpp            : : : : algorithms_within_sph_geo ]
     ;

--- a/test/algorithms/relational_operations/within/within.cpp
+++ b/test/algorithms/relational_operations/within/within.cpp
@@ -3,8 +3,8 @@
 // Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2013-2015 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2014, 2015.
-// Modifications copyright (c) 2014-2015 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014, 2015, 2016.
+// Modifications copyright (c) 2014-2016 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -52,34 +52,6 @@ void test_all()
     test_within_code<box_type, box_type>("BOX(1 1,3 2)", "BOX(0 0,3 3)", 0);
     test_within_code<box_type, box_type>("BOX(1 1,3 4)", "BOX(0 0,3 3)", -1);
     */
-}
-
-template <typename Point>
-void test_spherical()
-{
-    // Test spherical boxes
-    // See also http://www.gcmap.com/mapui?P=1E45N-19E45N-19E55N-1E55N-1E45N,10E55.1N,10E45.1N
-    bg::model::box<Point> box;
-    bg::read_wkt("POLYGON((1 45,19 55))", box);
-    BOOST_CHECK_EQUAL(bg::within(Point(10, 55.1), box), true);
-    BOOST_CHECK_EQUAL(bg::within(Point(10, 55.2), box), true);
-    BOOST_CHECK_EQUAL(bg::within(Point(10, 55.3), box), true);
-    BOOST_CHECK_EQUAL(bg::within(Point(10, 55.4), box), false);
-
-    BOOST_CHECK_EQUAL(bg::within(Point(10, 45.1), box), false);
-    BOOST_CHECK_EQUAL(bg::within(Point(10, 45.2), box), false);
-    BOOST_CHECK_EQUAL(bg::within(Point(10, 45.3), box), false);
-    BOOST_CHECK_EQUAL(bg::within(Point(10, 45.4), box), true);
-
-    // Crossing the dateline (Near Tuvalu)
-    // http://www.gcmap.com/mapui?P=178E10S-178W10S-178W6S-178E6S-178E10S,180W5.999S,180E9.999S
-    // http://en.wikipedia.org/wiki/Tuvalu
-
-    bg::model::box<Point> tuvalu(Point(178, -10), Point(-178, -6));
-    BOOST_CHECK_EQUAL(bg::within(Point(180, -8), tuvalu), true);
-    BOOST_CHECK_EQUAL(bg::within(Point(-180, -8), tuvalu), true);
-    BOOST_CHECK_EQUAL(bg::within(Point(180, -5.999), tuvalu), false);
-    BOOST_CHECK_EQUAL(bg::within(Point(180, -10.001), tuvalu), true);
 }
 
 void test_3d()
@@ -176,8 +148,6 @@ int test_main( int , char* [] )
     test_all<bg::model::d2::point_xy<int> >();
     test_all<bg::model::d2::point_xy<double> >();
 
-    test_spherical<bg::model::point<double, 2, bg::cs::spherical_equatorial<bg::degree> > >();
-
     test_mixed();
     test_3d();
     test_strategy();
@@ -185,7 +155,6 @@ int test_main( int , char* [] )
 
 #if defined(HAVE_TTMATH)
     test_all<bg::model::d2::point_xy<ttmath_big> >();
-    test_spherical<bg::model::point<ttmath_big, 2, bg::cs::spherical_equatorial<bg::degree> > >();
 #endif
 
     return 0;

--- a/test/algorithms/relational_operations/within/within_sph_geo.cpp
+++ b/test/algorithms/relational_operations/within/within_sph_geo.cpp
@@ -122,7 +122,7 @@ int test_main( int , char* [] )
 
 #if defined(HAVE_TTMATH)
     test_cs<bg::model::point<ttmath_big, 2, bg::cs::spherical_equatorial<bg::degree> > >();
-    test_cs<bg::model::point<ttmath_big, 2, bg::cs::geographic<bg::degree> > >();;
+    test_cs<bg::model::point<ttmath_big, 2, bg::cs::geographic<bg::degree> > >();
 #endif
 
     return 0;

--- a/test/algorithms/relational_operations/within/within_sph_geo.cpp
+++ b/test/algorithms/relational_operations/within/within_sph_geo.cpp
@@ -1,0 +1,129 @@
+// Boost.Geometry
+
+// Copyright (c) 2016 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "test_within.hpp"
+
+
+#include <boost/geometry/geometries/geometries.hpp>
+
+
+template <typename Point>
+void test_point_box_by_side()
+{
+    // Test spherical boxes
+    // See also http://www.gcmap.com/mapui?P=1E45N-19E45N-19E55N-1E55N-1E45N,10E55.1N,10E45.1N
+    typedef bg::model::box<Point> box_t;
+    bg::strategy::within::point_in_box_by_side<Point, box_t> by_side;
+    box_t box;
+    bg::read_wkt("POLYGON((1 45,19 55))", box);
+    BOOST_CHECK_EQUAL(bg::within(Point(10, 55.1), box, by_side), true);
+    BOOST_CHECK_EQUAL(bg::within(Point(10, 55.2), box, by_side), true);
+    BOOST_CHECK_EQUAL(bg::within(Point(10, 55.3), box, by_side), true);
+    BOOST_CHECK_EQUAL(bg::within(Point(10, 55.4), box, by_side), false);
+
+    BOOST_CHECK_EQUAL(bg::within(Point(10, 45.1), box, by_side), false);
+    BOOST_CHECK_EQUAL(bg::within(Point(10, 45.2), box, by_side), false);
+    BOOST_CHECK_EQUAL(bg::within(Point(10, 45.3), box, by_side), false);
+    BOOST_CHECK_EQUAL(bg::within(Point(10, 45.4), box, by_side), true);
+
+    // By default Box is not a polygon in spherical CS, edges are defined by small circles
+    BOOST_CHECK_EQUAL(bg::within(Point(10, 45.1), box), true);
+    BOOST_CHECK_EQUAL(bg::within(Point(10, 54.9), box), true);
+    BOOST_CHECK_EQUAL(bg::within(Point(10, 55), box), false);
+    BOOST_CHECK_EQUAL(bg::within(Point(10, 45), box), false);
+
+    // Crossing the dateline (Near Tuvalu)
+    // http://www.gcmap.com/mapui?P=178E10S-178W10S-178W6S-178E6S-178E10S,180W5.999S,180E9.999S
+    // http://en.wikipedia.org/wiki/Tuvalu
+
+    box_t tuvalu(Point(178, -10), Point(-178, -6));
+    BOOST_CHECK_EQUAL(bg::within(Point(180, -8), tuvalu, by_side), true);
+    BOOST_CHECK_EQUAL(bg::within(Point(-180, -8), tuvalu, by_side), true);
+    BOOST_CHECK_EQUAL(bg::within(Point(180, -5.999), tuvalu, by_side), false);
+    BOOST_CHECK_EQUAL(bg::within(Point(180, -10.001), tuvalu, by_side), true);
+
+    // The above definition of a Box is not valid
+    // min should be lesser than max
+    // By default Box is not a polygon in spherical CS, edges are defined by small circles
+    box_t tuvalu2(Point(178, -10), Point(182, -6));
+    BOOST_CHECK_EQUAL(bg::within(Point(180, -8), tuvalu2), true);
+    BOOST_CHECK_EQUAL(bg::within(Point(-180, -8), tuvalu2), true);
+    BOOST_CHECK_EQUAL(bg::within(Point(180, -6.001), tuvalu2), true);
+    BOOST_CHECK_EQUAL(bg::within(Point(180, -5.999), tuvalu2), false);
+    BOOST_CHECK_EQUAL(bg::within(Point(180, -9.999), tuvalu2), true);
+    BOOST_CHECK_EQUAL(bg::within(Point(180, -10.001), tuvalu2), false);
+}
+
+
+template <typename P>
+void test_point_box()
+{
+    typedef bg::model::box<P> box_t;
+
+    test_geometry<P, box_t>("POINT(0 0)",    "BOX(0 0, 1 1)", false);
+    test_geometry<P, box_t>("POINT(1 1)",    "BOX(0 0, 2 2)", true);
+
+    test_geometry<P, box_t>("POINT(180 1)",  "BOX(170 0, 190 2)", true);
+    test_geometry<P, box_t>("POINT(-180 1)", "BOX(170 0, 190 2)", true);
+    test_geometry<P, box_t>("POINT(180 1)",  "BOX(170 0, 180 2)", false);
+    test_geometry<P, box_t>("POINT(-180 1)", "BOX(170 0, 180 2)", false);
+    test_geometry<P, box_t>("POINT(179 1)",  "BOX(170 0, 190 2)", true);
+    test_geometry<P, box_t>("POINT(-179 1)", "BOX(170 0, 190 2)", true);
+    test_geometry<P, box_t>("POINT(179 1)",  "BOX(170 0, 180 2)", true);
+    test_geometry<P, box_t>("POINT(-179 1)", "BOX(170 0, 180 2)", false);
+    test_geometry<P, box_t>("POINT(169 1)",  "BOX(170 0, 180 2)", false);
+
+    test_point_box_by_side<P>();
+}
+
+template <typename P>
+void test_box_box()
+{
+    typedef bg::model::box<P> box_t;
+
+    test_geometry<box_t, box_t>("BOX(0 0, 1 1)", "BOX(0 0, 1 1)", true);
+
+    test_geometry<box_t, box_t>("BOX(-170 0,-160 1)", "BOX(-180 0, 180 1)", true);
+    test_geometry<box_t, box_t>("BOX(-170 0,-160 1)", "BOX(170 0, 200 1)",  true);
+    test_geometry<box_t, box_t>("BOX(-170 0,-150 1)", "BOX(170 0, 200 1)",  false);
+    test_geometry<box_t, box_t>("BOX(0 0,1 1)",       "BOX(170 0, 370 1)",  true);
+    test_geometry<box_t, box_t>("BOX(0 0,10 1)",      "BOX(170 0, 370 1)",  true);
+    test_geometry<box_t, box_t>("BOX(-180 0,10 1)",   "BOX(170 0, 370 1)",  true);
+    test_geometry<box_t, box_t>("BOX(-180 0,20 1)",   "BOX(170 0, 370 1)",  false);
+    test_geometry<box_t, box_t>("BOX(10 0,20 1)",     "BOX(170 0, 370 1)",  false);
+    test_geometry<box_t, box_t>("BOX(160 0,180 1)",   "BOX(170 0, 370 1)",  false);
+
+    test_geometry<box_t, box_t>("BOX(-180 0,-170 1)", "BOX(180 0, 190 1)",  true); // invalid?
+    test_geometry<box_t, box_t>("BOX(-180 0,-170 1)", "BOX(180 0, 191 1)",  true); // invalid?
+    test_geometry<box_t, box_t>("BOX(-180 0,-170 1)", "BOX(179 0, 190 1)",  true);
+    test_geometry<box_t, box_t>("BOX(-180 0,-170 1)", "BOX(181 0, 190 1)",  false); // invalid?
+    test_geometry<box_t, box_t>("BOX(-180 0,-170 1)", "BOX(180 0, 189 1)",  false); // invalid?
+}
+
+
+template <typename P>
+void test_cs()
+{
+    test_point_box<P>();
+    test_box_box<P>();
+}
+
+
+int test_main( int , char* [] )
+{
+    test_cs<bg::model::point<double, 2, bg::cs::spherical_equatorial<bg::degree> > >();
+    test_cs<bg::model::point<double, 2, bg::cs::geographic<bg::degree> > >();
+
+#if defined(HAVE_TTMATH)
+    test_cs<bg::model::point<ttmath_big, 2, bg::cs::spherical_equatorial<bg::degree> > >();
+    test_cs<bg::model::point<ttmath_big, 2, bg::cs::geographic<bg::degree> > >();;
+#endif
+
+    return 0;
+}


### PR DESCRIPTION
This PR adds or changes the following:
- support spherical/geographic CS in `box_in_box` strategy and enable it as the default one
- support spherical/geographic CS in `point_in_box` strategy and enable it as the default one
- fix `disjoint()`/`intersects()` for point/box in spherical/geographic CS (using tools implemented for `point_in_box` strategy)
- fix `disjoint()`/`intersects()` for box/box in spherical/geographic CS (separate implementation)

This PR changes the way how `within(point, box)` and `covered_by(point, box)` is calculated by default. The reason is that a Box in spherical and geographical CS is not a Polygon. The differences are:
- the horizontal edge of a Box may be longer than 180 deg
- the horizontal edge of a Box is not defined by geodesic but by small circle

`point_in_box_by_side` is no longer used by default. It returns wrong result for Boxes with edges longer than 180 deg. It's because when a side is calculated the closer direction is picked so for those long edges (length in (180, 360]) some sides are the opposite than expected.

This PR also fixes the ticket: https://svn.boost.org/trac/boost/ticket/11987

Since `point_in_box` and `box_in_box` now support all CSes I plan to move them to `strategies/agnostic` directory. This is not a part of this PR to make the review of the code more convenient, to avoid displaying the unchanged parts of implementations as new ones on GitHub.