### PR TITLE
Fix/cart intersect for different RobustPoint types

### DIFF
--- a/index/test/rtree/Jamfile.v2
+++ b/index/test/rtree/Jamfile.v2
@@ -14,6 +14,7 @@ test-suite boost-geometry-index-rtree
     :
     [ run rtree_epsilon.cpp ]
     [ run rtree_insert_remove.cpp ]
+    [ run rtree_intersects_geom.cpp ]
     [ run rtree_move_pack.cpp ]
     [ run rtree_non_cartesian.cpp ]
     [ run rtree_values.cpp ]

--- a/index/test/rtree/rtree_intersects_geom.cpp
+++ b/index/test/rtree/rtree_intersects_geom.cpp
@@ -1,0 +1,55 @@
+// Boost.Geometry Index
+// Unit Test
+
+// Copyright (c) 2016 Adam Wulkiewicz, Lodz, Poland.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <rtree/test_rtree.hpp>
+
+#include <boost/geometry/geometries/geometries.hpp>
+#include <boost/geometry/geometries/point_xy.hpp>
+
+template <typename Value, typename Point, typename Params>
+void test_all()
+{
+    typedef bg::model::box<Point> Box;
+    typedef bg::model::segment<Point> Seg;
+    typedef bg::model::ring<Point> Ring;
+    typedef bg::model::polygon<Point> Poly;
+    typedef bg::model::multi_polygon<Poly> MPoly;
+    typedef bg::model::linestring<Point> Ls;
+    typedef bg::model::multi_linestring<Ls> MLs;
+    typedef bg::model::multi_point<Point> MPt;
+
+    bgi::rtree<Value, Params> rt;
+    std::vector<Value> found;
+    
+    rt.query(bgi::intersects(Point()), back_inserter(found));
+    rt.query(bgi::intersects(Seg()), back_inserter(found));
+    rt.query(bgi::intersects(Box()), back_inserter(found));
+    rt.query(bgi::intersects(Ring()), back_inserter(found));
+    rt.query(bgi::intersects(Poly()), back_inserter(found));
+    rt.query(bgi::intersects(MPoly()), back_inserter(found));
+    rt.query(bgi::intersects(Ls()), back_inserter(found));
+    rt.query(bgi::intersects(MLs()), back_inserter(found));
+    rt.query(bgi::intersects(MPt()), back_inserter(found));
+}
+
+int test_main(int, char* [])
+{
+    typedef bg::model::d2::point_xy<double> Pt;
+    typedef bg::model::box<Pt> Box;
+
+    test_all< Pt, Pt, bgi::linear<16> >();
+    test_all< Pt, Pt, bgi::quadratic<4> >();
+    test_all< Pt, Pt, bgi::rstar<4> >();
+
+    test_all< Box, Pt, bgi::linear<16> >();
+    test_all< Box, Pt, bgi::quadratic<4> >();
+    test_all< Box, Pt, bgi::rstar<4> >();
+    
+    return 0;
+}

--- a/test/algorithms/relational_operations/intersects/intersects.cpp
+++ b/test/algorithms/relational_operations/intersects/intersects.cpp
@@ -3,8 +3,9 @@
 // Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2013-2015 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2013, 2015.
-// Modifications copyright (c) 2013-2015, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013, 2015, 2016.
+// Modifications copyright (c) 2013-2016, Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -18,20 +19,21 @@
 
 #include <boost/geometry/util/rational.hpp>
 
-template <typename P>
+template <typename P1, typename P2>
 void test_intersects_polygon_polygon()
 {
-    typedef bg::model::polygon<P, false, false> poly_ccw_o;
-    test_geometry<poly_ccw_o, poly_ccw_o>("POLYGON((1 1, 3 3, 2 5))", "POLYGON((0 0, 9 0, 9 9, 0 9),(5 5,5 8,8 8,8 5))", true);
-    test_geometry<poly_ccw_o, poly_ccw_o>("POLYGON((6 6, 7 6, 7 7, 6 7))", "POLYGON((0 0, 9 0, 9 9, 0 9),(5 5,5 8,8 8,8 5))", false);
-    test_geometry<poly_ccw_o, poly_ccw_o>("POLYGON((7 7, 9 7, 9 9, 7 9))", "POLYGON((0 0, 9 0, 9 9, 0 9),(5 5,5 8,8 8,8 5))", true);
+    typedef bg::model::polygon<P1, false, false> poly_ccw_o1;
+    typedef bg::model::polygon<P2, false, false> poly_ccw_o2;
+    test_geometry<poly_ccw_o1, poly_ccw_o2>("POLYGON((1 1, 3 3, 2 5))", "POLYGON((0 0, 9 0, 9 9, 0 9),(5 5,5 8,8 8,8 5))", true);
+    test_geometry<poly_ccw_o1, poly_ccw_o2>("POLYGON((6 6, 7 6, 7 7, 6 7))", "POLYGON((0 0, 9 0, 9 9, 0 9),(5 5,5 8,8 8,8 5))", false);
+    test_geometry<poly_ccw_o1, poly_ccw_o2>("POLYGON((7 7, 9 7, 9 9, 7 9))", "POLYGON((0 0, 9 0, 9 9, 0 9),(5 5,5 8,8 8,8 5))", true);
 }
 
-template <typename P>
+template <typename P1, typename P2>
 void test_intersects_linestring_segment()
 {
-    typedef bg::model::linestring<P> ls;
-    typedef bg::model::segment<P> seg;
+    typedef bg::model::linestring<P1> ls;
+    typedef bg::model::segment<P2> seg;
 
     test_geometry<ls, seg>("LINESTRING(1 1, 3 3, 2 5)", "SEGMENT(2 0, 2 6)", true);
     test_geometry<ls, seg>("LINESTRING(1 1, 3 3)", "SEGMENT(1 0, 1 1)", true);
@@ -39,28 +41,29 @@ void test_intersects_linestring_segment()
     test_geometry<ls, seg>("LINESTRING(1 1, 3 3)", "SEGMENT(3 0, 4 1)", false);
 }
 
-template <typename P>
+template <typename P1, typename P2>
 void test_intersects_linestring_linestring()
 {
-    typedef bg::model::linestring<P> ls;
+    typedef bg::model::linestring<P1> ls1;
+    typedef bg::model::linestring<P2> ls2;
 
-    test_geometry<ls, ls>("LINESTRING(0 0,2 0,3 0)", "LINESTRING(0 0,1 1,2 2)", true);
-    test_geometry<ls, ls>("LINESTRING(0 0,2 0,3 0)", "LINESTRING(2 2,1 1,0 0)", true);
-    test_geometry<ls, ls>("LINESTRING(3 0,2 0,0 0)", "LINESTRING(0 0,1 1,2 2)", true);
-    test_geometry<ls, ls>("LINESTRING(3 0,2 0,0 0)", "LINESTRING(2 2,1 1,0 0)", true);
+    test_geometry<ls1, ls2>("LINESTRING(0 0,2 0,3 0)", "LINESTRING(0 0,1 1,2 2)", true);
+    test_geometry<ls1, ls2>("LINESTRING(0 0,2 0,3 0)", "LINESTRING(2 2,1 1,0 0)", true);
+    test_geometry<ls1, ls2>("LINESTRING(3 0,2 0,0 0)", "LINESTRING(0 0,1 1,2 2)", true);
+    test_geometry<ls1, ls2>("LINESTRING(3 0,2 0,0 0)", "LINESTRING(2 2,1 1,0 0)", true);
 
-    test_geometry<ls, ls>("LINESTRING(0 0,2 0,3 0)", "LINESTRING(1 0,4 0,5 0)", true);
-    test_geometry<ls, ls>("LINESTRING(1 0,2 0)", "LINESTRING(1 0,0 0)", true);
+    test_geometry<ls1, ls2>("LINESTRING(0 0,2 0,3 0)", "LINESTRING(1 0,4 0,5 0)", true);
+    test_geometry<ls1, ls2>("LINESTRING(1 0,2 0)", "LINESTRING(1 0,0 0)", true);
 }
 
