### PR TITLE
Get rid of iterator.hpp

### DIFF
--- a/example/c08_custom_non_std_example.cpp
+++ b/example/c08_custom_non_std_example.cpp
@@ -14,7 +14,6 @@
 
 #include <boost/assert.hpp>
 
-#include <boost/iterator.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 #include <boost/iterator/iterator_categories.hpp>
 #include <boost/iterator/iterator_facade.hpp>

--- a/example/with_external_libs/x04_wxwidgets_world_mapper.cpp
+++ b/example/with_external_libs/x04_wxwidgets_world_mapper.cpp
@@ -72,9 +72,13 @@ namespace std
 
 template <>
 class back_insert_iterator<wxPointPointerPair>
-    : public std::iterator<std::output_iterator_tag, void, void, void, void>
 {
 public:
+    typedef std::output_iterator_tag iterator_category;
+    typedef void value_type;
+    typedef void difference_type;
+    typedef void pointer;
+    typedef void reference;
 
     typedef wxPointPointerPair container_type;
 

--- a/include/boost/geometry/extensions/iterators/circular_iterator.hpp
+++ b/include/boost/geometry/extensions/iterators/circular_iterator.hpp
@@ -14,7 +14,6 @@
 #ifndef BOOST_GEOMETRY_EXTENSIONS_ITERATORS_CIRCULAR_ITERATOR_HPP
 #define BOOST_GEOMETRY_EXTENSIONS_ITERATORS_CIRCULAR_ITERATOR_HPP
 
-#include <boost/iterator.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 #include <boost/iterator/iterator_categories.hpp>
 

--- a/include/boost/geometry/extensions/iterators/segment_returning_iterator.hpp
+++ b/include/boost/geometry/extensions/iterators/segment_returning_iterator.hpp
@@ -18,7 +18,6 @@
 
 #include <iterator>
 
-#include <boost/iterator.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 #include <boost/iterator/iterator_categories.hpp>
 

--- a/include/boost/geometry/geometries/adapted/boost_polygon/hole_iterator.hpp
+++ b/include/boost/geometry/geometries/adapted/boost_polygon/hole_iterator.hpp
@@ -15,7 +15,6 @@
 
 #include <boost/polygon/polygon.hpp>
 
-#include <boost/iterator.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 
 

--- a/include/boost/geometry/index/inserter.hpp
+++ b/include/boost/geometry/index/inserter.hpp
@@ -20,10 +20,15 @@
 namespace boost { namespace geometry { namespace index {
 
 template <class Container>
-class insert_iterator :
-    public std::iterator<std::output_iterator_tag, void, void, void, void>
+class insert_iterator
 {
 public:
+    typedef std::output_iterator_tag iterator_category;
+    typedef void value_type;
+    typedef void difference_type;
+    typedef void pointer;
+    typedef void reference;
+
     typedef Container container_type;
 
     inline explicit insert_iterator(Container & c)

--- a/include/boost/geometry/iterators/base.hpp
+++ b/include/boost/geometry/iterators/base.hpp
@@ -14,7 +14,6 @@
 #ifndef BOOST_GEOMETRY_ITERATORS_BASE_HPP
 #define BOOST_GEOMETRY_ITERATORS_BASE_HPP
 
-#include <boost/iterator.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 #include <boost/iterator/iterator_categories.hpp>
 #include <boost/mpl/if.hpp>

--- a/include/boost/geometry/iterators/closing_iterator.hpp
+++ b/include/boost/geometry/iterators/closing_iterator.hpp
@@ -15,7 +15,6 @@
 #define BOOST_GEOMETRY_ITERATORS_CLOSING_ITERATOR_HPP
 
 #include <boost/range.hpp>
-#include <boost/iterator.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/iterator/iterator_categories.hpp>
 

--- a/include/boost/geometry/iterators/concatenate_iterator.hpp
+++ b/include/boost/geometry/iterators/concatenate_iterator.hpp
@@ -12,7 +12,6 @@
 
 #include <boost/mpl/assert.hpp>
 #include <boost/type_traits/is_convertible.hpp>
-#include <boost/iterator.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/iterator/iterator_categories.hpp>
 

--- a/include/boost/geometry/iterators/detail/segment_iterator/range_segment_iterator.hpp
+++ b/include/boost/geometry/iterators/detail/segment_iterator/range_segment_iterator.hpp
@@ -12,7 +12,6 @@
 
 #include <boost/mpl/assert.hpp>
 #include <boost/type_traits/is_convertible.hpp>
-#include <boost/iterator.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/iterator/iterator_categories.hpp>
 #include <boost/range.hpp>

--- a/include/boost/geometry/iterators/ever_circling_iterator.hpp
+++ b/include/boost/geometry/iterators/ever_circling_iterator.hpp
@@ -15,7 +15,6 @@
 #define BOOST_GEOMETRY_ITERATORS_EVER_CIRCLING_ITERATOR_HPP
 
 #include <boost/range.hpp>
-#include <boost/iterator.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 #include <boost/iterator/iterator_categories.hpp>
 

--- a/include/boost/geometry/iterators/flatten_iterator.hpp
+++ b/include/boost/geometry/iterators/flatten_iterator.hpp
@@ -12,7 +12,6 @@
 
 #include <boost/mpl/assert.hpp>
 #include <boost/type_traits/is_convertible.hpp>
-#include <boost/iterator.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/iterator/iterator_categories.hpp>
 

--- a/include/boost/geometry/util/range.hpp
+++ b/include/boost/geometry/util/range.hpp
@@ -373,9 +373,14 @@ erase(Range & rng,
 
 template <class Container>
 class back_insert_iterator
-    : public std::iterator<std::output_iterator_tag, void, void, void, void>
 {
 public:
+    typedef std::output_iterator_tag iterator_category;
+    typedef void value_type;
+    typedef void difference_type;
+    typedef void pointer;
+    typedef void reference;
+
     typedef Container container_type;
 
     explicit back_insert_iterator(Container & c)

--- a/include/boost/geometry/views/detail/boundary_view/implementation.hpp
+++ b/include/boost/geometry/views/detail/boundary_view/implementation.hpp
@@ -19,7 +19,6 @@
 #include <vector>
 
 #include <boost/core/addressof.hpp>
-#include <boost/iterator.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/iterator/iterator_categories.hpp>
 #include <boost/mpl/assert.hpp>

--- a/include/boost/geometry/views/detail/points_view.hpp
+++ b/include/boost/geometry/views/detail/points_view.hpp
@@ -16,7 +16,6 @@
 
 
 #include <boost/range.hpp>
-#include <boost/iterator.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/iterator/iterator_categories.hpp>
 


### PR DESCRIPTION
Boost's iterator.hpp is deprecated (just like std::iterator in C++17). It does nothing but pulling std::iterator into namespace boost and including standard headers 'iterator' and 'cstddef'. Therefore get rid of including iterator.hpp (it had no effect in Boost.Geometry anyway) and replace inheritance by lifting std::iterator's members into the derived class. Instantiating std::iterator is granted with lengthy warning messages by latest MSVC when compiling in C++17 mode.

Signed-off-by: Daniela Engert <dani@ngrt.de>