### PR TITLE
Fix wrong results in intersection of linestrings with a common point

### DIFF
--- a/include/boost/geometry/algorithms/detail/disjoint/box_box.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/box_box.hpp
@@ -121,9 +121,18 @@ struct box_box<Box1, Box2, 0, DimensionCount, spherical_tag>
             // calculate positive longitude translation with b1_min as origin
             calc_t const diff_min = math::longitude_distance_unsigned<units_t>(b1_min, b2_min);
             calc_t const b2_min_transl = b1_min + diff_min; // always right of b1_min
+            calc_t b2_max_transl = b2_min_transl - constants::period() + diff2;;
 
-            if (b2_min_transl > b1_max                                // b2_min right of b1_max
-             && b2_min_transl - constants::period() + diff2 < b1_min) // b2_max left of b1_min
+            // if the translation is too close then use the original point
+            // note that math::abs(b2_max_transl - b2_max) takes values very
+            // close to k*2*constants::period() for k=0,1,2,...
+            if (math::abs(b2_max_transl - b2_max) < constants::period() / 2)
+            {
+                b2_max_transl = b2_max;
+            }
+
+            if (b2_min_transl > b1_max  // b2_min right of b1_max
+             && b2_max_transl < b1_min) // b2_max left of b1_min
             {
                 return true;
             }

--- a/test/algorithms/relational_operations/disjoint/disjoint_sph.cpp
+++ b/test/algorithms/relational_operations/disjoint/disjoint_sph.cpp
@@ -188,6 +188,21 @@ void test_linestring_linestring()
     test_geometry<ls, ls>("LINESTRING(1 0,2 2,2 3)", "LINESTRING(0 0, 2 2, 3 2)", false);
 }
 
+//https://svn.boost.org/trac10/ticket/13057
+template <typename P>
+void test_linestring_linestring_radians()
+{
+    typedef bg::model::linestring<P> ls;
+
+    test_geometry<ls, ls>("LINESTRING(0 -0.31415926535897897853,\
+                                      0.26179938779914918578 0,\
+                                     -0.034906585039886556254 0.13962634015954622502,\
+                                     -0.12217304763960294689 0.12217304763960294689)",\
+                          "LINESTRING(-0.034906585039886556254 0.13962634015954622502,\
+                                      -0.26179938779914918578 0)", false);
+
+}
+
 template <typename P>
 void test_linestring_multi_linestring()
 {
@@ -254,6 +269,9 @@ void test_all()
     test_linestring_linestring<P>();
     test_linestring_multi_linestring<P>();
     test_multi_linestring_multi_linestring<P>();
+
+    test_linestring_linestring_radians<bg::model::point<double, 2,
+                                     bg::cs::spherical_equatorial<bg::radian> > >();
 
     test_point_polygon<P>();
 }


### PR DESCRIPTION
This PR proposes a fix for the bug related to ticket https://svn.boost.org/trac10/ticket/13057

It is about producing wrong results when intersecting two linestrings with a common point. 