### PR TITLE
Feature/max latitude

### DIFF
--- a/include/boost/geometry/algorithms/detail/azimuth.hpp
+++ b/include/boost/geometry/algorithms/detail/azimuth.hpp
@@ -70,7 +70,7 @@ struct azimuth<ReturnType, spherical_equatorial_tag>
     template <typename P1, typename P2, typename Sphere>
     static inline ReturnType apply(P1 const& p1, P2 const& p2, Sphere const& /*unused*/)
     {
-        return geometry::formula::spherical_azimuth<ReturnType>
+        return geometry::formula::spherical_azimuth<ReturnType, false>
                     ( get_as_radian<0>(p1), get_as_radian<1>(p1),
                       get_as_radian<0>(p2), get_as_radian<1>(p2)).azimuth;
     }

--- a/include/boost/geometry/algorithms/detail/azimuth.hpp
+++ b/include/boost/geometry/algorithms/detail/azimuth.hpp
@@ -5,6 +5,7 @@
 // This file was modified by Oracle on 2014, 2016.
 // Modifications copyright (c) 2014-2016, Oracle and/or its affiliates.
 
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -69,22 +70,9 @@ struct azimuth<ReturnType, spherical_equatorial_tag>
     template <typename P1, typename P2, typename Sphere>
     static inline ReturnType apply(P1 const& p1, P2 const& p2, Sphere const& /*unused*/)
     {
-        // http://williams.best.vwh.net/avform.htm#Crs
-        ReturnType dlon = get_as_radian<0>(p2) - get_as_radian<0>(p1);
-        ReturnType cos_p2lat = cos(get_as_radian<1>(p2));
-
-        // An optimization which should kick in often for Boxes
-        //if ( math::equals(dlon, ReturnType(0)) )
-        //if ( get<0>(p1) == get<0>(p2) )
-        //{
-        //    return - sin(get_as_radian<1>(p1)) * cos_p2lat);
-        //}
-
-        // "An alternative formula, not requiring the pre-computation of d"
-        // In the formula below dlon is used as "d"
-        return atan2(sin(dlon) * cos_p2lat,
-            cos(get_as_radian<1>(p1)) * sin(get_as_radian<1>(p2))
-            - sin(get_as_radian<1>(p1)) * cos_p2lat * cos(dlon));
+        return geometry::formula::spherical_azimuth<ReturnType>
+                    ( get_as_radian<0>(p1), get_as_radian<1>(p1),
+                      get_as_radian<0>(p2), get_as_radian<1>(p2)).azimuth;
     }
 
     template <typename P1, typename P2>

--- a/include/boost/geometry/formulas/spherical.hpp
+++ b/include/boost/geometry/formulas/spherical.hpp
@@ -102,12 +102,11 @@ static inline int sph_side_value(Point3d1 const& norm, Point3d2 const& pt)
         : -1; // d < 0
 }
 
-template <typename CT, typename T1, typename T2>
+template <typename CT, bool ReverseAzimuth, typename T1, typename T2>
 static inline result_spherical<CT> spherical_azimuth(T1 const& lon1,
                                                  T1 const& lat1,
                                                  T2 const& lon2,
-                                                 T2 const& lat2,
-                                                 bool reverse_azimuth = false)
+                                                 T2 const& lat2)
 {
     typedef result_spherical<CT> result_type;
     result_type result;
@@ -132,10 +131,14 @@ static inline result_spherical<CT> spherical_azimuth(T1 const& lon1,
     // "An alternative formula, not requiring the pre-computation of d"
     // In the formula below dlon is used as "d"
     result.azimuth = atan2(sin_dlon * cos_lat2,
-                          cos_lat1 * sin_lat2 - sin_lat1 * cos_lat2 * cos_dlon);
+                           cos_lat1 * sin_lat2 - sin_lat1 * cos_lat2 * cos_dlon);
 
-    result.reverse_azimuth = atan2(sin_dlon * cos_lat1,
-                          sin_lat2 * cos_lat1 * cos_dlon - cos_lat2 * sin_lat1);
+    if (ReverseAzimuth)
+    {
+        result.reverse_azimuth =
+                     atan2(sin_dlon * cos_lat1,
+                           sin_lat2 * cos_lat1 * cos_dlon - cos_lat2 * sin_lat1);
+    }
 
     return result;
 }

--- a/include/boost/geometry/formulas/vertex_latitude.hpp
+++ b/include/boost/geometry/formulas/vertex_latitude.hpp
@@ -54,16 +54,16 @@ public:
         inverse_result i_res = inverse_type::apply(lon1, lat1, lon2, lat2,
                                                    spheroid);
 
-        CT const alp1 = i_res.azimuth;
-        CT const alp2 = i_res.reverse_azimuth;
+        CT const alp1 = std::abs(i_res.azimuth);
+        CT const alp2 = std::abs(i_res.reverse_azimuth);
 
-        std::cout << "a1=" << alp1 * 180 / math::pi<CT>()
-                  << " a2="
-                  << alp2 * 180 / math::pi<CT>()
-                  << std::endl;
+        //std::cout << "a1=" << alp1 * 180 / math::pi<CT>()
+        //          << " a2="
+        //          << alp2 * 180 / math::pi<CT>()
+        //          << std::endl;
 
         // if the segment does not contain the vertex of the geodesic
-        // then the vertex is one of the endpoints
+        // then return the endpoint of max (min) latitude
         if ((alp1 < half_pi && alp2 < half_pi)
             || (alp1 > half_pi && alp2 > half_pi)
             || (north == sign))
@@ -73,18 +73,13 @@ public:
 
         CT const sin_alp1 = sin(alp1);
         CT const sin_lat1 = sin(lat1);
-        //CT const sin_lat2 = sin(lat2);
         CT const cos_lat1 = math::sqrt(CT(1) - math::sqr(sin_lat1));
-        //CT const cos_lat2 = math::sqrt(CT(1) - math::sqr(sin_lat2));
 
-        //normal radius at point p1(lon1,lat1)
+        // normal radius at point p1(lon1,lat1)
         CT const n_b1 = a / (math::sqrt(CT(1) - e2 * math::sqr(sin_lat1)));
