### PR TITLE
Throw exceptions using BOOST_THROW_EXCEPTION.

### DIFF
--- a/include/boost/geometry/algorithms/centroid.hpp
+++ b/include/boost/geometry/algorithms/centroid.hpp
@@ -3,7 +3,7 @@
 // Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
-// Copyright (c) 2014-2015 Adam Wulkiewicz, Lodz, Poland.
+// Copyright (c) 2014-2017 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2014, 2015.
 // Modifications copyright (c) 2014-2015 Oracle and/or its affiliates.
@@ -26,6 +26,7 @@
 
 #include <boost/core/ignore_unused.hpp>
 #include <boost/range.hpp>
+#include <boost/throw_exception.hpp>
 
 #include <boost/variant/apply_visitor.hpp>
 #include <boost/variant/static_visitor.hpp>
@@ -183,7 +184,7 @@ inline bool range_ok(Range const& range, Point& centroid)
     else if (n <= 0)
     {
 #if ! defined(BOOST_GEOMETRY_CENTROID_NO_THROW)
-        throw centroid_exception();
+        BOOST_THROW_EXCEPTION(centroid_exception());
 #else
         return false;
 #endif
@@ -366,7 +367,7 @@ struct centroid_multi
         // to calculate the centroid
         if (geometry::is_empty(multi))
         {
-            throw centroid_exception();
+            BOOST_THROW_EXCEPTION(centroid_exception());
         }
 #endif
 

--- a/include/boost/geometry/algorithms/detail/has_self_intersections.hpp
+++ b/include/boost/geometry/algorithms/detail/has_self_intersections.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2011-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2017.
 // Modifications copyright (c) 2017 Oracle and/or its affiliates.
@@ -16,6 +17,8 @@
 #include <deque>
 
 #include <boost/range.hpp>
+#include <boost/throw_exception.hpp>
+
 #include <boost/geometry/core/point_type.hpp>
 #include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>
 #include <boost/geometry/algorithms/detail/overlay/get_turns.hpp>
@@ -118,7 +121,7 @@ inline bool has_self_intersections(Geometry const& geometry,
 #if ! defined(BOOST_GEOMETRY_OVERLAY_NO_THROW)
             if (throw_on_self_intersection)
             {
-                throw overlay_invalid_input_exception();
+                BOOST_THROW_EXCEPTION(overlay_invalid_input_exception());
             }
 #endif
             return true;

--- a/include/boost/geometry/algorithms/detail/overlay/follow_linear_linear.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/follow_linear_linear.hpp
@@ -1,5 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
+// Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
+
 // Copyright (c) 2014-2015, Oracle and/or its affiliates.
 
 // Licensed under the Boost Software License version 1.0.
@@ -15,6 +17,7 @@
 #include <iterator>
 
 #include <boost/range.hpp>
+#include <boost/throw_exception.hpp>
 
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/tag.hpp>
@@ -307,7 +310,7 @@ public:
 #if ! defined(BOOST_GEOMETRY_OVERLAY_NO_THROW)
         if (enter_count != 0)
         {
-            throw inconsistent_turns_exception();
+            BOOST_THROW_EXCEPTION(inconsistent_turns_exception());
         }
 #else
         BOOST_GEOMETRY_ASSERT(enter_count == 0);

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2015, 2017.
 // Modifications copyright (c) 2015-2017 Oracle and/or its affiliates.
@@ -16,6 +17,7 @@
 
 
 #include <boost/core/ignore_unused.hpp>
+#include <boost/throw_exception.hpp>
 
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/assert.hpp>
@@ -1102,7 +1104,7 @@ struct get_turn_info
                 std::cout << "TURN: Unknown method: " << method << std::endl;
 #endif
 #if ! defined(BOOST_GEOMETRY_OVERLAY_NO_THROW)
-                throw turn_info_exception(method);
+                BOOST_THROW_EXCEPTION(turn_info_exception(method));
 #endif
             }
             break;

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2013, 2014, 2015, 2017.
 // Modifications copyright (c) 2013-2017 Oracle and/or its affiliates.
@@ -13,6 +14,8 @@
 
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_TURN_INFO_LA_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_TURN_INFO_LA_HPP
+
+#include <boost/throw_exception.hpp>
 
 #include <boost/geometry/core/assert.hpp>
 
@@ -404,7 +407,7 @@ struct get_turn_info_linear_areal
                 std::cout << "TURN: Unknown method: " << method << std::endl;
 #endif
 #if ! defined(BOOST_GEOMETRY_OVERLAY_NO_THROW)
-                throw turn_info_exception(method);
+                BOOST_THROW_EXCEPTION(turn_info_exception(method));
 #endif
             }
             break;

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2013, 2014, 2015, 2017.
 // Modifications copyright (c) 2013-2017 Oracle and/or its affiliates.
