### PR TITLE
Fix geographic area strategy for sphere.

### DIFF
--- a/include/boost/geometry/strategies/geographic/area.hpp
+++ b/include/boost/geometry/strategies/geographic/area.hpp
@@ -83,7 +83,7 @@ protected :
         CT const m_e2;  // squared eccentricity
         CT const m_ep2; // squared second eccentricity
         CT const m_ep;  // second eccentricity
-        CT const m_c2;  // authalic radius
+        CT const m_c2;  // squared authalic radius
 
         inline spheroid_constants(Spheroid const& spheroid)
             : m_spheroid(spheroid)
@@ -92,11 +92,26 @@ protected :
                  * (CT(2.0) - CT(formula::flattening<CT>(spheroid))))
             , m_ep2(m_e2 / (CT(1.0) - m_e2))
             , m_ep(math::sqrt(m_ep2))
-            , m_c2((m_a2 / CT(2.0)) +
-              ((math::sqr(get_radius<2>(spheroid)) * boost::math::atanh(math::sqrt(m_e2)))
-               / (CT(2.0) * math::sqrt(m_e2))))
+            , m_c2(authalic_radius(spheroid, m_a2, m_e2))
         {}
     };
+
+    static inline CT authalic_radius(Spheroid const& sph, CT const& a2, CT const& e2)
+    {
+        CT const c0 = 0;
+
+        if (math::equals(e2, c0))
+        {
+            return a2;
+        }
+
+        CT const sqrt_e2 = math::sqrt(e2);
+        CT const c2 = 2;
+
+        return (a2 / c2) +
+                  ((math::sqr(get_radius<2>(sph)) * boost::math::atanh(sqrt_e2))
+                   / (c2 * sqrt_e2));
+    }
 
     struct area_sums
     {

--- a/test/algorithms/area/area_sph_geo.cpp
+++ b/test/algorithms/area/area_sph_geo.cpp
@@ -389,6 +389,21 @@ void test_spherical_geo()
         // for select geography::STGeomFromText('POLYGON((4.892 52.373,4.23 52.08,
         //      4.479 51.930,5.119 52.093,4.892 52.373))',4326).STArea()/1000000.0
     }
+
+    {
+        bg::model::polygon<pt, false> geometry_sph;
+        std::string wkt = "POLYGON((0 0, 5 0, 5 5, 0 5, 0 0))";
+        bg::read_wkt(wkt, geometry_sph);
+
+        area = bg::area(geometry_sph, bg::strategy::area::spherical<pt>(6371228.0));
+        BOOST_CHECK_CLOSE(area, 308932296103.83051, 0.0001);
+        
+        bg::model::polygon<pt_geo, false> geometry_geo;
+        bg::read_wkt(wkt, geometry_geo);
+
+        area = bg::area(geometry_geo, bg::strategy::area::geographic<pt_geo>(bg::srs::spheroid<double>(6371228.0, 6371228.0)));
+        BOOST_CHECK_CLOSE(area, 308932296103.82574, 0.001);
+    }
 }
 
 int test_main(int, char* [])


### PR DESCRIPTION
In this case `e2` is `0` which resulted in `c2` being `NaN` and at the end the final result being `NaN`. This PR sets `c2` to `a2` if `e2` is `0`.

Plus unnecessary `sqrt()` call is removed.