### PR TITLE
Remove extraneous semicolon

### DIFF
--- a/include/boost/geometry/algorithms/detail/envelope/transform_units.hpp
+++ b/include/boost/geometry/algorithms/detail/envelope/transform_units.hpp
@@ -92,7 +92,7 @@ inline void transform_units(GeometryIn const& geometry_in,
         <
             GeometryIn, GeometryOut
         >::apply(geometry_in, geometry_out);
-};
+}
 
 
 }} // namespace detail::envelope


### PR DESCRIPTION
As simple as it gets: remove semicolon after a function to silence GCC warnings (-Wpedantic)