### PR TITLE
Fix L/A set operations

### DIFF
--- a/include/boost/geometry/algorithms/detail/intersection/multi.hpp
+++ b/include/boost/geometry/algorithms/detail/intersection/multi.hpp
@@ -237,7 +237,7 @@ struct intersection_insert
         OverlayType,
         Reverse1, Reverse2, ReverseOut,
         multi_linestring_tag, multi_linestring_tag, point_tag,
-        false, false, false
+        linear_tag, linear_tag, pointlike_tag
     > : detail::intersection::intersection_multi_linestring_multi_linestring_point
             <
                 GeometryOut
@@ -259,7 +259,7 @@ struct intersection_insert
         OverlayType,
         Reverse1, Reverse2, ReverseOut,
         linestring_tag, multi_linestring_tag, point_tag,
-        false, false, false
+        linear_tag, linear_tag, pointlike_tag
     > : detail::intersection::intersection_linestring_multi_linestring_point
             <
                 GeometryOut
@@ -281,7 +281,7 @@ struct intersection_insert
         OverlayType,
         Reverse1, Reverse2, ReverseOut,
         multi_linestring_tag, box_tag, linestring_tag,
-        false, true, false
+        linear_tag, areal_tag, linear_tag
     > : detail::intersection::clip_multi_linestring
             <
                 GeometryOut
@@ -303,7 +303,7 @@ struct intersection_insert
         OverlayType,
         ReverseLinestring, ReverseMultiPolygon, ReverseOut,
         linestring_tag, multi_polygon_tag, linestring_tag,
-        false, true, false
+        linear_tag, areal_tag, linear_tag
     > : detail::intersection::intersection_of_linestring_with_areal
             <
                 ReverseMultiPolygon,
@@ -329,7 +329,7 @@ struct intersection_insert
         OverlayType,
         ReversePolygon, ReverseMultiLinestring, ReverseOut,
         polygon_tag, multi_linestring_tag, linestring_tag,
-        true, false, false
+        areal_tag, linear_tag, linear_tag
     > : detail::intersection::intersection_of_areal_with_multi_linestring
             <
                 ReversePolygon,
@@ -353,7 +353,7 @@ struct intersection_insert
         OverlayType,
         ReverseMultiLinestring, ReverseRing, ReverseOut,
         multi_linestring_tag, ring_tag, linestring_tag,
-        false, true, false
+        linear_tag, areal_tag, linear_tag
     > : detail::intersection::intersection_of_multi_linestring_with_areal
             <
                 ReverseRing,
@@ -376,7 +376,7 @@ struct intersection_insert
         OverlayType,
         ReverseMultiLinestring, ReverseRing, ReverseOut,
         multi_linestring_tag, polygon_tag, linestring_tag,
-        false, true, false
+        linear_tag, areal_tag, linear_tag
     > : detail::intersection::intersection_of_multi_linestring_with_areal
             <
                 ReverseRing,
@@ -401,7 +401,7 @@ struct intersection_insert
         OverlayType,
         ReverseMultiLinestring, ReverseMultiPolygon, ReverseOut,
         multi_linestring_tag, multi_polygon_tag, linestring_tag,
-        false, true, false
+        linear_tag, areal_tag, linear_tag
     > : detail::intersection::intersection_of_multi_linestring_with_areal
             <
                 ReverseMultiPolygon,

--- a/include/boost/geometry/algorithms/detail/overlay/follow.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/follow.hpp
@@ -26,6 +26,7 @@
 
 #include <boost/geometry/algorithms/covered_by.hpp>
 #include <boost/geometry/algorithms/clear.hpp>
