### PR TITLE
Typo: Add missing full stop to sentence

### DIFF
--- a/doc/reference/geometries/adapted/boost_array.qbk
+++ b/doc/reference/geometries/adapted/boost_array.qbk
@@ -20,7 +20,7 @@ A boost::array is (optionally) adapted to the Boost.Geometry
 point concept. It can therefore be used in all Boost.Geometry algorithms.
 
 A boost::array can be the point type used by the models linestring, polygon, segment, 
-box, and ring
+box, and ring.
 
 [heading Model of]
 [link geometry.reference.concepts.concept_point Point Concept]

--- a/doc/reference/geometries/adapted/boost_tuple.qbk
+++ b/doc/reference/geometries/adapted/boost_tuple.qbk
@@ -29,7 +29,7 @@ tuples with 10 elements (though most algorithms do not support so many
 dimensions).
 
 A tuple can be the point type used by the models linestring, polygon, segment, 
-box, and ring
+box, and ring.
 
 [heading Model of]
 [link geometry.reference.concepts.concept_point Point Concept]


### PR DESCRIPTION
I think there is a full stop missing in the docs. That's all there is in this PR.