### PR TITLE
Interruptable partition()

### DIFF
--- a/include/boost/geometry/algorithms/detail/buffer/get_piece_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/get_piece_turns.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2012-2014 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2017.
 // Modifications copyright (c) 2017 Oracle and/or its affiliates.
@@ -272,7 +273,7 @@ public:
     {}
 
     template <typename Section>
-    inline void apply(Section const& section1, Section const& section2,
+    inline bool apply(Section const& section1, Section const& section2,
                     bool first = true)
     {
         boost::ignore_unused_variable_warning(first);
@@ -285,12 +286,14 @@ public:
           || is_adjacent(piece1, piece2)
           || is_on_same_convex_ring(piece1, piece2)
           || detail::disjoint::disjoint_box_box(section1.bounding_box,
-                    section2.bounding_box) )
+                                                section2.bounding_box) )
         {
-            return;
+            return true;
         }
 
         calculate_turns(piece1, piece2, section1, section2);
+
+        return true;
     }
 };
 

--- a/include/boost/geometry/algorithms/detail/buffer/turn_in_original_visitor.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/turn_in_original_visitor.hpp
@@ -212,27 +212,27 @@ public:
     {}
 
     template <typename Turn, typename Original>
-    inline void apply(Turn const& turn, Original const& original, bool first = true)
+    inline bool apply(Turn const& turn, Original const& original, bool first = true)
     {
         boost::ignore_unused_variable_warning(first);
 
         if (turn.location != location_ok || turn.within_original)
         {
             // Skip all points already processed
-            return;
+            return true;
         }
 
         if (geometry::disjoint(turn.robust_point, original.m_box))
         {
             // Skip all disjoint
-            return;
+            return true;
         }
 
         int const code = point_in_original(turn.robust_point, original);
 
         if (code == -1)
         {
-            return;
+            return true;
         }
 
         Turn& mutable_turn = m_mutable_turns[turn.turn_index];
@@ -259,6 +259,8 @@ public:
             mutable_turn.within_original = true;
             mutable_turn.count_in_original = 1;
         }
+
+        return true;
     }
 
 private :

--- a/include/boost/geometry/algorithms/detail/buffer/turn_in_piece_visitor.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/turn_in_piece_visitor.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2012-2014 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2016.
 // Modifications copyright (c) 2016 Oracle and/or its affiliates.
@@ -686,32 +687,32 @@ public:
     {}
 
     template <typename Turn, typename Piece>
-    inline void apply(Turn const& turn, Piece const& piece, bool first = true)
+    inline bool apply(Turn const& turn, Piece const& piece, bool first = true)
     {
         boost::ignore_unused_variable_warning(first);
 
         if (turn.count_within > 0)
         {
             // Already inside - no need to check again
-            return;
+            return true;
         }
 
         if (piece.type == strategy::buffer::buffered_flat_end
             || piece.type == strategy::buffer::buffered_concave)
         {
             // Turns cannot be located within flat-end or concave pieces
-            return;
+            return true;
         }
 
         if (! geometry::covered_by(turn.robust_point, piece.robust_envelope))
         {
             // Easy check: if the turn is not in the envelope, we can safely return
-            return;
+            return true;
         }
 
         if (skip(turn.operations[0], piece) || skip(turn.operations[1], piece))
         {
-            return;
+            return true;
         }
 
         // TODO: mutable_piece to make some on-demand preparations in analyse
@@ -733,11 +734,11 @@ public:
             if (cd < piece.robust_min_comparable_radius)
             {
                 mutable_turn.count_within++;
-                return;
+                return true;
             }
             if (cd > piece.robust_max_comparable_radius)
             {
-                return;
+                return true;
             }
         }
 
@@ -749,20 +750,20 @@ public:
         switch(analyse_code)
         {
             case analyse_disjoint :
-                return;
+                return true;
             case analyse_on_offsetted :
                 mutable_turn.count_on_offsetted++; // value is not used anymore
-                return;
+                return true;
             case analyse_on_original_boundary :
                 mutable_turn.count_on_original_boundary++;
-                return;
+                return true;
             case analyse_within :
                 mutable_turn.count_within++;
-                return;
+                return true;
 #if ! defined(BOOST_GEOMETRY_BUFFER_USE_SIDE_OF_INTERSECTION)
             case analyse_near_offsetted :
                 mutable_turn.count_within_near_offsetted++;
-                return;
+                return true;
 #endif
             default :
                 break;
@@ -790,6 +791,8 @@ public:
         {
             mutable_turn.count_within++;
         }
+
+        return true;
     }
 };
 