+#include <boost/geometry/algorithms/detail/relate/turns.hpp>
 
 
 namespace boost { namespace geometry
@@ -343,6 +344,7 @@ template
 class follow
 {
 
+#ifdef BOOST_GEOMETRY_SETOPS_LA_OLD_BEHAVIOR
     template <typename Turn>
     struct sort_on_segment
     {
@@ -389,7 +391,7 @@ class follow
 
         }
     };
-
+#endif // BOOST_GEOMETRY_SETOPS_LA_OLD_BEHAVIOR
 
 
 public :
@@ -433,7 +435,15 @@ public :
 
         // Sort intersection points on segments-along-linestring, and distance
         // (like in enrich is done for poly/poly)
+        // sort turns by Linear seg_id, then by fraction, then
+        // for same ring id: x, u, i, c
+        // for different ring id: c, i, u, x
+#ifdef BOOST_GEOMETRY_SETOPS_LA_OLD_BEHAVIOR
         std::sort(boost::begin(turns), boost::end(turns), sort_on_segment<turn_type>());
+#else
+        typedef relate::turns::less<0, relate::turns::less_op_linear_areal_single<0> > turn_less;
+        std::sort(boost::begin(turns), boost::end(turns), turn_less());
+#endif
 
         LineStringOut current_piece;
         geometry::segment_identifier current_segment_id(0, -1, -1, -1);

--- a/include/boost/geometry/algorithms/detail/overlay/intersection_insert.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/intersection_insert.hpp
@@ -502,12 +502,13 @@ struct intersection_of_linestring_with_areal
         int inside_value = 0;
         if (simple_turns_analysis(linestring, areal, strategy, turns, inside_value))
         {
-            // No intersection points, it is either
+            // No crossing the boundary, it is either
             // inside (interior + borders)
             // or outside (exterior + borders)
+            // or on boundary
 
             // add linestring to the output if conditions are met
-            if (inside_value != 0 && follower::included(inside_value))
+            if (follower::included(inside_value))
             {
                 LineStringOut copy;
                 geometry::convert(linestring, copy);

--- a/test/algorithms/set_operations/difference/difference_areal_linear.cpp
+++ b/test/algorithms/set_operations/difference/difference_areal_linear.cpp
@@ -3,8 +3,8 @@
 
 // Copyright (c) 2010-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2015.
-// Modifications copyright (c) 2015, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2015, 2017.
+// Modifications copyright (c) 2015-2017, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -203,7 +203,6 @@ void test_areal_linear()
         "POLYGON((5 5,15 15,15 5,5 5))",
         1, 2, 6 * std::sqrt(2.0));
 
-#ifdef BOOST_GEOMETRY_ENABLE_FAILING_TESTS
     test_one_lp<LineString, LineString, Polygon>("case37_1",
         "LINESTRING(1 1,2 2)",
         "POLYGON((0 0,0 3,3 3,3 0,0 0),(1 1,1 2,2 2,2 1,1 1))",
@@ -213,7 +212,26 @@ void test_areal_linear()
         "LINESTRING(1 1,2 2,3 3)",
         "POLYGON((0 0,0 3,3 3,3 0,0 0),(1 1,1 2,2 2,2 1,1 1))",
         1, 2, std::sqrt(2.0));
-#endif
+
+    test_one_lp<LineString, LineString, Polygon>("case38",
+        "LINESTRING(0 0,1 1,2 2,3 3)",
+        "POLYGON((0 0,0 9,9 9,9 0,0 0),(0 0,2 1,2 2,1 2,0 0))",
+        1, 3, 2 * std::sqrt(2.0));
+
+    // several linestrings are in the output, the result is geometrically correct
+    // still single linestring could be generated
+    test_one_lp<LineString, LineString, Polygon>("case39",
+        "LINESTRING(0 0,1 1,2 2,3 3)",
+        "POLYGON((0 0,0 9,9 9,9 0,0 0),(0 0,2 1,2 2,1 2,0 0),(2 2,3 2,3 3,2 3,2 2))",
+        2, 5, 3 * std::sqrt(2.0));
+    test_one_lp<LineString, LineString, Polygon>("case40",
+        "LINESTRING(0 0,1 1,2 2,4 4)",
+        "POLYGON((0 0,0 9,9 9,9 0,0 0),(0 0,2 1,2 2,1 2,0 0),(2 2,3 2,3 3,2 3,2 2))",
+        2, 5, 3 * std::sqrt(2.0));
+    test_one_lp<LineString, LineString, Polygon>("case41",
+        "LINESTRING(0 0,1 1,2 2,9 9)",
+        "POLYGON((0 0,0 9,9 9,9 0,0 0),(0 0,2 1,2 2,1 2,0 0),(2 2,3 2,3 3,2 3,2 2),(7 7,8 7,9 9,7 8,7 7))",
+        3, 7, 5 * std::sqrt(2.0));
 }
 
 template <typename P>

--- a/test/algorithms/set_operations/intersection/intersection.cpp
+++ b/test/algorithms/set_operations/intersection/intersection.cpp
@@ -5,8 +5,8 @@
 // Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2015, 2016.
-// Modifications copyright (c) 2015-2016, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2015, 2016, 2017.
+// Modifications copyright (c) 2015-2017, Oracle and/or its affiliates.
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -602,6 +602,20 @@ void test_areal_linear()
     typedef typename bg::point_type<Polygon>::type Point;
     test_one<LineString, bg::model::ring<Point>, LineString>("simplex", poly_simplex, "LINESTRING(0 2,4 2)", 1, 2, 2.0);
 
+    test_one_lp<LineString, Polygon, LineString>("case30",
+        "POLYGON((25 0,0 15,30 15,22 10,25 0))",
+        "LINESTRING(10 15,20 15)",
+        1, 2, 10.0);
+
+    test_one_lp<LineString, Polygon, LineString>("case31",
+        "POLYGON((25 0,0 15,30 15,22 10,25 0))",
+        "LINESTRING(0 15,20 15)",
+        1, 2, 20.0);
+
+    test_one_lp<LineString, Polygon, LineString>("case32",
+        "POLYGON((25 0,0 15,30 15,22 10,25 0))",
+        "LINESTRING(25 0, 0 15,20 15)",
+        1, 3, 49.15475947422650 /*sqrt(25^2+15^2)+20*/);
 }
 
 

