### PR TITLE
Prevent integer overflow during segment touch ratio calculation

### DIFF
--- a/test/algorithms/is_simple.cpp
+++ b/test/algorithms/is_simple.cpp
@@ -268,11 +268,12 @@ BOOST_AUTO_TEST_CASE( test_geometry_with_NaN_coordinates )
     bg::read_wkt("LINESTRING(-1 1,1.115235e+308 1.738137e+308)", ls2);
 
     // the intersection of the two linestrings is a new linestring
-    // (multilinestring with a single element) that has NaN coordinates
+    // (multilinestring with a single element) that is an isolated point
     multi_linestring_type mls;
     bg::intersection(ls1, ls2, mls);
 
-    test_simple(mls, true, false);
+    // "isolated point"-linestring is not simple
+    test_simple(mls, false, false);
 }
 
 BOOST_AUTO_TEST_CASE( test_is_simple_variant )

--- a/test/algorithms/is_valid.cpp
+++ b/test/algorithms/is_valid.cpp
@@ -262,7 +262,7 @@ inline void test_open_rings()
     typedef bg::model::ring<Point, false, true> CG; // ccw, closed ring
     typedef bg::model::ring<Point, true, false> CW_OG; // cw, open ring
     typedef bg::model::ring<Point, true, true> CW_CG; // cw, closed ring
- 
+
     typedef validity_tester_areal<AllowDuplicates> tester;
     typedef test_valid<tester, OG, CG, CW_OG, CW_CG> test;
 

--- a/test/algorithms/set_operations/intersection/intersection_linear_linear.cpp
+++ b/test/algorithms/set_operations/intersection/intersection_linear_linear.cpp
@@ -1309,7 +1309,7 @@ BOOST_AUTO_TEST_CASE( test_intersection_ml_ml_degenerate )
                       (8.5655 2.85228),(5.26567 4.81254),(4 3.8),\
                       (1.4995 3.27036),(0.591231 3.43401),\
                       (-0.706503 3.66784),\
-                      (-0.7654 8.88178e-16,-0.7654 0,5 3))"),
+                      (-0.7654 0,5 3))"),
          from_wkt<ML>("MULTILINESTRING((1.87562 6.68515),(1.60494 6),\
                       (1.18124 4.9275),(1.00439 4.47984),(0.91526 4.25422),\
                       (0.729883 3.78498),(0.614728 3.49349),\
@@ -1340,7 +1340,7 @@ BOOST_AUTO_TEST_CASE( test_intersection_ml_ml_degenerate )
                       (9.98265 0.00543606),(9.09826 -100.515944),\
                       (7.08745 -329.0674155),(5.06428 -559.024344),\
                       (3.23365 -767.0972558),(3.16036 -775.427199),\
-                      (-0.7654 8.88178e-16,-0.7654 0,5 3))"),
+                      (-0.7654 0,5 3))"),
 #endif
           "mlmli21",
           1e-4
@@ -1355,7 +1355,7 @@ BOOST_AUTO_TEST_CASE( test_intersection_ml_ml_spikes )
 {
 #ifdef BOOST_GEOMETRY_TEST_DEBUG
     std::cout << std::endl << std::endl << std::endl;
-    std::cout << "*** MULTILINESTRING / MULTILINESTRING INTERSECTION" 
+    std::cout << "*** MULTILINESTRING / MULTILINESTRING INTERSECTION"
               << " (WITH SPIKES) ***"
               << std::endl;
     std::cout << std::endl;


### PR DESCRIPTION
I use boost/geometry clipping operations after snap rounding (to prevent robustness issues). So I have no intersecting segments in my areals, segments are intersecting with their endpoints. Integers are large (they can be about 2**30), but I use 64-bit integer coordinate type. So sides (side_info) are calculating perfectly, but when segment ratio calculation leads to integer overflow.

But we don't actually need to calculate these ratios, they are trivial.