-        //CT const n_b2 = a / (math::sqrt(CT(1) - e2 * math::sqr(sin_lat2)));
 
-        //the invariant of the geodesic
+        // the invariant of the geodesic
         CT const c = n_b1 * cos_lat1 * sin_alp1;
-
-        //CT const alp2b = std::asin(c / (n_b2 * cos_lat2));
 
         CT const a_c2 = math::sqr(a / c);
         CT const max_lat = std::asin(math::sqrt((a_c2 - 1) / (a_c2 - e2)));

--- a/include/boost/geometry/formulas/vertex_latitude.hpp
+++ b/include/boost/geometry/formulas/vertex_latitude.hpp
@@ -1,0 +1,99 @@
+// Boost.Geometry
+
+// Copyright (c) 2016 Oracle and/or its affiliates.
+
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_FORMULAS_MAXIMUM_LATITUDE_HPP
+#define BOOST_GEOMETRY_FORMULAS_MAXIMUM_LATITUDE_HPP
+
+namespace boost { namespace geometry { namespace formula
+{
+
+/*!
+\brief Algorithm to compute the vertex latitude of a geodesic segment. Vertex is
+a point on the geodesic that maximizes (or minimizes) the latitude.
+\author See
+    Wood - Vertex Latitudes on Ellipsoid Geodesics, SIAM Rev., 38(4), 637–644,
+    1996
+*/
+
+template <
+    typename CT,
+    template <typename, bool, bool, bool, bool, bool> class Inverse
+>
+class vertex_latitude
+{
+
+    typedef Inverse<CT, false, true, true, false, false> inverse_type;
+    typedef typename inverse_type::result_type inverse_result;
+
+public:
+
+    template <typename T1, typename T2, typename Spheroid>
+    static inline CT apply(T1 const& lon1,
+                           T1 const& lat1,
+                           T2 const& lon2,
+                           T2 const& lat2,
+                           Spheroid const& spheroid,
+                           bool north)
+    {
+        CT const a = get_radius<0>(spheroid);
+        CT const f = detail::flattening<CT>(spheroid);
+        CT const e2 = f * (CT(2) - f);
+        CT const half_pi = math::pi<CT>() / CT(2);
+
+        // signbit returns a non-zero value (true) if the sign is negative;
+        // and zero (false) otherwise.
+        bool sign = std::signbit(std::abs(lat1) > std::abs(lat2) ? lat1 : lat2);
+
+        inverse_result i_res = inverse_type::apply(lon1, lat1, lon2, lat2,
+                                                   spheroid);
+
+        CT const alp1 = i_res.azimuth;
+        CT const alp2 = i_res.reverse_azimuth;
+
+        std::cout << "a1=" << alp1 * 180 / math::pi<CT>()
+                  << " a2="
+                  << alp2 * 180 / math::pi<CT>()
+                  << std::endl;
+
+        // if the segment does not contain the vertex of the geodesic
+        // then the vertex is one of the endpoints
+        if ((alp1 < half_pi && alp2 < half_pi)
+            || (alp1 > half_pi && alp2 > half_pi)
+            || (north == sign))
+        {
+            return north ? std::max(lat1, lat2) : std::min(lat1, lat2);
+        }
+
+        CT const sin_alp1 = sin(alp1);
+        CT const sin_lat1 = sin(lat1);
+        //CT const sin_lat2 = sin(lat2);
+        CT const cos_lat1 = math::sqrt(CT(1) - math::sqr(sin_lat1));
+        //CT const cos_lat2 = math::sqrt(CT(1) - math::sqr(sin_lat2));
+
+        //normal radius at point p1(lon1,lat1)
+        CT const n_b1 = a / (math::sqrt(CT(1) - e2 * math::sqr(sin_lat1)));
+        //CT const n_b2 = a / (math::sqrt(CT(1) - e2 * math::sqr(sin_lat2)));
+
+        //the invariant of the geodesic
+        CT const c = n_b1 * cos_lat1 * sin_alp1;
+
+        //CT const alp2b = std::asin(c / (n_b2 * cos_lat2));
+
+        CT const a_c2 = math::sqr(a / c);
+        CT const max_lat = std::asin(math::sqrt((a_c2 - 1) / (a_c2 - e2)));
+
+        return (sign ? max_lat * CT(-1) : max_lat);
+    }
+};
+
+
+}}} // namespace boost::geometry::formula
+
+#endif // BOOST_GEOMETRY_FORMULAS_MAXIMUM_LATITUDE_HPP

--- a/include/boost/geometry/formulas/vertex_latitude.hpp
+++ b/include/boost/geometry/formulas/vertex_latitude.hpp
@@ -24,7 +24,8 @@ a point on the geodesic that maximizes (or minimizes) the latitude.
 
 template <
     typename CT,
