### PR TITLE
Grammar fix

### DIFF
--- a/include/boost/geometry/io/wkt/read.hpp
+++ b/include/boost/geometry/io/wkt/read.hpp
@@ -203,7 +203,7 @@ inline void check_end(Iterator& it,
 {
     if (it != end)
     {
-        throw read_wkt_exception("Too much tokens", it, end, wkt);
+        throw read_wkt_exception("Too many tokens", it, end, wkt);
     }
 }
 


### PR DESCRIPTION
Should presumably be 'too many tokens' rather than 'too much tokens'