### PR TITLE
Improve parameters handling in projections.

### DIFF
--- a/include/boost/geometry/srs/projections/impl/pj_datum_set.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_datum_set.hpp
@@ -75,7 +75,7 @@ inline void pj_datum_add_defn(BGParams const& , std::vector<pvalue<T> >& pvalues
     /*      definition will last into the pj_ell_set() function called      */
     /*      after this one.                                                 */
     /* -------------------------------------------------------------------- */
-    std::string name = pj_param(pvalues, "sdatum").s;
+    std::string name = pj_param_s(pvalues, "datum");
     if(! name.empty())
     {
         /* find the datum definition */
@@ -153,8 +153,8 @@ inline void pj_datum_set(BGParams const& bg_params, std::vector<pvalue<T> >& pva
 /* -------------------------------------------------------------------- */
 /*      Check for nadgrids parameter.                                   */
 /* -------------------------------------------------------------------- */
-    std::string nadgrids = pj_param(pvalues, "snadgrids").s;
-    std::string towgs84 = pj_param(pvalues, "stowgs84").s;
+    std::string nadgrids = pj_param_s(pvalues, "nadgrids");
+    std::string towgs84 = pj_param_s(pvalues, "towgs84");
     if(! nadgrids.empty())
     {
         /* We don't actually save the value separately.  It will continue

--- a/include/boost/geometry/srs/projections/impl/pj_ell_set.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_ell_set.hpp
@@ -78,12 +78,12 @@ inline void pj_ell_set(BGParams const& /*bg_params*/, std::vector<pvalue<T> >& p
     a = es = 0.;
 
     /* R takes precedence */
-    if (pj_param(parameters, "tR").i)
-        a = pj_param(parameters, "dR").f;
-    else { /* probable elliptical figure */
+    if (pj_param_f(parameters, "R", a)) {
+        /* empty */
+    } else { /* probable elliptical figure */
 
         /* check if ellps present and temporarily append its values to pl */
-        name = pj_param(parameters, "sellps").s;
+        name = pj_param_s(parameters, "ellps");
         if (! name.empty())
         {
             const int n = sizeof(pj_ellps) / sizeof(pj_ellps[0]);
@@ -103,57 +103,56 @@ inline void pj_ell_set(BGParams const& /*bg_params*/, std::vector<pvalue<T> >& p
             parameters.push_back(pj_mkparam<T>(pj_ellps[index].major));
             parameters.push_back(pj_mkparam<T>(pj_ellps[index].ell));
         }
-        a = pj_param(parameters, "da").f;
-        if (pj_param(parameters, "tes").i) /* eccentricity squared */
-            es = pj_param(parameters, "des").f;
-        else if (pj_param(parameters, "te").i) { /* eccentricity */
-            e = pj_param(parameters, "de").f;
+        a = pj_param_f(parameters, "a");
+        if (pj_param_f(parameters, "es", es)) {/* eccentricity squared */
+          /* empty */  
+        } else if (pj_param_f(parameters, "e", e)) { /* eccentricity */
             es = e * e;
-        } else if (pj_param(parameters, "trf").i) { /* recip flattening */
-            es = pj_param(parameters, "drf").f;
+        } else if (pj_param_f(parameters, "rf", es)) { /* recip flattening */
             if (!es) {
                 BOOST_THROW_EXCEPTION( projection_exception(-10) );
             }
             es = 1./ es;
             es = es * (2. - es);
-        } else if (pj_param(parameters, "tf").i) { /* flattening */
-            es = pj_param(parameters, "df").f;
+        } else if (pj_param_f(parameters, "f", es)) { /* flattening */
             es = es * (2. - es);
-        } else if (pj_param(parameters, "tb").i) { /* minor axis */
-            b = pj_param(parameters, "db").f;
+        } else if (pj_param_f(parameters, "b", b)) { /* minor axis */
             es = 1. - (b * b) / (a * a);
-        }     /* else es == 0. and sphere of radius a */
-        if (!b)
+        } /* else es == 0. and sphere of radius a */
+
+        if (b == 0.0)
             b = a * sqrt(1. - es);
+
         /* following options turn ellipsoid into equivalent sphere */
-        if (pj_param(parameters, "bR_A").i) { /* sphere--area of ellipsoid */
+        if (pj_param_b(parameters, "R_A")) { /* sphere--area of ellipsoid */
             a *= 1. - es * (SIXTH<T>() + es * (RA4<T>() + es * RA6<T>()));
             es = 0.;
-        } else if (pj_param(parameters, "bR_V").i) { /* sphere--vol. of ellipsoid */
+        } else if (pj_param_b(parameters, "R_V")) { /* sphere--vol. of ellipsoid */
             a *= 1. - es * (SIXTH<T>() + es * (RV4<T>() + es * RV6<T>()));
             es = 0.;
-        } else if (pj_param(parameters, "bR_a").i) { /* sphere--arithmetic mean */
+        } else if (pj_param_b(parameters, "R_a")) { /* sphere--arithmetic mean */
             a = .5 * (a + b);
             es = 0.;
-        } else if (pj_param(parameters, "bR_g").i) { /* sphere--geometric mean */
+        } else if (pj_param_b(parameters, "R_g")) { /* sphere--geometric mean */
             a = sqrt(a * b);
             es = 0.;
-        } else if (pj_param(parameters, "bR_h").i) { /* sphere--harmonic mean */
+        } else if (pj_param_b(parameters, "R_h")) { /* sphere--harmonic mean */
             a = 2. * a * b / (a + b);
             es = 0.;
         } else {
-            int i = pj_param(parameters, "tR_lat_a").i;
-            if (i || /* sphere--arith. */
-                pj_param(parameters, "tR_lat_g").i) { /* or geom. mean at latitude */
-                T tmp;
-
-                tmp = sin(pj_param(parameters, i ? "rR_lat_a" : "rR_lat_g").f);
+            T tmp = 0.0;
+            bool is_lat_a = pj_param_r(parameters, "R_lat_a", tmp);
+            if (is_lat_a || /* sphere--arith. */
+                pj_param_r(parameters, "R_lat_g", tmp)) /* or geom. mean at latitude */
+            {
+                tmp = sin(tmp);
                 if (geometry::math::abs(tmp) > geometry::math::half_pi<T>()) {
                     BOOST_THROW_EXCEPTION( projection_exception(-11) );
                 }
                 tmp = 1. - es * tmp * tmp;
-                a *= i ? .5 * (1. - es + tmp) / ( tmp * sqrt(tmp)) :
-                    sqrt(1. - es) / tmp;
+                a *= is_lat_a
+                   ? .5 * (1. - es + tmp) / ( tmp * sqrt(tmp))
+                   : sqrt(1. - es) / tmp;
                 es = 0.;
             }
         }

--- a/include/boost/geometry/srs/projections/impl/pj_init.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_init.hpp
@@ -71,21 +71,21 @@ namespace detail
 template <typename BGParams, typename T>
 inline void pj_push_defaults(BGParams const& /*bg_params*/, parameters<T>& pin)
 {
-    pin.params.push_back(pj_mkparam<T>("ellps=WGS84"));
+    pin.params.push_back(pj_mkparam<T>("ellps", "WGS84"));
 
     if (pin.name == "aea")
     {
-        pin.params.push_back(pj_mkparam<T>("lat_1=29.5"));
-        pin.params.push_back(pj_mkparam<T>("lat_2=45.5 "));
+        pin.params.push_back(pj_mkparam<T>("lat_1", "29.5"));
+        pin.params.push_back(pj_mkparam<T>("lat_2", "45.5 "));
     }
     else if (pin.name == "lcc")
     {
-        pin.params.push_back(pj_mkparam<T>("lat_1=33"));
-        pin.params.push_back(pj_mkparam<T>("lat_2=45"));
+        pin.params.push_back(pj_mkparam<T>("lat_1", "33"));
+        pin.params.push_back(pj_mkparam<T>("lat_2", "45"));
     }
     else if (pin.name == "lagrng")
     {
-        pin.params.push_back(pj_mkparam<T>("W=2"));
+        pin.params.push_back(pj_mkparam<T>("W", "2"));
     }
 }
 
@@ -100,21 +100,21 @@ inline void pj_push_defaults(srs::static_proj4<BOOST_GEOMETRY_PROJECTIONS_DETAIL
         >::type proj_tag;
 
     // statically defaulting to WGS84
-    //pin.params.push_back(pj_mkparam("ellps=WGS84"));
+    //pin.params.push_back(pj_mkparam("ellps", "WGS84"));
 
     if (BOOST_GEOMETRY_CONDITION((boost::is_same<proj_tag, srs::par4::aea>::value)))
     {
-        pin.params.push_back(pj_mkparam<T>("lat_1=29.5"));
-        pin.params.push_back(pj_mkparam<T>("lat_2=45.5 "));
+        pin.params.push_back(pj_mkparam<T>("lat_1", "29.5"));
+        pin.params.push_back(pj_mkparam<T>("lat_2", "45.5 "));
     }
     else if (BOOST_GEOMETRY_CONDITION((boost::is_same<proj_tag, srs::par4::lcc>::value)))
     {
-        pin.params.push_back(pj_mkparam<T>("lat_1=33"));
-        pin.params.push_back(pj_mkparam<T>("lat_2=45"));
+        pin.params.push_back(pj_mkparam<T>("lat_1", "33"));
+        pin.params.push_back(pj_mkparam<T>("lat_2", "45"));
     }
     else if (BOOST_GEOMETRY_CONDITION((boost::is_same<proj_tag, srs::par4::lagrng>::value)))
     {
-        pin.params.push_back(pj_mkparam<T>("W=2"));
+        pin.params.push_back(pj_mkparam<T>("W", "2"));
     }
 }
 
@@ -128,7 +128,7 @@ inline void pj_init_units(std::vector<pvalue<T> > const& params,
                           T const& default_fr_meter)
 {
     std::string s;
-    std::string units = pj_param(params, sunits).s;
+    std::string units = pj_param_s(params, sunits);
     if (! units.empty())
     {
         const int n = sizeof(pj_units) / sizeof(pj_units[0]);
@@ -149,7 +149,7 @@ inline void pj_init_units(std::vector<pvalue<T> > const& params,
 
     if (s.empty())
     {
-        s = pj_param(params, sto_meter).s;
+        s = pj_param_s(params, sto_meter);
     }
 
     if (! s.empty())
@@ -201,14 +201,14 @@ inline parameters<T> pj_init(BGParams const& bg_params, R const& arguments, bool
     }
 
     /* check if +init present */
-    if (pj_param(pin.params, "tinit").i)
-    {
-        // maybe TODO: handle "init" parameter
-        //if (!(curr = get_init(&arguments, curr, pj_param(pin.params, "sinit").s)))
-    }
+    // maybe TODO: handle "init" parameter
+    //if (pj_param_e(pin.params, "init"))
+    //{
+        //if (!(curr = get_init(&arguments, curr, pj_param_s(pin.params, "init"))))
+    //}
 
     // find projection -> implemented in projection factory
-    pin.name = pj_param(pin.params, "sproj").s;
+    pin.name = pj_param_s(pin.params, "proj");
     // exception thrown in projection<>
     // TODO: consider throwing here both projection_unknown_id_exception and
     // projection_not_named_exception in order to throw before other exceptions
@@ -217,7 +217,7 @@ inline parameters<T> pj_init(BGParams const& bg_params, R const& arguments, bool
 
     // set defaults, unless inhibited
     // GL-Addition, if use_defaults is false then defaults are ignored
-    if (use_defaults && ! pj_param(pin.params, "bno_defs").i)
+    if (use_defaults && ! pj_param_b(pin.params, "no_defs"))
     {
         // proj4 gets defaults from "proj_def.dat", file of 94/02/23 with a few defaults.
         // Here manually
@@ -262,45 +262,46 @@ inline parameters<T> pj_init(BGParams const& bg_params, R const& arguments, bool
     }
 
     /* set pin.geoc coordinate system */
-    pin.geoc = (pin.es && pj_param(pin.params, "bgeoc").i);
+    pin.geoc = (pin.es && pj_param_b(pin.params, "geoc"));
 
     /* over-ranging flag */
-    pin.over = pj_param(pin.params, "bover").i;
+    pin.over = pj_param_b(pin.params, "over");
 
     /* longitude center for wrapping */
-    pin.is_long_wrap_set = pj_param(pin.params, "tlon_wrap").i != 0;
-    if (pin.is_long_wrap_set)
-        pin.long_wrap_center = pj_param(pin.params, "rlon_wrap").f;
+    pin.is_long_wrap_set = pj_param_r(pin.params, "lon_wrap", pin.long_wrap_center);
 
     /* central meridian */
-    pin.lam0 = pj_param(pin.params, "rlon_0").f;
+    pin.lam0 = pj_param_r(pin.params, "lon_0");
 
     /* central latitude */
-    pin.phi0 = pj_param(pin.params, "rlat_0").f;
+    pin.phi0 = pj_param_r(pin.params, "lat_0");
 
     /* false easting and northing */
-    pin.x0 = pj_param(pin.params, "dx_0").f;
-    pin.y0 = pj_param(pin.params, "dy_0").f;
+    pin.x0 = pj_param_f(pin.params, "x_0");
+    pin.y0 = pj_param_f(pin.params, "y_0");
 
     /* general scaling factor */
-    if (pj_param(pin.params, "tk_0").i)
-        pin.k0 = pj_param(pin.params, "dk_0").f;
-    else if (pj_param(pin.params, "tk").i)
-        pin.k0 = pj_param(pin.params, "dk").f;
-    else
-        pin.k0 = 1.;
-    if (pin.k0 <= 0.) {
-        BOOST_THROW_EXCEPTION( projection_exception(-31) );
+    if (pj_param_f(pin.params, "k_0", pin.k0)
+     || pj_param_f(pin.params, "k", pin.k0))
+    {
+        if (pin.k0 <= 0.)
+        {
+            BOOST_THROW_EXCEPTION( projection_exception(-31) );
+        }
     }
-
+    else
+    {
+        pin.k0 = 1.;
+    }
+        
     /* set units */
-    pj_init_units(pin.params, "sunits", "sto_meter",
+    pj_init_units(pin.params, "units", "to_meter",
                   pin.to_meter, pin.fr_meter, 1., 1.);
-    pj_init_units(pin.params, "svunits", "svto_meter",
+    pj_init_units(pin.params, "vunits", "vto_meter",
                   pin.vto_meter, pin.vfr_meter, pin.to_meter, pin.fr_meter);
 
     /* prime meridian */
-    std::string pm = pj_param(pin.params, "spm").s;
+    std::string pm = pj_param_s(pin.params, "pm");
     if (! pm.empty())
     {
         std::string value;

--- a/include/boost/geometry/srs/projections/impl/pj_param.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_param.hpp
@@ -3,8 +3,8 @@
 
 // Copyright (c) 2008-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -55,6 +55,16 @@ namespace detail {
 
 /* create pvalue list entry */
 template <typename T>
+inline pvalue<T> pj_mkparam(std::string const& name, std::string const& value)
+{
+    pvalue<T> newitem;
+    newitem.param = name;
+    newitem.s = value;
+    //newitem.used = false;
+    return newitem;
+}
+
+template <typename T>
 inline pvalue<T> pj_mkparam(std::string const& str)
 {
     std::string name = str;
@@ -67,92 +77,167 @@ inline pvalue<T> pj_mkparam(std::string const& str)
         name.erase(loc);
     }
 
-
-    pvalue<T> newitem;
-    newitem.param = name;
-    newitem.s = value;
-    newitem.used = 0;
-    newitem.i = atoi(value.c_str());
-    newitem.f = atof(value.c_str());
-    return newitem;
+    return pj_mkparam<T>(name, value);
 }
 
 /************************************************************************/
-/*                              pj_param()                              */
+/*                              pj_param_X()                            */
 /*                                                                      */
-/*      Test for presence or get pvalue value.  The first            */
-/*      character in `opt' is a pvalue type which can take the       */
-/*      values:                                                         */
+/*      Test for presence and/or get pvalue value.                      */
+/*      Where X can be:                                                 */
 /*                                                                      */
-/*       `t' - test for presence, return TRUE/FALSE in pvalue.i         */
-/*       `i' - integer value returned in pvalue.i                       */
-/*       `d' - simple valued real input returned in pvalue.f            */
-/*       `r' - degrees (DMS translation applied), returned as           */
-/*             radians in pvalue.f                                      */
-/*       `s' - string returned in pvalue.s                              */
-/*       `b' - test for t/T/f/F, return in pvalue.i                     */
+/*       `e' - test for presence, return true/false                     */
+/*       `i' - integral number, returned as int                         */
+/*       `f' - floating point number, returned as T                     */
+/*       `r' - radians, returned as T                                   */
+/*       `s' - string, returned as std::string                          */
+/*       `b' - boolean, test for t/T/f/F, returned as bool              */
 /*                                                                      */
 /************************************************************************/
 
+/* input exists */
 template <typename T>
-inline pvalue<T> pj_param(std::vector<pvalue<T> > const& pl, std::string opt)
+inline bool pj_param_e(std::vector<pvalue<T> > const& pl, std::string const& name)
 {
-    char type = opt[0];
-    opt.erase(opt.begin());
-
-    pvalue<T> value;
-
-    /* simple linear lookup */
     typedef typename std::vector<pvalue<T> >::const_iterator iterator;
     for (iterator it = pl.begin(); it != pl.end(); it++)
     {
-        if (it->param == opt)
+        if (it->param == name)
         {
-            //it->used = 1;
-            switch (type)
-            {
-            case 't':
-                value.i = 1;
-                break;
-            case 'i':    /* integer input */
-                value.i = atoi(it->s.c_str());
-                break;
-            case 'd':    /* simple real input */
-                value.f = atof(it->s.c_str());
-                break;
-            case 'r':    /* degrees input */
-                {
-                    dms_parser<T, true> parser;
-                    value.f = parser.apply(it->s.c_str()).angle();
-                }
-                break;
-            case 's':    /* char string */
-                value.s = it->s;
-                break;
-            case 'b':    /* boolean */
-                switch (it->s[0])
-                {
-                case 'F': case 'f':
-                    value.i = 0;
-                    break;
-                case '\0': case 'T': case 't':
-                    value.i = 1;
-                    break;
-                default:
-                    value.i = 0;
-                    break;
-                }
-                break;
-            }
-            return value;
+            return true;
         }
-
     }
 
-    value.i = 0;
-    value.f = 0.0;
-    value.s = "";
-    return value;
+    return false;
+}
+
+/* integer input */
+template <typename T>
+inline bool pj_param_i(std::vector<pvalue<T> > const& pl, std::string const& name, int & par)
+{
+    typedef typename std::vector<pvalue<T> >::const_iterator iterator;
+    for (iterator it = pl.begin(); it != pl.end(); it++)
+    {
+        if (it->param == name)
+        {
+            //it->used = true;
+            par = atoi(it->s.c_str());
+            return true;
+        }
+    }
+
+    return false;
+}
+
+template <typename T>
+inline int pj_param_i(std::vector<pvalue<T> > const& pl, std::string const& name)
+{
+    int res = 0;
+    pj_param_i(pl, name, res);
+    return res;
+}
+
+/* floating point input */
+template <typename T>
+inline bool pj_param_f(std::vector<pvalue<T> > const& pl, std::string const& name, T & par)
+{
+    typedef typename std::vector<pvalue<T> >::const_iterator iterator;
+    for (iterator it = pl.begin(); it != pl.end(); it++)
+    {
+        if (it->param == name)
+        {
+            //it->used = true;
+            par = atof(it->s.c_str());
+            return true;
+        }
+    }
+
+    return false;
+}
+
+template <typename T>
+inline T pj_param_f(std::vector<pvalue<T> > const& pl, std::string const& name)
+{
+    T res = 0;
+    pj_param_f(pl, name, res);
+    return res;
+}
+
+/* radians input */
+template <typename T>
+inline bool pj_param_r(std::vector<pvalue<T> > const& pl, std::string const& name, T & par)
+{
+    typedef typename std::vector<pvalue<T> >::const_iterator iterator;
+    for (iterator it = pl.begin(); it != pl.end(); it++)
+    {
+        if (it->param == name)
+        {
+            //it->used = true;
+            dms_parser<T, true> parser;
+            par = parser.apply(it->s.c_str()).angle();
+            return true;
+        }
+    }
+
+    return false;
+}
+
+template <typename T>
+inline T pj_param_r(std::vector<pvalue<T> > const& pl, std::string const& name)
+{
+    T res = 0;
+    pj_param_r(pl, name, res);
+    return res;
+}
+
+/* string input */
+template <typename T>
+inline bool pj_param_s(std::vector<pvalue<T> > const& pl, std::string const& name, std::string & par)
+{
+    typedef typename std::vector<pvalue<T> >::const_iterator iterator;
+    for (iterator it = pl.begin(); it != pl.end(); it++)
+    {
+        if (it->param == name)
+        {
+            //it->used = true;
+            par = it->s;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+template <typename T>
+inline std::string pj_param_s(std::vector<pvalue<T> > const& pl, std::string const& name)
+{
+    std::string res;
+    pj_param_s(pl, name, res);
+    return res;
+}
+
+/* bool input */
+template <typename T>
+inline bool pj_param_b(std::vector<pvalue<T> > const& pl, std::string const& name)
+{
+    typedef typename std::vector<pvalue<T> >::const_iterator iterator;
+    for (iterator it = pl.begin(); it != pl.end(); it++)
+    {
+        if (it->param == name)
+        {
+            //it->used = true;
+            switch (it->s[0])
+            {
+            case '\0': case 'T': case 't':
+                return true;
+            case 'F': case 'f':
+            default:
+                return false;
+            }
+        }
+    }
+
+    return false;
 }
 
 } // namespace detail

--- a/include/boost/geometry/srs/projections/impl/pj_param.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_param.hpp
@@ -43,6 +43,8 @@
 #include <string>
 #include <vector>
 
+#include <boost/geometry/srs/projections/exception.hpp>
+
 #include <boost/geometry/srs/projections/impl/dms_parser.hpp>
 #include <boost/geometry/srs/projections/impl/projects.hpp>
 
@@ -231,7 +233,9 @@ inline bool pj_param_b(std::vector<pvalue<T> > const& pl, std::string const& nam
             case '\0': case 'T': case 't':
                 return true;
             case 'F': case 'f':
+                return false;
             default:
+                BOOST_THROW_EXCEPTION( projection_exception(-8) );
                 return false;
             }
         }

--- a/include/boost/geometry/srs/projections/impl/pj_transform.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_transform.hpp
@@ -732,8 +732,8 @@ inline bool pj_compare_datums( Par & srcdefn, Par & dstdefn )
     }
     else if( srcdefn.datum_type == PJD_GRIDSHIFT )
     {
-        return pj_param(srcdefn.params,"snadgrids").s
-            == pj_param(dstdefn.params,"snadgrids").s;
+        return pj_param_s(srcdefn.params, "nadgrids")
+            == pj_param_s(dstdefn.params, "nadgrids");
     }
     else
         return true;

--- a/include/boost/geometry/srs/projections/impl/projects.hpp
+++ b/include/boost/geometry/srs/projections/impl/projects.hpp
@@ -3,8 +3,8 @@
 
 // Copyright (c) 2008-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -96,15 +96,17 @@ static const int PJD_ERR_AXIS = -47;
 static const int PJD_ERR_GRID_AREA = -48;
 static const int PJD_ERR_CATALOG = -49;
 
+// NOTE: T was left because it is used in pj_param_f and pj_param_r
 template <typename T>
 struct pvalue
 {
     std::string param;
-    int used;
-
-    int i;
-    T f;
     std::string s;
+
+    // NOTE: This parameter is only used in pj_get_def(), a function returning
+    // the PROJ.4 command string compatible with the projection definition.
+    // Currently it's not used in Boost.Geometry.
+    //int used;
 };
 
 template <typename T>

--- a/include/boost/geometry/srs/projections/proj/aea.hpp
+++ b/include/boost/geometry/srs/projections/proj/aea.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -233,8 +233,8 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_aea(Parameters& par, par_aea<T>& proj_parm)
             {
-                proj_parm.phi1 = pj_param(par.params, "rlat_1").f;
-                proj_parm.phi2 = pj_param(par.params, "rlat_2").f;
+                proj_parm.phi1 = pj_param_r(par.params, "lat_1");
+                proj_parm.phi2 = pj_param_r(par.params, "lat_2");
                 setup(par, proj_parm);
             }
 
@@ -244,8 +244,8 @@ namespace projections
             {
                 static const T HALFPI = detail::HALFPI<T>();
 
-                proj_parm.phi2 = pj_param(par.params, "rlat_1").f;
-                proj_parm.phi1 = pj_param(par.params, "bsouth").i ? -HALFPI : HALFPI;
+                proj_parm.phi2 = pj_param_r(par.params, "lat_1");
+                proj_parm.phi1 = pj_param_b(par.params, "south") ? -HALFPI : HALFPI;
                 setup(par, proj_parm);
             }
 

--- a/include/boost/geometry/srs/projections/proj/aeqd.hpp
+++ b/include/boost/geometry/srs/projections/proj/aeqd.hpp
@@ -295,7 +295,7 @@ namespace projections
             {
                 static const T HALFPI = detail::HALFPI<T>();
 
-                par.phi0 = pj_param(par.params, "rlat_0").f;
+                par.phi0 = pj_param_r(par.params, "lat_0");
                 if (fabs(fabs(par.phi0) - HALFPI) < EPS10) {
                     proj_parm.mode = par.phi0 < 0. ? S_POLE : N_POLE;
                     proj_parm.sinph0 = par.phi0 < 0. ? -1. : 1.;
@@ -626,7 +626,7 @@ namespace projections
             public :
                 virtual base_v<CalculationType, Parameters>* create_new(const Parameters& par) const
                 {
-                    bool const guam = pj_param(par.params, "bguam").i != 0;
+                    bool const guam = pj_param_b(par.params, "guam");
 
                     if (par.es && ! guam)
                         return new base_v_fi<aeqd_e<CalculationType, Parameters>, CalculationType, Parameters>(par);

--- a/include/boost/geometry/srs/projections/proj/airy.hpp
+++ b/include/boost/geometry/srs/projections/proj/airy.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -166,8 +166,8 @@ namespace projections
 
                 T beta;
 
-                proj_parm.no_cut = pj_param(par.params, "bno_cut").i;
-                beta = 0.5 * (HALFPI - pj_param(par.params, "rlat_b").f);
+                proj_parm.no_cut = pj_param_b(par.params, "no_cut");
+                beta = 0.5 * (HALFPI - pj_param_r(par.params, "lat_b"));
                 if (fabs(beta) < EPS)
                     proj_parm.Cb = -0.5;
                 else {

--- a/include/boost/geometry/srs/projections/proj/aitoff.hpp
+++ b/include/boost/geometry/srs/projections/proj/aitoff.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -220,10 +220,11 @@ namespace projections
             inline void setup_wintri(Parameters& par, par_aitoff<T>& proj_parm)
             {
                 static const T TWO_D_PI = detail::TWO_D_PI<T>();
+                T phi1 = 0.0;
 
                 proj_parm.mode = 1;
-                if (pj_param(par.params, "tlat_1").i) {
-                    if ((proj_parm.cosphi1 = cos(pj_param(par.params, "rlat_1").f)) == 0.)
+                if (pj_param_r(par.params, "lat_1", phi1)) {
+                    if ((proj_parm.cosphi1 = cos(phi1)) == 0.)
                         BOOST_THROW_EXCEPTION( projection_exception(-22) );
                 } else /* 50d28' or phi1=acos(2/pi) */
                     proj_parm.cosphi1 = TWO_D_PI;

--- a/include/boost/geometry/srs/projections/proj/bipc.hpp
+++ b/include/boost/geometry/srs/projections/proj/bipc.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -86,7 +86,7 @@ namespace projections
 
             struct par_bipc
             {
-                int    noskew;
+                bool    noskew;
             };
 
             // template class, using CRTP to implement forward/inverse
@@ -232,7 +232,7 @@ namespace projections
             template <typename Parameters>
             inline void setup_bipc(Parameters& par, par_bipc& proj_parm)
             {
-                proj_parm.noskew = pj_param(par.params, "bns").i;
+                proj_parm.noskew = pj_param_b(par.params, "ns");
                 par.es = 0.;
             }
 

--- a/include/boost/geometry/srs/projections/proj/bonne.hpp
+++ b/include/boost/geometry/srs/projections/proj/bonne.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -193,7 +193,7 @@ namespace projections
 
                 T c;
 
-                proj_parm.phi1 = pj_param(par.params, "rlat_1").f;
+                proj_parm.phi1 = pj_param_r(par.params, "lat_1");
                 if (fabs(proj_parm.phi1) < EPS10)
                     BOOST_THROW_EXCEPTION( projection_exception(-23) );
                 if (par.es) {

--- a/include/boost/geometry/srs/projections/proj/cea.hpp
+++ b/include/boost/geometry/srs/projections/proj/cea.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -166,8 +166,8 @@ namespace projections
             {
                 T t = 0;
 
-                if (pj_param(par.params, "tlat_ts").i &&
-                    (par.k0 = cos(t = pj_param(par.params, "rlat_ts").f)) < 0.)
+                if (pj_param_r(par.params, "lat_ts", t) &&
+                    (par.k0 = cos(t)) < 0.)
                   BOOST_THROW_EXCEPTION( projection_exception(-24) );
                 if (par.es) {
                     t = sin(t);

--- a/include/boost/geometry/srs/projections/proj/chamb.hpp
+++ b/include/boost/geometry/srs/projections/proj/chamb.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -192,13 +192,12 @@ namespace projections
                 static const T ONEPI = detail::ONEPI<T>();
 
                 int i, j;
-                char line[10];
+                static const std::string lats[3] = {"lat_1", "lat_2", "lat_3"};
+                static const std::string lons[3] = {"lon_1", "lon_2", "lon_3"};
 
                 for (i = 0; i < 3; ++i) { /* get control point locations */
-                    (void)sprintf(line, "rlat_%d", i+1);
-                    proj_parm.c[i].phi = pj_param(par.params, line).f;
-                    (void)sprintf(line, "rlon_%d", i+1);
-                    proj_parm.c[i].lam = pj_param(par.params, line).f;
+                    proj_parm.c[i].phi = pj_param_r(par.params, lats[i]);
+                    proj_parm.c[i].lam = pj_param_r(par.params, lons[i]);
                     proj_parm.c[i].lam = adjlon(proj_parm.c[i].lam - par.lam0);
                     proj_parm.c[i].cosphi = cos(proj_parm.c[i].phi);
                     proj_parm.c[i].sinphi = sin(proj_parm.c[i].phi);

--- a/include/boost/geometry/srs/projections/proj/eqc.hpp
+++ b/include/boost/geometry/srs/projections/proj/eqc.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -108,7 +108,7 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_eqc(Parameters& par, par_eqc<T>& proj_parm)
             {
-                if ((proj_parm.rc = cos(pj_param(par.params, "rlat_ts").f)) <= 0.)
+                if ((proj_parm.rc = cos(pj_param_r(par.params, "lat_ts"))) <= 0.)
                     BOOST_THROW_EXCEPTION( projection_exception(-24) );
                 par.es = 0.;
             }

--- a/include/boost/geometry/srs/projections/proj/eqdc.hpp
+++ b/include/boost/geometry/srs/projections/proj/eqdc.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -156,8 +156,8 @@ namespace projections
                 T cosphi, sinphi;
                 int secant;
 
-                proj_parm.phi1 = pj_param(par.params, "rlat_1").f;
-                proj_parm.phi2 = pj_param(par.params, "rlat_2").f;
+                proj_parm.phi1 = pj_param_r(par.params, "lat_1");
+                proj_parm.phi2 = pj_param_r(par.params, "lat_2");
                 if (fabs(proj_parm.phi1 + proj_parm.phi2) < EPS10)
                     BOOST_THROW_EXCEPTION( projection_exception(-21) );
                 if (!pj_enfn(par.es, proj_parm.en))

--- a/include/boost/geometry/srs/projections/proj/fouc_s.hpp
+++ b/include/boost/geometry/srs/projections/proj/fouc_s.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -133,7 +133,7 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_fouc_s(Parameters& par, par_fouc_s<T>& proj_parm)
             {
-                proj_parm.n = pj_param(par.params, "dn").f;
+                proj_parm.n = pj_param_f(par.params, "n");
                 if (proj_parm.n < 0. || proj_parm.n > 1.)
                     BOOST_THROW_EXCEPTION( projection_exception(-99) );
                 proj_parm.n1 = 1. - proj_parm.n;

--- a/include/boost/geometry/srs/projections/proj/geos.hpp
+++ b/include/boost/geometry/srs/projections/proj/geos.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -257,11 +257,11 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_geos(Parameters& par, par_geos<T>& proj_parm)
             {
-                if ((proj_parm.h = pj_param(par.params, "dh").f) <= 0.)
+                if ((proj_parm.h = pj_param_f(par.params, "h")) <= 0.)
                     BOOST_THROW_EXCEPTION( projection_exception(-30) );
                 if (par.phi0)
                     BOOST_THROW_EXCEPTION( projection_exception(-46) );
-                proj_parm.sweep_axis = pj_param(par.params, "ssweep").s;
+                proj_parm.sweep_axis = pj_param_s(par.params, "sweep");
                 if (proj_parm.sweep_axis.empty())
                     proj_parm.flip_axis = 0;
                 else {

--- a/include/boost/geometry/srs/projections/proj/gn_sinu.hpp
+++ b/include/boost/geometry/srs/projections/proj/gn_sinu.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -199,9 +199,10 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_gn_sinu(Parameters& par, par_gn_sinu<T>& proj_parm)
             {
-                if (pj_param(par.params, "tn").i && pj_param(par.params, "tm").i) {
-                    proj_parm.n = pj_param(par.params, "dn").f;
-                    proj_parm.m = pj_param(par.params, "dm").f;
+                T n = 0, m = 0;
+                if (pj_param_f(par.params, "n", n) && pj_param_f(par.params, "m", m)) {
+                    proj_parm.n = n;
+                    proj_parm.m = m;
                 } else
                     BOOST_THROW_EXCEPTION( projection_exception(-99) );
                 setup(par, proj_parm);

--- a/include/boost/geometry/srs/projections/proj/hammer.hpp
+++ b/include/boost/geometry/srs/projections/proj/hammer.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -123,13 +123,14 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_hammer(Parameters& par, par_hammer<T>& proj_parm)
             {
-                if (pj_param(par.params, "tW").i) {
-                    if ((proj_parm.w = fabs(pj_param(par.params, "dW").f)) <= 0.)
+                T p = 0;
+                if (pj_param_f(par.params, "W", p)) {
+                    if ((proj_parm.w = fabs(p)) <= 0.)
                         BOOST_THROW_EXCEPTION( projection_exception(-27) );
                 } else
                     proj_parm.w = .5;
-                if (pj_param(par.params, "tM").i) {
-                    if ((proj_parm.m = fabs(pj_param(par.params, "dM").f)) <= 0.)
+                if (pj_param_f(par.params, "M", p)) {
+                    if ((proj_parm.m = fabs(p)) <= 0.)
                         BOOST_THROW_EXCEPTION( projection_exception(-27) );
                 } else
                     proj_parm.m = 1.;

--- a/include/boost/geometry/srs/projections/proj/healpix.hpp
+++ b/include/boost/geometry/srs/projections/proj/healpix.hpp
@@ -733,8 +733,8 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_rhealpix(Parameters& par, par_healpix<T>& proj_parm)
             {
-                proj_parm.north_square = pj_param(par.params,"inorth_square").i;
-                proj_parm.south_square = pj_param(par.params,"isouth_square").i;
+                proj_parm.north_square = pj_param_i(par.params, "north_square");
+                proj_parm.south_square = pj_param_i(par.params, "south_square");
                 /* Check for valid north_square and south_square inputs. */
                 if (proj_parm.north_square < 0 || proj_parm.north_square > 3) {
                     BOOST_THROW_EXCEPTION( projection_exception(-47) );

--- a/include/boost/geometry/srs/projections/proj/imw_p.hpp
+++ b/include/boost/geometry/srs/projections/proj/imw_p.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -85,12 +85,10 @@ namespace projections
             {
                 int err = 0;
 
-                if (!pj_param(par.params, "tlat_1").i ||
-                    !pj_param(par.params, "tlat_2").i) {
+                if (!pj_param_r(par.params, "lat_1", proj_parm.phi_1) ||
+                    !pj_param_r(par.params, "lat_2", proj_parm.phi_2)) {
                     err = -41;
                 } else {
-                    proj_parm.phi_1 = pj_param(par.params, "rlat_1").f;
-                    proj_parm.phi_2 = pj_param(par.params, "rlat_2").f;
                     *del = 0.5 * (proj_parm.phi_2 - proj_parm.phi_1);
                     *sig = 0.5 * (proj_parm.phi_2 + proj_parm.phi_1);
                     err = (fabs(*del) < EPS || fabs(*sig) < EPS) ? -42 : 0;
@@ -222,9 +220,9 @@ namespace projections
                     proj_parm.phi_1 = proj_parm.phi_2;
                     proj_parm.phi_2 = del;
                 }
-                if (pj_param(par.params, "tlon_1").i)
-                    proj_parm.lam_1 = pj_param(par.params, "rlon_1").f;
-                else { /* use predefined based upon latitude */
+                if (pj_param_r(par.params, "lon_1", proj_parm.lam_1)) {
+                    /* empty */
+                } else { /* use predefined based upon latitude */
                     sig = fabs(sig * geometry::math::r2d<T>());
                     if (sig <= 60)        sig = 2.;
                     else if (sig <= 76) sig = 4.;

--- a/include/boost/geometry/srs/projections/proj/isea.hpp
+++ b/include/boost/geometry/srs/projections/proj/isea.hpp
@@ -1171,13 +1171,13 @@ namespace projections
             {
                 std::string opt;
 
-                    isea_grid_init(&proj_parm.dgg);
+                isea_grid_init(&proj_parm.dgg);
 
-                    proj_parm.dgg.output = ISEA_PLANE;
-            /*        proj_parm.dgg.radius = par.a; / * otherwise defaults to 1 */
+                proj_parm.dgg.output = ISEA_PLANE;
+                /* proj_parm.dgg.radius = par.a; / * otherwise defaults to 1 */
                 /* calling library will scale, I think */
 
-                opt = pj_param(par.params, "sorient").s;
+                opt = pj_param_s(par.params, "orient");
                 if (! opt.empty()) {
                     if (opt == std::string("isea")) {
                         isea_orient_isea(&proj_parm.dgg);
@@ -1188,27 +1188,15 @@ namespace projections
                     }
                 }
 
-                if (pj_param(par.params, "tazi").i) {
-                    proj_parm.dgg.o_az = pj_param(par.params, "razi").f;
-                }
+                pj_param_r(par.params, "azi", proj_parm.dgg.o_az);
+                pj_param_r(par.params, "lon_0", proj_parm.dgg.o_lon);
+                pj_param_r(par.params, "lat_0", proj_parm.dgg.o_lat);
 
-                if (pj_param(par.params, "tlon_0").i) {
-                    proj_parm.dgg.o_lon = pj_param(par.params, "rlon_0").f;
-                }
+                // NOTE: the following are also set below so this is probably not needed
+                pj_param_i(par.params, "aperture", proj_parm.dgg.aperture);
+                pj_param_i(par.params, "resolution", proj_parm.dgg.resolution);
 
-                if (pj_param(par.params, "tlat_0").i) {
-                    proj_parm.dgg.o_lat = pj_param(par.params, "rlat_0").f;
-                }
-
-                if (pj_param(par.params, "taperture").i) {
-                    proj_parm.dgg.aperture = pj_param(par.params, "iaperture").i;
-                }
-
-                if (pj_param(par.params, "tresolution").i) {
-                    proj_parm.dgg.resolution = pj_param(par.params, "iresolution").i;
-                }
-
-                opt = pj_param(par.params, "smode").s;
+                opt = pj_param_s(par.params, "mode");
                 if (! opt.empty()) {
                     if (opt == std::string("plane")) {
                         proj_parm.dgg.output = ISEA_PLANE;
@@ -1227,18 +1215,18 @@ namespace projections
                     }
                 }
 
-                if (pj_param(par.params, "trescale").i) {
+                if (pj_param_e(par.params, "rescale")) {
                     proj_parm.dgg.radius = ISEA_SCALE;
                 }
 
-                if (pj_param(par.params, "tresolution").i) {
-                    proj_parm.dgg.resolution = pj_param(par.params, "iresolution").i;
+                if (pj_param_i(par.params, "resolution", proj_parm.dgg.resolution)) {
+                    /* empty */
                 } else {
                     proj_parm.dgg.resolution = 4;
                 }
 
-                if (pj_param(par.params, "taperture").i) {
-                    proj_parm.dgg.aperture = pj_param(par.params, "iaperture").i;
+                if (pj_param_i(par.params, "aperture", proj_parm.dgg.aperture)) {
+                    /* empty */
                 } else {
                     proj_parm.dgg.aperture = 3;
                 }

--- a/include/boost/geometry/srs/projections/proj/krovak.hpp
+++ b/include/boost/geometry/srs/projections/proj/krovak.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -167,11 +167,11 @@ namespace projections
                     xy_y = ro * cos(eps) / a;
                     xy_x = ro * sin(eps) / a;
 
-                        if( !pj_param(this->m_par.params, "tczech").i )
-                      {
+                    if( !pj_param_e(this->m_par.params, "czech") )
+                    {
                         xy_y *= -1.0;
                         xy_x *= -1.0;
-                      }
+                    }
                 }
 
                 // INVERSE(e_inverse)  ellipsoid
@@ -221,11 +221,11 @@ namespace projections
                     xy_x=xy_y;
                     xy_y=xy0;
 
-                        if( !pj_param(this->m_par.params, "tczech").i )
-                      {
+                    if( !pj_param_e(this->m_par.params, "czech") )
+                    {
                         xy_x *= -1.0;
                         xy_y *= -1.0;
-                      }
+                    }
 
                     ro = sqrt(xy_x * xy_x + xy_y * xy_y);
                     eps = atan2(xy_y, xy_x);
@@ -272,26 +272,26 @@ namespace projections
                 /* read some Parameters,
                  * here Latitude Truescale */
 
-                ts = pj_param(par.params, "rlat_ts").f;
+                ts = pj_param_r(par.params, "lat_ts");
                 proj_parm.C_x = ts;
 
                 /* we want Bessel as fixed ellipsoid */
                 par.a = 6377397.155;
                 par.e = sqrt(par.es = 0.006674372230614);
 
-                    /* if latitude of projection center is not set, use 49d30'N */
-                if (!pj_param(par.params, "tlat_0").i)
-                        par.phi0 = 0.863937979737193;
+                /* if latitude of projection center is not set, use 49d30'N */
+                if (!pj_param_e(par.params, "lat_0"))
+                    par.phi0 = 0.863937979737193;
 
-                    /* if center long is not set use 42d30'E of Ferro - 17d40' for Ferro */
-                    /* that will correspond to using longitudes relative to greenwich    */
-                    /* as input and output, instead of lat/long relative to Ferro */
-                if (!pj_param(par.params, "tlon_0").i)
-                        par.lam0 = 0.7417649320975901 - 0.308341501185665;
+                /* if center long is not set use 42d30'E of Ferro - 17d40' for Ferro */
+                /* that will correspond to using longitudes relative to greenwich    */
+                /* as input and output, instead of lat/long relative to Ferro */
+                if (!pj_param_e(par.params, "lon_0"))
+                    par.lam0 = 0.7417649320975901 - 0.308341501185665;
 
-                    /* if scale not set default to 0.9999 */
-                if (!pj_param(par.params, "tk").i)
-                        par.k0 = 0.9999;
+                /* if scale not set default to 0.9999 */
+                if (!pj_param_e(par.params, "k"))
+                    par.k0 = 0.9999;
 
                 /* always the same */
             }

--- a/include/boost/geometry/srs/projections/proj/labrd.hpp
+++ b/include/boost/geometry/srs/projections/proj/labrd.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -186,8 +186,8 @@ namespace projections
 
                 T Az, sinp, R, N, t;
 
-                proj_parm.rot    = pj_param(par.params, "bno_rot").i == 0;
-                Az = pj_param(par.params, "razi").f;
+                proj_parm.rot = ! pj_param_b(par.params, "no_rot");
+                Az = pj_param_r(par.params, "azi");
                 sinp = sin(par.phi0);
                 t = 1. - par.es * sinp * sinp;
                 N = 1. / sqrt(t);

--- a/include/boost/geometry/srs/projections/proj/lagrng.hpp
+++ b/include/boost/geometry/srs/projections/proj/lagrng.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -122,10 +122,10 @@ namespace projections
             {
                 T phi1;
 
-                if ((proj_parm.rw = pj_param(par.params, "dW").f) <= 0)
+                if ((proj_parm.rw = pj_param_f(par.params, "W")) <= 0)
                     BOOST_THROW_EXCEPTION( projection_exception(-27) );
                 proj_parm.hrw = 0.5 * (proj_parm.rw = 1. / proj_parm.rw);
-                phi1 = pj_param(par.params, "rlat_1").f;
+                phi1 = pj_param_r(par.params, "lat_1");
                 if (fabs(fabs(phi1 = sin(phi1)) - 1.) < TOL)
                     BOOST_THROW_EXCEPTION( projection_exception(-22) );
                 proj_parm.a1 = pow((1. - phi1)/(1. + phi1), proj_parm.hrw);

--- a/include/boost/geometry/srs/projections/proj/lcc.hpp
+++ b/include/boost/geometry/srs/projections/proj/lcc.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -180,12 +180,12 @@ namespace projections
                 T cosphi, sinphi;
                 int secant;
 
-                proj_parm.phi1 = pj_param(par.params, "rlat_1").f;
-                if (pj_param(par.params, "tlat_2").i)
-                    proj_parm.phi2 = pj_param(par.params, "rlat_2").f;
-                else {
+                proj_parm.phi1 = pj_param_r(par.params, "lat_1");
+                if (pj_param_r(par.params, "lat_2", proj_parm.phi2)) {
+                    /* empty */
+                } else {
                     proj_parm.phi2 = proj_parm.phi1;
-                    if (!pj_param(par.params, "tlat_0").i)
+                    if (!pj_param_e(par.params, "lat_0"))
                         par.phi0 = proj_parm.phi1;
                 }
                 if (fabs(proj_parm.phi1 + proj_parm.phi2) < EPS10)

--- a/include/boost/geometry/srs/projections/proj/lcca.hpp
+++ b/include/boost/geometry/srs/projections/proj/lcca.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -152,7 +152,7 @@ namespace projections
 
                 if (!pj_enfn(par.es, proj_parm.en))
                     BOOST_THROW_EXCEPTION( projection_exception(0) );
-                if (!pj_param(par.params, "tlat_0").i)
+                if (!pj_param_e(par.params, "lat_0"))
                     BOOST_THROW_EXCEPTION( projection_exception(50) );
                 if (par.phi0 == 0.)
                     BOOST_THROW_EXCEPTION( projection_exception(51) );

--- a/include/boost/geometry/srs/projections/proj/loxim.hpp
+++ b/include/boost/geometry/srs/projections/proj/loxim.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -137,7 +137,7 @@ namespace projections
             {
                 static const T FORTPI = detail::FORTPI<T>();
 
-                proj_parm.phi1 = pj_param(par.params, "rlat_1").f;
+                proj_parm.phi1 = pj_param_r(par.params, "lat_1");
                 if ((proj_parm.cosphi1 = cos(proj_parm.phi1)) < EPS)
                     BOOST_THROW_EXCEPTION( projection_exception(-22) );
                 proj_parm.tanphi1 = tan(FORTPI + 0.5 * proj_parm.phi1);

--- a/include/boost/geometry/srs/projections/proj/lsat.hpp
+++ b/include/boost/geometry/srs/projections/proj/lsat.hpp
@@ -234,10 +234,10 @@ namespace projections
                 int land, path;
                 T lam, alf, esc, ess;
 
-                land = pj_param(par.params, "ilsat").i;
+                land = pj_param_i(par.params, "lsat");
                 if (land <= 0 || land > 5)
                     BOOST_THROW_EXCEPTION( projection_exception(-28) );
-                path = pj_param(par.params, "ipath").i;
+                path = pj_param_i(par.params, "path");
                 if (path <= 0 || path > (land <= 3 ? 251 : 233))
                     BOOST_THROW_EXCEPTION( projection_exception(-29) );
                 if (land <= 3) {

--- a/include/boost/geometry/srs/projections/proj/merc.hpp
+++ b/include/boost/geometry/srs/projections/proj/merc.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -164,8 +164,8 @@ namespace projections
                 calc_t phits=0.0;
                 int is_phits;
 
-                if( (is_phits = pj_param(par.params, "tlat_ts").i) ) {
-                    phits = fabs(pj_param(par.params, "rlat_ts").f);
+                if( (is_phits = pj_param_r(par.params, "lat_ts", phits)) ) {
+                    phits = fabs(phits);
                     if (phits >= HALFPI)
                         BOOST_THROW_EXCEPTION( projection_exception(-24) );
                 }

--- a/include/boost/geometry/srs/projections/proj/nsper.hpp
+++ b/include/boost/geometry/srs/projections/proj/nsper.hpp
@@ -215,7 +215,7 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup(Parameters& par, par_nsper<T>& proj_parm) 
             {
-                if ((proj_parm.height = pj_param(par.params, "dh").f) <= 0.)
+                if ((proj_parm.height = pj_param_f(par.params, "h")) <= 0.)
                     BOOST_THROW_EXCEPTION( projection_exception(-30) );
                 if (fabs(fabs(par.phi0) - geometry::math::half_pi<T>()) < EPS10)
                     proj_parm.mode = par.phi0 < 0. ? S_POLE : N_POLE;
@@ -249,8 +249,9 @@ namespace projections
             {
                 T omega, gamma;
 
-                omega = pj_param(par.params, "dtilt").f * geometry::math::d2r<T>();
-                gamma = pj_param(par.params, "dazi").f * geometry::math::d2r<T>();
+                // TODO: shouldn't here pj_param_r without d2r be called instead?
+                omega = pj_param_f(par.params, "tilt") * geometry::math::d2r<T>();
+                gamma = pj_param_f(par.params, "azi") * geometry::math::d2r<T>();
                 proj_parm.tilt = 1;
                 proj_parm.cg = cos(gamma); proj_parm.sg = sin(gamma);
                 proj_parm.cw = cos(omega); proj_parm.sw = sin(omega);

--- a/include/boost/geometry/srs/projections/proj/ob_tran.hpp
+++ b/include/boost/geometry/srs/projections/proj/ob_tran.hpp
@@ -84,7 +84,7 @@ namespace projections
                 Parameters pj;
 
                 /* get name of projection to be translated */
-                pj.name = pj_param(par.params, "so_proj").s;
+                pj.name = pj_param_s(par.params, "o_proj");
                 /* copy existing header into new */
                 pj.params = par.params;
                 pj.over = par.over;
@@ -232,18 +232,17 @@ namespace projections
             {
                 static const CalculationType HALFPI = detail::HALFPI<CalculationType>();
 
-                CalculationType phip;
+                CalculationType phip, alpha;
 
                 par.es = 0.; /* force to spherical */
 
                 // proj_parm.link should be created at this point
 
-                if (pj_param(par.params, "to_alpha").i) {
-                    CalculationType lamc, phic, alpha;
+                if (pj_param_r(par.params, "o_alpha", alpha)) {
+                    CalculationType lamc, phic;
 
-                    lamc    = pj_param(par.params, "ro_lon_c").f;
-                    phic    = pj_param(par.params, "ro_lat_c").f;
-                    alpha    = pj_param(par.params, "ro_alpha").f;
+                    lamc = pj_param_r(par.params, "o_lon_c");
+                    phic = pj_param_r(par.params, "o_lat_c");
             /*
                     if (fabs(phic) <= TOL ||
                         fabs(fabs(phic) - HALFPI) <= TOL ||
@@ -253,16 +252,15 @@ namespace projections
                         BOOST_THROW_EXCEPTION( projection_exception(-32) );
                     proj_parm.lamp = lamc + aatan2(-cos(alpha), -sin(alpha) * sin(phic));
                     phip = aasin(cos(phic) * sin(alpha));
-                } else if (pj_param(par.params, "to_lat_p").i) { /* specified new pole */
-                    proj_parm.lamp = pj_param(par.params, "ro_lon_p").f;
-                    phip = pj_param(par.params, "ro_lat_p").f;
+                } else if (pj_param_r(par.params, "o_lat_p", phip)) { /* specified new pole */
+                    proj_parm.lamp = pj_param_r(par.params, "o_lon_p");
                 } else { /* specified new "equator" points */
                     CalculationType lam1, lam2, phi1, phi2, con;
 
-                    lam1 = pj_param(par.params, "ro_lon_1").f;
-                    phi1 = pj_param(par.params, "ro_lat_1").f;
-                    lam2 = pj_param(par.params, "ro_lon_2").f;
-                    phi2 = pj_param(par.params, "ro_lat_2").f;
+                    lam1 = pj_param_r(par.params, "o_lon_1");
+                    phi1 = pj_param_r(par.params, "o_lat_1");
+                    lam2 = pj_param_r(par.params, "o_lon_2");
+                    phi2 = pj_param_r(par.params, "o_lat_2");
                     if (fabs(phi1 - phi2) <= TOL ||
                         (con = fabs(phi1)) <= TOL ||
                         fabs(con - HALFPI) <= TOL ||

--- a/include/boost/geometry/srs/projections/proj/ocea.hpp
+++ b/include/boost/geometry/srs/projections/proj/ocea.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -139,16 +139,15 @@ namespace projections
 
                 proj_parm.rok = 1. / par.k0;
                 proj_parm.rtk = par.k0;
-                if ( pj_param(par.params, "talpha").i) {
-                    alpha    = pj_param(par.params, "ralpha").f;
-                    lonz = pj_param(par.params, "rlonc").f;
+                if ( pj_param_r(par.params, "alpha", alpha) ) {
+                    lonz = pj_param_r(par.params, "lonc");
                     proj_parm.singam = atan(-cos(alpha)/(-sin(phi_0) * sin(alpha))) + lonz;
                     proj_parm.sinphi = asin(cos(phi_0) * sin(alpha));
                 } else {
-                    phi_1 = pj_param(par.params, "rlat_1").f;
-                    phi_2 = pj_param(par.params, "rlat_2").f;
-                    lam_1 = pj_param(par.params, "rlon_1").f;
-                    lam_2 = pj_param(par.params, "rlon_2").f;
+                    phi_1 = pj_param_r(par.params, "lat_1");
+                    phi_2 = pj_param_r(par.params, "lat_2");
+                    lam_1 = pj_param_r(par.params, "lon_1");
+                    lam_2 = pj_param_r(par.params, "lon_2");
                     proj_parm.singam = atan2(cos(phi_1) * sin(phi_2) * cos(lam_1) -
                         sin(phi_1) * cos(phi_2) * cos(lam_2),
                         sin(phi_1) * cos(phi_2) * sin(lam_2) -

--- a/include/boost/geometry/srs/projections/proj/oea.hpp
+++ b/include/boost/geometry/srs/projections/proj/oea.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -134,11 +134,11 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_oea(Parameters& par, par_oea<T>& proj_parm)
             {
-                if (((proj_parm.n = pj_param(par.params, "dn").f) <= 0.) ||
-                    ((proj_parm.m = pj_param(par.params, "dm").f) <= 0.))
+                if (((proj_parm.n = pj_param_f(par.params, "n")) <= 0.) ||
+                    ((proj_parm.m = pj_param_f(par.params, "m")) <= 0.))
                     BOOST_THROW_EXCEPTION( projection_exception(-39) );
                 else {
-                    proj_parm.theta = pj_param(par.params, "rtheta").f;
+                    proj_parm.theta = pj_param_r(par.params, "theta");
                     proj_parm.sp0 = sin(par.phi0);
                     proj_parm.cp0 = cos(par.phi0);
                     proj_parm.rn = 1./ proj_parm.n;

--- a/include/boost/geometry/srs/projections/proj/omerc.hpp
+++ b/include/boost/geometry/srs/projections/proj/omerc.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -74,7 +74,7 @@ namespace projections
             {
                 T   A, B, E, AB, ArB, BrA, rB, singam, cosgam, sinrot, cosrot;
                 T   v_pole_n, v_pole_s, u_0;
-                int no_rot;
+                bool no_rot;
             };
 
             // template class, using CRTP to implement forward/inverse
@@ -182,29 +182,28 @@ namespace projections
                   gamma0, lamc=0, lam1=0, lam2=0, phi1=0, phi2=0, alpha_c=0.0;
                 int alp, gam, no_off = 0;
 
-                proj_parm.no_rot = pj_param(par.params, "tno_rot").i;
-                    if ((alp = pj_param(par.params, "talpha").i) != 0)
-                    alpha_c = pj_param(par.params, "ralpha").f;
-                    if ((gam = pj_param(par.params, "tgamma").i) != 0)
-                    gamma = pj_param(par.params, "rgamma").f;
+                // TODO: shouldn't here pj_param_b be called instead?
+                proj_parm.no_rot = pj_param_e(par.params, "no_rot");
+                alp = pj_param_r(par.params, "alpha", alpha_c);
+                gam = pj_param_r(par.params, "gamma", gamma);
                 if (alp || gam) {
-                    lamc    = pj_param(par.params, "rlonc").f;
-                    no_off =
-                                /* For libproj4 compatability */
-                                pj_param(par.params, "tno_off").i
-                                /* for backward compatibility */
-                                || pj_param(par.params, "tno_uoff").i;
+                    lamc   = pj_param_r(par.params, "lonc");
+                    no_off = /* For libproj4 compatability */
+                             pj_param_e(par.params, "no_off")
+                             /* for backward compatibility */
+                          || pj_param_e(par.params, "no_uoff");
                     if( no_off )
                     {
                         /* Mark the parameter as used, so that the pj_get_def() return them */
-                        pj_param(par.params, "sno_uoff");
-                        pj_param(par.params, "sno_off");
+                        // NOTE: Currently this has no effect
+                        pj_param_s(par.params, "no_uoff");
+                        pj_param_s(par.params, "no_off");
                     }
                 } else {
-                    lam1 = pj_param(par.params, "rlon_1").f;
-                    phi1 = pj_param(par.params, "rlat_1").f;
-                    lam2 = pj_param(par.params, "rlon_2").f;
-                    phi2 = pj_param(par.params, "rlat_2").f;
+                    lam1 = pj_param_r(par.params, "lon_1");
+                    phi1 = pj_param_r(par.params, "lat_1");
+                    lam2 = pj_param_r(par.params, "lon_2");
+                    phi2 = pj_param_r(par.params, "lat_2");
                     if (fabs(phi1 - phi2) <= TOL ||
                         (con = fabs(phi1)) <= TOL ||
                         fabs(con - HALFPI) <= TOL ||

--- a/include/boost/geometry/srs/projections/proj/rpoly.hpp
+++ b/include/boost/geometry/srs/projections/proj/rpoly.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -118,7 +118,7 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_rpoly(Parameters& par, par_rpoly<T>& proj_parm)
             {
-                if ((proj_parm.mode = (proj_parm.phi1 = fabs(pj_param(par.params, "rlat_ts").f)) > EPS)) {
+                if ((proj_parm.mode = (proj_parm.phi1 = fabs(pj_param_r(par.params, "lat_ts"))) > EPS)) {
                     proj_parm.fxb = 0.5 * sin(proj_parm.phi1);
                     proj_parm.fxa = 0.5 / proj_parm.fxb;
                 }

--- a/include/boost/geometry/srs/projections/proj/sconics.hpp
+++ b/include/boost/geometry/srs/projections/proj/sconics.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -98,12 +98,10 @@ namespace projections
                 T p1, p2;
                 int err = 0;
 
-                if (!pj_param(par.params, "tlat_1").i ||
-                    !pj_param(par.params, "tlat_2").i) {
+                if (!pj_param_r(par.params, "lat_1", p1) ||
+                    !pj_param_r(par.params, "lat_2", p2)) {
                     err = -41;
                 } else {
-                    p1 = pj_param(par.params, "rlat_1").f;
-                    p2 = pj_param(par.params, "rlat_2").f;
                     *del = 0.5 * (p2 - p1);
                     proj_parm.sig = 0.5 * (p2 + p1);
                     err = (fabs(*del) < EPS || fabs(proj_parm.sig) < EPS) ? -42 : 0;

--- a/include/boost/geometry/srs/projections/proj/stere.hpp
+++ b/include/boost/geometry/srs/projections/proj/stere.hpp
@@ -370,8 +370,8 @@ namespace projections
             {
                 static const T HALFPI = detail::HALFPI<T>();
 
-                proj_parm.phits = pj_param(par.params, "tlat_ts").i ?
-                        pj_param(par.params, "rlat_ts").f : HALFPI;
+                if (! pj_param_r(par.params, "lat_ts", proj_parm.phits))
+                    proj_parm.phits = HALFPI;
                 setup(par, proj_parm);
             }
 
@@ -382,7 +382,7 @@ namespace projections
                 static const T HALFPI = detail::HALFPI<T>();
 
                 /* International Ellipsoid */
-                par.phi0 = pj_param(par.params, "bsouth").i ? -HALFPI: HALFPI;
+                par.phi0 = pj_param_b(par.params, "south") ? -HALFPI: HALFPI;
                 if (!par.es)
                     BOOST_THROW_EXCEPTION( projection_exception(-34) );
                 par.k0 = .994;

--- a/include/boost/geometry/srs/projections/proj/tmerc.hpp
+++ b/include/boost/geometry/srs/projections/proj/tmerc.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -329,10 +329,10 @@ namespace projections
 
                 int zone;
 
-                par.y0 = pj_param(par.params, "bsouth").i ? 10000000. : 0.;
+                par.y0 = pj_param_b(par.params, "south") ? 10000000. : 0.;
                 par.x0 = 500000.;
-                if (pj_param(par.params, "tzone").i) /* zone input ? */
-                    if ((zone = pj_param(par.params, "izone").i) > 0 && zone <= 60)
+                if (pj_param_i(par.params, "zone", zone)) /* zone input ? */
+                    if (zone > 0 && zone <= 60)
                         --zone;
                     else
                         BOOST_THROW_EXCEPTION( projection_exception(-35) );

--- a/include/boost/geometry/srs/projections/proj/tpeqd.hpp
+++ b/include/boost/geometry/srs/projections/proj/tpeqd.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -140,10 +140,10 @@ namespace projections
                 T lam_1, lam_2, phi_1, phi_2, A12, pp;
 
                 /* get control point locations */
-                phi_1 = pj_param(par.params, "rlat_1").f;
-                lam_1 = pj_param(par.params, "rlon_1").f;
-                phi_2 = pj_param(par.params, "rlat_2").f;
-                lam_2 = pj_param(par.params, "rlon_2").f;
+                phi_1 = pj_param_r(par.params, "lat_1");
+                lam_1 = pj_param_r(par.params, "lon_1");
+                phi_2 = pj_param_r(par.params, "lat_2");
+                lam_2 = pj_param_r(par.params, "lon_2");
                 if (phi_1 == phi_2 && lam_1 == lam_2)
                     BOOST_THROW_EXCEPTION( projection_exception(-25) );
                 par.lam0 = adjlon(0.5 * (lam_1 + lam_2));

--- a/include/boost/geometry/srs/projections/proj/urm5.hpp
+++ b/include/boost/geometry/srs/projections/proj/urm5.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -107,14 +107,13 @@ namespace projections
             {
                 T alpha, t;
 
-                if (pj_param(par.params, "tn").i) {
-                    proj_parm.n = pj_param(par.params, "dn").f;
+                if (pj_param_f(par.params, "n", proj_parm.n)) {
                     if (proj_parm.n <= 0. || proj_parm.n > 1.)
                         BOOST_THROW_EXCEPTION( projection_exception(-40) );
                 } else
                     BOOST_THROW_EXCEPTION( projection_exception(-40) );
-                proj_parm.q3 = pj_param(par.params, "dq").f / 3.;
-                alpha = pj_param(par.params, "ralpha").f;
+                proj_parm.q3 = pj_param_f(par.params, "q") / 3.;
+                alpha = pj_param_r(par.params, "alpha");
                 t = proj_parm.n * sin(alpha);
                 proj_parm.m = cos(alpha) / sqrt(1. - t * t);
                 proj_parm.rmn = 1. / (proj_parm.m * proj_parm.n);

--- a/include/boost/geometry/srs/projections/proj/urmfps.hpp
+++ b/include/boost/geometry/srs/projections/proj/urmfps.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -124,8 +124,7 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_urmfps(Parameters& par, par_urmfps<T>& proj_parm)
             {
-                if (pj_param(par.params, "tn").i) {
-                    proj_parm.n = pj_param(par.params, "dn").f;
+                if (pj_param_f(par.params, "n", proj_parm.n)) {
                     if (proj_parm.n <= 0. || proj_parm.n > 1.)
                         BOOST_THROW_EXCEPTION( projection_exception(-40) );
                 } else

--- a/include/boost/geometry/srs/projections/proj/wag3.hpp
+++ b/include/boost/geometry/srs/projections/proj/wag3.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -112,9 +112,7 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_wag3(Parameters& par, par_wag3<T>& proj_parm)
             {
-                T ts;
-
-                ts = pj_param(par.params, "rlat_ts").f;
+                T ts = pj_param_r(par.params, "lat_ts");
                 proj_parm.C_x = cos(ts) / cos(2.*ts/3.);
                 par.es = 0.;
             }

--- a/include/boost/geometry/srs/projections/proj/wink1.hpp
+++ b/include/boost/geometry/srs/projections/proj/wink1.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -109,7 +109,7 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_wink1(Parameters& par, par_wink1<T>& proj_parm)
             {
-                proj_parm.cosphi1 = cos(pj_param(par.params, "rlat_ts").f);
+                proj_parm.cosphi1 = cos(pj_param_r(par.params, "lat_ts"));
                 par.es = 0.;
             }
 

--- a/include/boost/geometry/srs/projections/proj/wink2.hpp
+++ b/include/boost/geometry/srs/projections/proj/wink2.hpp
@@ -6,8 +6,8 @@
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle.
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -129,7 +129,7 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_wink2(Parameters& par, par_wink2<T>& proj_parm)
             {
-                proj_parm.cosphi1 = cos(pj_param(par.params, "rlat_1").f);
+                proj_parm.cosphi1 = cos(pj_param_r(par.params, "lat_1"));
                 par.es = 0.;
             }
 


### PR DESCRIPTION
This PR makes the following changes:

- When loading proj4 parameters the type of value is determined at compile time as it's a part of the `pj_param_X()` function's name instead of input string, together with parameter name. The code is clearer because the parameter names are not polluted and loading should be faster, though I haven't measured the performance.

- `pvalue<T>` is no longer returned from `pj_param_X()`. A value of required type is returned instead.

- `pj_param_X()` overloads taking 3 arguments and returning bool were added. These overloads checks if the parameter exists and then assigns value to the 3rd argument if possible. This allows to check for presence of parameter and assignment in 1 search of parameter list. In the original code in some cases this is done 2 times, to check if the parameter exists and then to get the parameter

- `pj_mkparam()` overload taking name and value as separate arguments was added to avoid parsing string to extract them in cases when they are passed at compile-time in code (defaults of some projections).

- `i` and `f` members of pvalue<T> are removed. They were only used to hold return value in `pj_param()` and assigned to in `pj_mkparam()` which was unnecessary since they were never used. The string value was converted again by `pj_param()` when needed.

- `used` member of `pvalue<T>` is commented out because it's not used anywhere in Boost.Geometry. AFAIU in the original proj4 it is used only in function `pj_get_def()`, which allows to get PROJ.4 command string compatible with the projection definition.

- Exception is thrown if the boolean parameter value is incorrect. This is consistent with the original proj4.