### PR TITLE
Use pointer_traits.to_address instead of addressof(*p)

### DIFF
--- a/include/boost/geometry/index/detail/rtree/node/variant_dynamic.hpp
+++ b/include/boost/geometry/index/detail/rtree/node/variant_dynamic.hpp
@@ -11,6 +11,8 @@
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_RTREE_NODE_VARIANT_DYNAMIC_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_RTREE_NODE_VARIANT_DYNAMIC_HPP
 
+#include <boost/core/pointer_traits.hpp>
+
 namespace boost { namespace geometry { namespace index {
 
 namespace detail { namespace rtree {
@@ -183,7 +185,7 @@ struct create_variant_node
 
         scoped_deallocator<AllocNode> deallocator(p, alloc_node);
 
-        Al::construct(alloc_node, boost::addressof(*p), Node(alloc_node)); // implicit cast to Variant
+        Al::construct(alloc_node, boost::pointer_traits<P>::to_address(p), Node(alloc_node)); // implicit cast to Variant
 
         deallocator.release();
         return p;

--- a/include/boost/geometry/index/detail/rtree/node/weak_dynamic.hpp
+++ b/include/boost/geometry/index/detail/rtree/node/weak_dynamic.hpp
@@ -199,7 +199,7 @@ struct create_weak_node
 
         scoped_deallocator<AllocNode> deallocator(p, alloc_node);
 
-        Al::construct(alloc_node, boost::addressof(*p), alloc_node);
+        Al::construct(alloc_node, boost::pointer_traits<P>::to_address(p), alloc_node);
 
         deallocator.release();
         return p;


### PR DESCRIPTION
addressof(*p) before construct() is not well-defined, since p does not alias storage that has an object constructed in it yet.