### PR TITLE
Improve projections' parameters handling.

### DIFF
--- a/include/boost/geometry/srs/projections/impl/pj_datum_set.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_datum_set.hpp
@@ -75,7 +75,7 @@ inline void pj_datum_add_defn(BGParams const& , std::vector<pvalue<T> >& pvalues
     /*      definition will last into the pj_ell_set() function called      */
     /*      after this one.                                                 */
     /* -------------------------------------------------------------------- */
-    std::string name = pj_param(pvalues, "sdatum").s;
+    std::string name = pj_get_param_s(pvalues, "datum");
     if(! name.empty())
     {
         /* find the datum definition */
@@ -153,8 +153,8 @@ inline void pj_datum_set(BGParams const& bg_params, std::vector<pvalue<T> >& pva
 /* -------------------------------------------------------------------- */
 /*      Check for nadgrids parameter.                                   */
 /* -------------------------------------------------------------------- */
-    std::string nadgrids = pj_param(pvalues, "snadgrids").s;
-    std::string towgs84 = pj_param(pvalues, "stowgs84").s;
+    std::string nadgrids = pj_get_param_s(pvalues, "nadgrids");
+    std::string towgs84 = pj_get_param_s(pvalues, "towgs84");
     if(! nadgrids.empty())
     {
         /* We don't actually save the value separately.  It will continue

--- a/include/boost/geometry/srs/projections/impl/pj_ell_set.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_ell_set.hpp
@@ -80,12 +80,12 @@ inline void pj_ell_set(BGParams const& /*bg_params*/, std::vector<pvalue<T> >& p
     a = es = 0.;
 
     /* R takes precedence */
-    if (pj_param(parameters, "tR").i)
-        a = pj_param(parameters, "dR").f;
-    else { /* probable elliptical figure */
+    if (pj_param_f(parameters, "R", a)) {
+        /* empty */
+    } else { /* probable elliptical figure */
 
         /* check if ellps present and temporarily append its values to pl */
-        name = pj_param(parameters, "sellps").s;
+        name = pj_get_param_s(parameters, "ellps");
         if (! name.empty())
         {
             const int n = sizeof(pj_ellps) / sizeof(pj_ellps[0]);
@@ -105,51 +105,47 @@ inline void pj_ell_set(BGParams const& /*bg_params*/, std::vector<pvalue<T> >& p
             parameters.push_back(pj_mkparam<T>(pj_ellps[index].major));
             parameters.push_back(pj_mkparam<T>(pj_ellps[index].ell));
         }
-        a = pj_param(parameters, "da").f;
-        if (pj_param(parameters, "tes").i) /* eccentricity squared */
-            es = pj_param(parameters, "des").f;
-        else if (pj_param(parameters, "te").i) { /* eccentricity */
-            e = pj_param(parameters, "de").f;
+        a = pj_get_param_f(parameters, "a");
+        if (pj_param_f(parameters, "es", es)) {/* eccentricity squared */
+            /* empty */
+        } else if (pj_param_f(parameters, "e", e)) { /* eccentricity */
             es = e * e;
-        } else if (pj_param(parameters, "trf").i) { /* recip flattening */
-            es = pj_param(parameters, "drf").f;
+        } else if (pj_param_f(parameters, "rf", es)) { /* recip flattening */
             if (!es) {
                 BOOST_THROW_EXCEPTION( projection_exception(-10) );
             }
             es = 1./ es;
             es = es * (2. - es);
-        } else if (pj_param(parameters, "tf").i) { /* flattening */
-            es = pj_param(parameters, "df").f;
+        } else if (pj_param_f(parameters, "f", es)) { /* flattening */
             es = es * (2. - es);
-        } else if (pj_param(parameters, "tb").i) { /* minor axis */
-            b = pj_param(parameters, "db").f;
+        } else if (pj_param_f(parameters, "b", b)) { /* minor axis */
             es = 1. - (b * b) / (a * a);
         }     /* else es == 0. and sphere of radius a */
         if (!b)
             b = a * sqrt(1. - es);
         /* following options turn ellipsoid into equivalent sphere */
-        if (pj_param(parameters, "bR_A").i) { /* sphere--area of ellipsoid */
+        if (pj_get_param_b(parameters, "R_A")) { /* sphere--area of ellipsoid */
             a *= 1. - es * (SIXTH<T>() + es * (RA4<T>() + es * RA6<T>()));
             es = 0.;
-        } else if (pj_param(parameters, "bR_V").i) { /* sphere--vol. of ellipsoid */
+        } else if (pj_get_param_b(parameters, "R_V")) { /* sphere--vol. of ellipsoid */
             a *= 1. - es * (SIXTH<T>() + es * (RV4<T>() + es * RV6<T>()));
             es = 0.;
-        } else if (pj_param(parameters, "bR_a").i) { /* sphere--arithmetic mean */
+        } else if (pj_get_param_b(parameters, "R_a")) { /* sphere--arithmetic mean */
             a = .5 * (a + b);
             es = 0.;
-        } else if (pj_param(parameters, "bR_g").i) { /* sphere--geometric mean */
+        } else if (pj_get_param_b(parameters, "R_g")) { /* sphere--geometric mean */
             a = sqrt(a * b);
             es = 0.;
-        } else if (pj_param(parameters, "bR_h").i) { /* sphere--harmonic mean */
+        } else if (pj_get_param_b(parameters, "R_h")) { /* sphere--harmonic mean */
             a = 2. * a * b / (a + b);
             es = 0.;
         } else {
-            int i = pj_param(parameters, "tR_lat_a").i;
+            T tmp;
+            int i = pj_param_r(parameters, "R_lat_a", tmp);
             if (i || /* sphere--arith. */
-                pj_param(parameters, "tR_lat_g").i) { /* or geom. mean at latitude */
-                T tmp;
+                pj_param_r(parameters, "R_lat_g", tmp)) { /* or geom. mean at latitude */
 
-                tmp = sin(pj_param(parameters, i ? "rR_lat_a" : "rR_lat_g").f);
+                tmp = sin(tmp);
                 if (geometry::math::abs(tmp) > geometry::math::half_pi<T>()) {
                     BOOST_THROW_EXCEPTION( projection_exception(-11) );
                 }

--- a/include/boost/geometry/srs/projections/impl/pj_init.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_init.hpp
@@ -71,21 +71,21 @@ namespace detail
 template <typename BGParams, typename T>
 inline void pj_push_defaults(BGParams const& /*bg_params*/, parameters<T>& pin)
 {
-    pin.params.push_back(pj_mkparam<T>("ellps=WGS84"));
+    pin.params.push_back(pj_mkparam<T>("ellps", "WGS84"));
 
     if (pin.name == "aea")
     {
-        pin.params.push_back(pj_mkparam<T>("lat_1=29.5"));
-        pin.params.push_back(pj_mkparam<T>("lat_2=45.5 "));
+        pin.params.push_back(pj_mkparam<T>("lat_1", "29.5"));
+        pin.params.push_back(pj_mkparam<T>("lat_2", "45.5 "));
     }
     else if (pin.name == "lcc")
     {
-        pin.params.push_back(pj_mkparam<T>("lat_1=33"));
-        pin.params.push_back(pj_mkparam<T>("lat_2=45"));
+        pin.params.push_back(pj_mkparam<T>("lat_1", "33"));
+        pin.params.push_back(pj_mkparam<T>("lat_2", "45"));
     }
     else if (pin.name == "lagrng")
     {
-        pin.params.push_back(pj_mkparam<T>("W=2"));
+        pin.params.push_back(pj_mkparam<T>("W", "2"));
     }
 }
 
@@ -100,21 +100,21 @@ inline void pj_push_defaults(srs::static_proj4<BOOST_GEOMETRY_PROJECTIONS_DETAIL
         >::type proj_tag;
 
     // statically defaulting to WGS84
-    //pin.params.push_back(pj_mkparam("ellps=WGS84"));
+    //pin.params.push_back(pj_mkparam("ellps", "WGS84"));
 
     if (BOOST_GEOMETRY_CONDITION((boost::is_same<proj_tag, srs::par4::aea>::value)))
     {
-        pin.params.push_back(pj_mkparam<T>("lat_1=29.5"));
-        pin.params.push_back(pj_mkparam<T>("lat_2=45.5 "));
+        pin.params.push_back(pj_mkparam<T>("lat_1", "29.5"));
+        pin.params.push_back(pj_mkparam<T>("lat_2", "45.5 "));
     }
     else if (BOOST_GEOMETRY_CONDITION((boost::is_same<proj_tag, srs::par4::lcc>::value)))
     {
-        pin.params.push_back(pj_mkparam<T>("lat_1=33"));
-        pin.params.push_back(pj_mkparam<T>("lat_2=45"));
+        pin.params.push_back(pj_mkparam<T>("lat_1", "33"));
+        pin.params.push_back(pj_mkparam<T>("lat_2", "45"));
     }
     else if (BOOST_GEOMETRY_CONDITION((boost::is_same<proj_tag, srs::par4::lagrng>::value)))
     {
-        pin.params.push_back(pj_mkparam<T>("W=2"));
+        pin.params.push_back(pj_mkparam<T>("W", "2"));
     }
 }
 
@@ -128,7 +128,7 @@ inline void pj_init_units(std::vector<pvalue<T> > const& params,
                           T const& default_fr_meter)
 {
     std::string s;
-    std::string units = pj_param(params, sunits).s;
+    std::string units = pj_get_param_s(params, sunits);
     if (! units.empty())
     {
         const int n = sizeof(pj_units) / sizeof(pj_units[0]);
@@ -149,7 +149,7 @@ inline void pj_init_units(std::vector<pvalue<T> > const& params,
 
     if (s.empty())
     {
-        s = pj_param(params, sto_meter).s;
+        s = pj_get_param_s(params, sto_meter);
     }
 
     if (! s.empty())
@@ -200,15 +200,16 @@ inline parameters<T> pj_init(BGParams const& bg_params, R const& arguments, bool
         pin.params.push_back(pj_mkparam<T>(*it));
     }
 
+    // maybe TODO: handle "init" parameter
     /* check if +init present */
-    if (pj_param(pin.params, "tinit").i)
-    {
-        // maybe TODO: handle "init" parameter
-        //if (!(curr = get_init(&arguments, curr, pj_param(pin.params, "sinit").s)))
-    }
+    //std::string sinit;
+    //if (pj_param_s(pin.params, "init", sinit))
+    //{
+    //    //if (!(curr = get_init(&arguments, curr, sinit)))
+    //}
 
     // find projection -> implemented in projection factory
-    pin.name = pj_param(pin.params, "sproj").s;
+    pin.name = pj_get_param_s(pin.params, "proj");
     // exception thrown in projection<>
     // TODO: consider throwing here both projection_unknown_id_exception and
     // projection_not_named_exception in order to throw before other exceptions
@@ -217,7 +218,7 @@ inline parameters<T> pj_init(BGParams const& bg_params, R const& arguments, bool
 
     // set defaults, unless inhibited
     // GL-Addition, if use_defaults is false then defaults are ignored
-    if (use_defaults && ! pj_param(pin.params, "bno_defs").i)
+    if (use_defaults && ! pj_get_param_b(pin.params, "no_defs"))
     {
         // proj4 gets defaults from "proj_def.dat", file of 94/02/23 with a few defaults.
         // Here manually
@@ -262,45 +263,43 @@ inline parameters<T> pj_init(BGParams const& bg_params, R const& arguments, bool
     }
 
     /* set pin.geoc coordinate system */
-    pin.geoc = (pin.es && pj_param(pin.params, "bgeoc").i);
+    pin.geoc = (pin.es && pj_get_param_b(pin.params, "geoc"));
 
     /* over-ranging flag */
-    pin.over = pj_param(pin.params, "bover").i;
+    pin.over = pj_get_param_b(pin.params, "over");
 
     /* longitude center for wrapping */
-    pin.is_long_wrap_set = pj_param(pin.params, "tlon_wrap").i != 0;
-    if (pin.is_long_wrap_set)
-        pin.long_wrap_center = pj_param(pin.params, "rlon_wrap").f;
+    pin.is_long_wrap_set = pj_param_r(pin.params, "lon_wrap", pin.long_wrap_center);
 
     /* central meridian */
-    pin.lam0 = pj_param(pin.params, "rlon_0").f;
+    pin.lam0 = pj_get_param_r(pin.params, "lon_0");
 
     /* central latitude */
-    pin.phi0 = pj_param(pin.params, "rlat_0").f;
+    pin.phi0 = pj_get_param_r(pin.params, "lat_0");
 
     /* false easting and northing */
-    pin.x0 = pj_param(pin.params, "dx_0").f;
-    pin.y0 = pj_param(pin.params, "dy_0").f;
+    pin.x0 = pj_get_param_f(pin.params, "x_0");
+    pin.y0 = pj_get_param_f(pin.params, "y_0");
 
     /* general scaling factor */
-    if (pj_param(pin.params, "tk_0").i)
-        pin.k0 = pj_param(pin.params, "dk_0").f;
-    else if (pj_param(pin.params, "tk").i)
-        pin.k0 = pj_param(pin.params, "dk").f;
-    else
+    if (pj_param_f(pin.params, "k_0", pin.k0)) {
+        /* empty */
+    } else if (pj_param_f(pin.params, "k", pin.k0)) {
+        /* empty */
+    } else
         pin.k0 = 1.;
     if (pin.k0 <= 0.) {
         BOOST_THROW_EXCEPTION( projection_exception(-31) );
     }
 
     /* set units */
-    pj_init_units(pin.params, "sunits", "sto_meter",
+    pj_init_units(pin.params, "units", "to_meter",
                   pin.to_meter, pin.fr_meter, 1., 1.);
-    pj_init_units(pin.params, "svunits", "svto_meter",
+    pj_init_units(pin.params, "vunits", "vto_meter",
                   pin.vto_meter, pin.vfr_meter, pin.to_meter, pin.fr_meter);
 
     /* prime meridian */
-    std::string pm = pj_param(pin.params, "spm").s;
+    std::string pm = pj_get_param_s(pin.params, "pm");
     if (! pm.empty())
     {
         std::string value;

--- a/include/boost/geometry/srs/projections/impl/pj_param.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_param.hpp
@@ -3,8 +3,8 @@
 
 // Copyright (c) 2008-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -43,8 +43,13 @@
 #include <string>
 #include <vector>
 
+#include <boost/geometry/srs/projections/exception.hpp>
+
 #include <boost/geometry/srs/projections/impl/dms_parser.hpp>
 #include <boost/geometry/srs/projections/impl/projects.hpp>
+
+#include <boost/mpl/assert.hpp>
+#include <boost/type_traits/is_integral.hpp>
 
 
 namespace boost { namespace geometry { namespace projections {
@@ -52,6 +57,16 @@ namespace boost { namespace geometry { namespace projections {
 namespace detail {
 
 
+/* create pvalue list entry */
+template <typename T>
+inline pvalue<T> pj_mkparam(std::string const& name, std::string const& value)
+{
+    pvalue<T> newitem;
+    newitem.param = name;
+    newitem.s = value;
+    //newitem.used = false;
+    return newitem;
+}
 
 /* create pvalue list entry */
 template <typename T>
@@ -67,92 +82,146 @@ inline pvalue<T> pj_mkparam(std::string const& str)
         name.erase(loc);
     }
 
-
-    pvalue<T> newitem;
-    newitem.param = name;
-    newitem.s = value;
-    newitem.used = 0;
-    newitem.i = atoi(value.c_str());
-    newitem.f = atof(value.c_str());
-    return newitem;
+    return pj_mkparam<T>(name, value);
 }
 
-/************************************************************************/
-/*                              pj_param()                              */
-/*                                                                      */
-/*      Test for presence or get pvalue value.  The first            */
-/*      character in `opt' is a pvalue type which can take the       */
-/*      values:                                                         */
-/*                                                                      */
-/*       `t' - test for presence, return TRUE/FALSE in pvalue.i         */
-/*       `i' - integer value returned in pvalue.i                       */
-/*       `d' - simple valued real input returned in pvalue.f            */
-/*       `r' - degrees (DMS translation applied), returned as           */
-/*             radians in pvalue.f                                      */
-/*       `s' - string returned in pvalue.s                              */
-/*       `b' - test for t/T/f/F, return in pvalue.i                     */
-/*                                                                      */
-/************************************************************************/
-
+/* input exists */
 template <typename T>
-inline pvalue<T> pj_param(std::vector<pvalue<T> > const& pl, std::string opt)
+inline typename std::vector<pvalue<T> >::const_iterator
+    pj_param_find(std::vector<pvalue<T> > const& pl, std::string const& name)
 {
-    char type = opt[0];
-    opt.erase(opt.begin());
-
-    pvalue<T> value;
-
-    /* simple linear lookup */
     typedef typename std::vector<pvalue<T> >::const_iterator iterator;
     for (iterator it = pl.begin(); it != pl.end(); it++)
     {
-        if (it->param == opt)
+        if (it->param == name)
         {
-            //it->used = 1;
-            switch (type)
-            {
-            case 't':
-                value.i = 1;
-                break;
-            case 'i':    /* integer input */
-                value.i = atoi(it->s.c_str());
-                break;
-            case 'd':    /* simple real input */
-                value.f = atof(it->s.c_str());
-                break;
-            case 'r':    /* degrees input */
-                {
-                    dms_parser<T, true> parser;
-                    value.f = parser.apply(it->s.c_str()).angle();
-                }
-                break;
-            case 's':    /* char string */
-                value.s = it->s;
-                break;
-            case 'b':    /* boolean */
-                switch (it->s[0])
-                {
-                case 'F': case 'f':
-                    value.i = 0;
-                    break;
-                case '\0': case 'T': case 't':
-                    value.i = 1;
-                    break;
-                default:
-                    value.i = 0;
-                    break;
-                }
-                break;
-            }
-            return value;
+            //it->used = true;
+            return it;
         }
-
+        // TODO: needed for pipeline
+        /*else if (it->param == "step")
+        {
+            return pl.end();
+        }*/
     }
 
-    value.i = 0;
-    value.f = 0.0;
-    value.s = "";
-    return value;
+    return pl.end();
+}
+
+/* input exists */
+template <typename T>
+inline bool pj_param_exists(std::vector<pvalue<T> > const& pl, std::string const& name)
+{
+    return pj_param_find(pl, name) != pl.end();
+}
+
+/* integer input */
+template <typename T>
+inline bool pj_param_i(std::vector<pvalue<T> > const& pl, std::string const& name, int & par)
+{
+    typename std::vector<pvalue<T> >::const_iterator it = pj_param_find(pl, name);        
+    if (it != pl.end())
+    {
+        par = atoi(it->s.c_str());
+        return true;
+    }    
+    return false;
+}
+
+/* floating point input */
+template <typename T>
+inline bool pj_param_f(std::vector<pvalue<T> > const& pl, std::string const& name, T & par)
+{
+    typename std::vector<pvalue<T> >::const_iterator it = pj_param_find(pl, name);        
+    if (it != pl.end())
+    {
+        par = atof(it->s.c_str());
+        return true;
+    }    
+    return false;
+}
+
+/* radians input */
+template <typename T>
+inline bool pj_param_r(std::vector<pvalue<T> > const& pl, std::string const& name, T & par)
+{
+    typename std::vector<pvalue<T> >::const_iterator it = pj_param_find(pl, name);        
+    if (it != pl.end())
+    {
+        dms_parser<T, true> parser;
+        par = parser.apply(it->s.c_str()).angle();
+        return true;
+    }    
+    return false;
+}
+
+/* string input */
+template <typename T>
+inline bool pj_param_s(std::vector<pvalue<T> > const& pl, std::string const& name, std::string & par)
+{
+    typename std::vector<pvalue<T> >::const_iterator it = pj_param_find(pl, name);        
+    if (it != pl.end())
+    {
+        par = it->s;
+        return true;
+    }    
+    return false;
+}
+
+/* bool input */
+template <typename T>
+inline bool pj_get_param_b(std::vector<pvalue<T> > const& pl, std::string const& name)
+{
+    typename std::vector<pvalue<T> >::const_iterator it = pj_param_find(pl, name);        
+    if (it != pl.end())
+    {
+        switch (it->s[0])
+        {
+        case '\0': case 'T': case 't':
+            return true;
+        case 'F': case 'f':
+            return false;
+        default:
+            BOOST_THROW_EXCEPTION( projection_exception(-8) );
+            return false;
+        }
+    }    
+    return false;
+}
+
+// NOTE: In the original code, in pl_ell_set.c there is a function pj_get_param
+// which behavior is similar to pj_param but it doesn't set `user` member to TRUE
+// while pj_param does in the original code. In Boost.Geometry this member is not used.
+template <typename T>
+inline int pj_get_param_i(std::vector<pvalue<T> > const& pl, std::string const& name)
+{
+    int res = 0;
+    pj_param_i(pl, name, res);
+    return res;
+}
+
+template <typename T>
+inline T pj_get_param_f(std::vector<pvalue<T> > const& pl, std::string const& name)
+{
+    T res = 0;
+    pj_param_f(pl, name, res);
+    return res;
+}
+
+template <typename T>
+inline T pj_get_param_r(std::vector<pvalue<T> > const& pl, std::string const& name)
+{
+    T res = 0;
+    pj_param_r(pl, name, res);
+    return res;
+}
+
+template <typename T>
+inline std::string pj_get_param_s(std::vector<pvalue<T> > const& pl, std::string const& name)
+{
+    std::string res;
+    pj_param_s(pl, name, res);
+    return res;
 }
 
 } // namespace detail

--- a/include/boost/geometry/srs/projections/impl/pj_transform.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_transform.hpp
@@ -742,8 +742,8 @@ inline bool pj_compare_datums( Par & srcdefn, Par & dstdefn )
     }
     else if( srcdefn.datum_type == PJD_GRIDSHIFT )
     {
-        return pj_param(srcdefn.params,"snadgrids").s
-            == pj_param(dstdefn.params,"snadgrids").s;
+        return pj_get_param_s(srcdefn.params,"nadgrids")
+            == pj_get_param_s(dstdefn.params,"nadgrids");
     }
     else
         return true;

--- a/include/boost/geometry/srs/projections/impl/projects.hpp
+++ b/include/boost/geometry/srs/projections/impl/projects.hpp
@@ -100,11 +100,8 @@ template <typename T>
 struct pvalue
 {
     std::string param;
-    int used;
-
-    int i;
-    T f;
     std::string s;
+    //int used;
 };
 
 template <typename T>

--- a/include/boost/geometry/srs/projections/proj/aea.hpp
+++ b/include/boost/geometry/srs/projections/proj/aea.hpp
@@ -238,8 +238,8 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_aea(Parameters& par, par_aea<T>& proj_parm)
             {
-                proj_parm.phi1 = pj_param(par.params, "rlat_1").f;
-                proj_parm.phi2 = pj_param(par.params, "rlat_2").f;
+                proj_parm.phi1 = pj_get_param_r(par.params, "lat_1");
+                proj_parm.phi2 = pj_get_param_r(par.params, "lat_2");
                 setup(par, proj_parm);
             }
 
@@ -249,8 +249,8 @@ namespace projections
             {
                 static const T HALFPI = detail::HALFPI<T>();
 
-                proj_parm.phi2 = pj_param(par.params, "rlat_1").f;
-                proj_parm.phi1 = pj_param(par.params, "bsouth").i ? -HALFPI : HALFPI;
+                proj_parm.phi2 = pj_get_param_r(par.params, "lat_1");
+                proj_parm.phi1 = pj_get_param_b(par.params, "south") ? -HALFPI : HALFPI;
                 setup(par, proj_parm);
             }
 

--- a/include/boost/geometry/srs/projections/proj/aeqd.hpp
+++ b/include/boost/geometry/srs/projections/proj/aeqd.hpp
@@ -292,7 +292,7 @@ namespace projections
             {
                 static const T HALFPI = detail::HALFPI<T>();
 
-                par.phi0 = pj_param(par.params, "rlat_0").f;
+                par.phi0 = pj_get_param_r(par.params, "lat_0");
                 if (fabs(fabs(par.phi0) - HALFPI) < EPS10) {
                     proj_parm.mode = par.phi0 < 0. ? S_POLE : N_POLE;
                     proj_parm.sinph0 = par.phi0 < 0. ? -1. : 1.;
@@ -626,7 +626,7 @@ namespace projections
             public :
                 virtual base_v<CalculationType, Parameters>* create_new(const Parameters& par) const
                 {
-                    bool const guam = pj_param(par.params, "bguam").i != 0;
+                    bool const guam = pj_get_param_b(par.params, "guam");
 
                     if (par.es && ! guam)
                         return new base_v_fi<aeqd_e<CalculationType, Parameters>, CalculationType, Parameters>(par);

--- a/include/boost/geometry/srs/projections/proj/airy.hpp
+++ b/include/boost/geometry/srs/projections/proj/airy.hpp
@@ -169,8 +169,8 @@ namespace projections
 
                 T beta;
 
-                proj_parm.no_cut = pj_param(par.params, "bno_cut").i;
-                beta = 0.5 * (HALFPI - pj_param(par.params, "rlat_b").f);
+                proj_parm.no_cut = pj_get_param_b(par.params, "no_cut");
+                beta = 0.5 * (HALFPI - pj_get_param_r(par.params, "lat_b"));
                 if (fabs(beta) < EPS)
                     proj_parm.Cb = -0.5;
                 else {

--- a/include/boost/geometry/srs/projections/proj/aitoff.hpp
+++ b/include/boost/geometry/srs/projections/proj/aitoff.hpp
@@ -233,9 +233,11 @@ namespace projections
             {
                 static const T TWO_D_PI = detail::TWO_D_PI<T>();
 
+                T phi1;
+
                 proj_parm.mode = WINKEL_TRIPEL;
-                if (pj_param(par.params, "tlat_1").i) {
-                    if ((proj_parm.cosphi1 = cos(pj_param(par.params, "rlat_1").f)) == 0.)
+                if (pj_param_r(par.params, "lat_1", phi1)) {
+                    if ((proj_parm.cosphi1 = cos(phi1)) == 0.)
                         BOOST_THROW_EXCEPTION( projection_exception(-22) );
                 } else /* 50d28' or phi1=acos(2/pi) */
                     proj_parm.cosphi1 = TWO_D_PI;

--- a/include/boost/geometry/srs/projections/proj/bipc.hpp
+++ b/include/boost/geometry/srs/projections/proj/bipc.hpp
@@ -234,7 +234,7 @@ namespace projections
             template <typename Parameters>
             inline void setup_bipc(Parameters& par, par_bipc& proj_parm)
             {
-                proj_parm.noskew = pj_param(par.params, "bns").i;
+                proj_parm.noskew = pj_get_param_b(par.params, "ns");
                 par.es = 0.;
             }
 

--- a/include/boost/geometry/srs/projections/proj/bonne.hpp
+++ b/include/boost/geometry/srs/projections/proj/bonne.hpp
@@ -193,7 +193,7 @@ namespace projections
 
                 T c;
 
-                proj_parm.phi1 = pj_param(par.params, "rlat_1").f;
+                proj_parm.phi1 = pj_get_param_r(par.params, "lat_1");
                 if (fabs(proj_parm.phi1) < EPS10)
                     BOOST_THROW_EXCEPTION( projection_exception(-23) );
 

--- a/include/boost/geometry/srs/projections/proj/cea.hpp
+++ b/include/boost/geometry/srs/projections/proj/cea.hpp
@@ -165,8 +165,8 @@ namespace projections
             {
                 T t = 0;
 
-                if (pj_param(par.params, "tlat_ts").i) {
-                    par.k0 = cos(t = pj_param(par.params, "rlat_ts").f);
+                if (pj_param_r(par.params, "lat_ts", t)) {
+                    par.k0 = cos(t);
                     if (par.k0 < 0.) {
                         BOOST_THROW_EXCEPTION( projection_exception(-24) );
                     }

--- a/include/boost/geometry/srs/projections/proj/chamb.hpp
+++ b/include/boost/geometry/srs/projections/proj/chamb.hpp
@@ -190,14 +190,14 @@ namespace projections
             {
                 static const T ONEPI = detail::ONEPI<T>();
 
+                static const std::string lat[3] = {"lat_1", "lat_2", "lat_3"};
+                static const std::string lon[3] = {"lon_1", "lon_2", "lon_3"};
+
                 int i, j;
-                char line[10];
 
                 for (i = 0; i < 3; ++i) { /* get control point locations */
-                    (void)sprintf(line, "rlat_%d", i+1);
-                    proj_parm.c[i].phi = pj_param(par.params, line).f;
-                    (void)sprintf(line, "rlon_%d", i+1);
-                    proj_parm.c[i].lam = pj_param(par.params, line).f;
+                    proj_parm.c[i].phi = pj_get_param_r(par.params, lat[i]);
+                    proj_parm.c[i].lam = pj_get_param_r(par.params, lon[i]);
                     proj_parm.c[i].lam = adjlon(proj_parm.c[i].lam - par.lam0);
                     proj_parm.c[i].cosphi = cos(proj_parm.c[i].phi);
                     proj_parm.c[i].sinphi = sin(proj_parm.c[i].phi);

--- a/include/boost/geometry/srs/projections/proj/eqc.hpp
+++ b/include/boost/geometry/srs/projections/proj/eqc.hpp
@@ -107,7 +107,7 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_eqc(Parameters& par, par_eqc<T>& proj_parm)
             {
-                if ((proj_parm.rc = cos(pj_param(par.params, "rlat_ts").f)) <= 0.)
+                if ((proj_parm.rc = cos(pj_get_param_r(par.params, "lat_ts"))) <= 0.)
                     BOOST_THROW_EXCEPTION( projection_exception(-24) );
                 par.es = 0.;
             }

--- a/include/boost/geometry/srs/projections/proj/eqdc.hpp
+++ b/include/boost/geometry/srs/projections/proj/eqdc.hpp
@@ -144,8 +144,8 @@ namespace projections
                 T cosphi, sinphi;
                 int secant;
 
-                proj_parm.phi1 = pj_param(par.params, "rlat_1").f;
-                proj_parm.phi2 = pj_param(par.params, "rlat_2").f;
+                proj_parm.phi1 = pj_get_param_r(par.params, "lat_1");
+                proj_parm.phi2 = pj_get_param_r(par.params, "lat_2");
 
                 if (fabs(proj_parm.phi1 + proj_parm.phi2) < EPS10)
                     BOOST_THROW_EXCEPTION( projection_exception(-21) );

--- a/include/boost/geometry/srs/projections/proj/etmerc.hpp
+++ b/include/boost/geometry/srs/projections/proj/etmerc.hpp
@@ -354,11 +354,10 @@ namespace projections
                     BOOST_THROW_EXCEPTION( projection_exception(-34) );
                 }
 
-                par.y0 = pj_param(par.params, "bsouth").i ? 10000000. : 0.;
+                par.y0 = pj_get_param_b(par.params, "south") ? 10000000. : 0.;
                 par.x0 = 500000.;
-                if (pj_param(par.params, "tzone").i) /* zone input ? */
+                if (pj_param_i(par.params, "zone", zone)) /* zone input ? */
                 {
-                    zone = pj_param(par.params, "izone").i;
                     if (zone > 0 && zone <= 60)
                         --zone;
                     else {

--- a/include/boost/geometry/srs/projections/proj/fouc_s.hpp
+++ b/include/boost/geometry/srs/projections/proj/fouc_s.hpp
@@ -134,7 +134,7 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_fouc_s(Parameters& par, par_fouc_s<T>& proj_parm)
             {
-                proj_parm.n = pj_param(par.params, "dn").f;
+                proj_parm.n = pj_get_param_f(par.params, "n");
                 if (proj_parm.n < 0. || proj_parm.n > 1.)
                     BOOST_THROW_EXCEPTION( projection_exception(-40) );
 

--- a/include/boost/geometry/srs/projections/proj/geos.hpp
+++ b/include/boost/geometry/srs/projections/proj/geos.hpp
@@ -264,13 +264,13 @@ namespace projections
             {
                 std::string sweep_axis;
 
-                if ((proj_parm.h = pj_param(par.params, "dh").f) <= 0.)
+                if ((proj_parm.h = pj_get_param_f(par.params, "h")) <= 0.)
                     BOOST_THROW_EXCEPTION( projection_exception(-30) );
 
                 if (par.phi0 != 0.0)
                     BOOST_THROW_EXCEPTION( projection_exception(-46) );
 
-                sweep_axis = pj_param(par.params, "ssweep").s;
+                sweep_axis = pj_get_param_s(par.params, "sweep");
                 if (sweep_axis.empty())
                     proj_parm.flip_axis = 0;
                 else {

--- a/include/boost/geometry/srs/projections/proj/gn_sinu.hpp
+++ b/include/boost/geometry/srs/projections/proj/gn_sinu.hpp
@@ -200,9 +200,8 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_gn_sinu(Parameters& par, par_gn_sinu<T>& proj_parm)
             {
-                if (pj_param(par.params, "tn").i && pj_param(par.params, "tm").i) {
-                    proj_parm.n = pj_param(par.params, "dn").f;
-                    proj_parm.m = pj_param(par.params, "dm").f;
+                if (pj_param_f(par.params, "n", proj_parm.n)
+                 && pj_param_f(par.params, "m", proj_parm.m)) {
                     if (proj_parm.n <= 0 || proj_parm.m < 0)
                         BOOST_THROW_EXCEPTION( projection_exception(-39) );
                 } else

--- a/include/boost/geometry/srs/projections/proj/hammer.hpp
+++ b/include/boost/geometry/srs/projections/proj/hammer.hpp
@@ -122,13 +122,15 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_hammer(Parameters& par, par_hammer<T>& proj_parm)
             {
-                if (pj_param(par.params, "tW").i) {
-                    if ((proj_parm.w = fabs(pj_param(par.params, "dW").f)) <= 0.)
+                T tmp;
+
+                if (pj_param_f(par.params, "W", tmp)) {
+                    if ((proj_parm.w = fabs(tmp)) <= 0.)
                         BOOST_THROW_EXCEPTION( projection_exception(-27) );
                 } else
                     proj_parm.w = .5;
-                if (pj_param(par.params, "tM").i) {
-                    if ((proj_parm.m = fabs(pj_param(par.params, "dM").f)) <= 0.)
+                if (pj_param_f(par.params, "M", tmp)) {
+                    if ((proj_parm.m = fabs(tmp)) <= 0.)
                         BOOST_THROW_EXCEPTION( projection_exception(-27) );
                 } else
                     proj_parm.m = 1.;

--- a/include/boost/geometry/srs/projections/proj/healpix.hpp
+++ b/include/boost/geometry/srs/projections/proj/healpix.hpp
@@ -745,8 +745,8 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_rhealpix(Parameters& par, par_healpix<T>& proj_parm)
             {
-                proj_parm.north_square = pj_param(par.params,"inorth_square").i;
-                proj_parm.south_square = pj_param(par.params,"isouth_square").i;
+                proj_parm.north_square = pj_get_param_i(par.params, "north_square");
+                proj_parm.south_square = pj_get_param_i(par.params, "south_square");
                 /* Check for valid north_square and south_square inputs. */
                 if (proj_parm.north_square < 0 || proj_parm.north_square > 3) {
                     BOOST_THROW_EXCEPTION( projection_exception(-47) );

--- a/include/boost/geometry/srs/projections/proj/imw_p.hpp
+++ b/include/boost/geometry/srs/projections/proj/imw_p.hpp
@@ -90,12 +90,12 @@ namespace projections
             {
                 int err = 0;
 
-                if (!pj_param(par.params, "tlat_1").i ||
-                    !pj_param(par.params, "tlat_2").i) {
+                if (!pj_param_r(par.params, "lat_1", proj_parm.phi_1) ||
+                    !pj_param_r(par.params, "lat_2", proj_parm.phi_2)) {
                     err = -41;
                 } else {
-                    proj_parm.phi_1 = pj_param(par.params, "rlat_1").f;
-                    proj_parm.phi_2 = pj_param(par.params, "rlat_2").f;
+                    //proj_parm.phi_1 = pj_get_param_r(par.params, "lat_1"); // set above
+                    //proj_parm.phi_2 = pj_get_param_r(par.params, "lat_2"); // set above
                     *del = 0.5 * (proj_parm.phi_2 - proj_parm.phi_1);
                     *sig = 0.5 * (proj_parm.phi_2 + proj_parm.phi_1);
                     err = (fabs(*del) < EPS || fabs(*sig) < EPS) ? -42 : 0;
@@ -235,9 +235,9 @@ namespace projections
                     proj_parm.phi_1 = proj_parm.phi_2;
                     proj_parm.phi_2 = del;
                 }
-                if (pj_param(par.params, "tlon_1").i)
-                    proj_parm.lam_1 = pj_param(par.params, "rlon_1").f;
-                else { /* use predefined based upon latitude */
+                if (pj_param_r(par.params, "lon_1", proj_parm.lam_1)) {
+                    /* empty */
+                } else { /* use predefined based upon latitude */
                     sig = fabs(sig * geometry::math::r2d<T>());
                     if (sig <= 60)      sig = 2.;
                     else if (sig <= 76) sig = 4.;

--- a/include/boost/geometry/srs/projections/proj/isea.hpp
+++ b/include/boost/geometry/srs/projections/proj/isea.hpp
@@ -1171,7 +1171,7 @@ namespace projections
             /*        proj_parm.dgg.radius = par.a; / * otherwise defaults to 1 */
                 /* calling library will scale, I think */
 
-                opt = pj_param(par.params, "sorient").s;
+                opt = pj_get_param_s(par.params, "orient");
                 if (! opt.empty()) {
                     if (opt == std::string("isea")) {
                         isea_orient_isea(&proj_parm.dgg);
@@ -1182,29 +1182,15 @@ namespace projections
                     }
                 }
 
-                if (pj_param(par.params, "tazi").i) {
-                    proj_parm.dgg.o_az = pj_param(par.params, "razi").f;
-                }
-
-                if (pj_param(par.params, "tlon_0").i) {
-                    proj_parm.dgg.o_lon = pj_param(par.params, "rlon_0").f;
-                }
-
-                if (pj_param(par.params, "tlat_0").i) {
-                    proj_parm.dgg.o_lat = pj_param(par.params, "rlat_0").f;
-                }
-
+                pj_param_r(par.params, "azi", proj_parm.dgg.o_az);
+                pj_param_r(par.params, "lon_0", proj_parm.dgg.o_lon);
+                pj_param_r(par.params, "lat_0", proj_parm.dgg.o_lat);
                 // TODO: this parameter is set below second time
-                if (pj_param(par.params, "taperture").i) {
-                    proj_parm.dgg.aperture = pj_param(par.params, "iaperture").i;
-                }
-
+                pj_param_i(par.params, "aperture", proj_parm.dgg.aperture);
                 // TODO: this parameter is set below second time
-                if (pj_param(par.params, "tresolution").i) {
-                    proj_parm.dgg.resolution = pj_param(par.params, "iresolution").i;
-                }
-
-                opt = pj_param(par.params, "smode").s;
+                pj_param_i(par.params, "resolution", proj_parm.dgg.resolution);
+                
+                opt = pj_get_param_s(par.params, "mode");
                 if (! opt.empty()) {
                     if (opt == std::string("plane")) {
                         proj_parm.dgg.output = ISEA_PLANE;
@@ -1223,18 +1209,19 @@ namespace projections
                     }
                 }
 
-                if (pj_param(par.params, "trescale").i) {
+                // TODO: pj_param_exists -> pj_get_param_b ?
+                if (pj_param_exists(par.params, "rescale")) {
                     proj_parm.dgg.radius = ISEA_SCALE;
                 }
 
-                if (pj_param(par.params, "tresolution").i) {
-                    proj_parm.dgg.resolution = pj_param(par.params, "iresolution").i;
+                if (pj_param_i(par.params, "resolution", proj_parm.dgg.resolution)) {
+                    /* empty */
                 } else {
                     proj_parm.dgg.resolution = 4;
                 }
 
-                if (pj_param(par.params, "taperture").i) {
-                    proj_parm.dgg.aperture = pj_param(par.params, "iaperture").i;
+                if (pj_param_i(par.params, "aperture", proj_parm.dgg.aperture)) {
+                    /* empty */
                 } else {
                     proj_parm.dgg.aperture = 3;
                 }

--- a/include/boost/geometry/srs/projections/proj/krovak.hpp
+++ b/include/boost/geometry/srs/projections/proj/krovak.hpp
@@ -208,21 +208,21 @@ namespace projections
                 par.e = sqrt(par.es = 0.006674372230614);
 
                 /* if latitude of projection center is not set, use 49d30'N */
-                if (!pj_param(par.params, "tlat_0").i)
+                if (!pj_param_exists(par.params, "lat_0"))
                     par.phi0 = 0.863937979737193;
 
                 /* if center long is not set use 42d30'E of Ferro - 17d40' for Ferro */
                 /* that will correspond to using longitudes relative to greenwich    */
                 /* as input and output, instead of lat/long relative to Ferro */
-                if (!pj_param(par.params, "tlon_0").i)
+                if (!pj_param_exists(par.params, "lon_0"))
                     par.lam0 = 0.7417649320975901 - 0.308341501185665;
 
                 /* if scale not set default to 0.9999 */
-                if (!pj_param(par.params, "tk").i)
+                if (!pj_param_exists(par.params, "k"))
                     par.k0 = 0.9999;
 
                 proj_parm.czech = 1;
-                if( !pj_param(par.params, "tczech").i )
+                if( !pj_param_exists(par.params, "czech") )
                     proj_parm.czech = -1;
 
                 /* Set up shared parameters between forward and inverse */

--- a/include/boost/geometry/srs/projections/proj/labrd.hpp
+++ b/include/boost/geometry/srs/projections/proj/labrd.hpp
@@ -185,8 +185,8 @@ namespace projections
 
                 T Az, sinp, R, N, t;
 
-                proj_parm.rot    = pj_param(par.params, "bno_rot").i == 0;
-                Az = pj_param(par.params, "razi").f;
+                proj_parm.rot    = pj_get_param_b(par.params, "no_rot");
+                Az = pj_get_param_r(par.params, "azi");
                 sinp = sin(par.phi0);
                 t = 1. - par.es * sinp * sinp;
                 N = 1. / sqrt(t);

--- a/include/boost/geometry/srs/projections/proj/lagrng.hpp
+++ b/include/boost/geometry/srs/projections/proj/lagrng.hpp
@@ -122,13 +122,13 @@ namespace projections
             {
                 T phi1;
 
-                proj_parm.rw = pj_param(par.params, "dW").f;
+                proj_parm.rw = pj_get_param_f(par.params, "W");
                 if (proj_parm.rw <= 0)
                     BOOST_THROW_EXCEPTION( projection_exception(-27) );
 
                 proj_parm.rw = 1. / proj_parm.rw;
                 proj_parm.hrw = 0.5 * proj_parm.rw;
-                phi1 = pj_param(par.params, "rlat_1").f;
+                phi1 = pj_get_param_r(par.params, "lat_1");
                 if (fabs(fabs(phi1 = sin(phi1)) - 1.) < TOL)
                     BOOST_THROW_EXCEPTION( projection_exception(-22) );
 

--- a/include/boost/geometry/srs/projections/proj/lcc.hpp
+++ b/include/boost/geometry/srs/projections/proj/lcc.hpp
@@ -167,12 +167,12 @@ namespace projections
                 T cosphi, sinphi;
                 int secant;
 
-                proj_parm.phi1 = pj_param(par.params, "rlat_1").f;
-                if (pj_param(par.params, "tlat_2").i)
-                    proj_parm.phi2 = pj_param(par.params, "rlat_2").f;
-                else {
+                proj_parm.phi1 = pj_get_param_r(par.params, "lat_1");
+                if (pj_param_r(par.params, "lat_2", proj_parm.phi2)) {
+                    /* empty */
+                } else {
                     proj_parm.phi2 = proj_parm.phi1;
-                    if (!pj_param(par.params, "tlat_0").i)
+                    if (!pj_param_exists(par.params, "lat_0"))
                         par.phi0 = proj_parm.phi1;
                 }
                 if (fabs(proj_parm.phi1 + proj_parm.phi2) < EPS10)

--- a/include/boost/geometry/srs/projections/proj/loxim.hpp
+++ b/include/boost/geometry/srs/projections/proj/loxim.hpp
@@ -137,7 +137,7 @@ namespace projections
             {
                 static const T FORTPI = detail::FORTPI<T>();
 
-                proj_parm.phi1 = pj_param(par.params, "rlat_1").f;
+                proj_parm.phi1 = pj_get_param_r(par.params, "lat_1");
                 proj_parm.cosphi1 = cos(proj_parm.phi1);
                 if (proj_parm.cosphi1 < EPS)
                     BOOST_THROW_EXCEPTION( projection_exception(-22) );

--- a/include/boost/geometry/srs/projections/proj/lsat.hpp
+++ b/include/boost/geometry/srs/projections/proj/lsat.hpp
@@ -247,11 +247,11 @@ namespace projections
                 int land, path;
                 T lam, alf, esc, ess;
 
-                land = pj_param(par.params, "ilsat").i;
+                land = pj_get_param_i(par.params, "lsat");
                 if (land <= 0 || land > 5)
                     BOOST_THROW_EXCEPTION( projection_exception(-28) );
 
-                path = pj_param(par.params, "ipath").i;
+                path = pj_get_param_i(par.params, "path");
                 if (path <= 0 || path > (land <= 3 ? 251 : 233))
                     BOOST_THROW_EXCEPTION( projection_exception(-29) );
 

--- a/include/boost/geometry/srs/projections/proj/merc.hpp
+++ b/include/boost/geometry/srs/projections/proj/merc.hpp
@@ -166,8 +166,8 @@ namespace projections
                 calc_t phits=0.0;
                 int is_phits;
 
-                if( (is_phits = pj_param(par.params, "tlat_ts").i) ) {
-                    phits = fabs(pj_param(par.params, "rlat_ts").f);
+                if( (is_phits = pj_param_r(par.params, "lat_ts", phits)) ) {
+                    phits = fabs(phits);
                     if (phits >= HALFPI)
                         BOOST_THROW_EXCEPTION( projection_exception(-24) );
                 }

--- a/include/boost/geometry/srs/projections/proj/nsper.hpp
+++ b/include/boost/geometry/srs/projections/proj/nsper.hpp
@@ -218,7 +218,7 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup(Parameters& par, par_nsper<T>& proj_parm) 
             {
-                if ((proj_parm.height = pj_param(par.params, "dh").f) <= 0.)
+                if ((proj_parm.height = pj_get_param_f(par.params, "h")) <= 0.)
                     BOOST_THROW_EXCEPTION( projection_exception(-30) );
 
                 if (fabs(fabs(par.phi0) - geometry::math::half_pi<T>()) < EPS10)
@@ -254,8 +254,8 @@ namespace projections
             {
                 T omega, gamma;
 
-                omega = pj_param(par.params, "dtilt").f * geometry::math::d2r<T>();
-                gamma = pj_param(par.params, "dazi").f * geometry::math::d2r<T>();
+                omega = pj_get_param_r(par.params, "tilt");
+                gamma = pj_get_param_r(par.params, "azi");
                 proj_parm.tilt = 1;
                 proj_parm.cg = cos(gamma); proj_parm.sg = sin(gamma);
                 proj_parm.cw = cos(omega); proj_parm.sw = sin(omega);

--- a/include/boost/geometry/srs/projections/proj/ob_tran.hpp
+++ b/include/boost/geometry/srs/projections/proj/ob_tran.hpp
@@ -84,7 +84,7 @@ namespace projections
                 Parameters pj = par;
 
                 /* get name of projection to be translated */
-                pj.name = pj_param(par.params, "so_proj").s;
+                pj.name = pj_get_param_s(par.params, "o_proj");
                 if (pj.name.empty())
                     BOOST_THROW_EXCEPTION( projection_exception(-26) );
 
@@ -233,34 +233,34 @@ namespace projections
             {
                 static const CalculationType HALFPI = detail::HALFPI<CalculationType>();
 
-                CalculationType phip;
+                CalculationType phip, alpha;
 
                 par.es = 0.; /* force to spherical */
 
                 // proj_parm.link should be created at this point
 
-                if (pj_param(par.params, "to_alpha").i) {
-                    CalculationType lamc, phic, alpha;
+                if (pj_param_r(par.params, "o_alpha", alpha)) {
+                    CalculationType lamc, phic;
 
-                    lamc    = pj_param(par.params, "ro_lon_c").f;
-                    phic    = pj_param(par.params, "ro_lat_c").f;
-                    alpha    = pj_param(par.params, "ro_alpha").f;
+                    lamc    = pj_get_param_r(par.params, "o_lon_c");
+                    phic    = pj_get_param_r(par.params, "o_lat_c");
+                    //alpha   = pj_get_param_r(par.params, "o_alpha");
             
                     if (fabs(fabs(phic) - HALFPI) <= TOL)
                         BOOST_THROW_EXCEPTION( projection_exception(-33) );
 
                     proj_parm.lamp = lamc + aatan2(-cos(alpha), -sin(alpha) * sin(phic));
                     phip = aasin(cos(phic) * sin(alpha));
-                } else if (pj_param(par.params, "to_lat_p").i) { /* specified new pole */
-                    proj_parm.lamp = pj_param(par.params, "ro_lon_p").f;
-                    phip = pj_param(par.params, "ro_lat_p").f;
+                } else if (pj_param_r(par.params, "o_lat_p", phip)) { /* specified new pole */
+                    proj_parm.lamp = pj_get_param_r(par.params, "o_lon_p");
+                    //phip = pj_param_r(par.params, "o_lat_p");
                 } else { /* specified new "equator" points */
                     CalculationType lam1, lam2, phi1, phi2, con;
 
-                    lam1 = pj_param(par.params, "ro_lon_1").f;
-                    phi1 = pj_param(par.params, "ro_lat_1").f;
-                    lam2 = pj_param(par.params, "ro_lon_2").f;
-                    phi2 = pj_param(par.params, "ro_lat_2").f;
+                    lam1 = pj_get_param_r(par.params, "o_lon_1");
+                    phi1 = pj_get_param_r(par.params, "o_lat_1");
+                    lam2 = pj_get_param_r(par.params, "o_lon_2");
+                    phi2 = pj_get_param_r(par.params, "o_lat_2");
                     if (fabs(phi1 - phi2) <= TOL || (con = fabs(phi1)) <= TOL ||
                         fabs(con - HALFPI) <= TOL || fabs(fabs(phi2) - HALFPI) <= TOL)
                         BOOST_THROW_EXCEPTION( projection_exception(-32) );

--- a/include/boost/geometry/srs/projections/proj/ocea.hpp
+++ b/include/boost/geometry/srs/projections/proj/ocea.hpp
@@ -136,10 +136,10 @@ namespace projections
                 proj_parm.rok = 1. / par.k0;
                 proj_parm.rtk = par.k0;
                 /*If the keyword "alpha" is found in the sentence then use 1point+1azimuth*/
-                if ( pj_param(par.params, "talpha").i) {
+                if ( pj_param_r(par.params, "alpha", alpha)) {
                     /*Define Pole of oblique transformation from 1 point & 1 azimuth*/
-                    alpha    = pj_param(par.params, "ralpha").f;
-                    lonz = pj_param(par.params, "rlonc").f;
+                    //alpha = pj_get_param_r(par.params, "alpha"); // set above
+                    lonz = pj_get_param_r(par.params, "lonc");
                     /*Equation 9-8 page 80 (http://pubs.usgs.gov/pp/1395/report.pdf)*/
                     proj_parm.singam = atan(-cos(alpha)/(-sin(phi_0) * sin(alpha))) + lonz;
                     /*Equation 9-7 page 80 (http://pubs.usgs.gov/pp/1395/report.pdf)*/
@@ -147,10 +147,10 @@ namespace projections
                 /*If the keyword "alpha" is NOT found in the sentence then use 2points*/
                 } else {
                     /*Define Pole of oblique transformation from 2 points*/
-                    phi_1 = pj_param(par.params, "rlat_1").f;
-                    phi_2 = pj_param(par.params, "rlat_2").f;
-                    lam_1 = pj_param(par.params, "rlon_1").f;
-                    lam_2 = pj_param(par.params, "rlon_2").f;
+                    phi_1 = pj_get_param_r(par.params, "lat_1");
+                    phi_2 = pj_get_param_r(par.params, "lat_2");
+                    lam_1 = pj_get_param_r(par.params, "lon_1");
+                    lam_2 = pj_get_param_r(par.params, "lon_2");
                     /*Equation 9-1 page 80 (http://pubs.usgs.gov/pp/1395/report.pdf)*/
                     proj_parm.singam = atan2(cos(phi_1) * sin(phi_2) * cos(lam_1) -
                         sin(phi_1) * cos(phi_2) * cos(lam_2),

--- a/include/boost/geometry/srs/projections/proj/oea.hpp
+++ b/include/boost/geometry/srs/projections/proj/oea.hpp
@@ -133,11 +133,11 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_oea(Parameters& par, par_oea<T>& proj_parm)
             {
-                if (((proj_parm.n = pj_param(par.params, "dn").f) <= 0.) ||
-                    ((proj_parm.m = pj_param(par.params, "dm").f) <= 0.)) {
+                if (((proj_parm.n = pj_get_param_f(par.params, "n")) <= 0.) ||
+                    ((proj_parm.m = pj_get_param_f(par.params, "m")) <= 0.)) {
                     BOOST_THROW_EXCEPTION( projection_exception(-39) );
                 } else {
-                    proj_parm.theta = pj_param(par.params, "rtheta").f;
+                    proj_parm.theta = pj_get_param_r(par.params, "theta");
                     proj_parm.sp0 = sin(par.phi0);
                     proj_parm.cp0 = cos(par.phi0);
                     proj_parm.rn = 1./ proj_parm.n;

--- a/include/boost/geometry/srs/projections/proj/omerc.hpp
+++ b/include/boost/geometry/srs/projections/proj/omerc.hpp
@@ -183,29 +183,28 @@ namespace projections
                   gamma0, lamc=0, lam1=0, lam2=0, phi1=0, phi2=0, alpha_c=0;
                 int alp, gam, no_off = 0;
 
-                proj_parm.no_rot = pj_param(par.params, "tno_rot").i;
-                if ((alp = pj_param(par.params, "talpha").i) != 0)
-                    alpha_c = pj_param(par.params, "ralpha").f;
-                if ((gam = pj_param(par.params, "tgamma").i) != 0)
-                    gamma = pj_param(par.params, "rgamma").f;
+                proj_parm.no_rot = pj_get_param_b(par.params, "no_rot");
+                alp = pj_param_r(par.params, "alpha", alpha_c);
+                gam = pj_param_r(par.params, "gamma", gamma);
                 if (alp || gam) {
-                    lamc    = pj_param(par.params, "rlonc").f;
-                    no_off =
-                                /* For libproj4 compatability */
-                                pj_param(par.params, "tno_off").i
-                                /* for backward compatibility */
-                                || pj_param(par.params, "tno_uoff").i;
-                    if( no_off )
-                    {
-                        /* Mark the parameter as used, so that the pj_get_def() return them */
-                        pj_param(par.params, "sno_uoff");
-                        pj_param(par.params, "sno_off");
-                    }
+                    lamc = pj_get_param_r(par.params, "lonc");
+                    // NOTE: This is not needed in Boost.Geometry
+                    //no_off =
+                    //            /* For libproj4 compatability */
+                    //            pj_param_exists(par.params, "no_off")
+                    //            /* for backward compatibility */
+                    //            || pj_param_exists(par.params, "no_uoff");
+                    //if( no_off )
+                    //{
+                    //    /* Mark the parameter as used, so that the pj_get_def() return them */
+                    //    pj_get_param_s(par.params, "no_uoff");
+                    //    pj_get_param_s(par.params, "no_off");
+                    //}
                 } else {
-                    lam1 = pj_param(par.params, "rlon_1").f;
-                    phi1 = pj_param(par.params, "rlat_1").f;
-                    lam2 = pj_param(par.params, "rlon_2").f;
-                    phi2 = pj_param(par.params, "rlat_2").f;
+                    lam1 = pj_get_param_r(par.params, "lon_1");
+                    phi1 = pj_get_param_r(par.params, "lat_1");
+                    lam2 = pj_get_param_r(par.params, "lon_2");
+                    phi2 = pj_get_param_r(par.params, "lat_2");
                     if (fabs(phi1 - phi2) <= TOL ||
                         (con = fabs(phi1)) <= TOL ||
                         fabs(con - HALFPI) <= TOL ||

--- a/include/boost/geometry/srs/projections/proj/rpoly.hpp
+++ b/include/boost/geometry/srs/projections/proj/rpoly.hpp
@@ -117,7 +117,7 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_rpoly(Parameters& par, par_rpoly<T>& proj_parm)
             {
-                if ((proj_parm.mode = (proj_parm.phi1 = fabs(pj_param(par.params, "rlat_ts").f)) > EPS)) {
+                if ((proj_parm.mode = (proj_parm.phi1 = fabs(pj_get_param_r(par.params, "lat_ts"))) > EPS)) {
                     proj_parm.fxb = 0.5 * sin(proj_parm.phi1);
                     proj_parm.fxa = 0.5 / proj_parm.fxb;
                 }

--- a/include/boost/geometry/srs/projections/proj/sconics.hpp
+++ b/include/boost/geometry/srs/projections/proj/sconics.hpp
@@ -100,12 +100,12 @@ namespace projections
                 T p1, p2;
                 int err = 0;
 
-                if (!pj_param(par.params, "tlat_1").i ||
-                    !pj_param(par.params, "tlat_2").i) {
+                if (!pj_param_r(par.params, "lat_1", p1) ||
+                    !pj_param_r(par.params, "lat_2", p2)) {
                     err = -41;
                 } else {
-                    p1 = pj_param(par.params, "rlat_1").f;
-                    p2 = pj_param(par.params, "rlat_2").f;
+                    //p1 = pj_get_param_r(par.params, "lat_1"); // set above
+                    //p2 = pj_get_param_r(par.params, "lat_2"); // set above
                     *del = 0.5 * (p2 - p1);
                     proj_parm.sig = 0.5 * (p2 + p1);
                     err = (fabs(*del) < EPS || fabs(proj_parm.sig) < EPS) ? -42 : 0;

--- a/include/boost/geometry/srs/projections/proj/stere.hpp
+++ b/include/boost/geometry/srs/projections/proj/stere.hpp
@@ -385,8 +385,8 @@ namespace projections
             {
                 static const T HALFPI = detail::HALFPI<T>();
 
-                proj_parm.phits = pj_param(par.params, "tlat_ts").i ?
-                                  pj_param(par.params, "rlat_ts").f : HALFPI;
+                if (! pj_param_r(par.params, "lat_ts", proj_parm.phits))
+                    proj_parm.phits = HALFPI;
 
                 setup(par, proj_parm);
             }
@@ -398,7 +398,7 @@ namespace projections
                 static const T HALFPI = detail::HALFPI<T>();
 
                 /* International Ellipsoid */
-                par.phi0 = pj_param(par.params, "bsouth").i ? -HALFPI: HALFPI;
+                par.phi0 = pj_get_param_b(par.params, "south") ? -HALFPI: HALFPI;
                 if (par.es == 0.0) {
                     BOOST_THROW_EXCEPTION( projection_exception(-34) );
                 }

--- a/include/boost/geometry/srs/projections/proj/tpeqd.hpp
+++ b/include/boost/geometry/srs/projections/proj/tpeqd.hpp
@@ -140,10 +140,10 @@ namespace projections
                 T lam_1, lam_2, phi_1, phi_2, A12, pp;
 
                 /* get control point locations */
-                phi_1 = pj_param(par.params, "rlat_1").f;
-                lam_1 = pj_param(par.params, "rlon_1").f;
-                phi_2 = pj_param(par.params, "rlat_2").f;
-                lam_2 = pj_param(par.params, "rlon_2").f;
+                phi_1 = pj_get_param_r(par.params, "lat_1");
+                lam_1 = pj_get_param_r(par.params, "lon_1");
+                phi_2 = pj_get_param_r(par.params, "lat_2");
+                lam_2 = pj_get_param_r(par.params, "lon_2");
 
                 if (phi_1 == phi_2 && lam_1 == lam_2)
                     BOOST_THROW_EXCEPTION( projection_exception(-25) );

--- a/include/boost/geometry/srs/projections/proj/urm5.hpp
+++ b/include/boost/geometry/srs/projections/proj/urm5.hpp
@@ -106,15 +106,14 @@ namespace projections
             {
                 T alpha, t;
 
-                if (pj_param(par.params, "tn").i) {
-                    proj_parm.n = pj_param(par.params, "dn").f;
+                if (pj_param_f(par.params, "n", proj_parm.n)) {
                     if (proj_parm.n <= 0. || proj_parm.n > 1.)
                         BOOST_THROW_EXCEPTION( projection_exception(-40) );
                 } else {
                     BOOST_THROW_EXCEPTION( projection_exception(-40) );
                 }
-                proj_parm.q3 = pj_param(par.params, "dq").f / 3.;
-                alpha = pj_param(par.params, "ralpha").f;
+                proj_parm.q3 = pj_get_param_f(par.params, "q") / 3.;
+                alpha = pj_get_param_r(par.params, "alpha");
                 t = proj_parm.n * sin(alpha);
                 proj_parm.m = cos(alpha) / sqrt(1. - t * t);
                 proj_parm.rmn = 1. / (proj_parm.m * proj_parm.n);

--- a/include/boost/geometry/srs/projections/proj/urmfps.hpp
+++ b/include/boost/geometry/srs/projections/proj/urmfps.hpp
@@ -123,8 +123,7 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_urmfps(Parameters& par, par_urmfps<T>& proj_parm)
             {
-                if (pj_param(par.params, "tn").i) {
-                    proj_parm.n = pj_param(par.params, "dn").f;
+                if (pj_param_f(par.params, "n", proj_parm.n)) {
                     if (proj_parm.n <= 0. || proj_parm.n > 1.)
                         BOOST_THROW_EXCEPTION( projection_exception(-40) );
                 } else

--- a/include/boost/geometry/srs/projections/proj/wag3.hpp
+++ b/include/boost/geometry/srs/projections/proj/wag3.hpp
@@ -113,7 +113,7 @@ namespace projections
             {
                 T ts;
 
-                ts = pj_param(par.params, "rlat_ts").f;
+                ts = pj_get_param_r(par.params, "lat_ts");
                 proj_parm.C_x = cos(ts) / cos(2.*ts/3.);
                 par.es = 0.;
             }

--- a/include/boost/geometry/srs/projections/proj/wink1.hpp
+++ b/include/boost/geometry/srs/projections/proj/wink1.hpp
@@ -108,7 +108,7 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_wink1(Parameters& par, par_wink1<T>& proj_parm)
             {
-                proj_parm.cosphi1 = cos(pj_param(par.params, "rlat_ts").f);
+                proj_parm.cosphi1 = cos(pj_get_param_r(par.params, "lat_ts"));
                 par.es = 0.;
             }
 

--- a/include/boost/geometry/srs/projections/proj/wink2.hpp
+++ b/include/boost/geometry/srs/projections/proj/wink2.hpp
@@ -126,7 +126,7 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_wink2(Parameters& par, par_wink2<T>& proj_parm)
             {
-                proj_parm.cosphi1 = cos(pj_param(par.params, "rlat_1").f);
+                proj_parm.cosphi1 = cos(pj_get_param_r(par.params, "lat_1"));
                 par.es = 0.;
             }
 


### PR DESCRIPTION
This PR makes the same changes as closed https://github.com/boostorg/geometry/pull/461 but it's implemented on top of https://github.com/boostorg/geometry/pull/465.

In short it allows to replace this:

    pj_param(pvalues, "sdatum").s; //old

with this:

    pj_get_param_s(pvalues, "datum"); //new

and this:

    //old
    if (pj_param(parameters, "tR").i)
        a = pj_param(parameters, "dR").f;

with this:

    //new
    pj_param_f(parameters, "R", a);

So the information about the parameter type is expressed in compile-time as function name instead of passed as character in cstring. But most importantly the function doesn't have to be called twice to check if the parameter is set and then get it.