### PR TITLE
Add C++11 std::array point adaptor

### DIFF
--- a/include/boost/geometry/geometries/adapted/std_array.hpp
+++ b/include/boost/geometry/geometries/adapted/std_array.hpp
@@ -1,0 +1,115 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2010 Alfredo Correa
+// Copyright (c) 2010-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2016 Norbert Wenzel
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_GEOMETRIES_ADAPTED_STD_ARRAY_HPP
+#define BOOST_GEOMETRY_GEOMETRIES_ADAPTED_STD_ARRAY_HPP
+
+
+#define BOOST_GEOMETRY_ADAPTED_STD_ARRAY_TAG_DEFINED
+
+
+#include <cstddef>
+
+#include <boost/type_traits/is_arithmetic.hpp>
+
+#include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/cs.hpp>
+#include <boost/geometry/core/coordinate_dimension.hpp>
+#include <boost/geometry/core/coordinate_type.hpp>
+#include <boost/geometry/core/tags.hpp>
+
+#include <array>
+
+namespace boost { namespace geometry
+{
+
+
+#ifndef DOXYGEN_NO_TRAITS_SPECIALIZATIONS
+namespace traits
+{
+
+
+#ifndef DOXYGEN_NO_DETAIL
+namespace detail
+{
+
+
+// Create class and specialization to indicate the tag
+// for normal cases and the case that the type of the std-array is arithmetic
+template <bool>
+struct std_array_tag
+{
+    typedef geometry_not_recognized_tag type;
+};
+
+
+template <>
+struct std_array_tag<true>
+{
+    typedef point_tag type;
+};
+
+
+} // namespace detail
+#endif // DOXYGEN_NO_DETAIL
+
+
+// Assign the point-tag, preventing arrays of points getting a point-tag
+template <typename CoordinateType, std::size_t DimensionCount>
+struct tag<std::array<CoordinateType, DimensionCount> >
+    : detail::std_array_tag<boost::is_arithmetic<CoordinateType>::value> {};
+
+
+template <typename CoordinateType, std::size_t DimensionCount>
+struct coordinate_type<std::array<CoordinateType, DimensionCount> >
+{
+    typedef CoordinateType type;
+};
+
+
+template <typename CoordinateType, std::size_t DimensionCount>
+struct dimension<std::array<CoordinateType, DimensionCount> >: boost::mpl::int_<DimensionCount> {};
+
+
+template <typename CoordinateType, std::size_t DimensionCount, std::size_t Dimension>
+struct access<std::array<CoordinateType, DimensionCount>, Dimension>
+{
+    static inline CoordinateType get(std::array<CoordinateType, DimensionCount> const& a)
+    {
+        return a[Dimension];
+    }
+
+    static inline void set(std::array<CoordinateType, DimensionCount>& a,
+        CoordinateType const& value)
+    {
+        a[Dimension] = value;
+    }
+};
+
+
+} // namespace traits
+#endif // DOXYGEN_NO_TRAITS_SPECIALIZATIONS
+
+
+}} // namespace boost::geometry
+
+
+#define BOOST_GEOMETRY_REGISTER_STD_ARRAY_CS(CoordinateSystem) \
+    namespace boost { namespace geometry { namespace traits { \
+    template <class T, std::size_t N> \
+    struct coordinate_system<std::array<T, N> > \
+    { \
+        typedef CoordinateSystem type; \
+    }; \
+    }}}
+
+
+#endif // BOOST_GEOMETRY_GEOMETRIES_ADAPTED_STD_ARRAY_HPP
+

--- a/test/geometries/boost_array_as_point.cpp
+++ b/test/geometries/boost_array_as_point.cpp
@@ -8,8 +8,8 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/config.hpp>
 #include <geometry_test_common.hpp>
-
 
 #include<boost/geometry/geometry.hpp>
 #include<boost/geometry/geometries/adapted/boost_array.hpp>
@@ -21,6 +21,10 @@ BOOST_GEOMETRY_REGISTER_C_ARRAY_CS(cs::cartesian)
 BOOST_GEOMETRY_REGISTER_BOOST_ARRAY_CS(cs::cartesian)
 BOOST_GEOMETRY_REGISTER_BOOST_TUPLE_CS(cs::cartesian)
 
+#ifndef BOOST_NO_CXX11_HDR_ARRAY 
+#include<boost/geometry/geometries/adapted/std_array.hpp>
+BOOST_GEOMETRY_REGISTER_STD_ARRAY_CS(cs::cartesian)
+#endif //BOOST_NO_CXX11_HDR_ARRAY 
 
 int test_main(int, char* [])
 {
@@ -31,6 +35,12 @@ int test_main(int, char* [])
     std::clog << bg::distance(p1, p2) << std::endl;
     std::clog << bg::distance(p2, p3) << std::endl;
     std::clog << bg::distance(p3, p4) << std::endl;
+
+#ifndef BOOST_NO_CXX11_HDR_ARRAY 
+    std::array<double, 3> p5{13,14,15};
+    std::clog << bg::distance(p4, p5) << std::endl;
+#endif //BOOST_NO_CXX11_HDR_ARRAY 
+
     return 0;
 }
 


### PR DESCRIPTION
Add point adaptor based on existing Boost.Array adaptor for C++11 std::array. I'm currently not very happy with the preprocessor checks in the test, but since the whole test is really small I think the preprocessor checks are not too bad. Anyway, I'm open to suggestions if changes are required.