### PR TITLE
Add missing propagation of area strategy in buffer, is_valid and overlay.

### DIFF
--- a/include/boost/geometry/algorithms/correct.hpp
+++ b/include/boost/geometry/algorithms/correct.hpp
@@ -5,6 +5,10 @@
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 // Copyright (c) 2014 Adam Wulkiewicz, Lodz, Poland.
 
+// This file was modified by Oracle on 2017.
+// Modifications copyright (c) 2017 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -61,7 +65,8 @@ namespace detail { namespace correct
 template <typename Geometry>
 struct correct_nop
 {
-    static inline void apply(Geometry& )
+    template <typename Strategy>
+    static inline void apply(Geometry& , Strategy const& )
     {}
 };
 
@@ -104,8 +109,8 @@ struct correct_box_loop<Box, DimensionCount, DimensionCount>
 template <typename Box>
 struct correct_box
 {
-
-    static inline void apply(Box& box)
+    template <typename Strategy>
+    static inline void apply(Box& box, Strategy const& )
     {
         // Currently only for Cartesian coordinates
         // (or spherical without crossing dateline)
@@ -119,17 +124,11 @@ struct correct_box
 
 
 // Close a ring, if not closed
-template <typename Ring, typename Predicate>
+template <typename Ring, template <typename> class Predicate>
 struct correct_ring
 {
     typedef typename point_type<Ring>::type point_type;
     typedef typename coordinate_type<Ring>::type coordinate_type;
-
-    typedef typename strategy::area::services::default_strategy
-        <
-            typename cs_tag<point_type>::type,
-            point_type
-        >::type strategy_type;
 
     typedef detail::area::ring_area
             <
@@ -138,7 +137,8 @@ struct correct_ring
             > ring_area_type;
 
 
-    static inline void apply(Ring& r)
+    template <typename Strategy>
+    static inline void apply(Ring& r, Strategy const& strategy)
     {
         // Check close-ness
         if (boost::size(r) > 2)
@@ -158,10 +158,10 @@ struct correct_ring
             }
         }
         // Check area
-        Predicate predicate;
-        typedef typename default_area_result<Ring>::type area_result_type;
-        area_result_type const zero = area_result_type();
-        if (predicate(ring_area_type::apply(r, strategy_type()), zero))
+        typedef typename Strategy::return_type area_result_type;
+        Predicate<area_result_type> predicate;
+        area_result_type const zero = 0;
+        if (predicate(ring_area_type::apply(r, strategy), zero))
         {
             std::reverse(boost::begin(r), boost::end(r));
         }
@@ -174,15 +174,15 @@ template <typename Polygon>
 struct correct_polygon
 {
     typedef typename ring_type<Polygon>::type ring_type;
-    typedef typename default_area_result<Polygon>::type area_result_type;
-
-    static inline void apply(Polygon& poly)
+    
+    template <typename Strategy>
+    static inline void apply(Polygon& poly, Strategy const& strategy)
     {
         correct_ring
             <
                 ring_type,
-                std::less<area_result_type>
-            >::apply(exterior_ring(poly));
+                std::less
+            >::apply(exterior_ring(poly), strategy);
 
         typename interior_return_type<Polygon>::type
             rings = interior_rings(poly);
@@ -192,8 +192,8 @@ struct correct_polygon
             correct_ring
                 <
                     ring_type,
-                    std::greater<area_result_type>
-                >::apply(*it);
+                    std::greater
+                >::apply(*it, strategy);
         }
     }
 };
@@ -237,7 +237,7 @@ struct correct<Ring, ring_tag>
     : detail::correct::correct_ring
         <
             Ring,
-            std::less<typename default_area_result<Ring>::type>
+            std::less
         >
 {};
 
@@ -281,29 +281,36 @@ namespace resolve_variant {
 template <typename Geometry>
 struct correct
 {
-    static inline void apply(Geometry& geometry)
+    template <typename Strategy>
+    static inline void apply(Geometry& geometry, Strategy const& strategy)
     {
         concepts::check<Geometry const>();
-        dispatch::correct<Geometry>::apply(geometry);
+        dispatch::correct<Geometry>::apply(geometry, strategy);
     }
 };
 
 template <BOOST_VARIANT_ENUM_PARAMS(typename T)>
 struct correct<boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)> >
 {
+    template <typename Strategy>
     struct visitor: boost::static_visitor<void>
     {
+        Strategy const& m_strategy;
+
+        visitor(Strategy const& strategy): m_strategy(strategy) {}
+
         template <typename Geometry>
         void operator()(Geometry& geometry) const
         {
-            correct<Geometry>::apply(geometry);
+            correct<Geometry>::apply(geometry, m_strategy);
         }
     };
 
+    template <typename Strategy>
     static inline void
-    apply(boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>& geometry)
+    apply(boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>& geometry, Strategy const& strategy)
     {
-        boost::apply_visitor(visitor(), geometry);
+        boost::apply_visitor(visitor<Strategy>(strategy), geometry);
     }
 };
 
@@ -325,7 +332,37 @@ struct correct<boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)> >
 template <typename Geometry>
 inline void correct(Geometry& geometry)
 {
-    resolve_variant::correct<Geometry>::apply(geometry);
+    typedef typename point_type<Geometry>::type point_type;
+
+    typedef typename strategy::area::services::default_strategy
+        <
+            typename cs_tag<point_type>::type,
+            point_type
+        >::type strategy_type;
+
+    resolve_variant::correct<Geometry>::apply(geometry, strategy_type());
+}
+
+/*!
+\brief Corrects a geometry
+\details Corrects a geometry: all rings which are wrongly oriented with respect
+    to their expected orientation are reversed. To all rings which do not have a
+    closing point and are typed as they should have one, the first point is
+    appended. Also boxes can be corrected.
+\ingroup correct
+\tparam Geometry \tparam_geometry
+\tparam Strategy \tparam_strategy{Area}
+\param geometry \param_geometry which will be corrected if necessary
+\param strategy \param_strategy{area}
+
+\qbk{distinguish,with strategy}
+
+\qbk{[include reference/algorithms/correct.qbk]}
+*/
+template <typename Geometry, typename Strategy>
+inline void correct(Geometry& geometry, Strategy const& strategy)
+{
+    resolve_variant::correct<Geometry>::apply(geometry, strategy);
 }
 
 #if defined(_MSC_VER)

