### PR TITLE
Add C++11 std::array point adaptor docs

### DIFF
--- a/doc/concept/point.qbk
+++ b/doc/concept/point.qbk
@@ -38,6 +38,7 @@ The Point Concept is defined as following:
 * [link geometry.reference.models.model_d2_point_xy model::d2::point_xy]
 * a lat long point (currently in an extension)
 * [link geometry.reference.adapted.c_array C array]
+* [link geometry.reference.adapted.std_array C++ array container]
 * [link geometry.reference.adapted.boost_array Boost.Array]
 * [link geometry.reference.adapted.boost_fusion Boost.Fusion]
 * [link geometry.reference.adapted.boost_polygon Boost.Polygon]

--- a/doc/imports.qbk
+++ b/doc/imports.qbk
@@ -102,6 +102,7 @@
 [import src/examples/geometries/segment.cpp]
 
 [import src/examples/geometries/adapted/c_array.cpp]
+[import src/examples/geometries/adapted/std_array.cpp]
 [import src/examples/geometries/adapted/boost_array.cpp]
 [import src/examples/geometries/adapted/boost_fusion.cpp]
 [import src/examples/geometries/adapted/boost_polygon_box.cpp]

--- a/doc/quickref.xml
+++ b/doc/quickref.xml
@@ -114,6 +114,7 @@
      <member><link linkend="geometry.reference.adapted.boost_polygon.point_data">Boost.Polygon's point_data</link></member>
      <member><link linkend="geometry.reference.adapted.boost_tuple">Boost.Tuple</link></member>
      <member><link linkend="geometry.reference.adapted.c_array">C arrays</link></member>
+     <member><link linkend="geometry.reference.adapted.std_array">C++11 array containers</link></member>
     </simplelist>
    </entry>
    <entry valign="top">

--- a/doc/reference.qbk
+++ b/doc/reference.qbk
@@ -45,6 +45,7 @@
 
 [section:adapted Adapted models]
 [include reference/geometries/adapted/c_array.qbk]
+[include reference/geometries/adapted/std_array.qbk]
 [include reference/geometries/adapted/boost_array.qbk]
 [include reference/geometries/adapted/boost_fusion.qbk]
 [include reference/geometries/adapted/boost_tuple.qbk]

--- a/doc/reference/geometries/adapted/std_array.qbk
+++ b/doc/reference/geometries/adapted/std_array.qbk
@@ -1,0 +1,38 @@
+[/============================================================================
+  Boost.Geometry (aka GGL, Generic Geometry Library)
+
+  Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
+  Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
+  Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
+
+  Use, modification and distribution is subject to the Boost Software License,
+  Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+  http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================/]
+
+[section:std_array C++11 Array Container]
+
+C++11 array containers are adapted to the Boost.Geometry point concept
+
+[heading Description]
+
+A C++11 std::array is (optionally) adapted to the Boost.Geometry
+point concept. It can therefore be used in all Boost.Geometry algorithms.
+
+A std::array can be the point type used by the models linestring, polygon, segment,
+box, and ring.
+
+[heading Model of]
+[link geometry.reference.concepts.concept_point Point Concept]
+
+[heading Header]
+`#include <boost/geometry/geometries/adapted/std_array.hpp>`
+
+__not_in_boost_geometry_hpp__
+
+[heading Example]
+[std_array]
+[std_array_output]
+
+[endsect]
+

--- a/doc/src/examples/geometries/adapted/Jamfile.v2
+++ b/doc/src/examples/geometries/adapted/Jamfile.v2
@@ -21,5 +21,6 @@ exe boost_polygon_point : boost_polygon_point.cpp ;
 exe boost_polygon_polygon : boost_polygon_polygon.cpp ;
 exe boost_polygon_ring : boost_polygon_ring.cpp ;
 exe boost_tuple : boost_tuple.cpp ;
+exe std_array : std_array.cpp ;
 
 build-project boost_range ;

--- a/doc/src/examples/geometries/adapted/std_array.cpp
+++ b/doc/src/examples/geometries/adapted/std_array.cpp
@@ -1,0 +1,63 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+// QuickBook Example
+
+// Copyright (c) 2011-2012 Barend Gehrels, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/config.hpp>
+#ifdef BOOST_NO_CXX11_HDR_ARRAY
+
+int main()
+{
+    return 0;
+}
+
+#else //this example needs C++11 std::array
+
+//[std_array
+//` Shows how to use a C++11 std::array using Boost.Geometry's distance, set and assign_values algorithms
+
+#include <iostream>
+
+#include <boost/geometry.hpp>
+#include <boost/geometry/geometries/linestring.hpp>
+#include <boost/geometry/geometries/adapted/std_array.hpp>
+
+BOOST_GEOMETRY_REGISTER_STD_ARRAY_CS(cs::cartesian)
+
+int main()
+{
+    std::array<float, 2> a = { {1, 2} };
+    std::array<double, 2> b = { {2, 3} };
+    std::cout << boost::geometry::distance(a, b) << std::endl;
+
+    boost::geometry::set<0>(a, 1.1f);
+    boost::geometry::set<1>(a, 2.2f);
+    std::cout << boost::geometry::distance(a, b) << std::endl;
+
+    boost::geometry::assign_values(b, 2.2, 3.3);
+    std::cout << boost::geometry::distance(a, b) << std::endl;
+
+    boost::geometry::model::linestring<std::array<double, 2> > line;
+    line.push_back(b);
+
+    return 0;
+}
+
+//]
+
+#endif //BOOST_NO_CXX11_HDR_ARRAY
+
+//[std_array_output
+/*`
+Output:
+[pre
+1.41421
+1.20416
+1.55563
+]
+*/
+//]


### PR DESCRIPTION
This adds the missing documentation for the `std::array` point adaptor added in #357. 

Copied the documentation entry and example from Boost.Array. Referred to `std::array` as "C++11 array container" throughout the text.

Link to new C++11 array container documentation page from
* reference
* quickref
* point concept

Generated the documentation locally and it seems everything was working fine.

### Questions:
* `std::array` needs C++11. Its example code is built successfully by the corresponding [Jamfile](https://github.com/boostorg/geometry/compare/develop...norbertwenzel:std-array-adaptor-docs?expand=1#diff-703795a7579032a7fd20c5ab34814bd0) only if compiled in C++11 mode or greater. I'm not sure if this causes any issues and/or if this can be worked around using `b2` (other than maybe explicitly adding the `-std=c++11` flag for gcc and clang).
* Also I'm not sure if there should be an explicit warning in the docs, that C++11 array containers actually require (at least) a C++11 compiler. Are you aware of any existing doc templates that could/should be used for that?