### PR TITLE
Fix several algorithms for segments with antipodal endpoints.

### DIFF
--- a/include/boost/geometry/algorithms/detail/envelope/segment.hpp
+++ b/include/boost/geometry/algorithms/detail/envelope/segment.hpp
@@ -200,7 +200,7 @@ private:
                     lat1 = lat_min;
                 }
             }
-            else if (mid_lat > 0)
+            else
             {
                 // update using max latitude
                 CalculationType const lat_max_rad = p_max;

--- a/include/boost/geometry/formulas/andoyer_inverse.hpp
+++ b/include/boost/geometry/formulas/andoyer_inverse.hpp
@@ -129,7 +129,18 @@ public:
                 // T = inf
                 // dA = inf
                 // azimuth = -inf
-                if (lat1 <= lat2)
+
+                // TODO: The following azimuths are inconsistent with distance
+                // i.e. according to azimuths below a segment with antipodal endpoints
+                // travels through the north pole, however the distance returned above
+                // is the length of a segment traveling along the equator.
+                // Furthermore, this special case handling is only done in andoyer
+                // formula.
+                // The most correct way of fixing it is to handle antipodal regions
+                // correctly and consistently across all formulas.
+
+                // Set azimuth to 0 unless the first endpoint is the north pole
+                if (! math::equals(sin_lat1, c1))
                 {
                     result.azimuth = c0;
                     result.reverse_azimuth = pi;

--- a/include/boost/geometry/formulas/andoyer_inverse.hpp
+++ b/include/boost/geometry/formulas/andoyer_inverse.hpp
@@ -123,13 +123,22 @@ public:
 
         if ( BOOST_GEOMETRY_CONDITION(CalcAzimuths) )
         {
-            // sin_d = 0 <=> antipodal points
+            // sin_d = 0 <=> antipodal points (incl. poles)
             if (math::equals(sin_d, c0))
             {
                 // T = inf
                 // dA = inf
                 // azimuth = -inf
-                result.azimuth = lat1 <= lat2 ? c0 : pi;
+                if (lat1 <= lat2)
+                {
+                    result.azimuth = c0;
+                    result.reverse_azimuth = pi;
+                }
+                else
+                {
+                    result.azimuth = pi;
+                    result.reverse_azimuth = 0;
+                }
             }
             else
             {
@@ -188,11 +197,10 @@ public:
                 if (BOOST_GEOMETRY_CONDITION(CalcRevAzimuth))
                 {
                     CT const dB = -U*T + V;
-                    result.reverse_azimuth = pi - B - dB;
-                    if (result.reverse_azimuth > pi)
-                    {
-                        result.reverse_azimuth -= 2 * pi;
-                    }
+                    if (B >= 0)
+                        result.reverse_azimuth = pi - B - dB;
+                    else
+                        result.reverse_azimuth = -pi - B - dB;
                     normalize_azimuth(result.reverse_azimuth, B, dB);
                 }
             }

--- a/include/boost/geometry/formulas/thomas_direct.hpp
+++ b/include/boost/geometry/formulas/thomas_direct.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2016 Oracle and/or its affiliates.
+// Copyright (c) 2016-2017 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -169,7 +169,9 @@ public:
             {
                 CT const sigma2 = S_sigma - sigma1;
                 //theta2 = asin(cos(sigma2)) <=> sin_theta0 = 1
-                CT const tan_theta2 = cos(sigma2) / sin(sigma2);
+                // calculate absolute value because the geodesic is reversed
+                // if azimuth is pi and the result is altered below
+                CT const tan_theta2 = math::abs(cos(sigma2) / sin(sigma2));
                 result.lat2 = atan(tan_theta2 / one_minus_f);
             }
 

--- a/test/algorithms/envelope_expand/envelope_on_spheroid.cpp
+++ b/test/algorithms/envelope_expand/envelope_on_spheroid.cpp
@@ -1318,6 +1318,22 @@ BOOST_AUTO_TEST_CASE( envelope_segment_spheroid_with_strategy_andoyer )
                   from_wkt<G>("SEGMENT(100 80, 20 10)"),
                   20, 10, 100, 80);
 
+    // segments intersecting pole
+    tester::apply("s19",
+                  from_wkt<G>("SEGMENT(0 0, 180 0)"),
+                  0, 0, 180, 90);
+    tester::apply("s20",
+                  from_wkt<G>("SEGMENT(0 0, -180 0)"),
+                  0, 0, 180, 90);
+    tester::apply("s21",
+                  from_wkt<G>("SEGMENT(0 1, 180 1)"),
+                  0, 1, 180, 90,
+                  std::numeric_limits<double>::epsilon() * 10);
+    tester::apply("s22",
+                  from_wkt<G>("SEGMENT(0 -1, 180 -1)"),
+                  0, -90, 180, -1,
+                  std::numeric_limits<double>::epsilon() * 10);
+
 }
 
 BOOST_AUTO_TEST_CASE( envelope_segment_spheroid_with_strategy_vincenty )

--- a/test/algorithms/overlay/Jamfile.v2
+++ b/test/algorithms/overlay/Jamfile.v2
@@ -4,8 +4,8 @@
 # Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
 # Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 #
-# This file was modified by Oracle on 2014, 2015, 2016.
-# Modifications copyright (c) 2014-2016 Oracle and/or its affiliates.
+# This file was modified by Oracle on 2014, 2015, 2016, 2017.
+# Modifications copyright (c) 2014-2017 Oracle and/or its affiliates.
 #
 # Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 #
@@ -23,6 +23,7 @@ test-suite boost-geometry-algorithms-overlay
     [ run get_turns_linear_areal.cpp       : : : : algorithms_get_turns_linear_areal ]
     [ run get_turns_linear_areal_sph.cpp   : : : : algorithms_get_turns_linear_areal_sph ]
     [ run get_turns_linear_linear.cpp      : : : : algorithms_get_turns_linear_linear ]
+    [ run get_turns_linear_linear_geo.cpp  : : : : algorithms_get_turns_linear_linear_geo ]
     [ run get_turns_linear_linear_sph.cpp  : : : : algorithms_get_turns_linear_linear_sph ]
     [ run overlay.cpp                      : : : : algorithms_overlay ]
     [ run sort_by_side_basic.cpp           : : : : algorithms_sort_by_side_basic ]

--- a/test/algorithms/overlay/get_turns_linear_linear_geo.cpp
+++ b/test/algorithms/overlay/get_turns_linear_linear_geo.cpp
@@ -1,0 +1,50 @@
+// Boost.Geometry
+// Unit Test
+
+// Copyright (c) 2017, Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+
+#include "test_get_turns.hpp"
+#include <boost/geometry/geometries/geometries.hpp>
+
+
+template <typename T>
+void test_radian()
+{
+    typedef bg::model::point<T, 2, bg::cs::geographic<bg::radian> > pt;
+    typedef bg::model::linestring<pt> ls;
+    typedef bg::model::multi_linestring<ls> mls;
+
+    bg::srs::spheroid<double> sph_wgs84(6378137.0, 6356752.3142451793);
+    boost::geometry::strategy::intersection::geographic_segments<> wgs84(sph_wgs84);
+
+    test_geometry<ls, mls>(
+        "LINESTRING(0 0, -3.14159265358979 0)",
+        "MULTILINESTRING((-2.1467549799530232 -0.12217304763960295,"
+                         "-2.5481807079117185 -0.90757121103705041,"
+                         "-2.6529004630313784 0.85521133347722067,"
+                         " 0.92502450355699373 0.62831853071795796,"
+                         "-2.5307274153917754 0,"
+                         " 2.8099800957108676 1.0646508437165401,"
+                         "-1.6057029118347816 -1.5009831567151219,"
+                         " 0.2268928027592626 1.0646508437165401,"
+                         "-2.199114857512853 -0.017453292519943278,"
+                         " 0 0.31415926535897898,"
+                         " 0 0.57595865315812822,"
+                         " 1.0471975511965967 -0.73303828583761765,"
+                         " 2.1118483949131366 -0.54105206811824158))",
+                         expected("mii++")("muu==")("iuu++")("iuu++")("iuu++")("iuu++"),
+                         wgs84);
+}
+
+int test_main(int, char* [])
+{
+    test_radian<double>();
+
+    return 0;
+}

--- a/test/algorithms/overlay/test_get_turns.hpp
+++ b/test/algorithms/overlay/test_get_turns.hpp
@@ -116,18 +116,14 @@ struct equal_turn
     const std::string * turn_ptr;
 };
 
