### PR TITLE
Support both RadiusType and Sphere as template parameter in spherial strategies.

### DIFF
--- a/doc/doxy/Doxyfile
+++ b/doc/doxy/Doxyfile
@@ -55,6 +55,7 @@ ALIASES                = qbk{1}="\xmlonly <qbk>\1</qbk> \endxmlonly" \
                          tparam_box_or_segment="Any type fulfilling a Box Concept or a Segment Concept" \
                          tparam_calculation="numeric type for calculation (e.g. high precision); if [*void] then it is extracted automatically from the coordinate type and (if necessary) promoted to floating point" \
                          tparam_radius="numeric type for radius (of sphere, earth)" \
+                         tparam_radius_or_sphere="numeric type for radius (of sphere, earth) or sphere model" \
                          tparam_container="container type, for example std::vector, std::deque" \
                          tparam_dimension_required="Dimension, this template parameter is required. Should contain \\[0 .. n-1\\] for an n-dimensional geometry" \
                          tparam_functor="Function or class with operator()" \

--- a/include/boost/geometry/strategies/spherical/area.hpp
+++ b/include/boost/geometry/strategies/spherical/area.hpp
@@ -2,7 +2,7 @@
 
 // Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
-// Copyright (c) 2016-2017 Oracle and/or its affiliates.
+// Copyright (c) 2016-2018 Oracle and/or its affiliates.
 // Contributed and/or modified by Vissarion Fisikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -14,10 +14,10 @@
 #define BOOST_GEOMETRY_STRATEGIES_SPHERICAL_AREA_HPP
 
 
-#include <boost/geometry/core/radius.hpp>
 #include <boost/geometry/formulas/area_formulas.hpp>
 #include <boost/geometry/srs/sphere.hpp>
 #include <boost/geometry/strategies/area.hpp>
