### PR TITLE
enrich_intersection_points: fix to_index0/to_index1 confusion

### DIFF
--- a/include/boost/geometry/algorithms/detail/overlay/enrich_intersection_points.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/enrich_intersection_points.hpp
@@ -257,7 +257,7 @@ inline void calculate_remaining_distance(Turns& turns)
 
         int const to_index0 = op0.enriched.get_next_turn_index();
         int const to_index1 = op1.enriched.get_next_turn_index();
-        if (to_index1 >= 0
+        if (to_index0 >= 0
                 && to_index1 >= 0
                 && to_index0 != to_index1)
         {


### PR DESCRIPTION
Found by Coverity:

 "pointless_expression: The expression to_index1 >= 0 && to_index1 >=
 0 does not accomplish anything because it evaluates to either of its
 identical operands, to_index1 >= 0."