### PR TITLE
Fix problematic initialization of strategy passed as contant reference

### DIFF
--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
@@ -45,7 +45,7 @@ struct side_calculator
 {
     inline side_calculator(Pi const& pi, Pj const& pj, Pk const& pk,
                            Qi const& qi, Qj const& qj, Qk const& qk,
-                           SideStrategy const& side_strategy)
+                           SideStrategy side_strategy)
         : m_pi(pi), m_pj(pj), m_pk(pk)
         , m_qi(qi), m_qj(qj), m_qk(qk)
         , m_side_strategy(side_strategy)
@@ -66,7 +66,7 @@ struct side_calculator
     Qj const& m_qj;
     Qk const& m_qk;
 
-    SideStrategy const& m_side_strategy;
+    SideStrategy m_side_strategy;
 };
 
 template <typename Point1, typename Point2, typename RobustPolicy>


### PR DESCRIPTION
The problem appears when side_calculator called from here: https://github.com/boostorg/geometry/blob/develop/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp#L430 does not initialize the side strategy (i.e. inters.get_side_strategy()) passed as cont&. 

To fix this the PR proposes to remove const& from the declaration of m_side_strategy member.

Note that the issue is reported by using both gcc and clang (versions 4.8 and 3.4 respectively).