-    template <typename, bool, bool, bool, bool, bool> class Inverse
+    template <typename, bool, bool, bool, bool, bool> class Inverse,
+    bool north
 >
 class vertex_latitude
 {
@@ -39,8 +40,7 @@ public:
                            T1 const& lat1,
                            T2 const& lon2,
                            T2 const& lat2,
-                           Spheroid const& spheroid,
-                           bool north)
+                           Spheroid const& spheroid)
     {
         CT const a = get_radius<0>(spheroid);
         CT const f = detail::flattening<CT>(spheroid);
@@ -51,16 +51,10 @@ public:
         // and zero (false) otherwise.
         bool sign = std::signbit(std::abs(lat1) > std::abs(lat2) ? lat1 : lat2);
 
-        inverse_result i_res = inverse_type::apply(lon1, lat1, lon2, lat2,
-                                                   spheroid);
+        inverse_result i_res = inverse_type::apply(lon1, lat1, lon2, lat2, spheroid);
 
         CT const alp1 = std::abs(i_res.azimuth);
         CT const alp2 = std::abs(i_res.reverse_azimuth);
-
-        //std::cout << "a1=" << alp1 * 180 / math::pi<CT>()
-        //          << " a2="
-        //          << alp2 * 180 / math::pi<CT>()
-        //          << std::endl;
 
         // if the segment does not contain the vertex of the geodesic
         // then return the endpoint of max (min) latitude

--- a/include/boost/geometry/formulas/vertex_latitude.hpp
+++ b/include/boost/geometry/formulas/vertex_latitude.hpp
@@ -30,21 +30,26 @@ class vertex_latitude
 
 public:
 
+    struct vertex_lat_result
+    {
+        vertex_lat_result()
+            :   north(0),
+              south(0)
+        {}
+
+        CT north, south;
+    };
+
     template <
-            bool north,
             typename T1,
             typename T2
             >
-    static inline CT spherical(T1 const& lon1,
-                               T1 const& lat1,
-                               T2 const& lon2,
-                               T2 const& lat2)
+    static inline vertex_lat_result spherical(T1 const& lon1,
+                                              T1 const& lat1,
+                                              T2 const& lon2,
+                                              T2 const& lat2)
     {
-        CT const half_pi = math::pi<CT>() / CT(2);
-
-        // signbit returns a non-zero value (true) if the sign is negative;
-        // and zero (false) otherwise.
-        bool sign = std::signbit(std::abs(lat1) > std::abs(lat2) ? lat1 : lat2);
+        vertex_lat_result vrt_result;
 
         geometry::formula::result_spherical<CT> result = geometry::formula::
                 spherical_azimuth<CT, true>(lon1, lat1, lon2, lat2);
@@ -52,76 +57,89 @@ public:
         CT const alp1 = std::abs(result.azimuth);
         CT const alp2 = std::abs(result.reverse_azimuth);
 
-        // if the segment does not contain the vertex of the geodesic
-        // then return the endpoint of max (min) latitude
-        if ((alp1 < half_pi && alp2 < half_pi)
-                || (alp1 > half_pi && alp2 > half_pi)
-                || (north == sign))
+        if(vertex_on_segment(alp1, alp2, lat1, lat2, vrt_result))
         {
-            return north ? std::max(lat1, lat2) : std::min(lat1, lat2);
+            CT const cos2_lat1 = math::sqr(cos(lat1));
+            CT const sin2_alp1 = math::sqr(sin(alp1));
+            CT const vertex_lat = std::asin(math::sqrt(1 - cos2_lat1 * sin2_alp1));
+
+            sign_adjastment(lat1, lat2, vertex_lat, vrt_result);
         }
-
-        CT const cos2_lat1 = math::sqr(cos(lat1));
-        CT const sin2_alp1 = math::sqr(sin(alp1));
-        CT const vertex_lat = std::asin(math::sqrt(1 - cos2_lat1 * sin2_alp1));
-
-        return (sign ? vertex_lat * CT(-1) : vertex_lat);
+        return vrt_result;
     }
 
 
     template <
             template <typename, bool, bool, bool, bool, bool> class Inverse,
-            bool north,
             typename T1,
             typename T2,
             typename Spheroid
             >
-    static inline CT geographic(T1 const& lon1,
+    static inline vertex_lat_result geographic(T1 const& lon1,
                                 T1 const& lat1,
                                 T2 const& lon2,
                                 T2 const& lat2,
                                 Spheroid const& spheroid)
     {
+        vertex_lat_result vrt_result;
+
         typedef Inverse<CT, false, true, true, false, false> inverse_type;
         typedef typename inverse_type::result_type inverse_result;
-
-        CT const a = get_radius<0>(spheroid);
-        CT const f = detail::flattening<CT>(spheroid);
-        CT const e2 = f * (CT(2) - f);
-        CT const half_pi = math::pi<CT>() / CT(2);
-
-        // signbit returns a non-zero value (true) if the sign is negative;
-        // and zero (false) otherwise.
-        bool sign = std::signbit(std::abs(lat1) > std::abs(lat2) ? lat1 : lat2);
-
         inverse_result i_res = inverse_type::apply(lon1, lat1, lon2, lat2, spheroid);
 
         CT const alp1 = std::abs(i_res.azimuth);
         CT const alp2 = std::abs(i_res.reverse_azimuth);
 
+        if(vertex_on_segment(alp1, alp2, lat1, lat2, vrt_result))
+        {
+            CT const a = get_radius<0>(spheroid);
+            CT const f = detail::flattening<CT>(spheroid);
+            CT const e2 = f * (CT(2) - f);
+
+            CT const sin_alp1 = sin(alp1);
+            CT const sin2_lat1 = math::sqr(sin(lat1));
+            CT const cos_lat1 = math::sqrt(CT(1) - sin2_lat1);
+
+            // normal radius at point p1(lon1,lat1)
+            CT const n_b1 = a / (math::sqrt(CT(1) - e2 * sin2_lat1));
+
+            // the invariant of the geodesic
+            CT const c = n_b1 * cos_lat1 * sin_alp1;
+
+            CT const a_c2 = math::sqr(a / c);
+            CT const vertex_lat = std::asin(math::sqrt((a_c2 - 1) / (a_c2 - e2)));
+
+            sign_adjastment(lat1, lat2, vertex_lat, vrt_result);
+        }
+        return vrt_result;
+    }
+
+    template <typename T>
+    inline static void sign_adjastment(CT lat1, CT lat2, CT vertex_lat, T& vrt_result)
+    {
+        // signbit returns a non-zero value (true) if the sign is negative;
+        // and zero (false) otherwise.
+        bool sign = std::signbit(std::abs(lat1) > std::abs(lat2) ? lat1 : lat2);
+
+        vrt_result.north = sign ? std::max(lat1, lat2) : vertex_lat;
+        vrt_result.south = sign ? vertex_lat * CT(-1) : std::min(lat1, lat2);
+    }
+
+    template <typename T>
+    inline static bool vertex_on_segment(CT alp1, CT alp2, CT lat1, CT lat2, T& vrt_result)
+    {
+        CT const half_pi = math::pi<CT>() / CT(2);
+
         // if the segment does not contain the vertex of the geodesic
         // then return the endpoint of max (min) latitude
         if ((alp1 < half_pi && alp2 < half_pi)
-                || (alp1 > half_pi && alp2 > half_pi)
-                || (north == sign))
+                || (alp1 > half_pi && alp2 > half_pi))
         {
-            return north ? std::max(lat1, lat2) : std::min(lat1, lat2);
+            vrt_result.north = std::max(lat1, lat2);
+            vrt_result.south = std::min(lat1, lat2);
+            return false;
         }
-
-        CT const sin_alp1 = sin(alp1);
-        CT const sin2_lat1 = math::sqr(sin(lat1));
-        CT const cos_lat1 = math::sqrt(CT(1) - sin2_lat1);
-
-        // normal radius at point p1(lon1,lat1)
-        CT const n_b1 = a / (math::sqrt(CT(1) - e2 * sin2_lat1));
-
-        // the invariant of the geodesic
-        CT const c = n_b1 * cos_lat1 * sin_alp1;
-
-        CT const a_c2 = math::sqr(a / c);
-        CT const vertex_lat = std::asin(math::sqrt((a_c2 - 1) / (a_c2 - e2)));
-
-        return (sign ? vertex_lat * CT(-1) : vertex_lat);
+        return true;
     }
 };
 