--- a/test/algorithms/set_operations/intersection/intersection.cpp
+++ b/test/algorithms/set_operations/intersection/intersection.cpp
@@ -616,6 +616,13 @@ void test_areal_linear()
         "POLYGON((25 0,0 15,30 15,22 10,25 0))",
         "LINESTRING(25 0, 0 15,20 15)",
         1, 3, 49.15475947422650 /*sqrt(25^2+15^2)+20*/);
+
+    typedef typename bg::point_type<Polygon>::type P;
+
+    test_one_lp<P, Polygon, LineString>("case30p",
+        "POLYGON((25 0,0 15,30 15,22 10,25 0))",
+        "LINESTRING(10 15,20 15)",
+        2, 2, 0);
 }
 
 


### PR DESCRIPTION
This PR contains two fixes for the following bugs:

1. Regression in set operations caused by a different fix done in the past https://github.com/boostorg/geometry/pull/386 removing midpoint calculation. It manifests with 1.65 when both linestring's endpoints lie on a boundary but the interior of the linestring is in the exterior of polygon. In the following case the linestring is considered to be inside polygon so e.g. the result of difference(L, A, L) is empty:

![obraz](https://user-images.githubusercontent.com/1226951/30331901-4205fb6c-97d9-11e7-9b96-86a9d60cc370.png)

2. Lack of intersection point if the first endpoint of a linestring lies on a boundary of polygon. E.g. in the following case the result of intersection(L, A, P) is empty:

![obraz](https://user-images.githubusercontent.com/1226951/30332413-8153a1a6-97da-11e7-8167-7536e186f046.png)

Both bugs were fixed by using linear/areal turn operation, turn info policy and less function obejct for sorting turns (implemented for `relate`) in `intersection_insert` and slightly adapting the algorithms. In the case of L/A->L the old code was left for now in `intersection_insert` and `follow`. It can be enabled by defining `BOOST_GEOMETRY_SETOPS_LA_OLD_BEHAVIOR`.