### PR TITLE
[doc] Add doxygen files clean-up if run with --release-build

### DIFF
--- a/doc/index/make_qbk.py
+++ b/doc/index/make_qbk.py
@@ -9,7 +9,7 @@
 #  http://www.boost.org/LICENSE_1_0.txt)9
 # ============================================================================
 
-import os, sys
+import os, sys, shutil
 
 cmd = "doxygen_xml2qbk"
 cmd = cmd + " --xml xml/%s.xml"
@@ -21,10 +21,11 @@ def run_command(command):
     if os.system(command) != 0:
         raise Exception("Error running %s" % command)
 
-def remove_all_files(dir):
-    if os.path.exists(dir):
-        for f in os.listdir(dir):
-            os.remove(dir+f)
+def remove_all_files(dir_relpath):
+    if os.path.exists(dir_relpath):
+        dir_abspath = os.path.join(os.getcwd(), dir_relpath)
+        print("Boost.Geometry is cleaning Doxygen files in %s" % dir_abspath)
+        shutil.rmtree(dir_abspath, ignore_errors=True)
 
 remove_all_files("xml/")
 
@@ -46,5 +47,10 @@ run_command(cmd % ("group__predicates", "predicates"))
 #run_command(cmd % ("group__nearest__relations", "nearest_relations"))
 run_command(cmd % ("group__adaptors", "adaptors"))
 run_command(cmd % ("group__inserters", "inserters"))
+
+# Clean up generated intermediate files
+if "--release-build" in sys.argv:
+    remove_all_files("xml/")
+    remove_all_files("html_by_doxygen/")
 
 #run_command("b2")

--- a/doc/make_qbk.py
+++ b/doc/make_qbk.py
@@ -11,7 +11,7 @@
 #  http://www.boost.org/LICENSE_1_0.txt)
 # ============================================================================
 
-import os, sys
+import os, sys, shutil
 
 script_dir = os.path.dirname(__file__)
 os.chdir(os.path.abspath(script_dir))
@@ -45,10 +45,11 @@ def run_command(command):
     if os.system(command) != 0:
         raise Exception("Error running %s" % command)
 
-def remove_all_files(dir):
-    if os.path.exists(dir):
-        for f in os.listdir(dir):
-            os.remove(dir+f)
+def remove_all_files(dir_relpath):
+    if os.path.exists(dir_relpath):
+        dir_abspath = os.path.join(os.getcwd(), dir_relpath)
+        print("Boost.Geometry is cleaning Doxygen files in %s" % dir_abspath)
+        shutil.rmtree(dir_abspath, ignore_errors=True)
 
 def call_doxygen():
     os.chdir("doxy")
@@ -189,6 +190,13 @@ class_to_quickbook2("de9im_1_1static__mask", "de9im_static_mask")
 os.chdir("index")
 execfile("make_qbk.py")
 os.chdir("..")
+
+# Clean up generated intermediate files
+if "--release-build" in sys.argv:
+    remove_all_files("doxy/doxygen_output/xml/")
+    remove_all_files("doxy/doxygen_output/html_by_doxygen/")
+    remove_all_files("index/xml/")
+    remove_all_files("index/html_by_doxygen/")
 
 # Use either bjam or b2 or ../../../b2 (the last should be done on Release branch)
 if "--release-build" not in sys.argv:


### PR DESCRIPTION
Delete Doxygen-generated files to avoid copying them into release archive.
Replace os.remove with shutil.rmtree to cope with sub-directories.

------

Boost 1.64.0 Beta1 source archive should not include  `html_by_doxygen` or `xml`.
It was discussed here http://lists.boost.org/geometry/2017/03/3618.php

I tried to follow Rene Rivera suggestions, http://lists.boost.org/Archives/boost/2017/03/233878.php, and regenerate release process to generate source archive w/o any Doxygen intermediate files generated in `libs/geometry/docs`. Hopefully, this will work for Rene.

If accepted and merged into `develop`, it should also be merged into `master` according to Rene's info http://lists.boost.org/Archives/boost/2017/03/233810.php

If there is anything I can do, let me know.