-template <typename P>
+template <typename P1, typename P2>
 void test_intersects_linestring_polygon()
 {
-    typedef bg::model::linestring<P> ls;
+    typedef bg::model::linestring<P1> ls;
     typedef bg::model::multi_linestring<ls> mls;
-    typedef bg::model::polygon<P> poly_cw_c;
-    typedef bg::model::polygon<P, false> poly_ccw_c;
-    typedef bg::model::polygon<P, false, false> poly_ccw_o;
+    typedef bg::model::polygon<P2> poly_cw_c;
+    typedef bg::model::polygon<P2, false> poly_ccw_c;
+    typedef bg::model::polygon<P2, false, false> poly_ccw_o;
     typedef bg::model::multi_polygon<poly_ccw_c> mpoly_ccw_c;
 
     test_geometry<ls, poly_ccw_c>("LINESTRING(1 1,2 2)", "POLYGON((0 0,10 0,10 10,0 10,0 0))", true);
@@ -81,12 +84,12 @@ void test_intersects_linestring_polygon()
     test_geometry<mls, mpoly_ccw_c>("MULTILINESTRING((1 1,2 2))", "MULTIPOLYGON(((0 0,10 0,10 10,0 10,0 0)))", true);
 }
 
-template <typename P>
+template <typename P1, typename P2>
 void test_intersects_linestring_ring()
 {
-    typedef bg::model::linestring<P> ls;
+    typedef bg::model::linestring<P1> ls;
     typedef bg::model::multi_linestring<ls> mls;
-    typedef bg::model::ring<P, false> ring_ccw_c;
+    typedef bg::model::ring<P2, false> ring_ccw_c;
 
     test_geometry<ls, ring_ccw_c>("LINESTRING(1 1,2 2)", "POLYGON((0 0,10 0,10 10,0 10,0 0))", true);
     test_geometry<ls, ring_ccw_c>("LINESTRING(1 0,2 2)", "POLYGON((0 0,10 0,10 10,0 10,0 0))", true);
@@ -96,11 +99,11 @@ void test_intersects_linestring_ring()
     test_geometry<mls, ring_ccw_c>("MULTILINESTRING((1 1,2 2))", "POLYGON((0 0,10 0,10 10,0 10,0 0))", true);
 }
 
-template <typename P>
+template <typename P1, typename P2>
 void test_intersects_ring_polygon()
 {
-    typedef bg::model::ring<P, false, false> ring_ccw_o;
-    typedef bg::model::polygon<P, false, false> poly_ccw_o;
+    typedef bg::model::ring<P1, false, false> ring_ccw_o;
+    typedef bg::model::polygon<P2, false, false> poly_ccw_o;
 
     test_geometry<ring_ccw_o, poly_ccw_o>("POLYGON((1 1, 3 3, 2 5))", "POLYGON((0 0, 9 0, 9 9, 0 9),(5 5,5 8,8 8,8 5))", true);
     test_geometry<ring_ccw_o, poly_ccw_o>("POLYGON((6 6, 7 6, 7 7, 6 7))", "POLYGON((0 0, 9 0, 9 9, 0 9),(5 5,5 8,8 8,8 5))", false);
@@ -109,36 +112,36 @@ void test_intersects_ring_polygon()
     test_geometry<ring_ccw_o, poly_ccw_o>("POLYGON((6 6,7 6,7 7,6 7))", "POLYGON((0 0, 9 0, 9 9, 0 9),(5 5,5 8,8 8,8 5))", false);
 }
 
-template <typename P>
+template <typename P1, typename P2>
 void test_intersects_point_linestring()
 {
-    typedef bg::model::linestring<P> ls;
+    typedef bg::model::linestring<P2> ls;
     typedef bg::model::multi_linestring<ls> mls;
 
-    test_geometry<P, ls>("POINT(0 0)", "LINESTRING(0 0,2 2,4 0)", true);
-    test_geometry<P, ls>("POINT(1 1)", "LINESTRING(0 0,2 2,4 0)", true);
-    test_geometry<P, ls>("POINT(1 0)", "LINESTRING(0 0,2 2,4 0)", false);
+    test_geometry<P1, ls>("POINT(0 0)", "LINESTRING(0 0,2 2,4 0)", true);
+    test_geometry<P1, ls>("POINT(1 1)", "LINESTRING(0 0,2 2,4 0)", true);
+    test_geometry<P1, ls>("POINT(1 0)", "LINESTRING(0 0,2 2,4 0)", false);
 
     // MULTI
-    test_geometry<P, mls>("POINT(0 0)", "MULTILINESTRING((0 0,2 2,4 0))", true);
+    test_geometry<P1, mls>("POINT(0 0)", "MULTILINESTRING((0 0,2 2,4 0))", true);
 }
 
-template <typename P>
+template <typename P1, typename P2>
 void test_intersects_point_segment()
 {
-    typedef bg::model::segment<P> seg;
+    typedef bg::model::segment<P2> seg;
 
-    test_geometry<P, seg>("POINT(0 0)", "LINESTRING(0 0,2 2)", true);
-    test_geometry<P, seg>("POINT(1 1)", "LINESTRING(0 0,2 2)", true);
-    test_geometry<P, seg>("POINT(1 0)", "LINESTRING(0 0,2 2)", false);
+    test_geometry<P1, seg>("POINT(0 0)", "LINESTRING(0 0,2 2)", true);
+    test_geometry<P1, seg>("POINT(1 1)", "LINESTRING(0 0,2 2)", true);
+    test_geometry<P1, seg>("POINT(1 0)", "LINESTRING(0 0,2 2)", false);
 }
 
-template <typename P>
+template <typename P1, typename P2>
 void test_multi_linestring_polygon()
 {
-    typedef bg::model::linestring<P> ls;
+    typedef bg::model::linestring<P1> ls;
     typedef bg::model::multi_linestring<ls> mls;
-    typedef bg::model::polygon<P> poly;
+    typedef bg::model::polygon<P2> poly;
 
     test_geometry<mls, poly>("MULTILINESTRING((11 11, 20 20),(5 7, 4 1))",
                              "POLYGON((0 0,0 10,10 10,10 0,0 0),(2 2,4 2,4 4,2 4,2 2))",
@@ -148,56 +151,72 @@ void test_multi_linestring_polygon()
                              true);
 }
 
