### PR TITLE
Silence unused parameter warnings (GCC/Clang -Wextra).

### DIFF
--- a/include/boost/geometry/algorithms/detail/buffer/buffer_policies.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/buffer_policies.hpp
@@ -58,14 +58,14 @@ public :
     static inline void apply(std::size_t size_at_start,
                 Rings& rings, typename boost::range_value<Rings>::type& ring,
                 Turns& turns,
-                typename boost::range_value<Turns>::type const& turn,
+                typename boost::range_value<Turns>::type const& /*turn*/,
                 Operation& operation,
-                detail::overlay::traverse_error_type traverse_error,
+                detail::overlay::traverse_error_type /*traverse_error*/,
                 Geometry const& ,
                 Geometry const& ,
                 RobustPolicy const& ,
                 state_type& state,
-                Visitor& visitor
+                Visitor& /*visitor*/
                 )
     {
 #if defined(BOOST_GEOMETRY_COUNT_BACKTRACK_WARNINGS)
@@ -92,17 +92,17 @@ g_backtrack_warning_count++;
 struct buffer_overlay_visitor
 {
 public :
-    void print(char const* header)
+    void print(char const* /*header*/)
     {
     }
 
     template <typename Turns>
-    void print(char const* header, Turns const& turns, int turn_index)
+    void print(char const* /*header*/, Turns const& /*turns*/, int /*turn_index*/)
     {
     }
 
     template <typename Turns>
-    void print(char const* header, Turns const& turns, int turn_index, int op_index)
+    void print(char const* /*header*/, Turns const& /*turns*/, int /*turn_index*/, int /*op_index*/)
     {
     }
 
@@ -113,7 +113,7 @@ public :
     void visit_clusters(Clusters const& , Turns const& ) {}
 
     template <typename Turns, typename Turn, typename Operation>
-    void visit_traverse(Turns const& turns, Turn const& turn, Operation const& op, const char* header)
+    void visit_traverse(Turns const& /*turns*/, Turn const& /*turn*/, Operation const& /*op*/, const char* /*header*/)
     {
     }
 

--- a/include/boost/geometry/algorithms/detail/overlay/enrich_intersection_points.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/enrich_intersection_points.hpp
@@ -66,7 +66,7 @@ inline void enrich_sort(Operations& operations,
             Geometry1 const& geometry1,
             Geometry2 const& geometry2,
             RobustPolicy const& robust_policy,
-            Strategy const& strategy)
+            Strategy const& /*strategy*/)
 {
     std::sort(boost::begin(operations),
             boost::end(operations),

--- a/include/boost/geometry/algorithms/detail/overlay/handle_colocations.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/handle_colocations.hpp
@@ -212,7 +212,7 @@ inline void handle_colocation_cluster(Turns& turns,
         signed_size_type& cluster_id,
         ClusterPerSegment& cluster_per_segment,
         Operations const& operations,
-        Geometry1 const& geometry1, Geometry2 const& geometry2)
+        Geometry1 const& /*geometry1*/, Geometry2 const& /*geometry2*/)
 {
     typedef typename boost::range_value<Turns>::type turn_type;
     typedef typename turn_type::turn_operation_type turn_operation_type;

--- a/include/boost/geometry/algorithms/detail/overlay/handle_touch.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/handle_touch.hpp
@@ -46,7 +46,7 @@ public :
         : m_visitor(visitor)
     {}
 
-    inline void apply(detail::overlay::operation_type operation, Turns& turns)
+    inline void apply(detail::overlay::operation_type /*operation*/, Turns& turns)
     {
         if (! has_uu(turns))
         {


### PR DESCRIPTION
For all I know, some of these might even be real bugs...

But in any event, it's nice when Boost does not generate warnings for those of us who like to enable lots and lots of warnings.