+#include <boost/geometry/strategies/spherical/get_radius.hpp>
 
 
 namespace boost { namespace geometry
@@ -27,63 +27,11 @@ namespace strategy { namespace area
 {
 
 
-#ifndef DOXYGEN_NO_DETAIL
-namespace detail
-{
-
-template
-<
-    typename RadiusTypeOrSphere,
-    typename Tag = typename tag<RadiusTypeOrSphere>::type
->
-struct get_radius
-{
-    typedef typename geometry::radius_type<RadiusTypeOrSphere>::type type;
-    static type apply(RadiusTypeOrSphere const& sphere)
-    {
-        return geometry::get_radius<0>(sphere);
-    }
-};
-
-template <typename RadiusTypeOrSphere>
-struct get_radius<RadiusTypeOrSphere, void>
-{
-    typedef RadiusTypeOrSphere type;
-    static type apply(RadiusTypeOrSphere const& radius)
-    {
-        return radius;
-    }
-};
-
-// For backward compatibility
-template <typename Point>
-struct get_radius<Point, point_tag>
-{
-    typedef typename select_most_precise
-        <
-            typename coordinate_type<Point>::type,
-            double
-        >::type type;
-
-    template <typename RadiusOrSphere>
-    static typename get_radius<RadiusOrSphere>::type
-        apply(RadiusOrSphere const& radius_or_sphere)
-    {
-        return get_radius<RadiusOrSphere>::apply(radius_or_sphere);
-    }
-};
-
-
-} // namespace detail
-#endif // DOXYGEN_NO_DETAIL
-
-
 /*!
 \brief Spherical area calculation
 \ingroup strategies
 \details Calculates area on the surface of a sphere using the trapezoidal rule
-\tparam RadiusTypeOrSphere Radius type definition, may be Radius type, Sphere
-                           or Point (only for backward compatibility)
+\tparam RadiusTypeOrSphere \tparam_radius_or_sphere
 \tparam CalculationType \tparam_calculation
 
 \qbk{
@@ -171,7 +119,7 @@ public :
 
     template <typename RadiusOrSphere>
     explicit inline spherical(RadiusOrSphere const& radius_or_sphere)
-        : m_radius(strategy::area::detail::get_radius
+        : m_radius(strategy_detail::get_radius
                     <
                         RadiusOrSphere
                     >::apply(radius_or_sphere))
@@ -207,7 +155,7 @@ public :
     }
 
 private :
-    typename strategy::area::detail::get_radius
+    typename strategy_detail::get_radius
         <
             RadiusTypeOrSphere
         >::type m_radius;

--- a/include/boost/geometry/strategies/spherical/densify.hpp
+++ b/include/boost/geometry/strategies/spherical/densify.hpp
@@ -24,6 +24,7 @@
 #include <boost/geometry/formulas/spherical.hpp>
 #include <boost/geometry/srs/sphere.hpp>
 #include <boost/geometry/strategies/densify.hpp>
+#include <boost/geometry/strategies/spherical/get_radius.hpp>
 #include <boost/geometry/util/math.hpp>
 #include <boost/geometry/util/select_most_precise.hpp>
 
@@ -38,7 +39,7 @@ namespace strategy { namespace densify
 /*!
 \brief Densification of spherical segment.
 \ingroup strategies
-\tparam Sphere The sphere model.
+\tparam RadiusTypeOrSphere \tparam_radius_or_sphere
 \tparam CalculationType \tparam_calculation
 
 \qbk{
@@ -48,25 +49,23 @@ namespace strategy { namespace densify
  */
 template
 <
-    typename Sphere = srs::sphere<double>,
+    typename RadiusTypeOrSphere = double,
     typename CalculationType = void
 >
 class spherical
 {
 public:
     // For consistency with area strategy the radius is set to 1
-    spherical()
+    inline spherical()
         : m_radius(1.0)
     {}
 
-    explicit spherical(Sphere const& sphere)
-        : m_radius(geometry::get_radius<0>(sphere))
-    {}
-
-    // TODO: use enable_if/disable_if to distinguish between Sphere and Radius?
-    template <typename OtherSphere>
-    explicit spherical(OtherSphere const& sphere)
-        : m_radius(geometry::get_radius<0>(sphere))
+    template <typename RadiusOrSphere>
+    explicit inline spherical(RadiusOrSphere const& radius_or_sphere)
+        : m_radius(strategy_detail::get_radius
+                    <
+                        RadiusOrSphere
+                    >::apply(radius_or_sphere))
     {}
 
     template <typename Point, typename AssignPolicy, typename T>
@@ -160,7 +159,10 @@ public:
     }
 
 private:
-    typename geometry::radius_type<Sphere>::type m_radius;
+    typename strategy_detail::get_radius
+        <
+            RadiusTypeOrSphere
+        >::type m_radius;
 };
 
 

--- a/include/boost/geometry/strategies/spherical/distance_haversine.hpp
+++ b/include/boost/geometry/strategies/spherical/distance_haversine.hpp
@@ -2,10 +2,11 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -15,16 +16,18 @@
 #define BOOST_GEOMETRY_STRATEGIES_SPHERICAL_DISTANCE_HAVERSINE_HPP
 
 
-#include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/radian_access.hpp>
 
-#include <boost/geometry/util/math.hpp>
-#include <boost/geometry/util/select_calculation_type.hpp>
-#include <boost/geometry/util/promote_floating_point.hpp>
+#include <boost/geometry/srs/sphere.hpp>
 
 #include <boost/geometry/strategies/distance.hpp>
+#include <boost/geometry/strategies/spherical/get_radius.hpp>
 
+#include <boost/geometry/util/math.hpp>
+#include <boost/geometry/util/promote_floating_point.hpp>
+#include <boost/geometry/util/select_calculation_type.hpp>
 
 
 namespace boost { namespace geometry
@@ -45,7 +48,7 @@ namespace comparable
 // - applying asin (which is strictly (monotone) increasing)
 template
 <
-    typename RadiusType,
+    typename RadiusTypeOrSphere = double,
     typename CalculationType = void
 >
 class haversine
@@ -64,10 +67,21 @@ public :
           >
     {};
 
-    typedef RadiusType radius_type;
+    typedef typename strategy_detail::get_radius
+        <
+            RadiusTypeOrSphere
+        >::type radius_type;
 
-    explicit inline haversine(RadiusType const& r = 1.0)
-        : m_radius(r)
+    inline haversine()
+        : m_radius(1.0)
+    {}
+
+    template <typename RadiusOrSphere>
+    explicit inline haversine(RadiusOrSphere const& radius_or_sphere)
+        : m_radius(strategy_detail::get_radius
+                    <
+                        RadiusOrSphere
+                    >::apply(radius_or_sphere))
     {}
 
     template <typename Point1, typename Point2>
@@ -81,12 +95,12 @@ public :
     }
 
     template <typename T1, typename T2>
-    inline RadiusType meridian(T1 lat1, T2 lat2) const
+    inline radius_type meridian(T1 lat1, T2 lat2) const
     {
         return m_radius * (lat1 - lat2);
     }
 
-    inline RadiusType radius() const
+    inline radius_type radius() const
     {
         return m_radius;
     }
@@ -101,7 +115,7 @@ private :
                 + cos(lat1) * cos(lat2) * math::hav(lon2 - lon1);
     }
 
-    RadiusType m_radius;
+    radius_type m_radius;
 };
 
 
@@ -112,7 +126,7 @@ private :
 \brief Distance calculation for spherical coordinates
 on a perfect sphere using haversine
 \ingroup strategies