--- a/include/boost/geometry/formulas/vertex_latitude.hpp
+++ b/include/boost/geometry/formulas/vertex_latitude.hpp
@@ -24,27 +24,67 @@ a point on the geodesic that maximizes (or minimizes) the latitude.
     1996
 */
 
-template <
-    typename CT,
-    template <typename, bool, bool, bool, bool, bool> class Inverse,
-    bool north,
-    bool spherical = false
->
+template <typename CT>
 class vertex_latitude
 {
 
-    typedef Inverse<CT, false, true, true, false, false> inverse_type;
-    typedef typename inverse_type::result_type inverse_result;
-
 public:
 
-    template <typename T1, typename T2, typename Spheroid>
-    static inline CT apply(T1 const& lon1,
-                           T1 const& lat1,
-                           T2 const& lon2,
-                           T2 const& lat2,
-                           Spheroid const& spheroid)
+    template <
+            bool north,
+            typename T1,
+            typename T2
+            >
+    static inline CT spherical(T1 const& lon1,
+                               T1 const& lat1,
+                               T2 const& lon2,
+                               T2 const& lat2)
     {
+        CT const half_pi = math::pi<CT>() / CT(2);
+
+        // signbit returns a non-zero value (true) if the sign is negative;
+        // and zero (false) otherwise.
+        bool sign = std::signbit(std::abs(lat1) > std::abs(lat2) ? lat1 : lat2);
+
+        geometry::formula::result_spherical<CT> result = geometry::formula::
+                spherical_azimuth<CT, true>(lon1, lat1, lon2, lat2);
+
+        CT const alp1 = std::abs(result.azimuth);
+        CT const alp2 = std::abs(result.reverse_azimuth);
+
+        // if the segment does not contain the vertex of the geodesic
+        // then return the endpoint of max (min) latitude
+        if ((alp1 < half_pi && alp2 < half_pi)
+                || (alp1 > half_pi && alp2 > half_pi)
+                || (north == sign))
+        {
+            return north ? std::max(lat1, lat2) : std::min(lat1, lat2);
+        }
+
+        CT const cos2_lat1 = math::sqr(cos(lat1));
+        CT const sin2_alp1 = math::sqr(sin(alp1));
+        CT const vertex_lat = std::asin(math::sqrt(1 - cos2_lat1 * sin2_alp1));
+
+        return (sign ? vertex_lat * CT(-1) : vertex_lat);
+    }
+
+
+    template <
+            template <typename, bool, bool, bool, bool, bool> class Inverse,
+            bool north,
+            typename T1,
+            typename T2,
+            typename Spheroid
+            >
+    static inline CT geographic(T1 const& lon1,
+                                T1 const& lat1,
+                                T2 const& lon2,
+                                T2 const& lat2,
+                                Spheroid const& spheroid)
+    {
+        typedef Inverse<CT, false, true, true, false, false> inverse_type;
+        typedef typename inverse_type::result_type inverse_result;
+
         CT const a = get_radius<0>(spheroid);
         CT const f = detail::flattening<CT>(spheroid);
         CT const e2 = f * (CT(2) - f);
@@ -54,55 +94,32 @@ public:
         // and zero (false) otherwise.
         bool sign = std::signbit(std::abs(lat1) > std::abs(lat2) ? lat1 : lat2);
 
-        CT alp1, alp2;
+        inverse_result i_res = inverse_type::apply(lon1, lat1, lon2, lat2, spheroid);
 
-        if (spherical)
-        {
-            geometry::formula::result_spherical<CT> result = geometry::formula::
-                                  spherical_azimuth<CT>(lon1, lat1, lon2, lat2);
-            alp1 = std::abs(result.azimuth);
-            alp2 = std::abs(result.reverse_azimuth);
-        }
-        else
-        {
-            inverse_result i_res = inverse_type::apply(lon1, lat1, lon2, lat2, spheroid);
-
-            alp1 = std::abs(i_res.azimuth);
-            alp2 = std::abs(i_res.reverse_azimuth);
-        }
+        CT const alp1 = std::abs(i_res.azimuth);
+        CT const alp2 = std::abs(i_res.reverse_azimuth);
 
         // if the segment does not contain the vertex of the geodesic
         // then return the endpoint of max (min) latitude
         if ((alp1 < half_pi && alp2 < half_pi)
-            || (alp1 > half_pi && alp2 > half_pi)
-            || (north == sign))
+                || (alp1 > half_pi && alp2 > half_pi)
+                || (north == sign))
         {
             return north ? std::max(lat1, lat2) : std::min(lat1, lat2);
         }
 
-        CT vertex_lat;
+        CT const sin_alp1 = sin(alp1);
+        CT const sin2_lat1 = math::sqr(sin(lat1));
+        CT const cos_lat1 = math::sqrt(CT(1) - sin2_lat1);
 
-        if (spherical)
-        {
-            CT const cos2_lat1 = math::sqr(cos(lat1));
-            CT const sin2_alp2 = math::sqr(sin(alp2));
-            vertex_lat = std::asin(math::sqrt(1 - cos2_lat1 * sin2_alp2));
-        }
-        else
-        {
-            CT const sin_alp1 = sin(alp1);
-            CT const sin2_lat1 = math::sqr(sin(lat1));
-            CT const cos_lat1 = math::sqrt(CT(1) - sin2_lat1);
+        // normal radius at point p1(lon1,lat1)
+        CT const n_b1 = a / (math::sqrt(CT(1) - e2 * sin2_lat1));
 
-            // normal radius at point p1(lon1,lat1)
-            CT const n_b1 = a / (math::sqrt(CT(1) - e2 * sin2_lat1));
+        // the invariant of the geodesic
+        CT const c = n_b1 * cos_lat1 * sin_alp1;
 
-            // the invariant of the geodesic
-            CT const c = n_b1 * cos_lat1 * sin_alp1;
-
-            CT const a_c2 = math::sqr(a / c);
-            vertex_lat = std::asin(math::sqrt((a_c2 - 1) / (a_c2 - e2)));
-        }
+        CT const a_c2 = math::sqr(a / c);
+        CT const vertex_lat = std::asin(math::sqrt((a_c2 - 1) / (a_c2 - e2)));
 
         return (sign ? vertex_lat * CT(-1) : vertex_lat);
     }