-template <typename Geometry1, typename Geometry2, typename Expected>
+template <typename Geometry1, typename Geometry2, typename Expected, typename Strategy>
 void check_geometry_range(Geometry1 const& g1,
                           Geometry2 const& g2,
                           std::string const& wkt1,
                           std::string const& wkt2,
-                          Expected const& expected)
+                          Expected const& expected,
+                          Strategy const& strategy)
 {
-    typedef typename bg::strategy::intersection::services::default_strategy
-        <
-            typename bg::cs_tag<Geometry1>::type
-        >::type strategy_type;
-
     typedef bg::detail::no_rescale_policy robust_policy_type;
     typedef typename bg::point_type<Geometry2>::type point_type;
 
@@ -152,7 +148,6 @@ void check_geometry_range(Geometry1 const& g1,
 
     std::vector<turn_info> turns;
     interrupt_policy_t interrupt_policy;
-    strategy_type strategy;
     robust_policy_type robust_policy;
     
     // Don't switch the geometries
@@ -228,6 +223,32 @@ void check_geometry_range(Geometry1 const& g1,
 }
 
 template <typename Geometry1, typename Geometry2, typename Expected>
+void check_geometry_range(Geometry1 const& g1,
+                          Geometry2 const& g2,
+                          std::string const& wkt1,
+                          std::string const& wkt2,
+                          Expected const& expected)
+{
+    typename bg::strategy::intersection::services::default_strategy
+        <
+            typename bg::cs_tag<Geometry1>::type
+        >::type strategy;
+
+    check_geometry_range(g1, g2, wkt1, wkt2, expected, strategy);
+}
+
+template <typename Geometry1, typename Geometry2, typename Expected, typename Strategy>
+void test_geometry_range(std::string const& wkt1, std::string const& wkt2,
+                         Expected const& expected, Strategy const& strategy)
+{
+    Geometry1 geometry1;
+    Geometry2 geometry2;
+    bg::read_wkt(wkt1, geometry1);
+    bg::read_wkt(wkt2, geometry2);
+    check_geometry_range(geometry1, geometry2, wkt1, wkt2, expected, strategy);
+}
+
+template <typename Geometry1, typename Geometry2, typename Expected>
 void test_geometry_range(std::string const& wkt1, std::string const& wkt2,
                          Expected const& expected)
 {
@@ -264,6 +285,14 @@ void test_geometry(std::string const& wkt1, std::string const& wkt2,
                    expected_pusher const& expected)
 {
     test_geometry_range<G1, G2>(wkt1, wkt2, expected);
+}
+
+template <typename G1, typename G2, typename Strategy>
+void test_geometry(std::string const& wkt1, std::string const& wkt2,
+                   expected_pusher const& expected,
+                   Strategy const& strategy)
+{
+    test_geometry_range<G1, G2>(wkt1, wkt2, expected, strategy);
 }
 
 #endif // BOOST_GEOMETRY_TEST_ALGORITHMS_OVERLAY_TEST_GET_TURNS_HPP

--- a/test/algorithms/set_operations/difference/difference_linear_linear.cpp
+++ b/test/algorithms/set_operations/difference/difference_linear_linear.cpp
@@ -1508,3 +1508,35 @@ BOOST_AUTO_TEST_CASE( test_difference_ml_ml_spikes )
          "mlmldf-spikes-19"
          );
 }
+
+BOOST_AUTO_TEST_CASE( test_difference_ls_mls_geo_rad )
+{
+    typedef bg::model::point<double, 2, bg::cs::geographic<bg::radian> > pt;
+    typedef bg::model::linestring<pt> ls;
+    typedef bg::model::multi_linestring<ls> mls;
+
+    bg::srs::spheroid<double> sph_wgs84(6378137.0, 6356752.3142451793);
+    boost::geometry::strategy::intersection::geographic_segments<> wgs84(sph_wgs84);
+
+    ls g1 = from_wkt<ls>("LINESTRING(0 0, -3.14159265358979 0)");
+    mls g2 = from_wkt<mls>("MULTILINESTRING((-2.1467549799530232 -0.12217304763960295,"
+                                            "-2.5481807079117185 -0.90757121103705041,"
+                                            "-2.6529004630313784 0.85521133347722067,"
+                                            " 0.92502450355699373 0.62831853071795796,"
+                                            "-2.5307274153917754 0,"
+                                            " 2.8099800957108676 1.0646508437165401,"
+                                            "-1.6057029118347816 -1.5009831567151219,"
+                                            " 0.2268928027592626 1.0646508437165401,"
+                                            "-2.199114857512853 -0.017453292519943278,"
+                                            " 0 0.31415926535897898,"
+                                            " 0 0.57595865315812822,"
+                                            " 1.0471975511965967 -0.73303828583761765,"
+                                            " 2.1118483949131366 -0.54105206811824158))");
+    mls out;
+    bg::difference(g1, g2, out, wgs84);
+
+    check_result(g1, g2, out,
+                 from_wkt<mls>("MULTILINESTRING((0 0,0 0.31415926535897897853),"
+                                               "(0 0.57595865315812821983,-3.1415926535897900074 0))"),
+                 "geo_lmldf-1");
+}

--- a/test/algorithms/set_operations/difference/test_difference_linear_linear.hpp
+++ b/test/algorithms/set_operations/difference/test_difference_linear_linear.hpp
@@ -32,7 +32,7 @@ inline void check_result(Geometry1 const& geometry1,
                          MultiLineString const& mls_output,
                          MultiLineString const& mls_diff,
                          std::string const& case_id,
-                         double tolerance)
+                         double tolerance = std::numeric_limits<double>::epsilon())
 {
     BOOST_CHECK_MESSAGE( equals::apply(mls_diff, mls_output, tolerance),
                          "case id: " << case_id

--- a/test/strategies/andoyer.cpp
+++ b/test/strategies/andoyer.cpp
@@ -153,7 +153,8 @@ void test_azimuth(double lon1, double lat1,
 }
 
 template <typename P1, typename P2>
-void test_distazi(double lon1, double lat1, double lon2, double lat2, double expected_km, double expected_azimuth_deg)
+void test_distazi(double lon1, double lat1, double lon2, double lat2,
+                  double expected_km, double expected_azimuth_deg)
 {
     test_distance<P1, P2>(lon1, lat1, lon2, lat2, expected_km);
     test_azimuth<P1, P2>(lon1, lat1, lon2, lat2, expected_azimuth_deg);
@@ -161,16 +162,20 @@ void test_distazi(double lon1, double lat1, double lon2, double lat2, double exp
 
 // requires SW->NE
 template <typename P1, typename P2>
-void test_distazi_symm(double lon1, double lat1, double lon2, double lat2, double expected_km, double expected_azimuth_deg)
+void test_distazi_symm(double lon1, double lat1, double lon2, double lat2,
+                       double expected_km, double expected_azimuth_deg,
+                       bool is_antipodal = false)
 {
+    double d180 = is_antipodal ? 0 : 180;
     test_distazi<P1, P2>(lon1, lat1, lon2, lat2, expected_km, expected_azimuth_deg);
     test_distazi<P1, P2>(-lon1, lat1, -lon2, lat2, expected_km, -expected_azimuth_deg);
-    test_distazi<P1, P2>(lon1, -lat1, lon2, -lat2, expected_km, 180 - expected_azimuth_deg);
-    test_distazi<P1, P2>(-lon1, -lat1, -lon2, -lat2, expected_km, -180 + expected_azimuth_deg);
+    test_distazi<P1, P2>(lon1, -lat1, lon2, -lat2, expected_km, d180 - expected_azimuth_deg);
+    test_distazi<P1, P2>(-lon1, -lat1, -lon2, -lat2, expected_km, -d180 + expected_azimuth_deg);
 }
 
 template <typename P1, typename P2>
-void test_distazi_symmNS(double lon1, double lat1, double lon2, double lat2, double expected_km, double expected_azimuth_deg)
+void test_distazi_symmNS(double lon1, double lat1, double lon2, double lat2,
+                         double expected_km, double expected_azimuth_deg)
 {
     test_distazi<P1, P2>(lon1, lat1, lon2, lat2, expected_km, expected_azimuth_deg);
     test_distazi<P1, P2>(lon1, -lat1, lon2, -lat2, expected_km, 180 - expected_azimuth_deg);
@@ -282,7 +287,7 @@ void test_all()
         test_distazi_symm<P1, P2>(normlized_deg(l-44.99), -44.99, normlized_deg(l+135), 45, 20008.1, 0.0);
         test_distazi_symm<P1, P2>(normlized_deg(l-44.999), -44.999, normlized_deg(l+135), 45, 20009.4, 0.0);
         // antipodal
-        test_distazi_symm<P1, P2>(normlized_deg(l-45), -45, normlized_deg(l+135), 45, 20003.92, 0.0);
+        test_distazi_symm<P1, P2>(normlized_deg(l-45), -45, normlized_deg(l+135), 45, 20003.92, 0.0, true);
     }
 
     /* SQL Server gives:


### PR DESCRIPTION
This PR fixes handling of geometries containing segments having antipodal endpoints in particular with both endpoints at equator. It affects andoyer inverse, thomas direct and sjoberg intersection formulas as well as envelope algorithm.

Initially detected for `difference()` of these two geometries:

    g1 = "LINESTRING(0 0, -3.14159265358979 0)"
    g2 = "MULTILINESTRING((-2.1467549799530232 -0.12217304763960295,-2.5481807079117185 -0.90757121103705041,-2.6529004630313784 0.85521133347722067,0.92502450355699373 0.62831853071795796,-2.5307274153917754 0,2.8099800957108676 1.0646508437165401,-1.6057029118347816 -1.5009831567151219,0.2268928027592626 1.0646508437165401,-2.199114857512853 -0.017453292519943278,0 0.31415926535897898,0 0.57595865315812822,1.0471975511965967 -0.73303828583761765,2.1118483949131366 -0.54105206811824158))"

which looks like this:

![aaa](https://user-images.githubusercontent.com/1226951/33040647-fe1eeeb0-ce3b-11e7-88dd-12bb2323497b.png)