--- a/include/boost/geometry/algorithms/detail/is_valid/ring.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/ring.hpp
@@ -115,7 +115,10 @@ struct is_properly_oriented
                 geometry::closure<Ring>::value
             > ring_area_type;
 
-        typedef typename default_area_result<Ring>::type area_result_type;
+        typedef typename Strategy::template area_strategy
+            <
+                point_type
+            >::type::return_type area_result_type;
 
         typename ring_area_predicate
             <

--- a/include/boost/geometry/algorithms/detail/multi_modify.hpp
+++ b/include/boost/geometry/algorithms/detail/multi_modify.hpp
@@ -4,6 +4,10 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
+// This file was modified by Oracle on 2017.
+// Modifications copyright (c) 2017 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -38,6 +42,18 @@ struct multi_modify
             ++it)
         {
             Policy::apply(*it);
+        }
+    }
+
+    template <typename Strategy>
+    static inline void apply(MultiGeometry& multi, Strategy const& strategy)
+    {
+        typedef typename boost::range_iterator<MultiGeometry>::type iterator_type;
+        for (iterator_type it = boost::begin(multi);
+            it != boost::end(multi);
+            ++it)
+        {
+            Policy::apply(*it, strategy);
         }
     }
 };

--- a/include/boost/geometry/algorithms/detail/overlay/assign_parents.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/assign_parents.hpp
@@ -107,21 +107,19 @@ static inline bool within_selected_input(Item const& item2,
 }
 
 
-template <typename Point>
+template <typename Point, typename AreaType>
 struct ring_info_helper
 {
-    typedef typename geometry::default_area_result<Point>::type area_type;
-
     ring_identifier id;
-    area_type real_area;
-    area_type abs_area;
+    AreaType real_area;
+    AreaType abs_area;
     model::box<Point> envelope;
 
     inline ring_info_helper()
         : real_area(0), abs_area(0)
     {}
 
-    inline ring_info_helper(ring_identifier i, area_type a)
+    inline ring_info_helper(ring_identifier i, AreaType const& a)
         : id(i), real_area(a), abs_area(geometry::math::abs(a))
     {}
 };