--- a/test/algorithms/Jamfile.v2
+++ b/test/algorithms/Jamfile.v2
@@ -58,6 +58,7 @@ test-suite boost-geometry-algorithms
     [ run transform_multi.cpp          : : : : algorithms_transform_multi ]
     [ run unique.cpp                   : : : : algorithms_unique ]
     [ run unique_multi.cpp             : : : : algorithms_unique_multi ]
+    [ run vertex_latitude.cpp          : : : : algorithms_vertex_latitude ]
     ;
 
 build-project buffer ;

--- a/test/algorithms/vertex_latitude.cpp
+++ b/test/algorithms/vertex_latitude.cpp
@@ -16,27 +16,42 @@
 #include <boost/geometry/formulas/vertex_latitude.hpp>
 
 template <
-            template <typename, bool, bool, bool, bool, bool> class Inverse,
-            typename P,
-            typename CT
->
-void test_vertex_lat(P p1, P p2, CT expected_max, CT expected_min, CT error = 0.0001)
+        template <typename, bool, bool, bool, bool, bool> class Inverse,
+        typename P,
+        typename CT
+        >
+void test_vertex_lat(P p1, P p2, CT expected_max, CT expected_min,
+                     CT expected_max_sph, CT expected_min_sph, CT error = 0.0001)
 {
     CT p10 = bg::get_as_radian<0>(p1),
-       p11 = bg::get_as_radian<1>(p1),
-       p20 = bg::get_as_radian<0>(p2),
-       p21 = bg::get_as_radian<1>(p2);
+            p11 = bg::get_as_radian<1>(p1),
+            p20 = bg::get_as_radian<0>(p2),
+            p21 = bg::get_as_radian<1>(p2);
 
-    CT p_max = bg::formula::vertex_latitude<CT, Inverse, true>
-                 ::apply(p10, p11, p20, p21, bg::srs::spheroid<CT>());
+    CT p_max = bg::formula::vertex_latitude<CT>
+            ::template geographic<Inverse, true>
+            (p10, p11, p20, p21, bg::srs::spheroid<CT>());
     CT p_max_degree = p_max * 180 / bg::math::pi<CT>();
     BOOST_CHECK_CLOSE(p_max_degree, expected_max, error);
 
-    CT p_min = bg::formula::vertex_latitude<CT, Inverse, false>
-                 ::apply(p10, p11, p20, p21, bg::srs::spheroid<CT>());
+    CT p_min = bg::formula::vertex_latitude<CT>
+            ::template geographic<Inverse, false>
+            (p10, p11, p20, p21, bg::srs::spheroid<CT>());
     CT p_min_degree = p_min * 180 / bg::math::pi<CT>();
     BOOST_CHECK_CLOSE(p_min_degree, expected_min, error);
+
+    CT p_max_sph = bg::formula::vertex_latitude<CT>
+            ::template spherical<true>(p10, p11, p20, p21);
+    CT p_max_degree_sph = p_max_sph * 180 / bg::math::pi<CT>();
+    BOOST_CHECK_CLOSE(p_max_degree_sph, expected_max_sph, error);
+
+    CT p_min_sph = bg::formula::vertex_latitude<CT>
+            ::template spherical<false>(p10, p11, p20, p21);
+    CT p_min_degree_sph = p_min_sph * 180 / bg::math::pi<CT>();
+    BOOST_CHECK_CLOSE(p_min_degree_sph, expected_min_sph, error);
+
 }
+
 
 template <typename CT>
 void test_all()
@@ -44,45 +59,71 @@ void test_all()
     typedef bg::model::point<CT, 2, bg::cs::geographic<bg::degree> > Pg;
 
     // Short segments
-    test_vertex_lat<bg::formula::thomas_inverse>(Pg(1, 1), Pg(10, 5), 5.0, 1.0);
-    test_vertex_lat<bg::formula::thomas_inverse>(Pg(1, 1), Pg(10, 1), 1.0031124506594733, 1.0);
-    test_vertex_lat<bg::formula::thomas_inverse>(Pg(-5, 1), Pg(4, 1), 1.0031124506594733, 1.0);
-    test_vertex_lat<bg::formula::thomas_inverse>(Pg(175, 1), Pg(184, 1), 1.0031124506594733, 1.0);
-    test_vertex_lat<bg::formula::thomas_inverse>(Pg(355, 1), Pg(4, 1), 1.0031124506594733, 1.0);
+    test_vertex_lat<bg::formula::thomas_inverse>
+            (Pg(1, 1), Pg(10, 5), 5.0, 1.0, 5.0, 1.0);
+    test_vertex_lat<bg::formula::thomas_inverse>
+            (Pg(1, 1), Pg(10, 1), 1.0031124506594733, 1.0, 1.0030915676477881, 1.0);
+    test_vertex_lat<bg::formula::thomas_inverse>
+            (Pg(-5, 1), Pg(4, 1), 1.0031124506594733, 1.0, 1.0030915676477881, 1.0);
+    test_vertex_lat<bg::formula::thomas_inverse>
+            (Pg(175, 1), Pg(184, 1), 1.0031124506594733, 1.0, 1.0030915676477881, 1.0);
+    test_vertex_lat<bg::formula::thomas_inverse>
+            (Pg(355, 1), Pg(4, 1), 1.0031124506594733, 1.0, 1.0030915676477881, 1.0);
 
     // Reverse direction