-\tparam RadiusType \tparam_radius
+\tparam RadiusTypeOrSphere \tparam_radius_or_sphere
 \tparam CalculationType \tparam_calculation
 \author Adapted from: http://williams.best.vwh.net/avform.htm
 \see http://en.wikipedia.org/wiki/Great-circle_distance
@@ -130,12 +144,12 @@ A mathematically equivalent formula, which is less subject
 */
 template
 <
-    typename RadiusType,
+    typename RadiusTypeOrSphere = double,
     typename CalculationType = void
 >
 class haversine
 {
-    typedef comparable::haversine<RadiusType, CalculationType> comparable_type;
+    typedef comparable::haversine<RadiusTypeOrSphere, CalculationType> comparable_type;
 
 public :
     template <typename Point1, typename Point2>
@@ -143,14 +157,28 @@ public :
         : services::return_type<comparable_type, Point1, Point2>
     {};
 
-    typedef RadiusType radius_type;
+    typedef typename strategy_detail::get_radius
+        <
+            RadiusTypeOrSphere
+        >::type radius_type;
+
+    /*!
+    \brief Default constructor, radius set to 1.0 for the unit sphere
+    */
+    inline haversine()
+        : m_radius(1.0)
+    {}
 
     /*!
     \brief Constructor
-    \param radius radius of the sphere, defaults to 1.0 for the unit sphere
+    \param radius_or_sphere radius of the sphere or sphere model
     */
-    inline haversine(RadiusType const& radius = 1.0)
-        : m_radius(radius)
+    template <typename RadiusOrSphere>
+    explicit inline haversine(RadiusOrSphere const& radius_or_sphere)
+        : m_radius(strategy_detail::get_radius
+                    <
+                        RadiusOrSphere
+                    >::apply(radius_or_sphere))
     {}
 
     /*!
@@ -177,7 +205,7 @@ public :
     */
 
     template <typename T1, typename T2>
-    inline RadiusType meridian(T1 lat1, T2 lat2) const
+    inline radius_type meridian(T1 lat1, T2 lat2) const
     {
         return m_radius * (lat1 - lat2);
     }
@@ -186,13 +214,13 @@ public :
     \brief access to radius value
     \return the radius
     */
-    inline RadiusType radius() const
+    inline radius_type radius() const
     {
         return m_radius;
     }
 
 private :
-    RadiusType m_radius;
+    radius_type m_radius;
 };
 
 

--- a/include/boost/geometry/strategies/spherical/get_radius.hpp
+++ b/include/boost/geometry/strategies/spherical/get_radius.hpp
@@ -1,0 +1,81 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
+
+// Copyright (c) 2016-2018 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fisikopoulos, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_STRATEGIES_SPHERICAL_GET_RADIUS_HPP
+#define BOOST_GEOMETRY_STRATEGIES_SPHERICAL_GET_RADIUS_HPP
+
+
+#include <boost/geometry/core/coordinate_type.hpp>
+#include <boost/geometry/core/radius.hpp>
+#include <boost/geometry/core/tag.hpp>
+#include <boost/geometry/core/tags.hpp>
+#include <boost/geometry/util/select_most_precise.hpp>
+
+
+namespace boost { namespace geometry
+{
+
+
+#ifndef DOXYGEN_NO_DETAIL
+namespace strategy_detail
+{
+
+template
+<
+    typename RadiusTypeOrSphere,
+    typename Tag = typename tag<RadiusTypeOrSphere>::type
+>
+struct get_radius
+{
+    typedef typename geometry::radius_type<RadiusTypeOrSphere>::type type;
+    static type apply(RadiusTypeOrSphere const& sphere)
+    {
+        return geometry::get_radius<0>(sphere);
+    }
+};
+
+template <typename RadiusTypeOrSphere>
+struct get_radius<RadiusTypeOrSphere, void>
+{
+    typedef RadiusTypeOrSphere type;
+    static type apply(RadiusTypeOrSphere const& radius)
+    {
+        return radius;
+    }
+};
+
+// For backward compatibility
+template <typename Point>
+struct get_radius<Point, point_tag>
+{
+    typedef typename select_most_precise
+        <
+            typename coordinate_type<Point>::type,
+            double
+        >::type type;
+
+    template <typename RadiusOrSphere>
+    static typename get_radius<RadiusOrSphere>::type
+        apply(RadiusOrSphere const& radius_or_sphere)
+    {
+        return get_radius<RadiusOrSphere>::apply(radius_or_sphere);
+    }
+};
+
+
+} // namespace strategy_detail
+#endif // DOXYGEN_NO_DETAIL
+
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_STRATEGIES_SPHERICAL_GET_RADIUS_HPP


### PR DESCRIPTION
For consistency with old spherical strategies and new geographic strategies allow specifying the type of member radius as either numeric radius type or sphere model. Make `double` the default radius type.