--- a/include/boost/geometry/algorithms/detail/disjoint/multipoint_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/multipoint_geometry.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2014-2017, Oracle and/or its affiliates.
+// Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -172,13 +173,15 @@ private:
         {}
 
         template <typename Item1, typename Item2>
-        inline void apply(Item1 const& item1, Item2 const& item2)
+        inline bool apply(Item1 const& item1, Item2 const& item2)
         {
             if (! m_intersection_found
                 && ! dispatch::disjoint<Item1, Item2>::apply(item1, item2, m_strategy))
             {
                 m_intersection_found = true;
+                return false;
             }
+            return true;
         }
 
         inline bool intersection_found() const { return m_intersection_found; }

--- a/include/boost/geometry/algorithms/detail/is_valid/polygon.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/polygon.hpp
@@ -1,5 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
+// Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
+
 // Copyright (c) 2014-2017, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
@@ -170,7 +172,7 @@ protected:
         item_visitor_type() : items_overlap(false) {}
 
         template <typename Item1, typename Item2>
-        inline void apply(Item1 const& item1, Item2 const& item2)
+        inline bool apply(Item1 const& item1, Item2 const& item2)
         {
             if (! items_overlap
                 && (geometry::within(*points_begin(*item1), *item2)
@@ -178,7 +180,9 @@ protected:
                 )
             {
                 items_overlap = true;
+                return false; // interrupt
             }
+            return true;
         }
     };
     // structs for partition -- end

--- a/include/boost/geometry/algorithms/detail/overlay/assign_parents.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/assign_parents.hpp
@@ -115,7 +115,6 @@ struct assign_visitor
     RingMap& m_ring_map;
     bool m_check_for_orientation;
 
-
     inline assign_visitor(Geometry1 const& g1, Geometry2 const& g2, Collection const& c,
                 RingMap& map, bool check)
         : m_geometry1(g1)
@@ -126,13 +125,13 @@ struct assign_visitor
     {}
 
     template <typename Item>
-    inline void apply(Item const& outer, Item const& inner, bool first = true)
+    inline bool apply(Item const& outer, Item const& inner, bool first = true)
     {
         if (first && outer.abs_area < inner.abs_area)
         {
             // Apply with reversed arguments
             apply(inner, outer, false);
-            return;
+            return true;
         }
 
         if (m_check_for_orientation
@@ -155,6 +154,8 @@ struct assign_visitor
                 }
             }
         }
+
+        return true;
     }
 };
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
@@ -1,7 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
-// Copyright (c) 2014 Adam Wulkiewicz, Lodz, Poland.
+// Copyright (c) 2014-2017 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2014, 2016, 2017.
 // Modifications copyright (c) 2014-2017 Oracle and/or its affiliates.
@@ -418,6 +418,7 @@ struct section_visitor
     {
         if (! detail::disjoint::disjoint_box_box(sec1.bounding_box, sec2.bounding_box))
         {
+            // false if interrupted
             return get_turns_in_sections
                     <
                         Geometry1,
@@ -425,13 +426,12 @@ struct section_visitor
                         Reverse1, Reverse2,
                         Section, Section,
                         TurnPolicy
-                    >::apply(
-                            m_source_id1, m_geometry1, sec1,
-                            m_source_id2, m_geometry2, sec2,
-                            false,
-                            m_intersection_strategy,
-                            m_rescale_policy,
-                            m_turns, m_interrupt_policy);
+                    >::apply(m_source_id1, m_geometry1, sec1,
+                             m_source_id2, m_geometry2, sec2,
+                             false,
+                             m_intersection_strategy,
+                             m_rescale_policy,
+                             m_turns, m_interrupt_policy);
         }
         return true;
     }

--- a/include/boost/geometry/algorithms/detail/overlay/pointlike_linear.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/pointlike_linear.hpp
@@ -1,5 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
+// Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
+
 // Copyright (c) 2015-2017, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
@@ -156,12 +158,14 @@ private:
         {}
 
         template <typename Item1, typename Item2>
-        inline void apply(Item1 const& item1, Item2 const& item2)
+        inline bool apply(Item1 const& item1, Item2 const& item2)
         {
             action_selector_pl_l
                 <
                     PointOut, overlay_intersection
                 >::apply(item1, Policy::apply(item1, item2, m_strategy), m_oit);
+
+            return true;
         }
 
     private:

--- a/include/boost/geometry/algorithms/detail/partition.hpp
+++ b/include/boost/geometry/algorithms/detail/partition.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2011-2015 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2015, 2017.
 // Modifications copyright (c) 2015-2017 Oracle and/or its affiliates.
@@ -106,11 +107,11 @@ inline void expand_with_elements(Box& total, IteratorVector const& input,
 
 // Match forward_range with itself
 template <typename IteratorVector, typename VisitPolicy>
-inline void handle_one(IteratorVector const& input, VisitPolicy& visitor)
+inline bool handle_one(IteratorVector const& input, VisitPolicy& visitor)
 {
     if (boost::size(input) == 0)
     {
-        return;
+        return true;
     }
 
     typedef typename boost::range_iterator<IteratorVector const>::type it_type;
@@ -121,9 +122,14 @@ inline void handle_one(IteratorVector const& input, VisitPolicy& visitor)
         it_type it2 = it1;
         for (++it2; it2 != boost::end(input); ++it2)
         {
-            visitor.apply(**it1, **it2);
+            if (! visitor.apply(**it1, **it2))
+            {
+                return false; // interrupt
+            }
         }
     }
+
+    return true;
 }
 
 // Match forward range 1 with forward range 2
@@ -133,7 +139,7 @@ template
     typename IteratorVector2,
     typename VisitPolicy
 >