-    test_vertex_lat<bg::formula::thomas_inverse>(Pg(1, 2), Pg(70, 1), 2.02397, 1.0);
-    test_vertex_lat<bg::formula::thomas_inverse>(Pg(70, 1), Pg(1, 2), 2.02397, 1.0);
+    test_vertex_lat<bg::formula::thomas_inverse>
+            (Pg(1, 2), Pg(70, 1), 2.0239716998355468, 1.0, 2.0228167431951536, 1.0);
+    test_vertex_lat<bg::formula::thomas_inverse>
+            (Pg(70, 1), Pg(1, 2), 2.0239716998351849, 1.0, 2.022816743195063, 1.0);
 
     // Long segments
-    test_vertex_lat<bg::formula::thomas_inverse>(Pg(0, 1), Pg(170, 1), 11.975026023950877, 1.0);
-    test_vertex_lat<bg::formula::thomas_inverse>(Pg(0, 1), Pg(179, 1), 68.452669316418039, 1.0);
-    test_vertex_lat<bg::formula::thomas_inverse>(Pg(0, 1), Pg(179.5, 1), 78.84050225214871, 1.0);
-    test_vertex_lat<bg::formula::thomas_inverse>(Pg(0, 1), Pg(180.5, 1), 78.84050225214871, 1.0);
-    test_vertex_lat<bg::formula::thomas_inverse>(Pg(0, 1), Pg(180, 1), 90.0, 1.0);
+    test_vertex_lat<bg::formula::thomas_inverse>
+            (Pg(0, 1), Pg(170, 1), 11.975026023950877, 1.0, 11.325049479775814, 1.0);
+    test_vertex_lat<bg::formula::thomas_inverse>
+            (Pg(0, 1), Pg(179, 1), 68.452669316418039, 1.0, 63.437566893227093, 1.0);
+    test_vertex_lat<bg::formula::thomas_inverse>
+            (Pg(0, 1), Pg(179.5, 1), 78.84050225214871, 1.0, 75.96516822754981, 1.0);
+    test_vertex_lat<bg::formula::thomas_inverse>
+            (Pg(0, 1), Pg(180.5, 1), 78.84050225214871, 1.0, 75.965168227550194, 1.0);
+    test_vertex_lat<bg::formula::thomas_inverse>
+            (Pg(0, 1), Pg(180, 1), 90.0, 1.0, 90.0, 1.0);
 
     // South hemisphere
-    test_vertex_lat<bg::formula::thomas_inverse>(Pg(1, -1), Pg(10, -5), -1.0, -5.0);
-    test_vertex_lat<bg::formula::thomas_inverse>(Pg(1, -1), Pg(10, -1), -1.0, -1.0031124506594733);
-    test_vertex_lat<bg::formula::thomas_inverse>(Pg(1, -1), Pg(170, -1), -1.0, -10.85834257048573);
+    test_vertex_lat<bg::formula::thomas_inverse>
+            (Pg(1, -1), Pg(10, -5), -1.0, -5.0, -1.0, -5.0);
+    test_vertex_lat<bg::formula::thomas_inverse>
+            (Pg(1, -1), Pg(10, -1), -1.0, -1.0031124506594733, -1.0, -1.0030915676477881);
+    test_vertex_lat<bg::formula::thomas_inverse>
+            (Pg(1, -1), Pg(170, -1), -1.0, -10.85834257048573, -1.0, -10.321374780571153);
 
     // Different strategies for inverse
     test_vertex_lat<bg::formula::thomas_inverse>
-            (Pg(1, 1), Pg(10, 1), 1.0031124506594733, 1.0, 0.00000001);
+            (Pg(1, 1), Pg(10, 1), 1.0031124506594733, 1.0,
+                                  1.0030915676477881, 1.0, 0.00000001);
     test_vertex_lat<bg::formula::andoyer_inverse>
-            (Pg(1, 1), Pg(10, 1), 1.0031124504591062, 1.0, 0.00000001);
+            (Pg(1, 1), Pg(10, 1), 1.0031124504591062, 1.0,
+                                  1.0030915676477881, 1.0, 0.00000001);
     test_vertex_lat<bg::formula::vincenty_inverse>
-            (Pg(1, 1), Pg(10, 1), 1.0031124508942098, 1.0, 0.00000001);
+            (Pg(1, 1), Pg(10, 1), 1.0031124508942098, 1.0,
+                                  1.0030915676477881, 1.0, 0.00000001);
 
     // Meridian and equator
-    test_vertex_lat<bg::formula::thomas_inverse>(Pg(1, 10), Pg(1, -10), 10.0, -10.0);
-    test_vertex_lat<bg::formula::thomas_inverse>(Pg(1, 0), Pg(10, 0), 0.0, 0.0);
+    test_vertex_lat<bg::formula::thomas_inverse>
+            (Pg(1, 10), Pg(1, -10), 10.0, -10.0, 10.0, -10.0);
+    test_vertex_lat<bg::formula::thomas_inverse>
+            (Pg(1, 0), Pg(10, 0), 0.0, 0.0, 0.0, 0.0);
 
     // One endpoint in northern hemisphere and the other in southern hemisphere