@@ -234,11 +232,15 @@ inline void assign_parents(Geometry1 const& geometry1,
     typedef typename RingMap::mapped_type ring_info_type;
     typedef typename ring_info_type::point_type point_type;
     typedef model::box<point_type> box_type;
+    typedef typename Strategy::template area_strategy
+        <
+            point_type
+        >::type::return_type area_result_type;
 
     typedef typename RingMap::iterator map_iterator_type;
 
     {
-        typedef ring_info_helper<point_type> helper;
+        typedef ring_info_helper<point_type, area_result_type> helper;
         typedef std::vector<helper> vector_type;
         typedef typename boost::range_iterator<vector_type const>::type vector_iterator_type;
 

--- a/include/boost/geometry/algorithms/detail/overlay/ring_properties.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/ring_properties.hpp
@@ -27,11 +27,11 @@ namespace boost { namespace geometry
 namespace detail { namespace overlay
 {
 
-template <typename Point>
+template <typename Point, typename AreaType>
 struct ring_properties
 {
     typedef Point point_type;
-    typedef typename default_area_result<Point>::type area_type;
+    typedef AreaType area_type;
 
     bool valid;
 
@@ -56,13 +56,13 @@ struct ring_properties
         , parent_area(-1)
     {}
 
-    template <typename RingOrBox>
-    inline ring_properties(RingOrBox const& ring_or_box)
+    template <typename RingOrBox, typename AreaStrategy>
+    inline ring_properties(RingOrBox const& ring_or_box, AreaStrategy const& strategy)
         : reversed(false)
         , discarded(false)
         , parent_area(-1)
     {
-        this->area = geometry::area(ring_or_box);
+        this->area = geometry::area(ring_or_box, strategy);
         valid = geometry::point_on_border(this->point, ring_or_box);
     }
 

--- a/include/boost/geometry/extensions/algorithms/dissolve.hpp
+++ b/include/boost/geometry/extensions/algorithms/dissolve.hpp
@@ -226,7 +226,13 @@ struct dissolve_ring_or_polygon
             std::map<ring_identifier, detail::overlay::ring_turn_info> map;
             detail::overlay::get_ring_turn_info<overlay_dissolve>(map, turns, clusters);
 
-            typedef detail::overlay::ring_properties<typename geometry::point_type<Geometry>::type> properties;
+            typedef typename geometry::point_type<Geometry>::type point_type;
+            typedef typename Strategy::template area_strategy
+                <
+                    point_type
+                >::type area_strategy_type;
+            typedef typename area_strategy_type::return_type area_result_type;
+            typedef detail::overlay::ring_properties<point_type, area_result_type> properties;
 
             std::map<ring_identifier, properties> selected;
 
@@ -234,13 +240,15 @@ struct dissolve_ring_or_polygon
 
             // Add intersected rings
             {
+                area_strategy_type const area_strategy = strategy.template get_area_strategy<point_type>();
+
                 ring_identifier id(2, 0, -1);
                 for (typename boost::range_iterator<std::vector<ring_type> const>::type
                         it = boost::begin(rings);
                         it != boost::end(rings);
                         ++it)
                 {
-                    selected[id] = properties(*it);
+                    selected[id] = properties(*it, area_strategy);
                     id.multi_index++;
                 }
             }

--- a/test/algorithms/overlay/select_rings.cpp
+++ b/test/algorithms/overlay/select_rings.cpp
@@ -1,6 +1,11 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 //
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
+//
+// This file was modified by Oracle on 2017.
+// Modifications copyright (c) 2017 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+//
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -36,7 +41,11 @@ template
 void test_geometry(std::string const& wkt1, std::string const& wkt2,
     RingIdVector const& expected_ids)
 {
-    typedef bg::detail::overlay::ring_properties<typename bg::point_type<Geometry1>::type> properties;
+    typedef bg::detail::overlay::ring_properties
+        <
+            typename bg::point_type<Geometry1>::type,
+            double
+        > properties;
 
     Geometry1 geometry1;
     Geometry2 geometry2;


### PR DESCRIPTION
The area strategy isn't propagated in all places where it should be, default strategy is used. This PR changes that.

It also adds strategy parameter to `correct()` algorithm allowing to pass area strategy.