-inline void handle_two(IteratorVector1 const& input1,
+inline bool handle_two(IteratorVector1 const& input1,
                        IteratorVector2 const& input2,
                        VisitPolicy& visitor)
 {
@@ -149,7 +155,7 @@ inline void handle_two(IteratorVector1 const& input1,
 
     if (boost::size(input1) == 0 || boost::size(input2) == 0)
     {
-        return;
+        return true;
     }
 
     for(iterator_type1 it1 = boost::begin(input1);
@@ -160,9 +166,14 @@ inline void handle_two(IteratorVector1 const& input1,
             it2 != boost::end(input2);
             ++it2)
         {
-            visitor.apply(**it1, **it2);
+            if (! visitor.apply(**it1, **it2))
+            {
+                return false; // interrupt
+            }
         }
     }
+
+    return true;
 }
 
 template <typename IteratorVector>
@@ -223,7 +234,7 @@ class partition_one_range
         typename OverlapsPolicy,
         typename VisitBoxPolicy
     >
-    static inline void next_level(Box const& box,
+    static inline bool next_level(Box const& box,
                                   IteratorVector const& input,
                                   std::size_t level, std::size_t min_elements,
                                   VisitPolicy& visitor,
@@ -233,7 +244,7 @@ class partition_one_range
     {
         if (recurse_ok(input, min_elements, level))
         {
-            partition_one_range
+            return partition_one_range
                 <
                     1 - Dimension,
                     Box
@@ -242,7 +253,7 @@ class partition_one_range
         }
         else
         {
-            handle_one(input, visitor);
+            return handle_one(input, visitor);
         }
     }
 
@@ -256,18 +267,18 @@ class partition_one_range
         typename OverlapsPolicy,
         typename VisitBoxPolicy
     >
-    static inline void next_level2(Box const& box,
-            IteratorVector const& input1,
-            IteratorVector const& input2,
-            std::size_t level, std::size_t min_elements,
-            VisitPolicy& visitor,
-            ExpandPolicy const& expand_policy,
-            OverlapsPolicy const& overlaps_policy,
-            VisitBoxPolicy& box_policy)
+    static inline bool next_level2(Box const& box,
+                                   IteratorVector const& input1,
+                                   IteratorVector const& input2,
+                                   std::size_t level, std::size_t min_elements,
+                                   VisitPolicy& visitor,
+                                   ExpandPolicy const& expand_policy,
+                                   OverlapsPolicy const& overlaps_policy,
+                                   VisitBoxPolicy& box_policy)
     {
         if (recurse_ok(input1, input2, min_elements, level))
         {
-            partition_two_ranges
+            return partition_two_ranges
                 <
                     1 - Dimension, Box
                 >::apply(box, input1, input2, level + 1, min_elements,
@@ -276,7 +287,7 @@ class partition_one_range
         }
         else
         {
-            handle_two(input1, input2, visitor);
+            return handle_two(input1, input2, visitor);
         }
     }
 
@@ -289,7 +300,7 @@ public :
         typename OverlapsPolicy,
         typename VisitBoxPolicy
     >
-    static inline void apply(Box const& box,
+    static inline bool apply(Box const& box,
                              IteratorVector const& input,
                              std::size_t level,
                              std::size_t min_elements,
@@ -313,24 +324,26 @@ public :
             // Get the box of exceeding-only
             Box exceeding_box = get_new_box(exceeding, expand_policy);
 
-            // Recursively do exceeding elements only, in next dimension they
-            // will probably be less exceeding within the new box
-            next_level(exceeding_box, exceeding, level, min_elements,
-                       visitor, expand_policy, overlaps_policy, box_policy);
-
-            // Switch to two forward ranges, combine exceeding with
-            // lower resp upper, but not lower/lower, upper/upper
-            next_level2(exceeding_box, exceeding, lower, level, min_elements,
-                        visitor, expand_policy, overlaps_policy, box_policy);
-            next_level2(exceeding_box, exceeding, upper, level, min_elements,
-                        visitor, expand_policy, overlaps_policy, box_policy);
+                   // Recursively do exceeding elements only, in next dimension they
+                   // will probably be less exceeding within the new box
+            if (! (next_level(exceeding_box, exceeding, level, min_elements,
+                              visitor, expand_policy, overlaps_policy, box_policy)
+                   // Switch to two forward ranges, combine exceeding with
+                   // lower resp upper, but not lower/lower, upper/upper
+                && next_level2(exceeding_box, exceeding, lower, level, min_elements,
+                               visitor, expand_policy, overlaps_policy, box_policy)
+                && next_level2(exceeding_box, exceeding, upper, level, min_elements,
+                               visitor, expand_policy, overlaps_policy, box_policy)) )
+            {
+                return false; // interrupt
+            }
         }
 
         // Recursively call operation both parts
-        next_level(lower_box, lower, level, min_elements,
-                   visitor, expand_policy, overlaps_policy, box_policy);
-        next_level(upper_box, upper, level, min_elements,
-                   visitor, expand_policy, overlaps_policy, box_policy);
+        return next_level(lower_box, lower, level, min_elements,
+                          visitor, expand_policy, overlaps_policy, box_policy)
+            && next_level(upper_box, upper, level, min_elements,
+                          visitor, expand_policy, overlaps_policy, box_policy);
     }
 };
 
@@ -352,23 +365,23 @@ class partition_two_ranges
         typename OverlapsPolicy2,
         typename VisitBoxPolicy
     >
-    static inline void next_level(Box const& box,
-            IteratorVector1 const& input1,
-            IteratorVector2 const& input2,
-            std::size_t level, std::size_t min_elements,
-            VisitPolicy& visitor,
-            ExpandPolicy1 const& expand_policy1,
-            OverlapsPolicy1 const& overlaps_policy1,
-            ExpandPolicy2 const& expand_policy2,
-            OverlapsPolicy2 const& overlaps_policy2,
-            VisitBoxPolicy& box_policy)
+    static inline bool next_level(Box const& box,
+                                  IteratorVector1 const& input1,
+                                  IteratorVector2 const& input2,
+                                  std::size_t level, std::size_t min_elements,
+                                  VisitPolicy& visitor,
+                                  ExpandPolicy1 const& expand_policy1,
+                                  OverlapsPolicy1 const& overlaps_policy1,
+                                  ExpandPolicy2 const& expand_policy2,
+                                  OverlapsPolicy2 const& overlaps_policy2,
+                                  VisitBoxPolicy& box_policy)
     {
-        partition_two_ranges
-        <
-            1 - Dimension, Box
-        >::apply(box, input1, input2, level + 1, min_elements,
-                 visitor, expand_policy1, overlaps_policy1,
-                 expand_policy2, overlaps_policy2, box_policy);
+        return partition_two_ranges
+            <
+                1 - Dimension, Box
+            >::apply(box, input1, input2, level + 1, min_elements,
+                     visitor, expand_policy1, overlaps_policy1,
+                     expand_policy2, overlaps_policy2, box_policy);
     }
 
     template <typename IteratorVector, typename ExpandPolicy>
@@ -408,17 +421,17 @@ public :
         typename OverlapsPolicy2,
         typename VisitBoxPolicy
     >
-    static inline void apply(Box const& box,
-            IteratorVector1 const& input1,
-            IteratorVector2 const& input2,
-            std::size_t level,
-            std::size_t min_elements,
-            VisitPolicy& visitor,
-            ExpandPolicy1 const& expand_policy1,
-            OverlapsPolicy1 const& overlaps_policy1,
-            ExpandPolicy2 const& expand_policy2,
-            OverlapsPolicy2 const& overlaps_policy2,
-            VisitBoxPolicy& box_policy)
+    static inline bool apply(Box const& box,
+                             IteratorVector1 const& input1,
+                             IteratorVector2 const& input2,
+                             std::size_t level,
+                             std::size_t min_elements,
+                             VisitPolicy& visitor,
+                             ExpandPolicy1 const& expand_policy1,
+                             OverlapsPolicy1 const& overlaps_policy1,
+                             ExpandPolicy2 const& expand_policy2,
+                             OverlapsPolicy2 const& overlaps_policy2,
+                             VisitBoxPolicy& box_policy)
     {
         box_policy.apply(box, level);
 
@@ -442,13 +455,19 @@ public :
             {
                 Box exceeding_box = get_new_box(exceeding1, exceeding2,
                                                 expand_policy1, expand_policy2);
-                next_level(exceeding_box, exceeding1, exceeding2, level,
-                           min_elements, visitor, expand_policy1, overlaps_policy1,
-                           expand_policy2, overlaps_policy2, box_policy);
+                if (! next_level(exceeding_box, exceeding1, exceeding2, level,
+                                 min_elements, visitor, expand_policy1, overlaps_policy1,
+                                 expand_policy2, overlaps_policy2, box_policy))
+                {
+                    return false; // interrupt
+                }
             }
             else
             {
-                handle_two(exceeding1, exceeding2, visitor);
+                if (! handle_two(exceeding1, exceeding2, visitor))
+                {
+                    return false; // interrupt
+                }
             }
 
             // All exceeding from 1 with lower and upper of 2:
@@ -458,17 +477,23 @@ public :
             if (recurse_ok(lower2, upper2, exceeding1, min_elements, level))
             {
                 Box exceeding_box = get_new_box(exceeding1, expand_policy1);
-                next_level(exceeding_box, exceeding1, lower2, level,
-                           min_elements, visitor, expand_policy1, overlaps_policy1,
-                           expand_policy2, overlaps_policy2, box_policy);
-                next_level(exceeding_box, exceeding1, upper2, level,
-                           min_elements, visitor, expand_policy1, overlaps_policy1,
-                           expand_policy2, overlaps_policy2, box_policy);
+                if (! (next_level(exceeding_box, exceeding1, lower2, level,
+                                  min_elements, visitor, expand_policy1, overlaps_policy1,
+                                  expand_policy2, overlaps_policy2, box_policy)
+                    && next_level(exceeding_box, exceeding1, upper2, level,
+                                  min_elements, visitor, expand_policy1, overlaps_policy1,
+                                  expand_policy2, overlaps_policy2, box_policy)) )
+                {
+                    return false; // interrupt
+                }
             }
             else
             {
-                handle_two(exceeding1, lower2, visitor);
-                handle_two(exceeding1, upper2, visitor);
+                if (! (handle_two(exceeding1, lower2, visitor)
+                    && handle_two(exceeding1, upper2, visitor)) )
+                {
+                    return false; // interrupt
+                }
             }
         }
 
@@ -478,40 +503,61 @@ public :
             if (recurse_ok(lower1, upper1, exceeding2, min_elements, level))
             {
                 Box exceeding_box = get_new_box(exceeding2, expand_policy2);
-                next_level(exceeding_box, lower1, exceeding2, level,
-                           min_elements, visitor, expand_policy1, overlaps_policy1,
-                           expand_policy2, overlaps_policy2, box_policy);
-                next_level(exceeding_box, upper1, exceeding2, level,
-                           min_elements, visitor, expand_policy1, overlaps_policy1,
-                           expand_policy2, overlaps_policy2, box_policy);
+                if (! (next_level(exceeding_box, lower1, exceeding2, level,
+                                  min_elements, visitor, expand_policy1, overlaps_policy1,
+                                  expand_policy2, overlaps_policy2, box_policy)
+                    && next_level(exceeding_box, upper1, exceeding2, level,
+                                  min_elements, visitor, expand_policy1, overlaps_policy1,
+                                  expand_policy2, overlaps_policy2, box_policy)) )
+                {
+                    return false; // interrupt
+                }
             }
             else
             {
-                handle_two(lower1, exceeding2, visitor);
-                handle_two(upper1, exceeding2, visitor);
+                if (! (handle_two(lower1, exceeding2, visitor)
+                    && handle_two(upper1, exceeding2, visitor)) )
+                {
+                    return false; // interrupt
+                }
             }
         }
 
         if (recurse_ok(lower1, lower2, min_elements, level))
         {
-            next_level(lower_box, lower1, lower2, level,
-                       min_elements, visitor, expand_policy1, overlaps_policy1,
-                       expand_policy2, overlaps_policy2, box_policy);
+            if (! next_level(lower_box, lower1, lower2, level,
+                             min_elements, visitor, expand_policy1, overlaps_policy1,
+                             expand_policy2, overlaps_policy2, box_policy) )
+            {
+                return false; // interrupt
+            }
         }
         else
         {
-            handle_two(lower1, lower2, visitor);
+            if (! handle_two(lower1, lower2, visitor))
+            {
+                return false; // interrupt
+            }
         }
+
         if (recurse_ok(upper1, upper2, min_elements, level))
         {
-            next_level(upper_box, upper1, upper2, level,
-                       min_elements, visitor, expand_policy1, overlaps_policy1,
-                       expand_policy2, overlaps_policy2, box_policy);
+            if (! next_level(upper_box, upper1, upper2, level,
+                             min_elements, visitor, expand_policy1, overlaps_policy1,
+                             expand_policy2, overlaps_policy2, box_policy) )
+            {
+                return false; // interrupt
+            }
         }
         else
         {
-            handle_two(upper1, upper2, visitor);
+            if (! handle_two(upper1, upper2, visitor))
+            {
+                return false; // interrupt
+            }
         }
+
+        return true;
     }
 };
 
@@ -577,13 +623,13 @@ public:
         typename ExpandPolicy,
         typename OverlapsPolicy
     >
-    static inline void apply(ForwardRange const& forward_range,
+    static inline bool apply(ForwardRange const& forward_range,
                              VisitPolicy& visitor,
                              ExpandPolicy const& expand_policy,
                              OverlapsPolicy const& overlaps_policy)
     {
-        apply(forward_range, visitor, expand_policy, overlaps_policy,
-              default_min_elements, detail::partition::visit_no_policy());
+        return apply(forward_range, visitor, expand_policy, overlaps_policy,
+                     default_min_elements, detail::partition::visit_no_policy());
     }
 
     template
@@ -593,14 +639,14 @@ public:
         typename ExpandPolicy,
         typename OverlapsPolicy
     >
-    static inline void apply(ForwardRange const& forward_range,
+    static inline bool apply(ForwardRange const& forward_range,
                              VisitPolicy& visitor,
                              ExpandPolicy const& expand_policy,
                              OverlapsPolicy const& overlaps_policy,
                              std::size_t min_elements)
     {
-        apply(forward_range, visitor, expand_policy, overlaps_policy,
-              min_elements, detail::partition::visit_no_policy());
+        return apply(forward_range, visitor, expand_policy, overlaps_policy,
+                     min_elements, detail::partition::visit_no_policy());
     }
 
     template
@@ -611,7 +657,7 @@ public:
         typename OverlapsPolicy,
         typename VisitBoxPolicy
     >
-    static inline void apply(ForwardRange const& forward_range,
+    static inline bool apply(ForwardRange const& forward_range,
                              VisitPolicy& visitor,
                              ExpandPolicy const& expand_policy,
                              OverlapsPolicy const& overlaps_policy,
@@ -631,7 +677,7 @@ public:
             expand_to_range<IncludePolicy1>(forward_range, total,
                                             iterator_vector, expand_policy);
 
-            detail::partition::partition_one_range
+            return detail::partition::partition_one_range
                 <
                     0, Box
                 >::apply(total, iterator_vector, 0, min_elements,
@@ -646,10 +692,15 @@ public:
                 iterator_type it2 = it1;
                 for(++it2; it2 != boost::end(forward_range); ++it2)
                 {
-                    visitor.apply(*it1, *it2);
+                    if (! visitor.apply(*it1, *it2))
+                    {
+                        return false; // interrupt
+                    }
                 }
             }
         }
+
+        return true;
     }
 
     template
@@ -660,15 +711,15 @@ public:
         typename ExpandPolicy1,
         typename OverlapsPolicy1
     >
-    static inline void apply(ForwardRange1 const& forward_range1,
+    static inline bool apply(ForwardRange1 const& forward_range1,
                              ForwardRange2 const& forward_range2,
                              VisitPolicy& visitor,
                              ExpandPolicy1 const& expand_policy1,
                              OverlapsPolicy1 const& overlaps_policy1)
     {
-        apply(forward_range1, forward_range2, visitor,
-              expand_policy1, overlaps_policy1, expand_policy1, overlaps_policy1,
-              default_min_elements, detail::partition::visit_no_policy());
+        return apply(forward_range1, forward_range2, visitor,
+                     expand_policy1, overlaps_policy1, expand_policy1, overlaps_policy1,
+                     default_min_elements, detail::partition::visit_no_policy());
     }
 
     template
@@ -681,7 +732,7 @@ public:
         typename ExpandPolicy2,
         typename OverlapsPolicy2
     >
-    static inline void apply(ForwardRange1 const& forward_range1,
+    static inline bool apply(ForwardRange1 const& forward_range1,
                              ForwardRange2 const& forward_range2,
                              VisitPolicy& visitor,
                              ExpandPolicy1 const& expand_policy1,
@@ -689,9 +740,9 @@ public:
                              ExpandPolicy2 const& expand_policy2,
                              OverlapsPolicy2 const& overlaps_policy2)
     {
-        apply(forward_range1, forward_range2, visitor,
-              expand_policy1, overlaps_policy1, expand_policy2, overlaps_policy2,
-              default_min_elements, detail::partition::visit_no_policy());
+        return apply(forward_range1, forward_range2, visitor,
+                     expand_policy1, overlaps_policy1, expand_policy2, overlaps_policy2,
+                     default_min_elements, detail::partition::visit_no_policy());
     }
 
     template
@@ -704,7 +755,7 @@ public:
         typename ExpandPolicy2,
         typename OverlapsPolicy2
     >
-    static inline void apply(ForwardRange1 const& forward_range1,
+    static inline bool apply(ForwardRange1 const& forward_range1,
                              ForwardRange2 const& forward_range2,
                              VisitPolicy& visitor,
                              ExpandPolicy1 const& expand_policy1,
@@ -713,9 +764,9 @@ public:
                              OverlapsPolicy2 const& overlaps_policy2,
                              std::size_t min_elements)
     {
-        apply(forward_range1, forward_range2, visitor,
-              expand_policy1, overlaps_policy1, expand_policy2, overlaps_policy1,
-              min_elements, detail::partition::visit_no_policy());
+        return apply(forward_range1, forward_range2, visitor,
+                     expand_policy1, overlaps_policy1, expand_policy2, overlaps_policy1,
+                     min_elements, detail::partition::visit_no_policy());
     }
 
     template
@@ -729,7 +780,7 @@ public:
         typename OverlapsPolicy2,
         typename VisitBoxPolicy
     >
-    static inline void apply(ForwardRange1 const& forward_range1,
+    static inline bool apply(ForwardRange1 const& forward_range1,
                              ForwardRange2 const& forward_range2,
                              VisitPolicy& visitor,
                              ExpandPolicy1 const& expand_policy1,
@@ -761,7 +812,7 @@ public:
             expand_to_range<IncludePolicy2>(forward_range2, total,
                                             iterator_vector2, expand_policy2);
 
-            detail::partition::partition_two_ranges
+            return detail::partition::partition_two_ranges
                 <
                     0, Box
                 >::apply(total, iterator_vector1, iterator_vector2,
@@ -779,10 +830,15 @@ public:
                     it2 != boost::end(forward_range2);
                     ++it2)
                 {
-                    visitor.apply(*it1, *it2);
+                    if (! visitor.apply(*it1, *it2))
+                    {
+                        return false; // interrupt
+                    }
                 }
             }
         }
+
+        return true;
     }
 };
 

--- a/test/algorithms/detail/partition.cpp
+++ b/test/algorithms/detail/partition.cpp
@@ -1,6 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 //
 // Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 //
 // This file was modified by Oracle on 2017.
 // Modifications copyright (c) 2017 Oracle and/or its affiliates.
@@ -81,7 +82,7 @@ struct box_visitor
     {}
 
     template <typename Item>
-    inline void apply(Item const& item1, Item const& item2)
+    inline bool apply(Item const& item1, Item const& item2)
     {
         if (bg::intersects(item1.box, item2.box))
         {
@@ -90,40 +91,45 @@ struct box_visitor
             area += bg::area(b);
             count++;
         }
+        return true;
     }
 };
 
 struct point_in_box_visitor
 {
     int count;
+
     point_in_box_visitor()
         : count(0)
     {}
 
     template <typename Point, typename BoxItem>
-    inline void apply(Point const& point, BoxItem const& box_item)
+    inline bool apply(Point const& point, BoxItem const& box_item)
     {
         if (bg::within(point, box_item.box))
         {
             count++;
         }
+        return true;
     }
 };
 
 struct reversed_point_in_box_visitor
 {
     int count;
+
     reversed_point_in_box_visitor()
         : count(0)
     {}
 
     template <typename BoxItem, typename Point>
-    inline void apply(BoxItem const& box_item, Point const& point)
+    inline bool apply(BoxItem const& box_item, Point const& point)
     {
         if (bg::within(point, box_item.box))
         {
             count++;
         }
+        return true;
     }
 };
 
@@ -199,12 +205,13 @@ struct point_visitor
     {}
 
     template <typename Item>
-    inline void apply(Item const& item1, Item const& item2)
+    inline bool apply(Item const& item1, Item const& item2)
     {
         if (bg::equals(item1, item2))
         {
             count++;
         }
+        return true;
     }
 };
 


### PR DESCRIPTION
This PR makes partition() algorithm interruptable. The partition is interrupted when `visitor.apply(...)` returns `false`.

`self_ip_exception` is no longer needed, so removed. It's related to https://github.com/boostorg/geometry/pull/384

A side effect is performance increase. Below I show times gathered using this benchmark:
https://github.com/awulkiew/benchmark-geometry/blob/master/benchmarks/algorithms.cpp
data generated like this:
https://github.com/awulkiew/benchmark-geometry/blob/master/benchmarks/data.hpp
below:
 - gcc is mingw-w64 4.9.1 -O2
 - msvc is msvc-14 /O2
 - develop - times for develop branch, interrupt - times for this branch
 - relate-disj is relate() with disjoint mask
 - zero - there is no overlap between geometries
 - min - there is minimal overlap btween geometries (touching)
 - max - each segment of one geometry overlaps two segments of other geometry
 - zigzag - each segment of one geometry overlaps all segments of other geometry
 - time of one function call in seconds
 - zero/min/max geometries contain 100001 points, zigzag linestrings contain 400 points

| test name           | gcc develop | gcc interrupt | msvc develop | msvc interrupt |
| ------------------- | ----------- | ------------- | ------------ | -------------- |
relate-disj-poly-zero | 0.00780 | 0.00780 | 0.00839 | 0.00876 |
relate-disj-poly-min  | **0.00557** | 0.00452 | **0.00616** | 0.00457 |
relate-disj-poly-max  | **0.02275** | 0.00450 | **0.02758** | 0.00442 |
relate-disj-ls-zero   | 0.00446 | 0.00448 | 0.00455 | 0.00439 |
relate-disj-ls-min    | **0.00560** | 0.00450 | **0.00594** | 0.00436 |
relate-disj-ls-max    | **0.02248** | 0.00455 | **0.02775** | 0.00440 |
relate-disj-ls-zigzag | **0.11100** | 0.00009 | **0.13010** | 0.00008 |
intersects-poly-zero  | 0.00775 | 0.00784 | 0.00854 | 0.00812 |
intersects-poly-min   | **0.00553** | 0.00450 | **0.00603** | 0.00440 |
intersects-poly-max   | **0.02095** | 0.00442 | **0.02766** | 0.00450 |
intersects-ls-zero    | 0.00441 | 0.00447 | 0.00479 | 0.00441 |
intersects-ls-min     | **0.00547** | 0.00447 | **0.00635** | 0.00442 |
intersects-ls-max     | **0.02106** | 0.00447 | **0.02828** | 0.00447 |
intersects-ls-zigzag  | **0.09510** | 0.00006 | **0.11216** | 0.00008 |
touches-poly-zero     | 0.00779 | 0.00784 | 0.00837 | 0.00832 |
touches-poly-min      | 0.00545 | 0.00547 | 0.00604 | 0.00621 |
touches-poly-max      | 0.44652 | 0.44052 | 0.45616 | 0.45228 |
touches-poly          | 0.00620 | 0.00610 | 0.00852 | 0.00863 |
intersects-poly       | 0.00619 | 0.00613 | 0.00869 | 0.00855 |
is_valid-poly         | 0.02374 | 0.02306 | 0.03384 | 0.03265 |