-    test_vertex_lat<bg::formula::thomas_inverse>(Pg(1, 1), Pg(150, -5), 1.0, -8.1825389632359933);
-    test_vertex_lat<bg::formula::thomas_inverse>(Pg(150, -5), Pg(1, 1), 1.0, -8.1825389632359933);
-    test_vertex_lat<bg::formula::thomas_inverse>(Pg(150, 5), Pg(1, -1), 8.1825389632359933, -1.0);
+    test_vertex_lat<bg::formula::thomas_inverse>
+            (Pg(1, 1), Pg(150, -5), 1.0, -8.1825389632359933, 1.0, -8.0761230625567588);
+    test_vertex_lat<bg::formula::thomas_inverse>
+            (Pg(150, -5), Pg(1, 1), 1.0, -8.1825389632359933, 1.0, -8.0761230625568015);
+    test_vertex_lat<bg::formula::thomas_inverse>
+            (Pg(150, 5), Pg(1, -1), 8.1825389632359933, -1.0, 8.0761230625568015, -1.0);
+
 }
+
+
 
 int test_main( int , char* [] )
 {

--- a/test/algorithms/vertex_latitude.cpp
+++ b/test/algorithms/vertex_latitude.cpp
@@ -1,0 +1,95 @@
+// Boost.Geometry
+
+// Copyright (c) 2016 Oracle and/or its affiliates.
+
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/geometry/core/coordinate_type.hpp>
+#include <boost/geometry/core/radian_access.hpp>
+#include <boost/geometry/core/srs.hpp>
+
+#include <boost/geometry/algorithms/detail/flattening.hpp>
+
+#include <iostream>
+#include <boost/geometry/formulas/andoyer_inverse.hpp>
+#include <boost/geometry/formulas/thomas_inverse.hpp>
+#include <boost/geometry/formulas/vincenty_inverse.hpp>
+#include <boost/geometry/formulas/vertex_latitude.hpp>
+
+#include <geometry_test_common.hpp>
+
+#include <boost/geometry/io/wkt/wkt.hpp>
+
+template <
+            template <typename, bool, bool, bool, bool, bool> class Inverse,
+            typename P,
+            typename CT
+>
+void test_vertex_lat(P p1, P p2, CT expected_max, CT expected_min, CT error = 0.0001)
+{
+    CT p10 = bg::get_as_radian<0>(p1),
+       p11 = bg::get_as_radian<1>(p1),
+       p20 = bg::get_as_radian<0>(p2),
+       p21 = bg::get_as_radian<1>(p2);
+
+    bg::formula::vertex_latitude<CT, Inverse> vrt_lat;
+
+    CT p_max = vrt_lat.apply(p10, p11, p20, p21,
+                             bg::srs::spheroid<CT>(), true);
+    CT p_max_degree = p_max * 180 / bg::math::pi<CT>();
+    BOOST_CHECK_CLOSE(p_max_degree, expected_max, error);
+
+    CT p_min = vrt_lat.apply(p10, p11, p20, p21,
+                             bg::srs::spheroid<CT>(), false);
+    CT p_min_degree = p_min * 180 / bg::math::pi<CT>();
+    BOOST_CHECK_CLOSE(p_min_degree, expected_min, error);
+}
+
+template <typename CT>
+void test_all()
+{
+    typedef bg::model::point<CT, 2, bg::cs::geographic<bg::degree> > Pg;
+
+    // Short segments
+    test_vertex_lat<bg::formula::thomas_inverse>(Pg(1, 1), Pg(10, 5), 5.0, 1.0);
+    test_vertex_lat<bg::formula::thomas_inverse>(Pg(1, 1), Pg(10, 1), 1.0031124506594733, 1.0);
+    test_vertex_lat<bg::formula::thomas_inverse>(Pg(-5, 1), Pg(4, 1), 1.0031124506594733, 1.0);
+    test_vertex_lat<bg::formula::thomas_inverse>(Pg(175, 1), Pg(184, 1), 1.0031124506594733, 1.0);
+    test_vertex_lat<bg::formula::thomas_inverse>(Pg(355, 1), Pg(4, 1), 1.0031124506594733, 1.0);
+
+    // Reverse direction
+    test_vertex_lat<bg::formula::thomas_inverse>(Pg(1, 2), Pg(70, 1), 2.02397, 1.0);
+    test_vertex_lat<bg::formula::thomas_inverse>(Pg(70, 1), Pg(1, 2), 2.02397, 1.0);
+
+    // Long segments
+    test_vertex_lat<bg::formula::thomas_inverse>(Pg(0, 1), Pg(170, 1), 11.975026023950877, 1.0);
+    test_vertex_lat<bg::formula::thomas_inverse>(Pg(0, 1), Pg(179, 1), 68.452669316418039, 1.0);
+    test_vertex_lat<bg::formula::thomas_inverse>(Pg(0, 1), Pg(179.5, 1), 78.84050225214871, 1.0);
+    test_vertex_lat<bg::formula::thomas_inverse>(Pg(0, 1), Pg(180.5, 1), 78.84050225214871, 1.0);
+    test_vertex_lat<bg::formula::thomas_inverse>(Pg(0, 1), Pg(180, 1), 90.0, 1.0);
+
+    // South hemisphere
+    test_vertex_lat<bg::formula::thomas_inverse>(Pg(1, -1), Pg(10, -5), -1.0, -5.0);
+    test_vertex_lat<bg::formula::thomas_inverse>(Pg(1, -1), Pg(10, -1), -1.0, -1.0031124506594733);
+    test_vertex_lat<bg::formula::thomas_inverse>(Pg(1, -1), Pg(170, -1), -1.0, -10.85834257048573);
+
+    // Different strategies for inverse
+    test_vertex_lat<bg::formula::thomas_inverse>
+            (Pg(1, 1), Pg(10, 1), 1.0031124506594733, 1.0, 0.00000001);
+    test_vertex_lat<bg::formula::andoyer_inverse>
+            (Pg(1, 1), Pg(10, 1), 1.0031124504591062, 1.0, 0.00000001);
+    test_vertex_lat<bg::formula::vincenty_inverse>
+            (Pg(1, 1), Pg(10, 1), 1.0031124508942098, 1.0, 0.00000001);
+}
+
+int test_main( int , char* [] )
+{
+    test_all<double>();
+
+    return 0;
+}
+

--- a/test/algorithms/vertex_latitude.cpp
+++ b/test/algorithms/vertex_latitude.cpp
@@ -19,37 +19,34 @@ template <
         template <typename, bool, bool, bool, bool, bool> class Inverse,
         typename P,
         typename CT
-        >
+>
 void test_vertex_lat(P p1, P p2, CT expected_max, CT expected_min,
                      CT expected_max_sph, CT expected_min_sph, CT error = 0.0001)
 {
     CT p10 = bg::get_as_radian<0>(p1),
-            p11 = bg::get_as_radian<1>(p1),
-            p20 = bg::get_as_radian<0>(p2),
-            p21 = bg::get_as_radian<1>(p2);
+       p11 = bg::get_as_radian<1>(p1),
+       p20 = bg::get_as_radian<0>(p2),
+       p21 = bg::get_as_radian<1>(p2);
 
-    CT p_max = bg::formula::vertex_latitude<CT>
-            ::template geographic<Inverse, true>
-            (p10, p11, p20, p21, bg::srs::spheroid<CT>());
-    CT p_max_degree = p_max * 180 / bg::math::pi<CT>();
+    typename bg::formula::vertex_latitude<CT>::vertex_lat_result p_max
+             = bg::formula::vertex_latitude<CT>::template geographic<Inverse>
+               (p10, p11, p20, p21, bg::srs::spheroid<CT>());
+
+    CT p_max_degree = p_max.north * 180 / bg::math::pi<CT>();
     BOOST_CHECK_CLOSE(p_max_degree, expected_max, error);
 
-    CT p_min = bg::formula::vertex_latitude<CT>
-            ::template geographic<Inverse, false>
-            (p10, p11, p20, p21, bg::srs::spheroid<CT>());
-    CT p_min_degree = p_min * 180 / bg::math::pi<CT>();
+    CT p_min_degree = p_max.south * 180 / bg::math::pi<CT>();
     BOOST_CHECK_CLOSE(p_min_degree, expected_min, error);
 
-    CT p_max_sph = bg::formula::vertex_latitude<CT>
-            ::template spherical<true>(p10, p11, p20, p21);
-    CT p_max_degree_sph = p_max_sph * 180 / bg::math::pi<CT>();
+    typename bg::formula::vertex_latitude<CT>::vertex_lat_result p_max_sph
+             = bg::formula::vertex_latitude<CT>::template spherical
+               (p10, p11, p20, p21);
+
+    CT p_max_degree_sph = p_max_sph.north * 180 / bg::math::pi<CT>();
     BOOST_CHECK_CLOSE(p_max_degree_sph, expected_max_sph, error);
 
-    CT p_min_sph = bg::formula::vertex_latitude<CT>
-            ::template spherical<false>(p10, p11, p20, p21);
-    CT p_min_degree_sph = p_min_sph * 180 / bg::math::pi<CT>();
+    CT p_min_degree_sph = p_max_sph.south * 180 / bg::math::pi<CT>();
     BOOST_CHECK_CLOSE(p_min_degree_sph, expected_min_sph, error);
-
 }
 
 
@@ -61,6 +58,7 @@ void test_all()
     // Short segments
     test_vertex_lat<bg::formula::thomas_inverse>
             (Pg(1, 1), Pg(10, 5), 5.0, 1.0, 5.0, 1.0);
+
     test_vertex_lat<bg::formula::thomas_inverse>
             (Pg(1, 1), Pg(10, 1), 1.0031124506594733, 1.0, 1.0030915676477881, 1.0);
     test_vertex_lat<bg::formula::thomas_inverse>
@@ -99,13 +97,13 @@ void test_all()
     // Different strategies for inverse
     test_vertex_lat<bg::formula::thomas_inverse>
             (Pg(1, 1), Pg(10, 1), 1.0031124506594733, 1.0,
-                                  1.0030915676477881, 1.0, 0.00000001);
+             1.0030915676477881, 1.0, 0.00000001);
     test_vertex_lat<bg::formula::andoyer_inverse>
             (Pg(1, 1), Pg(10, 1), 1.0031124504591062, 1.0,
-                                  1.0030915676477881, 1.0, 0.00000001);
+             1.0030915676477881, 1.0, 0.00000001);
     test_vertex_lat<bg::formula::vincenty_inverse>
             (Pg(1, 1), Pg(10, 1), 1.0031124508942098, 1.0,
-                                  1.0030915676477881, 1.0, 0.00000001);
+             1.0030915676477881, 1.0, 0.00000001);
 
     // Meridian and equator
     test_vertex_lat<bg::formula::thomas_inverse>