@@ -13,6 +14,8 @@
 
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_TURN_INFO_LL_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_TURN_INFO_LL_HPP
+
+#include <boost/throw_exception.hpp>
 
 #include <boost/geometry/core/assert.hpp>
 
@@ -472,7 +475,7 @@ struct get_turn_info_linear_linear
                 std::cout << "TURN: Unknown method: " << method << std::endl;
 #endif
 #if ! defined(BOOST_GEOMETRY_OVERLAY_NO_THROW)
-                throw turn_info_exception(method);
+                BOOST_THROW_EXCEPTION(turn_info_exception(method));
 #endif
             }
             break;

--- a/include/boost/geometry/algorithms/detail/relate/result.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/result.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2013-2016.
 // Modifications copyright (c) 2013-2016 Oracle and/or its affiliates.
@@ -24,6 +25,7 @@
 #include <boost/mpl/is_sequence.hpp>
 #include <boost/mpl/next.hpp>
 #include <boost/static_assert.hpp>
+#include <boost/throw_exception.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/type_traits/integral_constant.hpp>
 
@@ -266,7 +268,7 @@ private:
                          || ( c >= '0' && c <= '9' );
         if ( !is_valid )
         {
-            throw geometry::invalid_input_exception();
+            BOOST_THROW_EXCEPTION(geometry::invalid_input_exception());
         }
     }
 

--- a/include/boost/geometry/algorithms/detail/throw_on_empty_input.hpp
+++ b/include/boost/geometry/algorithms/detail/throw_on_empty_input.hpp
@@ -3,6 +3,7 @@
 // Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
+// Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2015.
 // Modifications copyright (c) 2015, Oracle and/or its affiliates.
@@ -16,8 +17,12 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_THROW_ON_EMPTY_INPUT_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_THROW_ON_EMPTY_INPUT_HPP
 
+
 #include <boost/geometry/core/exception.hpp>
 #include <boost/geometry/algorithms/is_empty.hpp>
+
+#include <boost/throw_exception.hpp>
+
 
 // BSG 2012-02-06: we use this currently only for distance.
 // For other scalar results area,length,perimeter it is commented on purpose.
@@ -46,7 +51,7 @@ inline void throw_on_empty_input(Geometry const& geometry)
 #if ! defined(BOOST_GEOMETRY_EMPTY_INPUT_NO_THROW)
     if (geometry::is_empty(geometry))
     {
-        throw empty_input_exception();
+        BOOST_THROW_EXCEPTION(empty_input_exception());
     }
 #else
     boost::ignore_unused(geometry);

--- a/include/boost/geometry/io/wkt/read.hpp
+++ b/include/boost/geometry/io/wkt/read.hpp
@@ -3,6 +3,7 @@
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
+// Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2014, 2015.
 // Modifications copyright (c) 2014-2015 Oracle and/or its affiliates.
@@ -31,6 +32,7 @@
 #include <boost/range/end.hpp>
 #include <boost/range/size.hpp>
 #include <boost/range/value_type.hpp>
+#include <boost/throw_exception.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/remove_reference.hpp>
 