-template <typename P>
+template <typename P1, typename P2>
 void test_multi_polygon_polygon()
 {
-    typedef bg::model::polygon<P> poly;
-    typedef bg::model::multi_polygon<poly> mpoly;
+    typedef bg::model::polygon<P1> poly1;
+    typedef bg::model::multi_polygon<poly1> mpoly;
+    typedef bg::model::polygon<P2> poly2;
 
-    test_geometry<mpoly, poly>("MULTIPOLYGON(((11 11,11 20,20 20,20 11,11 11)),((5 5,5 6,6 6,6 5,5 5)))",
-                               "POLYGON((0 0,0 10,10 10,10 0,0 0),(2 2,4 2,4 4,2 4,2 2))",
-                               true);
+    test_geometry<mpoly, poly2>("MULTIPOLYGON(((11 11,11 20,20 20,20 11,11 11)),((5 5,5 6,6 6,6 5,5 5)))",
+                                "POLYGON((0 0,0 10,10 10,10 0,0 0),(2 2,4 2,4 4,2 4,2 2))",
+                                true);
+}
+
+template <typename P1, typename P2>
+void test_point_polygon()
+{
+    typedef bg::model::ring<P2> ring;
+    typedef bg::model::polygon<P2> poly;
+
+    test_geometry<P1, ring>(
+        "POINT(0 0)",
+        "POLYGON((0 0,3 3,3 3,4 1))",
+        true);
+    test_geometry<P1, poly>(
+        "POINT(0 0)",
+        "POLYGON((0 0,3 3,3 3,4 1))",
+        true);
+
+    test_geometry<ring, P1>(
+        "POLYGON((0 0,3 3,3 3,4 1))",
+        "POINT(0 0)",
+        true);
+    test_geometry<poly, P1>(
+        "POLYGON((0 0,3 3,3 3,4 1))",
+        "POINT(0 0)",
+        true);
+}
+
+template <typename P1, typename P2>
+void test_all()
+{
+    typedef bg::model::polygon<P2> polygon;
+    typedef bg::model::ring<P2> ring;
+
+    test_intersects_point_segment<P1, P2>();
+    test_intersects_point_linestring<P1, P2>();
+    test_intersects_polygon_polygon<P1, P2>();
+    test_intersects_linestring_polygon<P1, P2>();
+    test_intersects_linestring_ring<P1, P2>();
+    test_intersects_linestring_segment<P1, P2>();
+    test_intersects_linestring_linestring<P1, P2>();
+    test_intersects_ring_polygon<P1, P2>();
+    test_multi_linestring_polygon<P1, P2>();
+    test_multi_polygon_polygon<P1, P2>();
+    test_point_polygon<P1, P2>();
 }
 
 template <typename P>
 void test_all()
 {
-    typedef bg::model::polygon<P> polygon;
-    typedef bg::model::ring<P> ring;
-
-    test_intersects_point_segment<P>();
-    test_intersects_point_linestring<P>();
-    test_intersects_polygon_polygon<P>();
-    test_intersects_linestring_polygon<P>();
-    test_intersects_linestring_ring<P>();
-    test_intersects_linestring_segment<P>();
-    test_intersects_linestring_linestring<P>();
-    test_intersects_ring_polygon<P>();
-    test_multi_linestring_polygon<P>();
-    test_multi_polygon_polygon<P>();
-
-    test_geometry<P, ring>(
-        "POINT(0 0)",
-        "POLYGON((0 0,3 3,3 3,4 1))",
-        true);
-    test_geometry<P, polygon>(
-        "POINT(0 0)",
-        "POLYGON((0 0,3 3,3 3,4 1))",
-        true);
-
-    test_geometry<ring, P>(
-        "POLYGON((0 0,3 3,3 3,4 1))",
-        "POINT(0 0)",
-        true);
-    test_geometry<polygon, P>(
-        "POLYGON((0 0,3 3,3 3,4 1))",
-        "POINT(0 0)",
-        true);
+    test_all<P, P>();
 }
 
 int test_main( int , char* [] )
 {
     test_all<bg::model::d2::point_xy<double> >();
+    test_all<bg::model::d2::point_xy<double>, bg::model::point<double, 2, bg::cs::cartesian> >();
 
 #if ! defined(BOOST_GEOMETRY_RESCALE_TO_ROBUST)
     test_all<bg::model::d2::point_xy<boost::rational<int> > >();

--- a/test/algorithms/relational_operations/intersects/intersects_box_geometry.cpp
+++ b/test/algorithms/relational_operations/intersects/intersects_box_geometry.cpp
@@ -3,8 +3,8 @@
 // Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2013-2015 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2013, 2015.
-// Modifications copyright (c) 2013-2015, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013, 2015, 2016.
+// Modifications copyright (c) 2013-2016, Oracle and/or its affiliates.
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -19,33 +19,39 @@
 #include <boost/geometry/util/rational.hpp>
 
 
-template <typename P>
+template <typename P1, typename P2>
 void test_all()
 {
-    typedef bg::model::polygon<P> polygon;
-    typedef bg::model::ring<P> ring;
+    typedef bg::model::polygon<P1> polygon;
+    typedef bg::model::ring<P1> ring;
 
     // intersect <=> ! disjoint (in most cases)
     // so most tests are done in disjoint test.
     // We only test compilation of a few cases.
-    test_geometry<P, bg::model::box<P> >("POINT(1 1)", "BOX(0 0,2 2)", true);
+    test_geometry<P1, bg::model::box<P2> >("POINT(1 1)", "BOX(0 0,2 2)", true);
 
-    test_geometry<polygon, bg::model::box<P> >(
+    test_geometry<polygon, bg::model::box<P2> >(
         "POLYGON((1992 3240,1992 1440,3792 1800,3792 3240,1992 3240))",
         "BOX(1941 2066, 2055 2166)", true);
 
-    test_geometry<ring, bg::model::box<P> >(
+    test_geometry<ring, bg::model::box<P2> >(
         "POLYGON((1992 3240,1992 1440,3792 1800,3792 3240,1992 3240))",
         "BOX(1941 2066, 2055 2166)", true);
 
-    test_geometry<polygon, bg::model::box<P> >(
+    test_geometry<polygon, bg::model::box<P2> >(
         "POLYGON((1941 2066,2055 2066,2055 2166,1941 2166))",
         "BOX(1941 2066, 2055 2166)", true);
 
-    test_geometry<P, bg::model::box<P> >(
+    test_geometry<P1, bg::model::box<P2> >(
         "POINT(0 0)",
         "BOX(0 0,4 4)",
         true);
+}
+
+template <typename P>
+void test_all()
+{
+    test_all<P, P>();
 }
 
 // Those tests won't pass for rational<> because numeric_limits<> isn't specialized for this type
@@ -150,6 +156,7 @@ void test_additional()
 
 int test_main( int , char* [] )
 {
+    test_all<bg::model::d2::point_xy<float>, bg::model::point<double, 2, bg::cs::cartesian> >();
     test_all<bg::model::d2::point_xy<double> >();
     test_additional<bg::model::d2::point_xy<double> >();
 

--- a/test/algorithms/relational_operations/intersects/intersects_multi.cpp
+++ b/test/algorithms/relational_operations/intersects/intersects_multi.cpp
@@ -3,6 +3,10 @@
 
 // Copyright (c) 2012-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2016.
+// Modifications copyright (c) 2016, Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -20,26 +24,35 @@
 #include <boost/geometry/geometries/geometries.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
 
-template <typename P>
+template <typename P1, typename P2>
 void test_all()
 {
-    typedef bg::model::polygon<P> polygon;
-    typedef bg::model::multi_polygon<polygon> mp;
+    typedef bg::model::polygon<P1> polygon1;
+    typedef bg::model::multi_polygon<polygon1> mp1;
+    typedef bg::model::polygon<P2> polygon2;
+    typedef bg::model::multi_polygon<polygon2> mp2;
 
-    test_geometry<mp, mp>("MULTIPOLYGON(((0 0,0 10,10 10,10 0,0 0)))",
+    test_geometry<mp1, mp2>("MULTIPOLYGON(((0 0,0 10,10 10,10 0,0 0)))",
             "MULTIPOLYGON(((0 0,0 10,10 10,10 0,0 0)))",
         true);
 
-    test_geometry<P, mp>("POINT(0 0)",
+    test_geometry<P1, mp2>("POINT(0 0)",
         "MULTIPOLYGON(((0 0,0 10,10 10,10 0,0 0)))",
         true);
 
+}
+
+template <typename P>
+void test_all()
+{
+    test_all<P, P>();
 }
 
 int test_main(int, char* [])
 {
     //test_all<bg::model::d2::point_xy<float> >();
     test_all<bg::model::d2::point_xy<double> >();
+    test_all<bg::model::d2::point_xy<double>, bg::model::point<double, 2, bg::cs::cartesian> >();
 
 #ifdef HAVE_TTMATH
     test_all<bg::model::d2::point_xy<ttmath_big> >();

--- a/test/algorithms/relational_operations/within/within.cpp
+++ b/test/algorithms/relational_operations/within/within.cpp
@@ -21,22 +21,29 @@
 #include <boost/geometry/geometries/multi_linestring.hpp>
 #include <boost/geometry/geometries/multi_polygon.hpp>
 
-template <typename P>
-void test_all()
+template <typename P1, typename P2>
+void test_point_box()
 {
-    typedef bg::model::box<P> box_type;
+    typedef bg::model::box<P1> box_type1;
+    typedef bg::model::box<P2> box_type2;
 
-    test_geometry<P, box_type>("POINT(1 1)", "BOX(0 0,2 2)", true);
-    test_geometry<P, box_type>("POINT(0 0)", "BOX(0 0,2 2)", false);
-    test_geometry<P, box_type>("POINT(2 2)", "BOX(0 0,2 2)", false);
-    test_geometry<P, box_type>("POINT(0 1)", "BOX(0 0,2 2)", false);
-    test_geometry<P, box_type>("POINT(1 0)", "BOX(0 0,2 2)", false);
+    test_geometry<P1, box_type2>("POINT(1 1)", "BOX(0 0,2 2)", true);
+    test_geometry<P1, box_type2>("POINT(0 0)", "BOX(0 0,2 2)", false);
+    test_geometry<P1, box_type2>("POINT(2 2)", "BOX(0 0,2 2)", false);
+    test_geometry<P1, box_type2>("POINT(0 1)", "BOX(0 0,2 2)", false);
+    test_geometry<P1, box_type2>("POINT(1 0)", "BOX(0 0,2 2)", false);
 
-    test_geometry<box_type, box_type>("BOX(1 1,2 2)", "BOX(0 0,3 3)", true);
-    test_geometry<box_type, box_type>("BOX(0 0,3 3)", "BOX(1 1,2 2)", false);
+    test_geometry<P1, box_type2>("POINT(3 3)", "BOX(1 1,4 4)", true);
+    test_geometry<P2, box_type1>("POINT(3 3)", "BOX(0 0,5 5)", true);
 
-    test_geometry<box_type, box_type>("BOX(1 1,3 3)", "BOX(0 0,3 3)", true);
-    test_geometry<box_type, box_type>("BOX(3 1,3 3)", "BOX(0 0,3 3)", false);
+    test_geometry<box_type1, box_type2>("BOX(1 1,2 2)", "BOX(0 0,3 3)", true);
+    test_geometry<box_type1, box_type2>("BOX(0 0,3 3)", "BOX(1 1,2 2)", false);
+
+    test_geometry<box_type1, box_type2>("BOX(1 1,3 3)", "BOX(0 0,3 3)", true);
+    test_geometry<box_type1, box_type2>("BOX(3 1,3 3)", "BOX(0 0,3 3)", false);
+
+    test_geometry<box_type1, box_type2>("BOX(1 1,4 4)", "BOX(0 0,5 5)", true);
+    test_geometry<box_type2, box_type1>("BOX(0 0,5 5)", "BOX(1 1,4 4)", false);
 
     /*
     test_within_code<P, box_type>("POINT(1 1)", "BOX(0 0,2 2)", 1);
@@ -54,7 +61,7 @@ void test_all()
     */
 }
 
-void test_3d()
+void test_point_box_3d()
 {
     typedef boost::geometry::model::point<double, 3, boost::geometry::cs::cartesian> point_type;
     typedef boost::geometry::model::box<point_type> box_type;
@@ -70,50 +77,26 @@ void test_3d()
 }
 
 template <typename P1, typename P2>
-void test_mixed_of()
+void test_point_poly()
 {
-    typedef boost::geometry::model::polygon<P1> polygon_type1;
-    typedef boost::geometry::model::polygon<P2> polygon_type2;
-    typedef boost::geometry::model::box<P1> box_type1;
-    typedef boost::geometry::model::box<P2> box_type2;
+    typedef boost::geometry::model::polygon<P1> poly1;
+    typedef boost::geometry::model::polygon<P2> poly2;
 
-    polygon_type1 poly1;
-    polygon_type2 poly2;
-    boost::geometry::read_wkt("POLYGON((0 0,0 5,5 5,5 0,0 0))", poly1);
-    boost::geometry::read_wkt("POLYGON((0 0,0 5,5 5,5 0,0 0))", poly2);
-
-    box_type1 box1(P1(1, 1), P1(4, 4));
-    box_type2 box2(P2(0, 0), P2(5, 5));
-    P1 p1(3, 3);
-    P2 p2(3, 3);
-
-    BOOST_CHECK_EQUAL(bg::within(p1, poly2), true);
-    BOOST_CHECK_EQUAL(bg::within(p2, poly1), true);
-    BOOST_CHECK_EQUAL(bg::within(p2, box1), true);
-    BOOST_CHECK_EQUAL(bg::within(p1, box2), true);
-    BOOST_CHECK_EQUAL(bg::within(box1, box2), true);
-    BOOST_CHECK_EQUAL(bg::within(box2, box1), false);
+    test_geometry<P1, poly2>("POINT(3 3)", "POLYGON((0 0,0 5,5 5,5 0,0 0))", true);
+    test_geometry<P2, poly1>("POINT(3 3)", "POLYGON((0 0,0 5,5 5,5 0,0 0))", true);
 }
 
-
-void test_mixed()
+template <typename P1, typename P2>
+void test_all()
 {
-    // Mixing point types and coordinate types
-    test_mixed_of
-        <
-            boost::geometry::model::d2::point_xy<double>,
-            boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>
-        >();
-    test_mixed_of
-        <
-            boost::geometry::model::d2::point_xy<float>,
-            boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>
-        >();
-    test_mixed_of
-        <
-            boost::geometry::model::d2::point_xy<int>,
-            boost::geometry::model::d2::point_xy<double>
-        >();
+    test_point_box<P1, P2>();
+    test_point_poly<P1, P2>();
+}
+
+template <typename P>
+void test_all()
+{
+    test_all<P, P>();
 }
 
 void test_strategy()
@@ -145,11 +128,19 @@ void test_strategy()
 
 int test_main( int , char* [] )
 {
-    test_all<bg::model::d2::point_xy<int> >();
-    test_all<bg::model::d2::point_xy<double> >();
+    typedef boost::geometry::model::d2::point_xy<double> xyd;
+    typedef boost::geometry::model::d2::point_xy<float> xyf;
+    typedef boost::geometry::model::d2::point_xy<int> xyi;
+    typedef boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian> p2d;
+    
+    test_all<xyd, p2d>();
+    test_all<xyf, p2d>();
+    test_all<xyi, xyd>();
 
-    test_mixed();
-    test_3d();
+    test_all<xyi>();
+    test_all<xyd>();
+
+    test_point_box_3d();
     test_strategy();
 
 

--- a/test/algorithms/relational_operations/within/within_areal_areal.cpp
+++ b/test/algorithms/relational_operations/within/within_areal_areal.cpp
@@ -3,8 +3,8 @@
 // Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2013-2015 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2014, 2015.
-// Modifications copyright (c) 2014-2015 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014, 2015, 2016.
+// Modifications copyright (c) 2014-2016 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -20,72 +20,82 @@
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/multi_polygon.hpp>
 
-template <typename P>
+template <typename P1, typename P2>
 void test_a_a()
 {
-    typedef bg::model::polygon<P> poly;
-    typedef bg::model::ring<P> ring;
-    typedef bg::model::multi_polygon<poly> mpoly;
+    typedef bg::model::polygon<P1> poly1;
+    typedef bg::model::ring<P1> ring1;
+    typedef bg::model::multi_polygon<poly1> mpoly1;
+    typedef bg::model::polygon<P2> poly2;
+    typedef bg::model::ring<P2> ring2;
+    typedef bg::model::multi_polygon<poly2> mpoly2;
 
-    test_geometry<ring, ring>("POLYGON((0 0,0 2,2 2,2 0,0 0))", "POLYGON((0 0,0 5,5 5,5 0,0 0))", true);
-    test_geometry<ring, poly>("POLYGON((0 0,0 5,5 5,5 0,0 0))", "POLYGON((0 0,0 5,5 5,5 0,0 0))", true);
-    test_geometry<poly, ring>("POLYGON((0 0,0 6,6 6,6 0,0 0))", "POLYGON((0 0,0 5,5 5,5 0,0 0))", false);
+    test_geometry<ring1, ring2>("POLYGON((0 0,0 2,2 2,2 0,0 0))", "POLYGON((0 0,0 5,5 5,5 0,0 0))", true);
+    test_geometry<ring1, poly2>("POLYGON((0 0,0 5,5 5,5 0,0 0))", "POLYGON((0 0,0 5,5 5,5 0,0 0))", true);
+    test_geometry<poly1, ring2>("POLYGON((0 0,0 6,6 6,6 0,0 0))", "POLYGON((0 0,0 5,5 5,5 0,0 0))", false);
 
-    test_geometry<poly, poly>("POLYGON((0 0,0 9,9 9,9 0,0 0),(3 3,6 3,6 6,3 6,3 3))",
-                              "POLYGON((0 0,0 9,9 9,9 0,0 0),(3 3,6 3,6 6,3 6,3 3))", true);
-    test_geometry<poly, poly>("POLYGON((0 0,0 9,9 9,9 0,0 0),(3 3,6 3,6 6,3 6,3 3))",
-                              "POLYGON((0 0,0 9,9 9,9 0,0 0),(4 4,5 4,5 5,4 5,4 4))", true);
-    test_geometry<poly, poly>("POLYGON((1 1,1 8,8 8,8 1,1 1),(3 3,6 3,6 6,3 6,3 3))",
-                              "POLYGON((0 0,0 9,9 9,9 0,0 0),(3 3,6 3,6 6,3 6,3 3))", true);
-    test_geometry<poly, poly>("POLYGON((1 1,1 8,8 8,8 1,1 1),(3 3,6 3,6 6,3 6,3 3))",
-                              "POLYGON((0 0,0 9,9 9,9 0,0 0),(4 4,5 4,5 5,4 5,4 4))", true);
+    test_geometry<poly1, poly2>("POLYGON((0 0,0 9,9 9,9 0,0 0),(3 3,6 3,6 6,3 6,3 3))",
+                                "POLYGON((0 0,0 9,9 9,9 0,0 0),(3 3,6 3,6 6,3 6,3 3))", true);
+    test_geometry<poly1, poly2>("POLYGON((0 0,0 9,9 9,9 0,0 0),(3 3,6 3,6 6,3 6,3 3))",
+                                "POLYGON((0 0,0 9,9 9,9 0,0 0),(4 4,5 4,5 5,4 5,4 4))", true);
+    test_geometry<poly1, poly2>("POLYGON((1 1,1 8,8 8,8 1,1 1),(3 3,6 3,6 6,3 6,3 3))",
+                                "POLYGON((0 0,0 9,9 9,9 0,0 0),(3 3,6 3,6 6,3 6,3 3))", true);
+    test_geometry<poly1, poly2>("POLYGON((1 1,1 8,8 8,8 1,1 1),(3 3,6 3,6 6,3 6,3 3))",
+                                "POLYGON((0 0,0 9,9 9,9 0,0 0),(4 4,5 4,5 5,4 5,4 4))", true);
     
-    test_geometry<ring, mpoly>("POLYGON((0 0,0 2,2 2,2 0,0 0))",
-                               "MULTIPOLYGON(((0 0,0 5,5 5,5 0,0 0)),((5 5,5 10,10 10,10 5,5 5)))", true);
-    test_geometry<poly, mpoly>("POLYGON((0 0,0 2,2 2,2 0,0 0))",
-                               "MULTIPOLYGON(((0 0,0 5,5 5,5 0,0 0)),((5 5,5 10,10 10,10 5,5 5)))", true);
+    test_geometry<ring1, mpoly2>("POLYGON((0 0,0 2,2 2,2 0,0 0))",
+                                 "MULTIPOLYGON(((0 0,0 5,5 5,5 0,0 0)),((5 5,5 10,10 10,10 5,5 5)))", true);
+    test_geometry<poly1, mpoly2>("POLYGON((0 0,0 2,2 2,2 0,0 0))",
+                                 "MULTIPOLYGON(((0 0,0 5,5 5,5 0,0 0)),((5 5,5 10,10 10,10 5,5 5)))", true);
 
-    test_geometry<mpoly, ring>("MULTIPOLYGON(((0 0,0 5,5 5,5 0,0 0)),((5 5,5 10,10 10,10 5,5 5)))",
-                               "POLYGON((0 0,0 10,10 10,10 0,0 0))", true);
-    test_geometry<mpoly, poly>("MULTIPOLYGON(((0 0,0 5,5 5,5 0,0 0)),((15 15,15 110,110 110,110 15,15 15)))",
-                               "POLYGON((0 0,0 10,10 10,10 0,0 0))", false);
+    test_geometry<mpoly1, ring2>("MULTIPOLYGON(((0 0,0 5,5 5,5 0,0 0)),((5 5,5 10,10 10,10 5,5 5)))",
+                                 "POLYGON((0 0,0 10,10 10,10 0,0 0))", true);
+    test_geometry<mpoly1, poly2>("MULTIPOLYGON(((0 0,0 5,5 5,5 0,0 0)),((15 15,15 110,110 110,110 15,15 15)))",
+                                 "POLYGON((0 0,0 10,10 10,10 0,0 0))", false);
 
-    test_geometry<mpoly, poly>("MULTIPOLYGON(((0 0,0 1,1 0,0 0)),((3 3,3 4,4 3,3 3)))",
-                               "POLYGON((0 0,0 10,10 10,10 0,0 0),(3 3,4 3,4 4,3 4,3 3))", false);
+    test_geometry<mpoly1, poly2>("MULTIPOLYGON(((0 0,0 1,1 0,0 0)),((3 3,3 4,4 3,3 3)))",
+                                 "POLYGON((0 0,0 10,10 10,10 0,0 0),(3 3,4 3,4 4,3 4,3 3))", false);
 
-    test_geometry<mpoly, mpoly>("MULTIPOLYGON(((0 0,0 1,1 0,0 0)),((3 3,3 4,4 3,3 3)))",
-                                "MULTIPOLYGON(((0 0,0 1,1 0,0 0)),((3 3,3 4,4 3,3 3)))", true);
-    test_geometry<mpoly, mpoly>("MULTIPOLYGON(((0 0,0 1,1 0,0 0)),((3 3,3 4,4 3,3 3)))",
-                                "MULTIPOLYGON(((0 0,0 5,5 5,5 0,0 0)),((5 5,5 10,10 10,10 5,5 5)))", true);
-    test_geometry<mpoly, mpoly>("MULTIPOLYGON(((0 0,0 5,5 5,5 0,0 0)),((5 5,5 10,10 10,10 5,5 5)))",
-                                "MULTIPOLYGON(((0 0,0 1,1 0,0 0)),((3 3,3 4,4 3,3 3)))", false);
+    test_geometry<mpoly1, mpoly2>("MULTIPOLYGON(((0 0,0 1,1 0,0 0)),((3 3,3 4,4 3,3 3)))",
+                                  "MULTIPOLYGON(((0 0,0 1,1 0,0 0)),((3 3,3 4,4 3,3 3)))", true);
+    test_geometry<mpoly1, mpoly2>("MULTIPOLYGON(((0 0,0 1,1 0,0 0)),((3 3,3 4,4 3,3 3)))",
+                                  "MULTIPOLYGON(((0 0,0 5,5 5,5 0,0 0)),((5 5,5 10,10 10,10 5,5 5)))", true);
+    test_geometry<mpoly1, mpoly2>("MULTIPOLYGON(((0 0,0 5,5 5,5 0,0 0)),((5 5,5 10,10 10,10 5,5 5)))",
+                                  "MULTIPOLYGON(((0 0,0 1,1 0,0 0)),((3 3,3 4,4 3,3 3)))", false);
 
     // https://svn.boost.org/trac/boost/ticket/10912
-    test_geometry<poly, poly>("POLYGON((0 0,0 5,5 5,5 0,0 0))",
-                              "POLYGON((0 0,0 10,10 10,10 0,0 0),(2 2,4 2,4 4,2 4,2 2),(6 6,8 6,8 8,6 8,6 6))",
-                              false);
-    test_geometry<poly, poly>("POLYGON((0 0,0 10,10 10,10 0,0 0))",
-                              "POLYGON((0 0,0 10,10 10,10 0,0 0),(2 2,2 4,4 4,4 2,2 2))",
-                              false);
+    test_geometry<poly1, poly2>("POLYGON((0 0,0 5,5 5,5 0,0 0))",
+                                "POLYGON((0 0,0 10,10 10,10 0,0 0),(2 2,4 2,4 4,2 4,2 2),(6 6,8 6,8 8,6 8,6 6))",
+                                false);
+    test_geometry<poly1, poly2>("POLYGON((0 0,0 10,10 10,10 0,0 0))",
+                                "POLYGON((0 0,0 10,10 10,10 0,0 0),(2 2,2 4,4 4,4 2,2 2))",
+                                false);
 
-    test_geometry<poly, mpoly>("POLYGON((0 0,0 5,5 5,5 0,0 0))",
-                               "MULTIPOLYGON(((0 0,0 10,10 10,10 0,0 0)),((0 0,0 -10,-10 -10,-10 0,0 0)))",
-                               true);
-    test_geometry<poly, mpoly>("POLYGON((0 0,0 10,10 10,10 0,0 0))",
-                               "MULTIPOLYGON(((0 0,0 10,10 10,10 0,0 0)),((0 0,0 -10,-10 -10,-10 0,0 0)))",
-                               true);
+    test_geometry<poly1, mpoly2>("POLYGON((0 0,0 5,5 5,5 0,0 0))",
+                                 "MULTIPOLYGON(((0 0,0 10,10 10,10 0,0 0)),((0 0,0 -10,-10 -10,-10 0,0 0)))",
+                                 true);
+    test_geometry<poly1, mpoly2>("POLYGON((0 0,0 10,10 10,10 0,0 0))",
+                                 "MULTIPOLYGON(((0 0,0 10,10 10,10 0,0 0)),((0 0,0 -10,-10 -10,-10 0,0 0)))",
+                                 true);
+}
+
+template <typename P1, typename P2>
+void test_all()
+{
+    test_a_a<P1, P2>();
 }
 
 template <typename P>
 void test_all()
 {
-    test_a_a<P>();
+    test_a_a<P, P>();
 }
 
 int test_main( int , char* [] )
 {
     test_all<bg::model::d2::point_xy<int> >();
     test_all<bg::model::d2::point_xy<double> >();
+    test_all<bg::model::d2::point_xy<double>, bg::model::point<double, 2, bg::cs::cartesian> >();
 
 #if defined(HAVE_TTMATH)
     test_all<bg::model::d2::point_xy<ttmath_big> >();

--- a/test/algorithms/relational_operations/within/within_linear_areal.cpp
+++ b/test/algorithms/relational_operations/within/within_linear_areal.cpp
@@ -3,14 +3,14 @@
 // Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2013-2015 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2014, 2015.
-// Modifications copyright (c) 2014-2015 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014, 2015, 2016.
+// Modifications copyright (c) 2014-2016 Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
-
-// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 #include "test_within.hpp"
 
@@ -20,13 +20,13 @@
 #include <boost/geometry/geometries/multi_linestring.hpp>
 #include <boost/geometry/geometries/multi_polygon.hpp>
 
-template <typename P>
+template <typename P1, typename P2>
 void test_l_a()
 {
-    typedef bg::model::linestring<P> ls;
+    typedef bg::model::linestring<P1> ls;
     typedef bg::model::multi_linestring<ls> mls;
-    typedef bg::model::polygon<P> poly;
-    typedef bg::model::ring<P> ring;
+    typedef bg::model::polygon<P2> poly;
+    typedef bg::model::ring<P2> ring;
     typedef bg::model::multi_polygon<poly> mpoly;
 
     // B,I
@@ -100,16 +100,23 @@ void test_l_a()
                               false);
 }
 
+template <typename P1, typename P2>
+void test_all()
+{
+    test_l_a<P1, P2>();
+}
+
 template <typename P>
 void test_all()
 {
-    test_l_a<P>();
+    test_l_a<P, P>();
 }
 
 int test_main( int , char* [] )
 {
     test_all<bg::model::d2::point_xy<int> >();
     test_all<bg::model::d2::point_xy<double> >();
+    test_all<bg::model::d2::point_xy<double>, bg::model::point<double, 2, bg::cs::cartesian> >();
 
 
 #if defined(HAVE_TTMATH)

--- a/test/algorithms/relational_operations/within/within_linear_linear.cpp
+++ b/test/algorithms/relational_operations/within/within_linear_linear.cpp
@@ -3,14 +3,15 @@
 // Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2013-2015 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2014, 2015.
-// Modifications copyright (c) 2014-2015 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014, 2015, 2016.
+// Modifications copyright (c) 2014-2016 Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 #include "test_within.hpp"
 
@@ -19,76 +20,85 @@
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/multi_linestring.hpp>
 
-template <typename P>
+template <typename P1, typename P2>
 void test_l_l()
 {
-    typedef bg::model::linestring<P> ls;
-    typedef bg::model::multi_linestring<ls> mls;
+    typedef bg::model::linestring<P1> ls1;
+    typedef bg::model::multi_linestring<ls1> mls1;
+    typedef bg::model::linestring<P2> ls2;
+    typedef bg::model::multi_linestring<ls2> mls2;
 
-    test_geometry<ls, ls>("LINESTRING(0 0, 2 2, 3 2)", "LINESTRING(0 0, 2 2, 3 2)", true);
+    test_geometry<ls1, ls2>("LINESTRING(0 0, 2 2, 3 2)", "LINESTRING(0 0, 2 2, 3 2)", true);
 
-    test_geometry<ls, ls>("LINESTRING(0 0, 1 1, 2 2, 3 2)", "LINESTRING(0 0, 2 2, 3 2)", true);
-    test_geometry<ls, ls>("LINESTRING(3 2, 2 2, 1 1, 0 0)", "LINESTRING(0 0, 2 2, 3 2)", true);
-    test_geometry<ls, ls>("LINESTRING(0 0, 1 1, 2 2, 3 2)", "LINESTRING(3 2, 2 2, 0 0)", true);
-    test_geometry<ls, ls>("LINESTRING(3 2, 2 2, 1 1, 0 0)", "LINESTRING(3 2, 2 2, 0 0)", true);
+    test_geometry<ls1, ls2>("LINESTRING(0 0, 1 1, 2 2, 3 2)", "LINESTRING(0 0, 2 2, 3 2)", true);
+    test_geometry<ls1, ls2>("LINESTRING(3 2, 2 2, 1 1, 0 0)", "LINESTRING(0 0, 2 2, 3 2)", true);
+    test_geometry<ls1, ls2>("LINESTRING(0 0, 1 1, 2 2, 3 2)", "LINESTRING(3 2, 2 2, 0 0)", true);
+    test_geometry<ls1, ls2>("LINESTRING(3 2, 2 2, 1 1, 0 0)", "LINESTRING(3 2, 2 2, 0 0)", true);
 
-    test_geometry<ls, ls>("LINESTRING(1 1, 2 2, 3 2)", "LINESTRING(0 0, 2 2, 4 2)", true);
-    test_geometry<ls, ls>("LINESTRING(3 2, 2 2, 1 1)", "LINESTRING(0 0, 2 2, 4 2)", true);
-    test_geometry<ls, ls>("LINESTRING(1 1, 2 2, 3 2)", "LINESTRING(4 2, 2 2, 0 0)", true);
-    test_geometry<ls, ls>("LINESTRING(3 2, 2 2, 1 1)", "LINESTRING(4 2, 2 2, 0 0)", true);
+    test_geometry<ls1, ls2>("LINESTRING(1 1, 2 2, 3 2)", "LINESTRING(0 0, 2 2, 4 2)", true);
+    test_geometry<ls1, ls2>("LINESTRING(3 2, 2 2, 1 1)", "LINESTRING(0 0, 2 2, 4 2)", true);
+    test_geometry<ls1, ls2>("LINESTRING(1 1, 2 2, 3 2)", "LINESTRING(4 2, 2 2, 0 0)", true);
+    test_geometry<ls1, ls2>("LINESTRING(3 2, 2 2, 1 1)", "LINESTRING(4 2, 2 2, 0 0)", true);
 
-    test_geometry<ls, ls>("LINESTRING(1 1, 2 2, 3 3)", "LINESTRING(0 0, 2 2, 4 2)", false);
-    test_geometry<ls, ls>("LINESTRING(1 1, 2 2, 3 2, 3 3)", "LINESTRING(0 0, 2 2, 4 2)", false);
-    test_geometry<ls, ls>("LINESTRING(1 1, 2 2, 3 1)", "LINESTRING(0 0, 2 2, 4 2)", false);
-    test_geometry<ls, ls>("LINESTRING(1 1, 2 2, 3 2, 3 1)", "LINESTRING(0 0, 2 2, 4 2)", false);
+    test_geometry<ls1, ls2>("LINESTRING(1 1, 2 2, 3 3)", "LINESTRING(0 0, 2 2, 4 2)", false);
+    test_geometry<ls1, ls2>("LINESTRING(1 1, 2 2, 3 2, 3 3)", "LINESTRING(0 0, 2 2, 4 2)", false);
+    test_geometry<ls1, ls2>("LINESTRING(1 1, 2 2, 3 1)", "LINESTRING(0 0, 2 2, 4 2)", false);
+    test_geometry<ls1, ls2>("LINESTRING(1 1, 2 2, 3 2, 3 1)", "LINESTRING(0 0, 2 2, 4 2)", false);
 
-    test_geometry<ls, ls>("LINESTRING(0 1, 1 1, 2 2, 3 2)", "LINESTRING(0 0, 2 2, 4 2)", false);
-    test_geometry<ls, ls>("LINESTRING(0 1, 0 0, 2 2, 3 2)", "LINESTRING(0 0, 2 2, 4 2)", false);
-    test_geometry<ls, ls>("LINESTRING(1 0, 1 1, 2 2, 3 2)", "LINESTRING(0 0, 2 2, 4 2)", false);
-    test_geometry<ls, ls>("LINESTRING(1 0, 0 0, 2 2, 3 2)", "LINESTRING(0 0, 2 2, 4 2)", false);
+    test_geometry<ls1, ls2>("LINESTRING(0 1, 1 1, 2 2, 3 2)", "LINESTRING(0 0, 2 2, 4 2)", false);
+    test_geometry<ls1, ls2>("LINESTRING(0 1, 0 0, 2 2, 3 2)", "LINESTRING(0 0, 2 2, 4 2)", false);
+    test_geometry<ls1, ls2>("LINESTRING(1 0, 1 1, 2 2, 3 2)", "LINESTRING(0 0, 2 2, 4 2)", false);
+    test_geometry<ls1, ls2>("LINESTRING(1 0, 0 0, 2 2, 3 2)", "LINESTRING(0 0, 2 2, 4 2)", false);
 
     // duplicated points
-    test_geometry<ls, ls>("LINESTRING(1 1, 2 2, 2 2)", "LINESTRING(0 0, 2 2, 4 2)", true);
-    test_geometry<ls, ls>("LINESTRING(1 1, 1 1, 2 2)", "LINESTRING(0 0, 2 2, 4 2)", true);
+    test_geometry<ls1, ls2>("LINESTRING(1 1, 2 2, 2 2)", "LINESTRING(0 0, 2 2, 4 2)", true);
+    test_geometry<ls1, ls2>("LINESTRING(1 1, 1 1, 2 2)", "LINESTRING(0 0, 2 2, 4 2)", true);
 
-    test_geometry<ls, ls>("LINESTRING(0 0, 0 0, 0 0, 1 1, 2 2, 2 2, 2 2, 2 2, 2 2, 2 2, 2 2, 2 2, 2 2, 2 2, 2 2, 2 2, 2 2, 2 2, 2 2, 2 2, 2 2, 2 2, 3 3)",
+    test_geometry<ls1, ls2>("LINESTRING(0 0, 0 0, 0 0, 1 1, 2 2, 2 2, 2 2, 2 2, 2 2, 2 2, 2 2, 2 2, 2 2, 2 2, 2 2, 2 2, 2 2, 2 2, 2 2, 2 2, 2 2, 2 2, 3 3)",
                           "LINESTRING(0 0, 2 2, 4 4)", true);
 
     // invalid linestrings
-//    test_geometry<ls, ls>("LINESTRING(0 0)", "LINESTRING(0 0)", false);
-//    test_geometry<ls, ls>("LINESTRING(1 1)", "LINESTRING(0 0, 2 2)", true);
-//    test_geometry<ls, ls>("LINESTRING(0 0)", "LINESTRING(0 0, 2 2)", false);
-//    test_geometry<ls, ls>("LINESTRING(0 0, 1 1)", "LINESTRING(0 0)", false);
+//    test_geometry<ls1, ls2>("LINESTRING(0 0)", "LINESTRING(0 0)", false);
+//    test_geometry<ls1, ls2>("LINESTRING(1 1)", "LINESTRING(0 0, 2 2)", true);
+//    test_geometry<ls1, ls2>("LINESTRING(0 0)", "LINESTRING(0 0, 2 2)", false);
+//    test_geometry<ls1, ls2>("LINESTRING(0 0, 1 1)", "LINESTRING(0 0)", false);
 
     // spikes
     // FOR NOW DISABLED
 
-    /*test_geometry<ls, ls>("LINESTRING(0 0,5 0,3 0,6 0)", "LINESTRING(0 0,6 0)", true);
+    /*test_geometry<ls1, ls2>("LINESTRING(0 0,5 0,3 0,6 0)", "LINESTRING(0 0,6 0)", true);
 
-    test_geometry<ls, ls>("LINESTRING(0 0,2 2,3 3,1 1)", "LINESTRING(0 0,3 3,6 3)", true);
-    test_geometry<ls, ls>("LINESTRING(0 0,3 3,6 3)", "LINESTRING(0 0,2 2,3 3,1 1)", false);
-    test_geometry<ls, ls>("LINESTRING(0 0,2 2,3 3,1 1)", "LINESTRING(0 0,4 4,6 3)", true);
-    test_geometry<ls, ls>("LINESTRING(0 0,4 4,6 3)", "LINESTRING(0 0,2 2,3 3,1 1)", false);
+    test_geometry<ls1, ls2>("LINESTRING(0 0,2 2,3 3,1 1)", "LINESTRING(0 0,3 3,6 3)", true);
+    test_geometry<ls1, ls2>("LINESTRING(0 0,3 3,6 3)", "LINESTRING(0 0,2 2,3 3,1 1)", false);
+    test_geometry<ls1, ls2>("LINESTRING(0 0,2 2,3 3,1 1)", "LINESTRING(0 0,4 4,6 3)", true);
+    test_geometry<ls1, ls2>("LINESTRING(0 0,4 4,6 3)", "LINESTRING(0 0,2 2,3 3,1 1)", false);
     
-    test_geometry<ls, ls>("LINESTRING(0 0,2 2,3 3,1 1,5 3)", "LINESTRING(0 0,3 3,6 3)", false);*/
+    test_geometry<ls1, ls2>("LINESTRING(0 0,2 2,3 3,1 1,5 3)", "LINESTRING(0 0,3 3,6 3)", false);*/
 
-    test_geometry<ls, mls>("LINESTRING(1 1, 2 2)", "MULTILINESTRING((0 0, 2 2),(3 3, 4 4))", true);
+    test_geometry<ls1, mls2>("LINESTRING(1 1, 2 2)", "MULTILINESTRING((0 0, 2 2),(3 3, 4 4))", true);
 
-    test_geometry<mls, ls>("MULTILINESTRING((0 0, 2 2),(3 3, 4 4))", "LINESTRING(0 0, 5 5)", true);
+    test_geometry<mls1, ls2>("MULTILINESTRING((0 0, 2 2),(3 3, 4 4))", "LINESTRING(0 0, 5 5)", true);
 
-    test_geometry<mls, mls>("MULTILINESTRING((1 1, 2 2),(3 3, 4 4))", "MULTILINESTRING((1 1, 2 2),(2 2, 5 5))", true);
+    test_geometry<mls1, mls2>("MULTILINESTRING((1 1, 2 2),(3 3, 4 4))", "MULTILINESTRING((1 1, 2 2),(2 2, 5 5))", true);
+}
+
+template <typename P1, typename P2>
+void test_all()
+{
+    test_l_l<P1, P2>();
 }
 
 template <typename P>
 void test_all()
 {
-    test_l_l<P>();
+    test_l_l<P, P>();
 }
 
 int test_main( int , char* [] )
 {
     test_all<bg::model::d2::point_xy<int> >();
     test_all<bg::model::d2::point_xy<double> >();
+    test_all<bg::model::d2::point_xy<double>, bg::model::point<double, 2, bg::cs::cartesian> >();
 
 #if defined(HAVE_TTMATH)
     test_all<bg::model::d2::point_xy<ttmath_big> >();


### PR DESCRIPTION
This fixes the ticket: https://svn.boost.org/trac/boost/ticket/12189
and issue reported in this thread: http://lists.boost.org/geometry/2016/05/3550.php

`relate_cartesian_segments::apply()` expects single `RobustPoint` type. This causes compilation error in e.g. relational operations when geometries using different point types are passed.