@@ -120,7 +118,6 @@ void test_all()
             (Pg(150, -5), Pg(1, 1), 1.0, -8.1825389632359933, 1.0, -8.0761230625568015);
     test_vertex_lat<bg::formula::thomas_inverse>
             (Pg(150, 5), Pg(1, -1), 8.1825389632359933, -1.0, 8.0761230625568015, -1.0);
-
 }
 
 


### PR DESCRIPTION
### Problem: compute the vertex latitude of a segment

Given a segment compute the point with the highest latitude, called vertex latitude. Note that on sphere/ellipsoid this could be higher than the maximum latitude of the segment's endpoints. 
### Solution

This PR implements formulas proposed in 

`Wood - Vertex Latitudes on Ellipsoid Geodesics, SIAM Rev., 38(4), 637–644, 1996` 

It is implemented in formulas/vertex_latitude.hpp for both geographic and spherical cases. The method computes both maximum and minimum latitude points of the segment. Several tests are also added.
### Comments
- The solution is expected to be much faster than computing the shortest distance between the segment and the North (or South) pole. Note that the later is a correct (but slower) solution for the problem. 
- This PR is going to be used by the algorithm that computes the envelope of a segment. 
- Azimuth algorithm for spherical segments was altered in order to use an azimuth formula. This is more consistent to geographic azimuth, i.e. the algorithm calls a formula. Then the azimuth formula is directly be used by the vertex latitude formula. 