@@ -139,15 +141,15 @@ struct parsing_assigner
         }
         catch(boost::bad_lexical_cast const& blc)
         {
-            throw read_wkt_exception(blc.what(), it, end, wkt);
+            BOOST_THROW_EXCEPTION(read_wkt_exception(blc.what(), it, end, wkt));
         }
         catch(std::exception const& e)
         {
-            throw read_wkt_exception(e.what(), it, end, wkt);
+            BOOST_THROW_EXCEPTION(read_wkt_exception(e.what(), it, end, wkt));
         }
         catch(...)
         {
-            throw read_wkt_exception("", it, end, wkt);
+            BOOST_THROW_EXCEPTION(read_wkt_exception("", it, end, wkt));
         }
 
         parsing_assigner<Point, Dimension + 1, DimensionCount>::apply(
@@ -175,7 +177,7 @@ inline void handle_open_parenthesis(Iterator& it,
 {
     if (it == end || *it != "(")
     {
-        throw read_wkt_exception("Expected '('", it, end, wkt);
+        BOOST_THROW_EXCEPTION(read_wkt_exception("Expected '('", it, end, wkt));
     }
     ++it;
 }
@@ -192,7 +194,7 @@ inline void handle_close_parenthesis(Iterator& it,
     }
     else
     {
-        throw read_wkt_exception("Expected ')'", it, end, wkt);
+        BOOST_THROW_EXCEPTION(read_wkt_exception("Expected ')'", it, end, wkt));
     }
 }
 
@@ -203,7 +205,7 @@ inline void check_end(Iterator& it,
 {
     if (it != end)
     {
-        throw read_wkt_exception("Too many tokens", it, end, wkt);
+        BOOST_THROW_EXCEPTION(read_wkt_exception("Too many tokens", it, end, wkt));
     }
 }
 
@@ -529,7 +531,7 @@ inline bool initialize(tokenizer const& tokens,
 
         if (has_z && dimension<Geometry>::type::value < 3)
         {
-            throw read_wkt_exception("Z only allowed for 3 or more dimensions", wkt);
+            BOOST_THROW_EXCEPTION(read_wkt_exception("Z only allowed for 3 or more dimensions", wkt));
         }
 
 #if defined(_MSC_VER)
@@ -545,7 +547,7 @@ inline bool initialize(tokenizer const& tokens,
 
         return true;
     }
-    throw read_wkt_exception(std::string("Should start with '") + geometry_name + "'", wkt);
+    BOOST_THROW_EXCEPTION(read_wkt_exception(std::string("Should start with '") + geometry_name + "'", wkt));
 }
 
 
@@ -702,7 +704,7 @@ struct box_parser
         }
         else
         {
-            throw read_wkt_exception("Should start with 'POLYGON' or 'BOX'", wkt);
+            BOOST_THROW_EXCEPTION(read_wkt_exception("Should start with 'POLYGON' or 'BOX'", wkt));
         }
 
         typedef typename point_type<Box>::type point_type;
@@ -729,7 +731,7 @@ struct box_parser
         }
         else
         {
-            throw read_wkt_exception("Box should have 2,4 or 5 points", wkt);
+            BOOST_THROW_EXCEPTION(read_wkt_exception("Box should have 2,4 or 5 points", wkt));
         }
 
         geometry::detail::assign_point_to_index<min_corner>(points.front(), box);
@@ -760,7 +762,7 @@ struct segment_parser
         }
         else
         {
-            throw read_wkt_exception("Should start with 'LINESTRING' or 'SEGMENT'", wkt);
+            BOOST_THROW_EXCEPTION(read_wkt_exception("Should start with 'LINESTRING' or 'SEGMENT'", wkt));
         }
 
         typedef typename point_type<Segment>::type point_type;
@@ -776,7 +778,7 @@ struct segment_parser
         }
         else
         {
-            throw read_wkt_exception("Segment should have 2 points", wkt);
+            BOOST_THROW_EXCEPTION(read_wkt_exception("Segment should have 2 points", wkt));
         }
 
     }


### PR DESCRIPTION
BOOST_THROW_EXCEPTION was used before in the library to throw exceptions but not in all places. This PR adds it consistently in all cases besides one place being `self_section_visitor` defined in `algorithms/detail/overlay/self_turn_points.hpp`. It's because in this case the exception should be removed entirely. This requires the changes in `partition` which will be proposed in another PR.

Related ticket: https://svn.boost.org/trac/boost/ticket/12885