### PR TITLE
Add support for horizontal grid shift (nadgrids) in transformation.

### DIFF
--- a/include/boost/geometry/srs/projections/grids.hpp
+++ b/include/boost/geometry/srs/projections/grids.hpp
@@ -1,0 +1,188 @@
+// Boost.Geometry
+
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018, Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_SRS_PROJECTIONS_GRIDS_HPP
+#define BOOST_GEOMETRY_SRS_PROJECTIONS_GRIDS_HPP
+
+
+#include <boost/geometry/srs/projections/impl/pj_gridinfo.hpp>
+
+#include <fstream>
+
+
+namespace boost { namespace geometry
+{
+
+namespace srs
+{
+
+// Forward declarations for functions declarations below
+class grids;
+
+template <typename GridsStorage>
+class projection_grids;
+
+} // namespace srs
+namespace projections { namespace detail
+{
+
+// Forward declaratios of grids friends
+template <typename StreamPolicy>
+inline bool pj_gridlist_merge_gridfile(std::string const& gridname,
+                                       StreamPolicy const& stream_policy,
+                                       srs::grids & grids,
+                                       std::vector<std::size_t> & gridindexes);
+template <bool Inverse, typename CalcT, typename StreamPolicy, typename Range>
+inline bool pj_apply_gridshift_3(StreamPolicy const& stream_policy,
+                                 Range & range,
+                                 srs::grids & grids,
+                                 std::vector<std::size_t> const& gridindexes);
+
+// Forward declaratios of projection_grids friends
+template <typename Par, typename GridsStorage>
+inline void pj_gridlist_from_nadgrids(Par const& defn,
+                                      srs::projection_grids<GridsStorage> & grids);
+template <bool Inverse, typename Par, typename Range, typename Grids>
+inline bool pj_apply_gridshift_2(Par const& defn, Range & range, Grids const& grids);
+
+}} // namespace projections::detail
+
+namespace srs
+{
+
+class grids
+{
+public:
+    std::size_t size() const
+    {
+        return gridinfo.size();
+    }
+
+    bool empty() const
+    {
+        return gridinfo.empty();
+    }
+
+private:
+    template <typename StreamPolicy>
+    friend inline bool projections::detail::pj_gridlist_merge_gridfile(
+                            std::string const& gridname,
+                            StreamPolicy const& stream_policy,
+                            srs::grids & grids,
+                            std::vector<std::size_t> & gridindexes);
+    template <bool Inverse, typename CalcT, typename StreamPolicy, typename Range>
+    friend inline bool projections::detail::pj_apply_gridshift_3(
+                            StreamPolicy const& stream_policy,
+                            Range & range,
+                            srs::grids & grids,
+                            std::vector<std::size_t> const& gridindexes);
+
+    projections::detail::pj_gridinfo gridinfo;
+
+};
+
+struct ifstream_policy
+{
+    typedef std::ifstream stream_type;
+
+    static inline void open(stream_type & is, std::string const& gridname)
+    {
+        is.open(gridname, std::ios::binary);
+    }
+};
+
+template
+<
+    typename StreamPolicy = srs::ifstream_policy,
+    typename Grids = grids
+>
+struct grids_storage
+{
+    typedef StreamPolicy stream_policy_type;
+    typedef Grids grids_type;
+
+    grids_storage()
+    {}
+
+    explicit grids_storage(stream_policy_type const& policy)
+        : stream_policy(policy)
+    {}
+
+    stream_policy_type stream_policy;
+    grids_type hgrids;
+};
+
+
+template <typename GridsStorage = grids_storage<> >
+class projection_grids
+{
+public:
+    projection_grids(GridsStorage & storage)
+        : storage_ptr(boost::addressof(storage))
+    {}
+
+    std::size_t size() const
+    {
+        return hindexes.size();
+    }
+
+    bool empty() const
+    {
+        return hindexes.empty();
+    }
+
+private:
+    template <typename Par, typename GridsStorage>
+    friend inline void projections::detail::pj_gridlist_from_nadgrids(
+                            Par const& defn,
+                            srs::projection_grids<GridsStorage> & grids);
+    template <bool Inverse, typename Par, typename Range, typename Grids>
+    friend inline bool projections::detail::pj_apply_gridshift_2(
+                            Par const& defn, Range & range, Grids const& grids);
+
+    GridsStorage * const storage_ptr;
+    std::vector<std::size_t> hindexes;
+};
+
+
+template <typename GridsStorage = grids_storage<> >
+struct transformation_grids
+{
+    explicit transformation_grids(GridsStorage & storage)
+        : src_grids(storage)
+        , dst_grids(storage)
+    {}
+
+    projection_grids<GridsStorage> src_grids;
+    projection_grids<GridsStorage> dst_grids;
+};
+
+
+namespace detail
+{
+
+struct empty_grids_storage {};
+struct empty_projection_grids {};
+
+} // namespace detail
+
+
+template <>
+struct transformation_grids<detail::empty_grids_storage>
+{
+    detail::empty_projection_grids src_grids;
+    detail::empty_projection_grids dst_grids;
+};
+
+
+}}} // namespace boost::geometry::srs
+
+
+#endif // BOOST_GEOMETRY_SRS_PROJECTIONS_GRIDS_HPP

--- a/include/boost/geometry/srs/projections/impl/pj_apply_gridshift.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_apply_gridshift.hpp
@@ -1,0 +1,429 @@
+// Boost.Geometry
+// This file is manually converted from PROJ4
+
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018, Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+// This file is converted from PROJ4, http://trac.osgeo.org/proj
+// PROJ4 is originally written by Gerald Evenden (then of the USGS)
+// PROJ4 is maintained by Frank Warmerdam
+// This file was converted to Geometry Library by Adam Wulkiewicz
+
+// Original copyright notice:
+// Author:   Frank Warmerdam, warmerdam@pobox.com
+
+// Copyright (c) 2000, Frank Warmerdam
+
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#ifndef BOOST_GEOMETRY_SRS_PROJECTIONS_IMPL_PJ_APPLY_GRIDSHIFT_HPP
+#define BOOST_GEOMETRY_SRS_PROJECTIONS_IMPL_PJ_APPLY_GRIDSHIFT_HPP
+
+
+#include <boost/geometry/core/assert.hpp>
+#include <boost/geometry/core/radian_access.hpp>
+
+#include <boost/geometry/srs/projections/impl/pj_gridlist.hpp>
+
+
+namespace boost { namespace geometry { namespace projections
+{
+
+namespace detail
+{
+
+// Originally implemented in nad_intr.c
+template <typename CalcT>
+inline void nad_intr(CalcT in_lon, CalcT in_lat,
+                     CalcT & out_lon, CalcT & out_lat,
+                     pj_ctable const& ct)
+{
+	pj_ctable::lp_t frct;
+	pj_ctable::ilp_t indx;
+	boost::int32_t in;
+
+	indx.lam = int_floor(in_lon /= ct.del.lam);
+	indx.phi = int_floor(in_lat /= ct.del.phi);
+	frct.lam = in_lon - indx.lam;
+	frct.phi = in_lat - indx.phi;
+    // TODO: implement differently
+	out_lon = out_lat = HUGE_VAL;
+	if (indx.lam < 0) {
+		if (indx.lam == -1 && frct.lam > 0.99999999999) {
+			++indx.lam;
+			frct.lam = 0.;
+		} else
+			return;
+	} else if ((in = indx.lam + 1) >= ct.lim.lam) {
+		if (in == ct.lim.lam && frct.lam < 1e-11) {
+			--indx.lam;
+			frct.lam = 1.;
+		} else
+			return;
+	}
+	if (indx.phi < 0) {
+		if (indx.phi == -1 && frct.phi > 0.99999999999) {
+			++indx.phi;
+			frct.phi = 0.;
+		} else
+			return;
+	} else if ((in = indx.phi + 1) >= ct.lim.phi) {
+		if (in == ct.lim.phi && frct.phi < 1e-11) {
+			--indx.phi;
+			frct.phi = 1.;
+		} else
+			return;
+	}
+	boost::int32_t index = indx.phi * ct.lim.lam + indx.lam;
+	pj_ctable::flp_t const& f00 = ct.cvs[index++];
+	pj_ctable::flp_t const& f10 = ct.cvs[index];
+	index += ct.lim.lam;
+	pj_ctable::flp_t const& f11 = ct.cvs[index--];
+	pj_ctable::flp_t const& f01 = ct.cvs[index];
+    CalcT m00, m10, m01, m11;
+	m11 = m10 = frct.lam;
+	m00 = m01 = 1. - frct.lam;
+	m11 *= frct.phi;
+	m01 *= frct.phi;
+	frct.phi = 1. - frct.phi;
+	m00 *= frct.phi;
+	m10 *= frct.phi;
+	out_lon = m00 * f00.lam + m10 * f10.lam +
+			  m01 * f01.lam + m11 * f11.lam;
+	out_lat = m00 * f00.phi + m10 * f10.phi +
+			  m01 * f01.phi + m11 * f11.phi;
+}
+
+// Originally implemented in nad_cvt.c
+template <bool Inverse, typename CalcT>
+inline void nad_cvt(CalcT const& in_lon, CalcT const& in_lat,
+                    CalcT & out_lon, CalcT & out_lat,
+                    pj_gi const& gi)
+{
+    static const int max_iterations = 10;
+    static const CalcT tol = 1e-12;
+    static const CalcT toltol = tol * tol;
+    static const CalcT pi = math::pi<CalcT>();
+
+    // horizontal grid expected
+    BOOST_GEOMETRY_ASSERT_MSG(gi.format != pj_gi::gtx,
+        "Vertical grid cannot be used in horizontal shift.");
+
+    pj_ctable const& ct = gi.ct;
+
+    // TODO: implement differently
+    if (in_lon == HUGE_VAL)
+    {
+        out_lon = HUGE_VAL;
+        out_lat = HUGE_VAL;
+        return;
+    }
+
+    // normalize input to ll origin
+    pj_ctable::lp_t tb;
+    tb.lam = in_lon - ct.ll.lam;
+    tb.phi = in_lat - ct.ll.phi;
+    tb.lam = adjlon (tb.lam - pi) + pi;
+
+    pj_ctable::lp_t t;
+    nad_intr(tb.lam, tb.phi, t.lam, t.phi, ct);
+    if (t.lam == HUGE_VAL)
+    {
+        out_lon = HUGE_VAL;
+        out_lat = HUGE_VAL;
+        return;
+    }
+
+    if (! Inverse)
+    {
+        out_lon = in_lon - t.lam;
+        out_lat = in_lat - t.phi;
+        return;
+    }
+
+    t.lam = tb.lam + t.lam;
+    t.phi = tb.phi - t.phi;
+
+    int i = max_iterations;
+    pj_ctable::lp_t del, dif;
+    do
+    {
+        nad_intr(t.lam, t.phi, del.lam, del.phi, ct);
+
+        // This case used to return failure, but I have
+        // changed it to return the first order approximation
+        // of the inverse shift.  This avoids cases where the
+        // grid shift *into* this grid came from another grid.
+        // While we aren't returning optimally correct results
+        // I feel a close result in this case is better than
+        // no result.  NFW
+        // To demonstrate use -112.5839956 49.4914451 against
+        // the NTv2 grid shift file from Canada.
+        if (del.lam == HUGE_VAL)
+        {
+            // Inverse grid shift iteration failed, presumably at grid edge. Using first approximation.
+            break;
+        }
+
+        dif.lam = t.lam - del.lam - tb.lam;
+        dif.phi = t.phi + del.phi - tb.phi;
+        t.lam -= dif.lam;
+        t.phi -= dif.phi;
+
+    }
+    while (--i && (dif.lam*dif.lam + dif.phi*dif.phi > toltol)); // prob. slightly faster than hypot()
+
+    if (i==0)
+    {
+        // Inverse grid shift iterator failed to converge.
+        out_lon = HUGE_VAL;
+        out_lat = HUGE_VAL;
+        return;
+    }
+
+    out_lon = adjlon (t.lam + ct.ll.lam);
+    out_lat = t.phi + ct.ll.phi;
+}
+
+
+/************************************************************************/
+/*                             find_grid()                              */
+/*                                                                      */
+/*    Determine which grid is the correct given an input coordinate.    */
+/************************************************************************/
+
+// Originally find_ctable()
+// here divided into grid_disjoint(), find_grid() and load_grid()
+
+template <typename T>
+inline bool grid_disjoint(T const& lam, T const& phi,
+                          pj_ctable const& ct)
+{
+    double epsilon = (fabs(ct.del.phi)+fabs(ct.del.lam))/10000.0;
+    return ct.ll.phi - epsilon > phi
+        || ct.ll.lam - epsilon > lam
+        || (ct.ll.phi + (ct.lim.phi-1) * ct.del.phi + epsilon < phi)
+        || (ct.ll.lam + (ct.lim.lam-1) * ct.del.lam + epsilon < lam);
+}
+
+template <typename T>
+inline pj_gi * find_grid(T const& lam,
+                         T const& phi,
+                         std::vector<pj_gi>::iterator first,
+                         std::vector<pj_gi>::iterator last)
+{
+    pj_gi * gip = NULL;
+
+    for( ; first != last ; ++first )
+    {
+        // skip tables that don't match our point at all.
+        if (! grid_disjoint(lam, phi, first->ct))
+        {
+            // skip vertical grids
+            if (first->format != pj_gi::gtx)
+            {
+                gip = boost::addressof(*first);
+                break;
+            }
+        }
+    }
+
+    // If we didn't find a child then nothing more to do
+    if( gip == NULL )
+        return gip;
+
+    // Otherwise use the child, first checking it's children
+    pj_gi * child = find_grid(lam, phi, first->children.begin(), first->children.end());
+    if (child != NULL)
+        gip = child;
+
+    return gip;
+}
+
+template <typename T>
+inline pj_gi * find_grid(T const& lam,
+                         T const& phi,
+                         pj_gridinfo & grids,
+                         std::vector<std::size_t> const& gridindexes)
+{
+    pj_gi * gip = NULL;
+
+    // keep trying till we find a table that works
+    for (std::size_t i = 0 ; i < gridindexes.size() ; ++i)
+    {
+        pj_gi & gi = grids[gridindexes[i]];
+
+        // skip tables that don't match our point at all.
+        if (! grid_disjoint(lam, phi, gi.ct))
+        {
+            // skip vertical grids
+            if (gi.format != pj_gi::gtx)
+            {
+                gip = boost::addressof(gi);
+                break;
+            }
+        }
+    }
+
+    if (gip == NULL)
+        return gip;
+
+    // If we have child nodes, check to see if any of them apply.
+    pj_gi * child = find_grid(lam, phi, gip->children.begin(), gip->children.end());
+    if (child != NULL)
+        gip = child;
+
+    // if we get this far we have found a suitable grid
+    return gip;
+}
+
+
+template <typename StreamPolicy>
+inline bool load_grid(StreamPolicy const& stream_policy, pj_gi_load & gi)
+{
+    // load the grid shift info if we don't have it.
+    if (gi.ct.cvs.empty())
+    {
+        typename StreamPolicy::stream_type is;
+        stream_policy.open(is, gi.gridname);
+
+        if (! pj_gridinfo_load(is, gi))
+        {
+            //pj_ctx_set_errno( ctx, PJD_ERR_FAILED_TO_LOAD_GRID );
+            return false;
+        }
+    }
+
+    return true;
+}
+
+
+/************************************************************************/
+/*                        pj_apply_gridshift_3()                        */
+/*                                                                      */
+/*      This is the real workhorse, given a gridlist.                   */
+/************************************************************************/
+
+template <bool Inverse, typename CalcT, typename StreamPolicy, typename Range>
+inline bool pj_apply_gridshift_3(StreamPolicy const& stream_policy,
+                                 Range & range,
+                                 srs::grids & grids,
+                                 std::vector<std::size_t> const& gridindexes)
+{
+    typedef typename boost::range_size<Range>::type size_type;
+    
+    // If the grids are empty the indexes are as well
+    if (gridindexes.empty())
+    {
+        //pj_ctx_set_errno(ctx, PJD_ERR_FAILED_TO_LOAD_GRID);
+        //return PJD_ERR_FAILED_TO_LOAD_GRID;
+        return false;
+    }
+
+    size_type point_count = boost::size(range);
+
+    for (size_type i = 0 ; i < point_count ; ++i)
+    {
+        typename boost::range_reference<Range>::type
+            point = range::at(range, i);
+
+        CalcT in_lon = geometry::get_as_radian<0>(point);
+        CalcT in_lat = geometry::get_as_radian<1>(point);
+        
+        pj_gi * gip = find_grid(in_lon, in_lat, grids.gridinfo, gridindexes);
+
+        if ( gip != NULL )
+        {
+            // load the grid shift info if we don't have it.
+            if (! gip->ct.cvs.empty() || load_grid(stream_policy, *gip))
+            {
+                // TODO: use set_invalid_point() or similar mechanism
+                CalcT out_lon = HUGE_VAL;
+                CalcT out_lat = HUGE_VAL;
+
+                nad_cvt<Inverse>(in_lon, in_lat, out_lon, out_lat, *gip);
+            
+                // TODO: check differently
+                if ( out_lon != HUGE_VAL )
+                {
+                    geometry::set_from_radian<0>(point, out_lon);
+                    geometry::set_from_radian<1>(point, out_lat);
+                }
+            }
+        }
+    }
+
+    return true;
+}
+
+
+/************************************************************************/
+/*                        pj_apply_gridshift_2()                        */
+/*                                                                      */
+/*      This implementation uses the gridlist from a coordinate         */
+/*      system definition.  If the gridlist has not yet been            */
+/*      populated in the coordinate system definition we set it up      */
+/*      now.                                                            */
+/************************************************************************/
+
+template <bool Inverse, typename Par, typename Range, typename ProjGrids>
+inline bool pj_apply_gridshift_2(Par const& defn, Range & range, ProjGrids const& grids)
+{
+    /*if( defn->catalog_name != NULL )
+        return pj_gc_apply_gridshift( defn, inverse, point_count, point_offset,
+                                      x, y, z );*/
+
+    /*std::vector<std::size_t> gridindexes;
+    pj_gridlist_from_nadgrids(pj_get_param_s(defn.params, "nadgrids"),
+                              grids.storage_ptr->stream_policy,
+                              grids.storage_ptr->grids,
+                              gridindexes);*/
+
+    BOOST_GEOMETRY_ASSERT(grids.storage_ptr != NULL);
+
+    // At this point the grids should be initialized
+    if (grids.hindexes.empty())
+        return false;
+
+    return pj_apply_gridshift_3
+            <
+                Inverse, typename Par::type
+            >(grids.storage_ptr->stream_policy,
+              range,
+              grids.storage_ptr->hgrids,
+              grids.hindexes);
+}
+
+template <bool Inverse, typename Par, typename Range>
+inline bool pj_apply_gridshift_2(Par const& , Range & , srs::detail::empty_projection_grids const& )
+{
+    return false;
+}
+
+
+} // namespace detail
+
+}}} // namespace boost::geometry::projections
+
+#endif // BOOST_GEOMETRY_SRS_PROJECTIONS_IMPL_PJ_APPLY_GRIDSHIFT_HPP

--- a/include/boost/geometry/srs/projections/impl/pj_apply_gridshift_shared.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_apply_gridshift_shared.hpp
@@ -1,0 +1,157 @@
+// Boost.Geometry
+// This file is manually converted from PROJ4
+
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018, Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+// This file is converted from PROJ4, http://trac.osgeo.org/proj
+// PROJ4 is originally written by Gerald Evenden (then of the USGS)
+// PROJ4 is maintained by Frank Warmerdam
+// This file was converted to Geometry Library by Adam Wulkiewicz
+
+// Original copyright notice:
+// Author:   Frank Warmerdam, warmerdam@pobox.com
+
+// Copyright (c) 2000, Frank Warmerdam
+
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#ifndef BOOST_GEOMETRY_SRS_PROJECTIONS_IMPL_PJ_APPLY_GRIDSHIFT_SHARED_HPP
+#define BOOST_GEOMETRY_SRS_PROJECTIONS_IMPL_PJ_APPLY_GRIDSHIFT_SHARED_HPP
+
+
+#include <boost/geometry/core/assert.hpp>
+#include <boost/geometry/core/radian_access.hpp>
+
+#include <boost/geometry/srs/projections/impl/pj_apply_gridshift.hpp>
+#include <boost/geometry/srs/projections/impl/pj_gridlist_shared.hpp>
+
+
+namespace boost { namespace geometry { namespace projections
+{
+
+namespace detail
+{
+
+template <bool Inverse, typename CalcT, typename StreamPolicy, typename Range>
+inline bool pj_apply_gridshift_3(StreamPolicy const& stream_policy,
+                                 Range & range,
+                                 srs::shared_grids & grids,
+                                 std::vector<std::size_t> const& gridindexes)
+{
+    typedef typename boost::range_size<Range>::type size_type;
+    
+    // If the grids are empty the indexes are as well
+    if (gridindexes.empty())
+    {
+        //pj_ctx_set_errno(ctx, PJD_ERR_FAILED_TO_LOAD_GRID);
+        //return PJD_ERR_FAILED_TO_LOAD_GRID;
+        return false;
+    }
+
+    size_type point_count = boost::size(range);
+
+    // local storage
+    pj_gi_load local_gi;
+
+    for (size_type i = 0 ; i < point_count ; )
+    {
+        bool load_needed = false;
+
+        CalcT in_lon = 0;
+        CalcT in_lat = 0;
+
+        {
+            boost::shared_lock<boost::shared_mutex> lock(grids.mutex);
+
+            for ( ; i < point_count ; ++i )
+            {
+                typename boost::range_reference<Range>::type
+                    point = range::at(range, i);
+
+                in_lon = geometry::get_as_radian<0>(point);
+                in_lat = geometry::get_as_radian<1>(point);
+
+                pj_gi * gip = find_grid(in_lon, in_lat, grids.gridinfo, gridindexes);
+
+                if (gip == NULL)
+                {
+                    // do nothing
+                }
+                else if (! gip->ct.cvs.empty())
+                {
+                    // TODO: use set_invalid_point() or similar mechanism
+                    CalcT out_lon = HUGE_VAL;
+                    CalcT out_lat = HUGE_VAL;
+
+                    nad_cvt<Inverse>(in_lon, in_lat, out_lon, out_lat, *gip);
+
+                    // TODO: check differently
+                    if (out_lon != HUGE_VAL)
+                    {
+                        geometry::set_from_radian<0>(point, out_lon);
+                        geometry::set_from_radian<1>(point, out_lat);
+                    }
+                }
+                else
+                {
+                    // loading is needed
+                    local_gi = *gip;
+                    load_needed = true;
+                    break;
+                }
+            }
+        }
+
+        if (load_needed)
+        {
+            if (load_grid(stream_policy, local_gi))
+            {
+                boost::unique_lock<boost::shared_mutex> lock(grids.mutex);
+
+                // check again in case other thread already loaded the grid.
+                pj_gi * gip = find_grid(in_lon, in_lat, grids.gridinfo, gridindexes);
+
+                if (gip != NULL && gip->ct.cvs.empty())
+                {
+                    // swap loaded local storage with empty grid
+                    local_gi.swap(*gip);
+                }
+            }
+            else
+            {
+                ++i;
+            }
+        }
+    }
+
+    return true;
+}
+
+
+} // namespace detail
+
+}}} // namespace boost::geometry::projections
+
+#endif // BOOST_GEOMETRY_SRS_PROJECTIONS_IMPL_PJ_APPLY_GRIDSHIFT_SHARED_HPP

--- a/include/boost/geometry/srs/projections/impl/pj_datum_set.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_datum_set.hpp
@@ -75,7 +75,7 @@ inline void pj_datum_add_defn(BGParams const& , std::vector<pvalue<T> >& pvalues
     /*      definition will last into the pj_ell_set() function called      */
     /*      after this one.                                                 */
     /* -------------------------------------------------------------------- */
-    std::string name = pj_param(pvalues, "sdatum").s;
+    std::string name = pj_get_param_s(pvalues, "datum");
     if(! name.empty())
     {
         /* find the datum definition */
@@ -153,8 +153,8 @@ inline void pj_datum_set(BGParams const& bg_params, std::vector<pvalue<T> >& pva
 /* -------------------------------------------------------------------- */
 /*      Check for nadgrids parameter.                                   */
 /* -------------------------------------------------------------------- */
-    std::string nadgrids = pj_param(pvalues, "snadgrids").s;
-    std::string towgs84 = pj_param(pvalues, "stowgs84").s;
+    std::string nadgrids = pj_get_param_s(pvalues, "nadgrids");
+    std::string towgs84 = pj_get_param_s(pvalues, "towgs84");
     if(! nadgrids.empty())
     {
         /* We don't actually save the value separately.  It will continue

--- a/include/boost/geometry/srs/projections/impl/pj_ell_set.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_ell_set.hpp
@@ -80,12 +80,12 @@ inline void pj_ell_set(BGParams const& /*bg_params*/, std::vector<pvalue<T> >& p
     a = es = 0.;
 
     /* R takes precedence */
-    if (pj_param(parameters, "tR").i)
-        a = pj_param(parameters, "dR").f;
-    else { /* probable elliptical figure */
+    if (pj_param_f(parameters, "R", a)) {
+        /* empty */
+    } else { /* probable elliptical figure */
 
         /* check if ellps present and temporarily append its values to pl */
-        name = pj_param(parameters, "sellps").s;
+        name = pj_get_param_s(parameters, "ellps");
         if (! name.empty())
         {
             const int n = sizeof(pj_ellps) / sizeof(pj_ellps[0]);
@@ -105,51 +105,47 @@ inline void pj_ell_set(BGParams const& /*bg_params*/, std::vector<pvalue<T> >& p
             parameters.push_back(pj_mkparam<T>(pj_ellps[index].major));
             parameters.push_back(pj_mkparam<T>(pj_ellps[index].ell));
         }
-        a = pj_param(parameters, "da").f;
-        if (pj_param(parameters, "tes").i) /* eccentricity squared */
-            es = pj_param(parameters, "des").f;
-        else if (pj_param(parameters, "te").i) { /* eccentricity */
-            e = pj_param(parameters, "de").f;
+        a = pj_get_param_f(parameters, "a");
+        if (pj_param_f(parameters, "es", es)) {/* eccentricity squared */
+            /* empty */
+        } else if (pj_param_f(parameters, "e", e)) { /* eccentricity */
             es = e * e;
-        } else if (pj_param(parameters, "trf").i) { /* recip flattening */
-            es = pj_param(parameters, "drf").f;
+        } else if (pj_param_f(parameters, "rf", es)) { /* recip flattening */
             if (!es) {
                 BOOST_THROW_EXCEPTION( projection_exception(-10) );
             }
             es = 1./ es;
             es = es * (2. - es);
-        } else if (pj_param(parameters, "tf").i) { /* flattening */
-            es = pj_param(parameters, "df").f;
+        } else if (pj_param_f(parameters, "f", es)) { /* flattening */
             es = es * (2. - es);
-        } else if (pj_param(parameters, "tb").i) { /* minor axis */
-            b = pj_param(parameters, "db").f;
+        } else if (pj_param_f(parameters, "b", b)) { /* minor axis */
             es = 1. - (b * b) / (a * a);
         }     /* else es == 0. and sphere of radius a */
         if (!b)
             b = a * sqrt(1. - es);
         /* following options turn ellipsoid into equivalent sphere */
-        if (pj_param(parameters, "bR_A").i) { /* sphere--area of ellipsoid */
+        if (pj_get_param_b(parameters, "R_A")) { /* sphere--area of ellipsoid */
             a *= 1. - es * (SIXTH<T>() + es * (RA4<T>() + es * RA6<T>()));
             es = 0.;
-        } else if (pj_param(parameters, "bR_V").i) { /* sphere--vol. of ellipsoid */
+        } else if (pj_get_param_b(parameters, "R_V")) { /* sphere--vol. of ellipsoid */
             a *= 1. - es * (SIXTH<T>() + es * (RV4<T>() + es * RV6<T>()));
             es = 0.;
-        } else if (pj_param(parameters, "bR_a").i) { /* sphere--arithmetic mean */
+        } else if (pj_get_param_b(parameters, "R_a")) { /* sphere--arithmetic mean */
             a = .5 * (a + b);
             es = 0.;
-        } else if (pj_param(parameters, "bR_g").i) { /* sphere--geometric mean */
+        } else if (pj_get_param_b(parameters, "R_g")) { /* sphere--geometric mean */
             a = sqrt(a * b);
             es = 0.;
-        } else if (pj_param(parameters, "bR_h").i) { /* sphere--harmonic mean */
+        } else if (pj_get_param_b(parameters, "R_h")) { /* sphere--harmonic mean */
             a = 2. * a * b / (a + b);
             es = 0.;
         } else {
-            int i = pj_param(parameters, "tR_lat_a").i;
+            T tmp;
+            int i = pj_param_r(parameters, "R_lat_a", tmp);
             if (i || /* sphere--arith. */
-                pj_param(parameters, "tR_lat_g").i) { /* or geom. mean at latitude */
-                T tmp;
+                pj_param_r(parameters, "R_lat_g", tmp)) { /* or geom. mean at latitude */
 
-                tmp = sin(pj_param(parameters, i ? "rR_lat_a" : "rR_lat_g").f);
+                tmp = sin(tmp);
                 if (geometry::math::abs(tmp) > geometry::math::half_pi<T>()) {
                     BOOST_THROW_EXCEPTION( projection_exception(-11) );
                 }

--- a/include/boost/geometry/srs/projections/impl/pj_gridinfo.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_gridinfo.hpp
@@ -1,0 +1,960 @@
+// Boost.Geometry
+// This file is manually converted from PROJ4
+
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018, Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+// This file is converted from PROJ4, http://trac.osgeo.org/proj
+// PROJ4 is originally written by Gerald Evenden (then of the USGS)
+// PROJ4 is maintained by Frank Warmerdam
+// This file was converted to Geometry Library by Adam Wulkiewicz
+
+// Original copyright notice:
+// Author:   Frank Warmerdam, warmerdam@pobox.com
+
+// Copyright (c) 2000, Frank Warmerdam
+
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#ifndef BOOST_GEOMETRY_SRS_PROJECTIONS_IMPL_PJ_GRIDINFO_HPP
+#define BOOST_GEOMETRY_SRS_PROJECTIONS_IMPL_PJ_GRIDINFO_HPP
+
+
+#include <boost/algorithm/string.hpp>
+
+#include <boost/geometry/core/assert.hpp>
+
+#include <boost/cstdint.hpp>
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+
+namespace boost { namespace geometry { namespace projections
+{
+
+namespace detail
+{
+
+/************************************************************************/
+/*                             swap_words()                             */
+/*                                                                      */
+/*      Convert the byte order of the given word(s) in place.           */
+/************************************************************************/
+
+inline bool is_lsb()
+{
+    static const int byte_order_test = 1;
+    static bool result = (1 == ((const unsigned char *) (&byte_order_test))[0]);
+    return result;
+}
+
+inline void swap_words( char *data, int word_size, int word_count )
+{
+    for (int word = 0; word < word_count; word++)
+    {
+        for (int i = 0; i < word_size/2; i++)
+        {
+            std::swap(data[i], data[word_size-i-1]);
+        }
+
+        data += word_size;
+    }
+}
+
+inline bool cstr_equal(const char * s1, const char * s2, std::size_t n)
+{
+    return std::equal(s1, s1 + n, s2);
+}
+
+struct is_trimmable_char
+{
+    inline bool operator()(char ch)
+    {
+        return ch == '\n' || ch == ' ';
+    }
+};
+
+// structs originally defined in projects.h
+
+struct pj_ctable
+{
+    struct lp_t  { double lam, phi; };
+    struct flp_t { float lam, phi; };
+    struct ilp_t { boost::int32_t lam, phi; };
+
+    std::string id;         // ascii info
+    lp_t ll;                // lower left corner coordinates
+    lp_t del;               // size of cells
+    ilp_t lim;              // limits of conversion matrix
+    std::vector<flp_t> cvs; // conversion matrix
+
+    inline void swap(pj_ctable & r)
+    {
+        id.swap(r.id);
+        std::swap(ll, r.ll);
+        std::swap(del, r.del);
+        std::swap(lim, r.lim);
+        cvs.swap(r.cvs);
+    }
+};
+
+struct pj_gi_load
+{
+    enum format_t { missing = 0, ntv1, ntv2, gtx, ctable, ctable2 };
+    typedef boost::long_long_type offset_t;
+
+    explicit pj_gi_load(std::string const& gname = "",
+                        format_t f = missing,
+                        offset_t off = 0,
+                        bool swap = false)
+        : gridname(gname)
+        , format(f)
+        , grid_offset(off)
+        , must_swap(swap)
+    {}
+
+    std::string gridname; // identifying name of grid, eg "conus" or ntv2_0.gsb
+
+    format_t format;      // format of this grid, ie "ctable", "ntv1", "ntv2" or "missing".
+
+    offset_t grid_offset; // offset in file, for delayed loading
+    bool must_swap;       // only for NTv2
+
+    pj_ctable ct;
+
+    inline void swap(pj_gi_load & r)
+    {
+        gridname.swap(r.gridname);
+        std::swap(format, r.format);
+        std::swap(grid_offset, r.grid_offset);
+        std::swap(must_swap, r.must_swap);
+        ct.swap(r.ct);
+    }
+
+};
+
+struct pj_gi
+    : pj_gi_load
+{
+    explicit pj_gi(std::string const& gname = "",
+                   pj_gi_load::format_t f = missing,
+                   pj_gi_load::offset_t off = 0,
+                   bool swap = false)
+        : pj_gi_load(gname, f, off, swap)
+    {}
+
+    std::vector<pj_gi> children;
+
+    inline void swap(pj_gi & r)
+    {
+        pj_gi_load::swap(r);
+        children.swap(r.children);
+    }
+};
+
+typedef std::vector<pj_gi> pj_gridinfo;
+
+
+/************************************************************************/
+/*                   pj_gridinfo_load_ctable()                          */
+/*                                                                      */
+/*      Load the data portion of a ctable formatted grid.               */
+/************************************************************************/
+
+// Originally nad_ctable_load() defined in nad_init.c
+template <typename IStream>
+bool pj_gridinfo_load_ctable(IStream & is, pj_gi_load & gi)
+{
+    pj_ctable & ct = gi.ct;
+    
+    // Move the input stream by the size of the proj4 original CTABLE
+    std::size_t header_size = 80
+                            + 2 * sizeof(pj_ctable::lp_t)
+                            + sizeof(pj_ctable::ilp_t)
+                            + sizeof(pj_ctable::flp_t*);
+    is.seekg(header_size);
+    
+    // read all the actual shift values
+    std::size_t a_size = ct.lim.lam * ct.lim.phi;
+    ct.cvs.resize(a_size);
+    
+    std::size_t ch_size = sizeof(pj_ctable::flp_t) * a_size;
+    is.read(reinterpret_cast<char*>(&ct.cvs[0]), ch_size);
+
+    if (is.fail() || is.gcount() != ch_size)
+    {
+        ct.cvs.clear();
+        //ctable loading failed on fread() - binary incompatible?
+        return false;
+    }
+
+    return true;
+} 
+
+/************************************************************************/
+/*                  pj_gridinfo_load_ctable2()                          */
+/*                                                                      */
+/*      Load the data portion of a ctable2 formatted grid.              */
+/************************************************************************/
+
+// Originally nad_ctable2_load() defined in nad_init.c
+template <typename IStream>
+bool pj_gridinfo_load_ctable2(IStream & is, pj_gi_load & gi)
+{
+    pj_ctable & ct = gi.ct;
+
+    is.seekg(160);
+
+    // read all the actual shift values
+    std::size_t a_size = ct.lim.lam * ct.lim.phi;
+    ct.cvs.resize(a_size);
+
+    std::size_t ch_size = sizeof(pj_ctable::flp_t) * a_size;
+    is.read(reinterpret_cast<char*>(&ct.cvs[0]), ch_size);
+
+    if (is.fail() || is.gcount() != ch_size)
+    {
+        //ctable2 loading failed on fread() - binary incompatible?
+        ct.cvs.clear();
+        return false;
+    }
+
+    if (! is_lsb())
+    {
+        swap_words(reinterpret_cast<char*>(&ct.cvs[0]), 4, (int)a_size * 2);
+    }
+
+    return true;
+}
+
+/************************************************************************/
+/*                      pj_gridinfo_load_ntv1()                         */
+/*                                                                      */
+/*      NTv1 format.                                                    */
+/*      We process one line at a time.  Note that the array storage     */
+/*      direction (e-w) is different in the NTv1 file and what          */
+/*      the CTABLE is supposed to have.  The phi/lam are also           */
+/*      reversed, and we have to be aware of byte swapping.             */
+/************************************************************************/
+
+// originally in pj_gridinfo_load() function
+template <typename IStream>
+inline bool pj_gridinfo_load_ntv1(IStream & is, pj_gi_load & gi)
+{
+    static const double s2r = math::d2r<double>() / 3600.0;
+
+    std::size_t const r_size = gi.ct.lim.lam * 2;
+    std::size_t const ch_size = sizeof(double) * r_size;
+
+    is.seekg(gi.grid_offset);
+
+    std::vector<double> row_buf(r_size);
+    gi.ct.cvs.resize(gi.ct.lim.lam * gi.ct.lim.phi);
+    
+    for (boost::int32_t row = 0; row < gi.ct.lim.phi; row++ )
+    {
+        is.read(reinterpret_cast<char*>(&row_buf[0]), ch_size);
+
+        if (is.fail() || is.gcount() != ch_size)
+        {
+            gi.ct.cvs.clear();
+            return false;
+        }
+
+        if (is_lsb())
+            swap_words(reinterpret_cast<char*>(&row_buf[0]), 8, (int)r_size);
+
+        // convert seconds to radians
+        for (boost::int32_t i = 0; i < gi.ct.lim.lam; i++ )
+        {
+            pj_ctable::flp_t & cvs = gi.ct.cvs[row * gi.ct.lim.lam + (gi.ct.lim.lam - i - 1)];
+
+            cvs.phi = (float) (row_buf[i*2] * s2r);
+            cvs.lam = (float) (row_buf[i*2+1] * s2r);
+        }
+    }
+
+    return true;
+}
+
+/* -------------------------------------------------------------------- */
+/*                         pj_gridinfo_load_ntv2()                      */
+/*                                                                      */
+/*      NTv2 format.                                                    */
+/*      We process one line at a time.  Note that the array storage     */
+/*      direction (e-w) is different in the NTv2 file and what          */
+/*      the CTABLE is supposed to have.  The phi/lam are also           */
+/*      reversed, and we have to be aware of byte swapping.             */
+/* -------------------------------------------------------------------- */
+
+// originally in pj_gridinfo_load() function
+template <typename IStream>
+inline bool pj_gridinfo_load_ntv2(IStream & is, pj_gi_load & gi)
+{
+    static const double s2r = math::d2r<double>() / 3600.0;
+
+    std::size_t const r_size = gi.ct.lim.lam * 4;
+    std::size_t const ch_size = sizeof(float) * r_size;
+
+    is.seekg(gi.grid_offset);
+
+    std::vector<float> row_buf(r_size);
+    gi.ct.cvs.resize(gi.ct.lim.lam * gi.ct.lim.phi);
+
+    for (boost::int32_t row = 0; row < gi.ct.lim.phi; row++ )
+    {
+        is.read(reinterpret_cast<char*>(&row_buf[0]), ch_size);
+
+        if (is.fail() || is.gcount() != ch_size)
+        {
+            gi.ct.cvs.clear();
+            return false;
+        }
+
+        if (gi.must_swap)
+        {
+            swap_words(reinterpret_cast<char*>(&row_buf[0]), 4, (int)r_size);
+        }
+
+        // convert seconds to radians
+        for (boost::int32_t i = 0; i < gi.ct.lim.lam; i++ )
+        {
+            pj_ctable::flp_t & cvs = gi.ct.cvs[row * gi.ct.lim.lam + (gi.ct.lim.lam - i - 1)];
+
+            // skip accuracy values
+            cvs.phi = (float) (row_buf[i*4] * s2r);
+            cvs.lam = (float) (row_buf[i*4+1] * s2r);
+        }
+    }
+
+    return true;
+}
+
+/************************************************************************/
+/*                   pj_gridinfo_load_gtx()                             */
+/*                                                                      */
+/*      GTX format.                                                     */
+/************************************************************************/
+
+// originally in pj_gridinfo_load() function
+template <typename IStream>
+inline bool pj_gridinfo_load_gtx(IStream & is, pj_gi_load & gi)
+{
+    boost::int32_t words = gi.ct.lim.lam * gi.ct.lim.phi;
+    std::size_t const ch_size = sizeof(float) * words;
+    
+    is.seekg(gi.grid_offset);
+
+    // TODO: Consider changing this unintuitive code
+    // NOTE: Vertical shift data (one float per point) is stored in a container
+    // holding horizontal shift data (two floats per point).
+    gi.ct.cvs.resize((words + 1) / 2);
+
+    is.read(reinterpret_cast<char*>(&gi.ct.cvs[0]), ch_size);
+
+    if (is.fail() || is.gcount() != ch_size)
+    {
+        gi.ct.cvs.clear();
+        return false;
+    }
+
+    if (is_lsb())
+    {
+        swap_words(reinterpret_cast<char*>(&gi.ct.cvs[0]), 4, words);
+    }
+
+    return true;
+}
+
+/************************************************************************/
+/*                          pj_gridinfo_load()                          */
+/*                                                                      */
+/*      This function is intended to implement delayed loading of       */
+/*      the data contents of a grid file.  The header and related       */
+/*      stuff are loaded by pj_gridinfo_init().                         */
+/************************************************************************/
+
+template <typename IStream>
+inline bool pj_gridinfo_load(IStream & is, pj_gi_load & gi)
+{
+    if (! gi.ct.cvs.empty())
+    {
+        return true;
+    }
+
+    if (! is.is_open())
+    {
+        return false;
+    }
+
+    // Original platform specific CTable format.
+    if (gi.format == pj_gi::ctable)
+    {
+        return pj_gridinfo_load_ctable(is, gi);
+    }
+    // CTable2 format.
+    else if (gi.format == pj_gi::ctable2)
+    {
+        return pj_gridinfo_load_ctable2(is, gi);
+    }
+    // NTv1 format.
+    else if (gi.format == pj_gi::ntv1)
+    {
+        return pj_gridinfo_load_ntv1(is, gi);
+    }
+    // NTv2 format.
+    else if (gi.format == pj_gi::ntv2)
+    {
+        return pj_gridinfo_load_ntv2(is, gi);
+    }
+    // GTX format.
+    else if (gi.format == pj_gi::gtx)
+    {
+        return pj_gridinfo_load_gtx(is, gi);
+    }
+    else
+    {
+        return false;
+    }
+}
+
+/************************************************************************/
+/*                        pj_gridinfo_parent()                          */
+/*                                                                      */
+/*      Seek a parent grid file by name from a grid list                */
+/************************************************************************/
+
+template <typename It>
+inline It pj_gridinfo_parent(It first, It last, std::string const& name)
+{
+    for ( ; first != last ; ++first)
+    {
+        if (first->ct.id == name)
+            return first;
+
+        It parent = pj_gridinfo_parent(first->children.begin(), first->children.end(), name);
+        if( parent != first->children.end() )
+            return parent;
+    }
+
+    return last;
+}
+
+/************************************************************************/
+/*                       pj_gridinfo_init_ntv2()                        */
+/*                                                                      */
+/*      Load a ntv2 (.gsb) file.                                        */
+/************************************************************************/
+
+template <typename IStream>
+inline bool pj_gridinfo_init_ntv2(std::string const& gridname,
+                                  IStream & is,
+                                  pj_gridinfo & gridinfo)
+{
+    BOOST_STATIC_ASSERT( sizeof(boost::int32_t) == 4 );
+    BOOST_STATIC_ASSERT( sizeof(double) == 8 );
+
+    static const double s2r = math::d2r<double>() / 3600.0;
+
+    std::size_t gridinfo_orig_size = gridinfo.size();
+
+    // Read the overview header.
+    char header[11*16];
+
+    is.read(header, sizeof(header));
+    if( is.fail() )
+    {
+        return false;
+    }
+
+    bool must_swap = (header[8] == 11)
+                   ? !is_lsb()
+                   : is_lsb();
+
+    // NOTE: This check is not implemented in proj4
+    if (! cstr_equal(header + 56, "SECONDS", 7))
+    {
+        return false;
+    }
+
+    // Byte swap interesting fields if needed.
+    if( must_swap )
+    {
+        swap_words( header+8, 4, 1 );
+        swap_words( header+8+16, 4, 1 );
+        swap_words( header+8+32, 4, 1 );
+        swap_words( header+8+7*16, 8, 1 );
+        swap_words( header+8+8*16, 8, 1 );
+        swap_words( header+8+9*16, 8, 1 );
+        swap_words( header+8+10*16, 8, 1 );
+    }
+
+    // Get the subfile count out ... all we really use for now.
+    boost::int32_t num_subfiles;
+    memcpy( &num_subfiles, header+8+32, 4 );
+
+    // Step through the subfiles, creating a PJ_GRIDINFO for each.
+    for( boost::int32_t subfile = 0; subfile < num_subfiles; subfile++ )
+    {
+        // Read header.
+        is.read(header, sizeof(header));
+        if( is.fail() )
+        {
+            return false;
+        }
+
+        if(! cstr_equal(header, "SUB_NAME", 8))
+        {
+            return false;
+        }
+
+        // Byte swap interesting fields if needed.
+        if( must_swap )
+        {
+            swap_words( header+8+16*4, 8, 1 );
+            swap_words( header+8+16*5, 8, 1 );
+            swap_words( header+8+16*6, 8, 1 );
+            swap_words( header+8+16*7, 8, 1 );
+            swap_words( header+8+16*8, 8, 1 );
+            swap_words( header+8+16*9, 8, 1 );
+            swap_words( header+8+16*10, 4, 1 );
+        }
+
+        // Initialize a corresponding "ct" structure.
+        pj_ctable ct;
+        pj_ctable::lp_t ur;
+
+        ct.id = std::string(header + 8, 8);
+
+        ct.ll.lam = - *((double *) (header+7*16+8)); /* W_LONG */
+        ct.ll.phi = *((double *) (header+4*16+8));   /* S_LAT */
+
+        ur.lam = - *((double *) (header+6*16+8));     /* E_LONG */
+        ur.phi = *((double *) (header+5*16+8));       /* N_LAT */
+
+        ct.del.lam = *((double *) (header+9*16+8));
+        ct.del.phi = *((double *) (header+8*16+8));
+
+        ct.lim.lam = (boost::int32_t) (fabs(ur.lam-ct.ll.lam)/ct.del.lam + 0.5) + 1;
+        ct.lim.phi = (boost::int32_t) (fabs(ur.phi-ct.ll.phi)/ct.del.phi + 0.5) + 1;
+
+        ct.ll.lam *= s2r;
+        ct.ll.phi *= s2r;
+        ct.del.lam *= s2r;
+        ct.del.phi *= s2r;
+
+        boost::int32_t gs_count;
+        memcpy( &gs_count, header + 8 + 16*10, 4 );
+        if( gs_count != ct.lim.lam * ct.lim.phi )
+        {
+            return false;
+        }
+
+        //ct.cvs.clear();
+
+        // Create a new gridinfo for this if we aren't processing the
+        // 1st subfile, and initialize our grid info.
+
+        // Attach to the correct list or sublist.
+
+        // TODO is offset needed?
+        pj_gi gi(gridname, pj_gi::ntv2, is.tellg(), must_swap);
+        gi.ct = ct;
+
+        if( subfile == 0 )
+        {
+            gridinfo.push_back(gi);
+        }
+        else if( cstr_equal(header+24, "NONE", 4) )
+        {
+            gridinfo.push_back(gi);
+        }
+        else
+        {
+            pj_gridinfo::iterator git = pj_gridinfo_parent(gridinfo.begin() + gridinfo_orig_size,
+                                                           gridinfo.end(),
+                                                           std::string((const char*)header+24, 8));
+
+            if( git == gridinfo.end() )
+            {
+                gridinfo.push_back(gi);
+            }
+            else
+            {
+                git->children.push_back(gi);
+            }
+        }
+
+        // Seek past the data.
+        is.seekg(gs_count * 16, std::ios::cur);
+    }
+
+    return true;
+}
+
+/************************************************************************/
+/*                       pj_gridinfo_init_ntv1()                        */
+/*                                                                      */
+/*      Load an NTv1 style Canadian grid shift file.                    */
+/************************************************************************/
+
+template <typename IStream>
+inline bool pj_gridinfo_init_ntv1(std::string const& gridname,
+                                  IStream & is,
+                                  pj_gridinfo & gridinfo)
+{
+    BOOST_STATIC_ASSERT( sizeof(boost::int32_t) == 4 );
+    BOOST_STATIC_ASSERT( sizeof(double) == 8 );
+
+    static const double d2r = math::d2r<double>();
+
+    // Read the header.
+    char header[176];
+
+    is.read(header, sizeof(header));
+    if( is.fail() )
+    {
+        return false;
+    }
+
+    // Regularize fields of interest.
+    if( is_lsb() )
+    {
+        swap_words( header+8, 4, 1 );
+        swap_words( header+24, 8, 1 );
+        swap_words( header+40, 8, 1 );
+        swap_words( header+56, 8, 1 );
+        swap_words( header+72, 8, 1 );
+        swap_words( header+88, 8, 1 );
+        swap_words( header+104, 8, 1 );
+    }
+
+    // NTv1 grid shift file has wrong record count, corrupt?
+    if( *((boost::int32_t *) (header+8)) != 12 )
+    {
+        return false;
+    }
+
+    // NOTE: This check is not implemented in proj4
+    if (! cstr_equal(header + 120, "SECONDS", 7))
+    {
+        return false;
+    }
+
+    // Fill in CTABLE structure.
+    pj_ctable ct;
+    pj_ctable::lp_t ur;
+
+    ct.id = "NTv1 Grid Shift File";
+
+    ct.ll.lam = - *((double *) (header+72));
+    ct.ll.phi = *((double *) (header+24));
+    ur.lam = - *((double *) (header+56));
+    ur.phi = *((double *) (header+40));
+    ct.del.lam = *((double *) (header+104));
+    ct.del.phi = *((double *) (header+88));
+    ct.lim.lam = (boost::int32_t) (fabs(ur.lam-ct.ll.lam)/ct.del.lam + 0.5) + 1;
+    ct.lim.phi = (boost::int32_t) (fabs(ur.phi-ct.ll.phi)/ct.del.phi + 0.5) + 1;
+
+    ct.ll.lam *= d2r;
+    ct.ll.phi *= d2r;
+    ct.del.lam *= d2r;
+    ct.del.phi *= d2r;
+    //ct.cvs.clear();
+
+    // is offset needed?
+    gridinfo.push_back(pj_gi(gridname, pj_gi::ntv1, is.tellg()));
+    gridinfo.back().ct = ct;
+
+    return true;
+}
+
+/************************************************************************/
+/*                       pj_gridinfo_init_gtx()                         */
+/*                                                                      */
+/*      Load a NOAA .gtx vertical datum shift file.                     */
+/************************************************************************/
+
+template <typename IStream>
+inline bool pj_gridinfo_init_gtx(std::string const& gridname,
+                                 IStream & is,
+                                 pj_gridinfo & gridinfo)
+{
+    BOOST_STATIC_ASSERT( sizeof(boost::int32_t) == 4 );
+    BOOST_STATIC_ASSERT( sizeof(double) == 8 );
+
+    static const double d2r = math::d2r<double>();
+
+    // Read the header.
+    char header[40];
+
+    is.read(header, sizeof(header));
+    if( is.fail() )
+    {
+        return false;
+    }
+
+    // Regularize fields of interest and extract.
+    double         xorigin, yorigin, xstep, ystep;
+    boost::int32_t rows, columns;
+
+    if( is_lsb() )
+    {
+        swap_words( header+0, 8, 4 );
+        swap_words( header+32, 4, 2 );
+    }
+
+    memcpy( &yorigin, header+0, 8 );
+    memcpy( &xorigin, header+8, 8 );
+    memcpy( &ystep, header+16, 8 );
+    memcpy( &xstep, header+24, 8 );
+
+    memcpy( &rows, header+32, 4 );
+    memcpy( &columns, header+36, 4 );
+
+    // gtx file header has invalid extents, corrupt?
+    if( xorigin < -360 || xorigin > 360
+        || yorigin < -90 || yorigin > 90 )
+    {
+        return false;
+    }
+
+    // Fill in CTABLE structure.
+    pj_ctable ct;
+
+    ct.id = "GTX Vertical Grid Shift File";
+
+    ct.ll.lam = xorigin;
+    ct.ll.phi = yorigin;
+    ct.del.lam = xstep;
+    ct.del.phi = ystep;
+    ct.lim.lam = columns;
+    ct.lim.phi = rows;
+
+    // some GTX files come in 0-360 and we shift them back into the
+    // expected -180 to 180 range if possible. This does not solve
+    // problems with grids spanning the dateline.
+    if( ct.ll.lam >= 180.0 )
+        ct.ll.lam -= 360.0;
+
+    if( ct.ll.lam >= 0.0 && ct.ll.lam + ct.del.lam * ct.lim.lam > 180.0 )
+    {
+        //"This GTX spans the dateline!  This will cause problems." );
+    }
+
+    ct.ll.lam *= d2r;
+    ct.ll.phi *= d2r;
+    ct.del.lam *= d2r;
+    ct.del.phi *= d2r;
+    //ct.cvs.clear();
+
+    // is offset needed?
+    gridinfo.push_back(pj_gi(gridname, pj_gi::gtx, 40));
+    gridinfo.back().ct = ct;
+
+    return true;
+}
+
+/************************************************************************/
+/*                   pj_gridinfo_init_ctable2()                         */
+/*                                                                      */
+/*      Read the header portion of a "ctable2" format grid.             */
+/************************************************************************/
+
+// Originally nad_ctable2_init() defined in nad_init.c
+template <typename IStream>
+inline bool pj_gridinfo_init_ctable2(std::string const& gridname,
+                                     IStream & is,
+                                     pj_gridinfo & gridinfo)
+{
+    BOOST_STATIC_ASSERT( sizeof(boost::int32_t) == 4 );
+    BOOST_STATIC_ASSERT( sizeof(double) == 8 );
+
+    char header[160];
+
+    is.read(header, sizeof(header));
+    if( is.fail() )
+    {
+        return false;
+    }
+
+    if( !is_lsb() )
+    {
+        swap_words( header +  96, 8, 4 );
+        swap_words( header + 128, 4, 2 );
+    }
+
+    // ctable2 - wrong header!
+    if (! cstr_equal(header, "CTABLE V2", 9))
+    {
+        return false;
+    }
+
+    // read the table header
+    pj_ctable ct;
+
+    ct.id = std::string(header + 16, std::find(header + 16, header + 16 + 80, '\0'));
+    //memcpy( &ct.ll.lam,  header +  96, 8 );
+    //memcpy( &ct.ll.phi,  header + 104, 8 );
+    //memcpy( &ct.del.lam, header + 112, 8 );
+    //memcpy( &ct.del.phi, header + 120, 8 );
+    //memcpy( &ct.lim.lam, header + 128, 4 );
+    //memcpy( &ct.lim.phi, header + 132, 4 );
+    memcpy( &ct.ll,  header +  96, 40 );
+
+    // do some minimal validation to ensure the structure isn't corrupt
+    if ( ct.lim.lam < 1 || ct.lim.lam > 100000 
+      || ct.lim.phi < 1 || ct.lim.phi > 100000 )
+    {
+        return false;
+    }
+    
+    // trim white space and newlines off id
+    boost::trim_right_if(ct.id, is_trimmable_char());
+
+    //ct.cvs.clear();
+
+    gridinfo.push_back(pj_gi(gridname, pj_gi::ctable2));
+    gridinfo.back().ct = ct;
+
+    return true;
+}
+
+/************************************************************************/
+/*                    pj_gridinfo_init_ctable()                         */
+/*                                                                      */
+/*      Read the header portion of a "ctable" format grid.              */
+/************************************************************************/
+
+// Originally nad_ctable_init() defined in nad_init.c
+template <typename IStream>
+inline bool pj_gridinfo_init_ctable(std::string const& gridname,
+                                    IStream & is,
+                                    pj_gridinfo & gridinfo)
+{
+    BOOST_STATIC_ASSERT( sizeof(boost::int32_t) == 4 );
+    BOOST_STATIC_ASSERT( sizeof(double) == 8 );
+
+    // 80 + 2*8 + 2*8 + 2*4
+    char header[120];
+
+    // NOTE: in proj4 data is loaded directly into CTABLE
+
+    is.read(header, sizeof(header));
+    if( is.fail() )
+    {
+        return false;
+    }
+
+    // NOTE: in proj4 LSB is not checked here
+
+    // read the table header
+    pj_ctable ct;
+
+    ct.id = std::string(header, std::find(header, header + 80, '\0'));
+    memcpy( &ct.ll, header + 80, 40 );
+
+    // do some minimal validation to ensure the structure isn't corrupt
+    if ( ct.lim.lam < 1 || ct.lim.lam > 100000 
+      || ct.lim.phi < 1 || ct.lim.phi > 100000 )
+    {
+        return false;
+    }
+    
+    // trim white space and newlines off id
+    boost::trim_right_if(ct.id, is_trimmable_char());
+
+    //ct.cvs.clear();
+
+    gridinfo.push_back(pj_gi(gridname, pj_gi::ctable));
+    gridinfo.back().ct = ct;
+
+    return true;
+}
+
+/************************************************************************/
+/*                          pj_gridinfo_init()                          */
+/*                                                                      */
+/*      Open and parse header details from a datum gridshift file       */
+/*      returning a list of PJ_GRIDINFOs for the grids in that          */
+/*      file.  This superceeds use of nad_init() for modern             */
+/*      applications.                                                   */
+/************************************************************************/
+
+template <typename IStream>
+inline bool pj_gridinfo_init(std::string const& gridname,
+                             IStream & is,
+                             pj_gridinfo & gridinfo)
+{
+    char header[160];
+
+    // Check if the stream is opened.
+    if (! is.is_open()) {
+        return false;
+    }
+
+    // Load a header, to determine the file type.
+    is.read(header, sizeof(header));
+
+    if ( is.fail() ) {
+        return false;
+    }
+    
+    is.seekg(0);
+
+    // Determine file type.
+    if ( cstr_equal(header + 0, "HEADER", 6)
+      && cstr_equal(header + 96, "W GRID", 6)
+      && cstr_equal(header + 144, "TO      NAD83   ", 16) )
+    {
+        return pj_gridinfo_init_ntv1(gridname, is, gridinfo);
+    }
+    else if( cstr_equal(header + 0, "NUM_OREC", 8)
+          && cstr_equal(header + 48, "GS_TYPE", 7) )
+    {
+        return pj_gridinfo_init_ntv2(gridname, is, gridinfo);
+    }
+    else if( boost::algorithm::ends_with(gridname, "gtx")
+          || boost::algorithm::ends_with(gridname, "GTX") )
+    {
+        return pj_gridinfo_init_gtx(gridname, is, gridinfo);
+    }
+    else if( cstr_equal(header + 0, "CTABLE V2", 9) )
+    {
+        return pj_gridinfo_init_ctable2(gridname, is, gridinfo);
+    }
+    else
+    {
+        return pj_gridinfo_init_ctable(gridname, is, gridinfo);
+    }
+}
+
+
+} // namespace detail
+
+}}} // namespace boost::geometry::projections
+
+#endif // BOOST_GEOMETRY_SRS_PROJECTIONS_IMPL_PJ_GRIDINFO_HPP

--- a/include/boost/geometry/srs/projections/impl/pj_gridlist.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_gridlist.hpp
@@ -1,0 +1,181 @@
+// Boost.Geometry
+// This file is manually converted from PROJ4
+
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018, Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+// This file is converted from PROJ4, http://trac.osgeo.org/proj
+// PROJ4 is originally written by Gerald Evenden (then of the USGS)
+// PROJ4 is maintained by Frank Warmerdam
+// This file was converted to Geometry Library by Adam Wulkiewicz
+
+// Original copyright notice:
+// Author:   Frank Warmerdam, warmerdam@pobox.com
+
+// Copyright (c) 2000, Frank Warmerdam
+
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#ifndef BOOST_GEOMETRY_SRS_PROJECTIONS_IMPL_PJ_GRIDLIST_HPP
+#define BOOST_GEOMETRY_SRS_PROJECTIONS_IMPL_PJ_GRIDLIST_HPP
+
+
+#include <boost/geometry/srs/projections/grids.hpp>
+#include <boost/geometry/srs/projections/impl/pj_gridinfo.hpp>
+
+
+namespace boost { namespace geometry { namespace projections
+{
+
+namespace detail
+{
+
+/************************************************************************/
+/*                       pj_gridlist_merge_grid()                       */
+/*                                                                      */
+/*      Find/load the named gridfile and merge it into the              */
+/*      last_nadgrids_list.                                             */
+/************************************************************************/
+
+// Originally one function, here divided into several functions
+// with overloads for various types of grids and stream policies
+
+inline bool pj_gridlist_find_all(std::string const& gridname,
+                                 pj_gridinfo const& grids,
+                                 std::vector<std::size_t> & gridindexes)
+{
+    bool result = false;
+    for (std::size_t i = 0 ; i < grids.size() ; ++i)
+    {
+        if (grids[i].gridname == gridname)
+        {
+            result = true;
+            gridindexes.push_back(i);
+        }
+    }
+    return result;
+}
+
+// Fill container with sequentially increasing numbers
+inline void pj_gridlist_add_seq_inc(std::vector<std::size_t> & gridindexes,
+                                    std::size_t first, std::size_t last)
+{
+    gridindexes.reserve(gridindexes.size() + (last - first));
+    for ( ; first < last ; ++first)
+    {
+        gridindexes.push_back(first);
+    }
+}
+
+// Generic stream policy and standard grids
+template <typename StreamPolicy>
+inline bool pj_gridlist_merge_gridfile(std::string const& gridname,
+                                       StreamPolicy const& stream_policy,
+                                       srs::grids & grids,
+                                       std::vector<std::size_t> & gridindexes)
+{
+    // Try to find in the existing list of loaded grids.  Add all
+    // matching grids as with NTv2 we can get many grids from one
+    // file (one shared gridname).    
+    if (pj_gridlist_find_all(gridname, grids.gridinfo, gridindexes))
+        return true;
+
+    std::size_t orig_size = grids.gridinfo.size();
+
+    // Try to load the named grid.
+    typename StreamPolicy::stream_type is;
+    stream_policy.open(is, gridname);
+
+    if (! pj_gridinfo_init(gridname, is, grids.gridinfo))
+    {
+        return false;
+    }
+
+    // Add the grid now that it is loaded.
+    pj_gridlist_add_seq_inc(gridindexes, orig_size, grids.gridinfo.size());
+    
+    return true;
+}
+
+
+/************************************************************************/
+/*                     pj_gridlist_from_nadgrids()                      */
+/*                                                                      */
+/*      This functions loads the list of grids corresponding to a       */
+/*      particular nadgrids string into a list, and returns it. The     */
+/*      list is kept around till a request is made with a different     */
+/*      string in order to cut down on the string parsing cost, and     */
+/*      the cost of building the list of tables each time.              */
+/************************************************************************/
+
+template <typename StreamPolicy, typename Grids>
+inline void pj_gridlist_from_nadgrids(std::string const& nadgrids,
+                                      StreamPolicy const& stream_policy,
+                                      Grids & grids,
+                                      std::vector<std::size_t> & gridindexes)
+
+{
+    // Loop processing names out of nadgrids one at a time.
+    for (std::string::size_type i = 0 ; i < nadgrids.size() ; )
+    {
+        bool required = true;
+        
+        if( nadgrids[i] == '@' )
+        {
+            required = false;
+            ++i;
+        }
+
+        std::string::size_type end = nadgrids.find(',', i);
+        std::string name = nadgrids.substr(i, end - i);
+                
+        i = end;
+        if (end != std::string::npos)
+            ++i;
+
+        if ( ! pj_gridlist_merge_gridfile(name, stream_policy, grids, gridindexes) 
+          && required )
+        {
+            BOOST_THROW_EXCEPTION( projection_exception(-38) );
+        }
+    }
+}
+
+template <typename Par, typename GridsStorage>
+inline void pj_gridlist_from_nadgrids(Par const& defn, srs::projection_grids<GridsStorage> & grids)
+{
+    BOOST_GEOMETRY_ASSERT(grids.storage_ptr != NULL);
+
+    pj_gridlist_from_nadgrids(pj_get_param_s(defn.params, "nadgrids"),
+                              grids.storage_ptr->stream_policy,
+                              grids.storage_ptr->hgrids,
+                              grids.hindexes);
+}
+
+
+} // namespace detail
+
+}}} // namespace boost::geometry::projections
+
+#endif // BOOST_GEOMETRY_SRS_PROJECTIONS_IMPL_PJ_GRIDLIST_HPP

--- a/include/boost/geometry/srs/projections/impl/pj_gridlist_shared.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_gridlist_shared.hpp
@@ -1,0 +1,121 @@
+// Boost.Geometry
+// This file is manually converted from PROJ4
+
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018, Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+// This file is converted from PROJ4, http://trac.osgeo.org/proj
+// PROJ4 is originally written by Gerald Evenden (then of the USGS)
+// PROJ4 is maintained by Frank Warmerdam
+// This file was converted to Geometry Library by Adam Wulkiewicz
+
+// Original copyright notice:
+// Author:   Frank Warmerdam, warmerdam@pobox.com
+
+// Copyright (c) 2000, Frank Warmerdam
+
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#ifndef BOOST_GEOMETRY_SRS_PROJECTIONS_IMPL_PJ_GRIDLIST_SHARED_HPP
+#define BOOST_GEOMETRY_SRS_PROJECTIONS_IMPL_PJ_GRIDLIST_SHARED_HPP
+
+
+#include <boost/geometry/srs/projections/shared_grids.hpp>
+#include <boost/geometry/srs/projections/impl/pj_gridinfo.hpp>
+
+
+namespace boost { namespace geometry { namespace projections
+{
+
+namespace detail
+{
+
+
+/************************************************************************/
+/*                       pj_gridlist_merge_grid()                       */
+/*                                                                      */
+/*      Find/load the named gridfile and merge it into the              */
+/*      last_nadgrids_list.                                             */
+/************************************************************************/
+
+// Generic stream policy and shared grids
+template <typename StreamPolicy>
+inline bool pj_gridlist_merge_gridfile(std::string const& gridname,
+                                       StreamPolicy const& stream_policy,
+                                       srs::shared_grids & grids,
+                                       std::vector<std::size_t> & gridindexes)
+{
+    // Try to find in the existing list of loaded grids.  Add all
+    // matching grids as with NTv2 we can get many grids from one
+    // file (one shared gridname).    
+    {
+        boost::shared_lock<boost::shared_mutex> lock(grids.mutex);
+
+        if (pj_gridlist_find_all(gridname, grids.gridinfo, gridindexes))
+            return true;
+    }
+
+    // Try to load the named grid.
+    typename StreamPolicy::stream_type is;
+    stream_policy.open(is, gridname);
+
+    pj_gridinfo new_grids;
+    
+    if (! pj_gridinfo_init(gridname, is, new_grids))
+    {
+        return false;
+    }
+
+    // Add the grid now that it is loaded.
+
+    std::size_t orig_size = 0;
+    std::size_t new_size = 0;
+
+    {
+        boost::unique_lock<boost::shared_mutex> lock(grids.mutex);
+
+        // Try to find in the existing list of loaded grids again
+        // in case other thread already added it.
+        if (pj_gridlist_find_all(gridname, grids.gridinfo, gridindexes))
+            return true;
+
+        orig_size = grids.gridinfo.size();
+        new_size = orig_size + new_grids.size();
+
+        grids.gridinfo.resize(new_size);
+        for (std::size_t i = 0 ; i < new_grids.size() ; ++ i)
+            new_grids[i].swap(grids.gridinfo[i + orig_size]);
+    }
+    
+    pj_gridlist_add_seq_inc(gridindexes, orig_size, new_size);
+    
+    return true;
+}
+
+
+} // namespace detail
+
+}}} // namespace boost::geometry::projections
+
+#endif // BOOST_GEOMETRY_SRS_PROJECTIONS_IMPL_PJ_GRIDLIST_SHARED_HPP

--- a/include/boost/geometry/srs/projections/impl/pj_init.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_init.hpp
@@ -71,21 +71,21 @@ namespace detail
 template <typename BGParams, typename T>
 inline void pj_push_defaults(BGParams const& /*bg_params*/, parameters<T>& pin)
 {
-    pin.params.push_back(pj_mkparam<T>("ellps=WGS84"));
+    pin.params.push_back(pj_mkparam<T>("ellps", "WGS84"));
 
     if (pin.name == "aea")
     {
-        pin.params.push_back(pj_mkparam<T>("lat_1=29.5"));
-        pin.params.push_back(pj_mkparam<T>("lat_2=45.5 "));
+        pin.params.push_back(pj_mkparam<T>("lat_1", "29.5"));
+        pin.params.push_back(pj_mkparam<T>("lat_2", "45.5 "));
     }
     else if (pin.name == "lcc")
     {
-        pin.params.push_back(pj_mkparam<T>("lat_1=33"));
-        pin.params.push_back(pj_mkparam<T>("lat_2=45"));
+        pin.params.push_back(pj_mkparam<T>("lat_1", "33"));
+        pin.params.push_back(pj_mkparam<T>("lat_2", "45"));
     }
     else if (pin.name == "lagrng")
     {
-        pin.params.push_back(pj_mkparam<T>("W=2"));
+        pin.params.push_back(pj_mkparam<T>("W", "2"));
     }
 }
 
@@ -100,21 +100,21 @@ inline void pj_push_defaults(srs::static_proj4<BOOST_GEOMETRY_PROJECTIONS_DETAIL
         >::type proj_tag;
 
     // statically defaulting to WGS84
-    //pin.params.push_back(pj_mkparam("ellps=WGS84"));
+    //pin.params.push_back(pj_mkparam("ellps", "WGS84"));
 
     if (BOOST_GEOMETRY_CONDITION((boost::is_same<proj_tag, srs::par4::aea>::value)))
     {
-        pin.params.push_back(pj_mkparam<T>("lat_1=29.5"));
-        pin.params.push_back(pj_mkparam<T>("lat_2=45.5 "));
+        pin.params.push_back(pj_mkparam<T>("lat_1", "29.5"));
+        pin.params.push_back(pj_mkparam<T>("lat_2", "45.5 "));
     }
     else if (BOOST_GEOMETRY_CONDITION((boost::is_same<proj_tag, srs::par4::lcc>::value)))
     {
-        pin.params.push_back(pj_mkparam<T>("lat_1=33"));
-        pin.params.push_back(pj_mkparam<T>("lat_2=45"));
+        pin.params.push_back(pj_mkparam<T>("lat_1", "33"));
+        pin.params.push_back(pj_mkparam<T>("lat_2", "45"));
     }
     else if (BOOST_GEOMETRY_CONDITION((boost::is_same<proj_tag, srs::par4::lagrng>::value)))
     {
-        pin.params.push_back(pj_mkparam<T>("W=2"));
+        pin.params.push_back(pj_mkparam<T>("W", "2"));
     }
 }
 
@@ -128,7 +128,7 @@ inline void pj_init_units(std::vector<pvalue<T> > const& params,
                           T const& default_fr_meter)
 {
     std::string s;
-    std::string units = pj_param(params, sunits).s;
+    std::string units = pj_get_param_s(params, sunits);
     if (! units.empty())
     {
         const int n = sizeof(pj_units) / sizeof(pj_units[0]);
@@ -149,7 +149,7 @@ inline void pj_init_units(std::vector<pvalue<T> > const& params,
 
     if (s.empty())
     {
-        s = pj_param(params, sto_meter).s;
+        s = pj_get_param_s(params, sto_meter);
     }
 
     if (! s.empty())
@@ -200,15 +200,16 @@ inline parameters<T> pj_init(BGParams const& bg_params, R const& arguments, bool
         pin.params.push_back(pj_mkparam<T>(*it));
     }
 
+    // maybe TODO: handle "init" parameter
     /* check if +init present */
-    if (pj_param(pin.params, "tinit").i)
-    {
-        // maybe TODO: handle "init" parameter
-        //if (!(curr = get_init(&arguments, curr, pj_param(pin.params, "sinit").s)))
-    }
+    //std::string sinit;
+    //if (pj_param_s(pin.params, "init", sinit))
+    //{
+    //    //if (!(curr = get_init(&arguments, curr, sinit)))
+    //}
 
     // find projection -> implemented in projection factory
-    pin.name = pj_param(pin.params, "sproj").s;
+    pin.name = pj_get_param_s(pin.params, "proj");
     // exception thrown in projection<>
     // TODO: consider throwing here both projection_unknown_id_exception and
     // projection_not_named_exception in order to throw before other exceptions
@@ -217,7 +218,7 @@ inline parameters<T> pj_init(BGParams const& bg_params, R const& arguments, bool
 
     // set defaults, unless inhibited
     // GL-Addition, if use_defaults is false then defaults are ignored
-    if (use_defaults && ! pj_param(pin.params, "bno_defs").i)
+    if (use_defaults && ! pj_get_param_b(pin.params, "no_defs"))
     {
         // proj4 gets defaults from "proj_def.dat", file of 94/02/23 with a few defaults.
         // Here manually
@@ -262,45 +263,43 @@ inline parameters<T> pj_init(BGParams const& bg_params, R const& arguments, bool
     }
 
     /* set pin.geoc coordinate system */
-    pin.geoc = (pin.es && pj_param(pin.params, "bgeoc").i);
+    pin.geoc = (pin.es && pj_get_param_b(pin.params, "geoc"));
 
     /* over-ranging flag */
-    pin.over = pj_param(pin.params, "bover").i;
+    pin.over = pj_get_param_b(pin.params, "over");
 
     /* longitude center for wrapping */
-    pin.is_long_wrap_set = pj_param(pin.params, "tlon_wrap").i != 0;
-    if (pin.is_long_wrap_set)
-        pin.long_wrap_center = pj_param(pin.params, "rlon_wrap").f;
+    pin.is_long_wrap_set = pj_param_r(pin.params, "lon_wrap", pin.long_wrap_center);
 
     /* central meridian */
-    pin.lam0 = pj_param(pin.params, "rlon_0").f;
+    pin.lam0 = pj_get_param_r(pin.params, "lon_0");
 
     /* central latitude */
-    pin.phi0 = pj_param(pin.params, "rlat_0").f;
+    pin.phi0 = pj_get_param_r(pin.params, "lat_0");
 
     /* false easting and northing */
-    pin.x0 = pj_param(pin.params, "dx_0").f;
-    pin.y0 = pj_param(pin.params, "dy_0").f;
+    pin.x0 = pj_get_param_f(pin.params, "x_0");
+    pin.y0 = pj_get_param_f(pin.params, "y_0");
 
     /* general scaling factor */
-    if (pj_param(pin.params, "tk_0").i)
-        pin.k0 = pj_param(pin.params, "dk_0").f;
-    else if (pj_param(pin.params, "tk").i)
-        pin.k0 = pj_param(pin.params, "dk").f;
-    else
+    if (pj_param_f(pin.params, "k_0", pin.k0)) {
+        /* empty */
+    } else if (pj_param_f(pin.params, "k", pin.k0)) {
+        /* empty */
+    } else
         pin.k0 = 1.;
     if (pin.k0 <= 0.) {
         BOOST_THROW_EXCEPTION( projection_exception(-31) );
     }
 
     /* set units */
-    pj_init_units(pin.params, "sunits", "sto_meter",
+    pj_init_units(pin.params, "units", "to_meter",
                   pin.to_meter, pin.fr_meter, 1., 1.);
-    pj_init_units(pin.params, "svunits", "svto_meter",
+    pj_init_units(pin.params, "vunits", "vto_meter",
                   pin.vto_meter, pin.vfr_meter, pin.to_meter, pin.fr_meter);
 
     /* prime meridian */
-    std::string pm = pj_param(pin.params, "spm").s;
+    std::string pm = pj_get_param_s(pin.params, "pm");
     if (! pm.empty())
     {
         std::string value;

--- a/include/boost/geometry/srs/projections/impl/pj_param.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_param.hpp
@@ -3,8 +3,8 @@
 
 // Copyright (c) 2008-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -43,8 +43,13 @@
 #include <string>
 #include <vector>
 
+#include <boost/geometry/srs/projections/exception.hpp>
+
 #include <boost/geometry/srs/projections/impl/dms_parser.hpp>
 #include <boost/geometry/srs/projections/impl/projects.hpp>
+
+#include <boost/mpl/assert.hpp>
+#include <boost/type_traits/is_integral.hpp>
 
 
 namespace boost { namespace geometry { namespace projections {
@@ -52,6 +57,16 @@ namespace boost { namespace geometry { namespace projections {
 namespace detail {
 
 
+/* create pvalue list entry */
+template <typename T>
+inline pvalue<T> pj_mkparam(std::string const& name, std::string const& value)
+{
+    pvalue<T> newitem;
+    newitem.param = name;
+    newitem.s = value;
+    //newitem.used = false;
+    return newitem;
+}
 
 /* create pvalue list entry */
 template <typename T>
@@ -67,92 +82,146 @@ inline pvalue<T> pj_mkparam(std::string const& str)
         name.erase(loc);
     }
 
-
-    pvalue<T> newitem;
-    newitem.param = name;
-    newitem.s = value;
-    newitem.used = 0;
-    newitem.i = atoi(value.c_str());
-    newitem.f = atof(value.c_str());
-    return newitem;
+    return pj_mkparam<T>(name, value);
 }
 
-/************************************************************************/
-/*                              pj_param()                              */
-/*                                                                      */
-/*      Test for presence or get pvalue value.  The first            */
-/*      character in `opt' is a pvalue type which can take the       */
-/*      values:                                                         */
-/*                                                                      */
-/*       `t' - test for presence, return TRUE/FALSE in pvalue.i         */
-/*       `i' - integer value returned in pvalue.i                       */
-/*       `d' - simple valued real input returned in pvalue.f            */
-/*       `r' - degrees (DMS translation applied), returned as           */
-/*             radians in pvalue.f                                      */
-/*       `s' - string returned in pvalue.s                              */
-/*       `b' - test for t/T/f/F, return in pvalue.i                     */
-/*                                                                      */
-/************************************************************************/
-
+/* input exists */
 template <typename T>
-inline pvalue<T> pj_param(std::vector<pvalue<T> > const& pl, std::string opt)
+inline typename std::vector<pvalue<T> >::const_iterator
+    pj_param_find(std::vector<pvalue<T> > const& pl, std::string const& name)
 {
-    char type = opt[0];
-    opt.erase(opt.begin());
-
-    pvalue<T> value;
-
-    /* simple linear lookup */
     typedef typename std::vector<pvalue<T> >::const_iterator iterator;
     for (iterator it = pl.begin(); it != pl.end(); it++)
     {
-        if (it->param == opt)
+        if (it->param == name)
         {
-            //it->used = 1;
-            switch (type)
-            {
-            case 't':
-                value.i = 1;
-                break;
-            case 'i':    /* integer input */
-                value.i = atoi(it->s.c_str());
-                break;
-            case 'd':    /* simple real input */
-                value.f = atof(it->s.c_str());
-                break;
-            case 'r':    /* degrees input */
-                {
-                    dms_parser<T, true> parser;
-                    value.f = parser.apply(it->s.c_str()).angle();
-                }
-                break;
-            case 's':    /* char string */
-                value.s = it->s;
-                break;
-            case 'b':    /* boolean */
-                switch (it->s[0])
-                {
-                case 'F': case 'f':
-                    value.i = 0;
-                    break;
-                case '\0': case 'T': case 't':
-                    value.i = 1;
-                    break;
-                default:
-                    value.i = 0;
-                    break;
-                }
-                break;
-            }
-            return value;
+            //it->used = true;
+            return it;
         }
-
+        // TODO: needed for pipeline
+        /*else if (it->param == "step")
+        {
+            return pl.end();
+        }*/
     }
 
-    value.i = 0;
-    value.f = 0.0;
-    value.s = "";
-    return value;
+    return pl.end();
+}
+
+/* input exists */
+template <typename T>
+inline bool pj_param_exists(std::vector<pvalue<T> > const& pl, std::string const& name)
+{
+    return pj_param_find(pl, name) != pl.end();
+}
+
+/* integer input */
+template <typename T>
+inline bool pj_param_i(std::vector<pvalue<T> > const& pl, std::string const& name, int & par)
+{
+    typename std::vector<pvalue<T> >::const_iterator it = pj_param_find(pl, name);        
+    if (it != pl.end())
+    {
+        par = atoi(it->s.c_str());
+        return true;
+    }    
+    return false;
+}
+
+/* floating point input */
+template <typename T>
+inline bool pj_param_f(std::vector<pvalue<T> > const& pl, std::string const& name, T & par)
+{
+    typename std::vector<pvalue<T> >::const_iterator it = pj_param_find(pl, name);        
+    if (it != pl.end())
+    {
+        par = atof(it->s.c_str());
+        return true;
+    }    
+    return false;
+}
+
+/* radians input */
+template <typename T>
+inline bool pj_param_r(std::vector<pvalue<T> > const& pl, std::string const& name, T & par)
+{
+    typename std::vector<pvalue<T> >::const_iterator it = pj_param_find(pl, name);        
+    if (it != pl.end())
+    {
+        dms_parser<T, true> parser;
+        par = parser.apply(it->s.c_str()).angle();
+        return true;
+    }    
+    return false;
+}
+
+/* string input */
+template <typename T>
+inline bool pj_param_s(std::vector<pvalue<T> > const& pl, std::string const& name, std::string & par)
+{
+    typename std::vector<pvalue<T> >::const_iterator it = pj_param_find(pl, name);        
+    if (it != pl.end())
+    {
+        par = it->s;
+        return true;
+    }    
+    return false;
+}
+
+/* bool input */
+template <typename T>
+inline bool pj_get_param_b(std::vector<pvalue<T> > const& pl, std::string const& name)
+{
+    typename std::vector<pvalue<T> >::const_iterator it = pj_param_find(pl, name);        
+    if (it != pl.end())
+    {
+        switch (it->s[0])
+        {
+        case '\0': case 'T': case 't':
+            return true;
+        case 'F': case 'f':
+            return false;
+        default:
+            BOOST_THROW_EXCEPTION( projection_exception(-8) );
+            return false;
+        }
+    }    
+    return false;
+}
+
+// NOTE: In the original code, in pl_ell_set.c there is a function pj_get_param
+// which behavior is similar to pj_param but it doesn't set `user` member to TRUE
+// while pj_param does in the original code. In Boost.Geometry this member is not used.
+template <typename T>
+inline int pj_get_param_i(std::vector<pvalue<T> > const& pl, std::string const& name)
+{
+    int res = 0;
+    pj_param_i(pl, name, res);
+    return res;
+}
+
+template <typename T>
+inline T pj_get_param_f(std::vector<pvalue<T> > const& pl, std::string const& name)
+{
+    T res = 0;
+    pj_param_f(pl, name, res);
+    return res;
+}
+
+template <typename T>
+inline T pj_get_param_r(std::vector<pvalue<T> > const& pl, std::string const& name)
+{
+    T res = 0;
+    pj_param_r(pl, name, res);
+    return res;
+}
+
+template <typename T>
+inline std::string pj_get_param_s(std::vector<pvalue<T> > const& pl, std::string const& name)
+{
+    std::string res;
+    pj_param_s(pl, name, res);
+    return res;
 }
 
 } // namespace detail

--- a/include/boost/geometry/srs/projections/impl/pj_transform.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_transform.hpp
@@ -742,8 +742,8 @@ inline bool pj_compare_datums( Par & srcdefn, Par & dstdefn )
     }
     else if( srcdefn.datum_type == PJD_GRIDSHIFT )
     {
-        return pj_param(srcdefn.params,"snadgrids").s
-            == pj_param(dstdefn.params,"snadgrids").s;
+        return pj_get_param_s(srcdefn.params,"nadgrids")
+            == pj_get_param_s(dstdefn.params,"nadgrids");
     }
     else
         return true;

--- a/include/boost/geometry/srs/projections/impl/projects.hpp
+++ b/include/boost/geometry/srs/projections/impl/projects.hpp
@@ -100,11 +100,8 @@ template <typename T>
 struct pvalue
 {
     std::string param;
-    int used;
-
-    int i;
-    T f;
     std::string s;
+    //int used;
 };
 
 template <typename T>

--- a/include/boost/geometry/srs/projections/proj/aea.hpp
+++ b/include/boost/geometry/srs/projections/proj/aea.hpp
@@ -238,8 +238,8 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_aea(Parameters& par, par_aea<T>& proj_parm)
             {
-                proj_parm.phi1 = pj_param(par.params, "rlat_1").f;
-                proj_parm.phi2 = pj_param(par.params, "rlat_2").f;
+                proj_parm.phi1 = pj_get_param_r(par.params, "lat_1");
+                proj_parm.phi2 = pj_get_param_r(par.params, "lat_2");
                 setup(par, proj_parm);
             }
 
@@ -249,8 +249,8 @@ namespace projections
             {
                 static const T HALFPI = detail::HALFPI<T>();
 
-                proj_parm.phi2 = pj_param(par.params, "rlat_1").f;
-                proj_parm.phi1 = pj_param(par.params, "bsouth").i ? -HALFPI : HALFPI;
+                proj_parm.phi2 = pj_get_param_r(par.params, "lat_1");
+                proj_parm.phi1 = pj_get_param_b(par.params, "south") ? -HALFPI : HALFPI;
                 setup(par, proj_parm);
             }
 

--- a/include/boost/geometry/srs/projections/proj/aeqd.hpp
+++ b/include/boost/geometry/srs/projections/proj/aeqd.hpp
@@ -292,7 +292,7 @@ namespace projections
             {
                 static const T HALFPI = detail::HALFPI<T>();
 
-                par.phi0 = pj_param(par.params, "rlat_0").f;
+                par.phi0 = pj_get_param_r(par.params, "lat_0");
                 if (fabs(fabs(par.phi0) - HALFPI) < EPS10) {
                     proj_parm.mode = par.phi0 < 0. ? S_POLE : N_POLE;
                     proj_parm.sinph0 = par.phi0 < 0. ? -1. : 1.;
@@ -626,7 +626,7 @@ namespace projections
             public :
                 virtual base_v<CalculationType, Parameters>* create_new(const Parameters& par) const
                 {
-                    bool const guam = pj_param(par.params, "bguam").i != 0;
+                    bool const guam = pj_get_param_b(par.params, "guam");
 
                     if (par.es && ! guam)
                         return new base_v_fi<aeqd_e<CalculationType, Parameters>, CalculationType, Parameters>(par);

--- a/include/boost/geometry/srs/projections/proj/airy.hpp
+++ b/include/boost/geometry/srs/projections/proj/airy.hpp
@@ -169,8 +169,8 @@ namespace projections
 
                 T beta;
 
-                proj_parm.no_cut = pj_param(par.params, "bno_cut").i;
-                beta = 0.5 * (HALFPI - pj_param(par.params, "rlat_b").f);
+                proj_parm.no_cut = pj_get_param_b(par.params, "no_cut");
+                beta = 0.5 * (HALFPI - pj_get_param_r(par.params, "lat_b"));
                 if (fabs(beta) < EPS)
                     proj_parm.Cb = -0.5;
                 else {

--- a/include/boost/geometry/srs/projections/proj/aitoff.hpp
+++ b/include/boost/geometry/srs/projections/proj/aitoff.hpp
@@ -233,9 +233,11 @@ namespace projections
             {
                 static const T TWO_D_PI = detail::TWO_D_PI<T>();
 
+                T phi1;
+
                 proj_parm.mode = WINKEL_TRIPEL;
-                if (pj_param(par.params, "tlat_1").i) {
-                    if ((proj_parm.cosphi1 = cos(pj_param(par.params, "rlat_1").f)) == 0.)
+                if (pj_param_r(par.params, "lat_1", phi1)) {
+                    if ((proj_parm.cosphi1 = cos(phi1)) == 0.)
                         BOOST_THROW_EXCEPTION( projection_exception(-22) );
                 } else /* 50d28' or phi1=acos(2/pi) */
                     proj_parm.cosphi1 = TWO_D_PI;

--- a/include/boost/geometry/srs/projections/proj/bipc.hpp
+++ b/include/boost/geometry/srs/projections/proj/bipc.hpp
@@ -234,7 +234,7 @@ namespace projections
             template <typename Parameters>
             inline void setup_bipc(Parameters& par, par_bipc& proj_parm)
             {
-                proj_parm.noskew = pj_param(par.params, "bns").i;
+                proj_parm.noskew = pj_get_param_b(par.params, "ns");
                 par.es = 0.;
             }
 

--- a/include/boost/geometry/srs/projections/proj/bonne.hpp
+++ b/include/boost/geometry/srs/projections/proj/bonne.hpp
@@ -193,7 +193,7 @@ namespace projections
 
                 T c;
 
-                proj_parm.phi1 = pj_param(par.params, "rlat_1").f;
+                proj_parm.phi1 = pj_get_param_r(par.params, "lat_1");
                 if (fabs(proj_parm.phi1) < EPS10)
                     BOOST_THROW_EXCEPTION( projection_exception(-23) );
 

--- a/include/boost/geometry/srs/projections/proj/cea.hpp
+++ b/include/boost/geometry/srs/projections/proj/cea.hpp
@@ -165,8 +165,8 @@ namespace projections
             {
                 T t = 0;
 
-                if (pj_param(par.params, "tlat_ts").i) {
-                    par.k0 = cos(t = pj_param(par.params, "rlat_ts").f);
+                if (pj_param_r(par.params, "lat_ts", t)) {
+                    par.k0 = cos(t);
                     if (par.k0 < 0.) {
                         BOOST_THROW_EXCEPTION( projection_exception(-24) );
                     }

--- a/include/boost/geometry/srs/projections/proj/chamb.hpp
+++ b/include/boost/geometry/srs/projections/proj/chamb.hpp
@@ -190,14 +190,14 @@ namespace projections
             {
                 static const T ONEPI = detail::ONEPI<T>();
 
+                static const std::string lat[3] = {"lat_1", "lat_2", "lat_3"};
+                static const std::string lon[3] = {"lon_1", "lon_2", "lon_3"};
+
                 int i, j;
-                char line[10];
 
                 for (i = 0; i < 3; ++i) { /* get control point locations */
-                    (void)sprintf(line, "rlat_%d", i+1);
-                    proj_parm.c[i].phi = pj_param(par.params, line).f;
-                    (void)sprintf(line, "rlon_%d", i+1);
-                    proj_parm.c[i].lam = pj_param(par.params, line).f;
+                    proj_parm.c[i].phi = pj_get_param_r(par.params, lat[i]);
+                    proj_parm.c[i].lam = pj_get_param_r(par.params, lon[i]);
                     proj_parm.c[i].lam = adjlon(proj_parm.c[i].lam - par.lam0);
                     proj_parm.c[i].cosphi = cos(proj_parm.c[i].phi);
                     proj_parm.c[i].sinphi = sin(proj_parm.c[i].phi);

--- a/include/boost/geometry/srs/projections/proj/eqc.hpp
+++ b/include/boost/geometry/srs/projections/proj/eqc.hpp
@@ -107,7 +107,7 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_eqc(Parameters& par, par_eqc<T>& proj_parm)
             {
-                if ((proj_parm.rc = cos(pj_param(par.params, "rlat_ts").f)) <= 0.)
+                if ((proj_parm.rc = cos(pj_get_param_r(par.params, "lat_ts"))) <= 0.)
                     BOOST_THROW_EXCEPTION( projection_exception(-24) );
                 par.es = 0.;
             }

--- a/include/boost/geometry/srs/projections/proj/eqdc.hpp
+++ b/include/boost/geometry/srs/projections/proj/eqdc.hpp
@@ -144,8 +144,8 @@ namespace projections
                 T cosphi, sinphi;
                 int secant;
 
-                proj_parm.phi1 = pj_param(par.params, "rlat_1").f;
-                proj_parm.phi2 = pj_param(par.params, "rlat_2").f;
+                proj_parm.phi1 = pj_get_param_r(par.params, "lat_1");
+                proj_parm.phi2 = pj_get_param_r(par.params, "lat_2");
 
                 if (fabs(proj_parm.phi1 + proj_parm.phi2) < EPS10)
                     BOOST_THROW_EXCEPTION( projection_exception(-21) );

--- a/include/boost/geometry/srs/projections/proj/etmerc.hpp
+++ b/include/boost/geometry/srs/projections/proj/etmerc.hpp
@@ -354,11 +354,10 @@ namespace projections
                     BOOST_THROW_EXCEPTION( projection_exception(-34) );
                 }
 
-                par.y0 = pj_param(par.params, "bsouth").i ? 10000000. : 0.;
+                par.y0 = pj_get_param_b(par.params, "south") ? 10000000. : 0.;
                 par.x0 = 500000.;
-                if (pj_param(par.params, "tzone").i) /* zone input ? */
+                if (pj_param_i(par.params, "zone", zone)) /* zone input ? */
                 {
-                    zone = pj_param(par.params, "izone").i;
                     if (zone > 0 && zone <= 60)
                         --zone;
                     else {

--- a/include/boost/geometry/srs/projections/proj/fouc_s.hpp
+++ b/include/boost/geometry/srs/projections/proj/fouc_s.hpp
@@ -134,7 +134,7 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_fouc_s(Parameters& par, par_fouc_s<T>& proj_parm)
             {
-                proj_parm.n = pj_param(par.params, "dn").f;
+                proj_parm.n = pj_get_param_f(par.params, "n");
                 if (proj_parm.n < 0. || proj_parm.n > 1.)
                     BOOST_THROW_EXCEPTION( projection_exception(-40) );
 

--- a/include/boost/geometry/srs/projections/proj/geos.hpp
+++ b/include/boost/geometry/srs/projections/proj/geos.hpp
@@ -264,13 +264,13 @@ namespace projections
             {
                 std::string sweep_axis;
 
-                if ((proj_parm.h = pj_param(par.params, "dh").f) <= 0.)
+                if ((proj_parm.h = pj_get_param_f(par.params, "h")) <= 0.)
                     BOOST_THROW_EXCEPTION( projection_exception(-30) );
 
                 if (par.phi0 != 0.0)
                     BOOST_THROW_EXCEPTION( projection_exception(-46) );
 
-                sweep_axis = pj_param(par.params, "ssweep").s;
+                sweep_axis = pj_get_param_s(par.params, "sweep");
                 if (sweep_axis.empty())
                     proj_parm.flip_axis = 0;
                 else {

--- a/include/boost/geometry/srs/projections/proj/gn_sinu.hpp
+++ b/include/boost/geometry/srs/projections/proj/gn_sinu.hpp
@@ -200,9 +200,8 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_gn_sinu(Parameters& par, par_gn_sinu<T>& proj_parm)
             {
-                if (pj_param(par.params, "tn").i && pj_param(par.params, "tm").i) {
-                    proj_parm.n = pj_param(par.params, "dn").f;
-                    proj_parm.m = pj_param(par.params, "dm").f;
+                if (pj_param_f(par.params, "n", proj_parm.n)
+                 && pj_param_f(par.params, "m", proj_parm.m)) {
                     if (proj_parm.n <= 0 || proj_parm.m < 0)
                         BOOST_THROW_EXCEPTION( projection_exception(-39) );
                 } else

--- a/include/boost/geometry/srs/projections/proj/hammer.hpp
+++ b/include/boost/geometry/srs/projections/proj/hammer.hpp
@@ -122,13 +122,15 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_hammer(Parameters& par, par_hammer<T>& proj_parm)
             {
-                if (pj_param(par.params, "tW").i) {
-                    if ((proj_parm.w = fabs(pj_param(par.params, "dW").f)) <= 0.)
+                T tmp;
+
+                if (pj_param_f(par.params, "W", tmp)) {
+                    if ((proj_parm.w = fabs(tmp)) <= 0.)
                         BOOST_THROW_EXCEPTION( projection_exception(-27) );
                 } else
                     proj_parm.w = .5;
-                if (pj_param(par.params, "tM").i) {
-                    if ((proj_parm.m = fabs(pj_param(par.params, "dM").f)) <= 0.)
+                if (pj_param_f(par.params, "M", tmp)) {
+                    if ((proj_parm.m = fabs(tmp)) <= 0.)
                         BOOST_THROW_EXCEPTION( projection_exception(-27) );
                 } else
                     proj_parm.m = 1.;

--- a/include/boost/geometry/srs/projections/proj/healpix.hpp
+++ b/include/boost/geometry/srs/projections/proj/healpix.hpp
@@ -745,8 +745,8 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_rhealpix(Parameters& par, par_healpix<T>& proj_parm)
             {
-                proj_parm.north_square = pj_param(par.params,"inorth_square").i;
-                proj_parm.south_square = pj_param(par.params,"isouth_square").i;
+                proj_parm.north_square = pj_get_param_i(par.params, "north_square");
+                proj_parm.south_square = pj_get_param_i(par.params, "south_square");
                 /* Check for valid north_square and south_square inputs. */
                 if (proj_parm.north_square < 0 || proj_parm.north_square > 3) {
                     BOOST_THROW_EXCEPTION( projection_exception(-47) );

--- a/include/boost/geometry/srs/projections/proj/imw_p.hpp
+++ b/include/boost/geometry/srs/projections/proj/imw_p.hpp
@@ -90,12 +90,12 @@ namespace projections
             {
                 int err = 0;
 
-                if (!pj_param(par.params, "tlat_1").i ||
-                    !pj_param(par.params, "tlat_2").i) {
+                if (!pj_param_r(par.params, "lat_1", proj_parm.phi_1) ||
+                    !pj_param_r(par.params, "lat_2", proj_parm.phi_2)) {
                     err = -41;
                 } else {
-                    proj_parm.phi_1 = pj_param(par.params, "rlat_1").f;
-                    proj_parm.phi_2 = pj_param(par.params, "rlat_2").f;
+                    //proj_parm.phi_1 = pj_get_param_r(par.params, "lat_1"); // set above
+                    //proj_parm.phi_2 = pj_get_param_r(par.params, "lat_2"); // set above
                     *del = 0.5 * (proj_parm.phi_2 - proj_parm.phi_1);
                     *sig = 0.5 * (proj_parm.phi_2 + proj_parm.phi_1);
                     err = (fabs(*del) < EPS || fabs(*sig) < EPS) ? -42 : 0;
@@ -235,9 +235,9 @@ namespace projections
                     proj_parm.phi_1 = proj_parm.phi_2;
                     proj_parm.phi_2 = del;
                 }
-                if (pj_param(par.params, "tlon_1").i)
-                    proj_parm.lam_1 = pj_param(par.params, "rlon_1").f;
-                else { /* use predefined based upon latitude */
+                if (pj_param_r(par.params, "lon_1", proj_parm.lam_1)) {
+                    /* empty */
+                } else { /* use predefined based upon latitude */
                     sig = fabs(sig * geometry::math::r2d<T>());
                     if (sig <= 60)      sig = 2.;
                     else if (sig <= 76) sig = 4.;

--- a/include/boost/geometry/srs/projections/proj/isea.hpp
+++ b/include/boost/geometry/srs/projections/proj/isea.hpp
@@ -1171,7 +1171,7 @@ namespace projections
             /*        proj_parm.dgg.radius = par.a; / * otherwise defaults to 1 */
                 /* calling library will scale, I think */
 
-                opt = pj_param(par.params, "sorient").s;
+                opt = pj_get_param_s(par.params, "orient");
                 if (! opt.empty()) {
                     if (opt == std::string("isea")) {
                         isea_orient_isea(&proj_parm.dgg);
@@ -1182,29 +1182,15 @@ namespace projections
                     }
                 }
 
-                if (pj_param(par.params, "tazi").i) {
-                    proj_parm.dgg.o_az = pj_param(par.params, "razi").f;
-                }
-
-                if (pj_param(par.params, "tlon_0").i) {
-                    proj_parm.dgg.o_lon = pj_param(par.params, "rlon_0").f;
-                }
-
-                if (pj_param(par.params, "tlat_0").i) {
-                    proj_parm.dgg.o_lat = pj_param(par.params, "rlat_0").f;
-                }
-
+                pj_param_r(par.params, "azi", proj_parm.dgg.o_az);
+                pj_param_r(par.params, "lon_0", proj_parm.dgg.o_lon);
+                pj_param_r(par.params, "lat_0", proj_parm.dgg.o_lat);
                 // TODO: this parameter is set below second time
-                if (pj_param(par.params, "taperture").i) {
-                    proj_parm.dgg.aperture = pj_param(par.params, "iaperture").i;
-                }
-
+                pj_param_i(par.params, "aperture", proj_parm.dgg.aperture);
                 // TODO: this parameter is set below second time
-                if (pj_param(par.params, "tresolution").i) {
-                    proj_parm.dgg.resolution = pj_param(par.params, "iresolution").i;
-                }
-
-                opt = pj_param(par.params, "smode").s;
+                pj_param_i(par.params, "resolution", proj_parm.dgg.resolution);
+                
+                opt = pj_get_param_s(par.params, "mode");
                 if (! opt.empty()) {
                     if (opt == std::string("plane")) {
                         proj_parm.dgg.output = ISEA_PLANE;
@@ -1223,18 +1209,19 @@ namespace projections
                     }
                 }
 
-                if (pj_param(par.params, "trescale").i) {
+                // TODO: pj_param_exists -> pj_get_param_b ?
+                if (pj_param_exists(par.params, "rescale")) {
                     proj_parm.dgg.radius = ISEA_SCALE;
                 }
 
-                if (pj_param(par.params, "tresolution").i) {
-                    proj_parm.dgg.resolution = pj_param(par.params, "iresolution").i;
+                if (pj_param_i(par.params, "resolution", proj_parm.dgg.resolution)) {
+                    /* empty */
                 } else {
                     proj_parm.dgg.resolution = 4;
                 }
 
-                if (pj_param(par.params, "taperture").i) {
-                    proj_parm.dgg.aperture = pj_param(par.params, "iaperture").i;
+                if (pj_param_i(par.params, "aperture", proj_parm.dgg.aperture)) {
+                    /* empty */
                 } else {
                     proj_parm.dgg.aperture = 3;
                 }

--- a/include/boost/geometry/srs/projections/proj/krovak.hpp
+++ b/include/boost/geometry/srs/projections/proj/krovak.hpp
@@ -208,21 +208,21 @@ namespace projections
                 par.e = sqrt(par.es = 0.006674372230614);
 
                 /* if latitude of projection center is not set, use 49d30'N */
-                if (!pj_param(par.params, "tlat_0").i)
+                if (!pj_param_exists(par.params, "lat_0"))
                     par.phi0 = 0.863937979737193;
 
                 /* if center long is not set use 42d30'E of Ferro - 17d40' for Ferro */
                 /* that will correspond to using longitudes relative to greenwich    */
                 /* as input and output, instead of lat/long relative to Ferro */
-                if (!pj_param(par.params, "tlon_0").i)
+                if (!pj_param_exists(par.params, "lon_0"))
                     par.lam0 = 0.7417649320975901 - 0.308341501185665;
 
                 /* if scale not set default to 0.9999 */
-                if (!pj_param(par.params, "tk").i)
+                if (!pj_param_exists(par.params, "k"))
                     par.k0 = 0.9999;
 
                 proj_parm.czech = 1;
-                if( !pj_param(par.params, "tczech").i )
+                if( !pj_param_exists(par.params, "czech") )
                     proj_parm.czech = -1;
 
                 /* Set up shared parameters between forward and inverse */

--- a/include/boost/geometry/srs/projections/proj/labrd.hpp
+++ b/include/boost/geometry/srs/projections/proj/labrd.hpp
@@ -185,8 +185,8 @@ namespace projections
 
                 T Az, sinp, R, N, t;
 
-                proj_parm.rot    = pj_param(par.params, "bno_rot").i == 0;
-                Az = pj_param(par.params, "razi").f;
+                proj_parm.rot    = pj_get_param_b(par.params, "no_rot");
+                Az = pj_get_param_r(par.params, "azi");
                 sinp = sin(par.phi0);
                 t = 1. - par.es * sinp * sinp;
                 N = 1. / sqrt(t);

--- a/include/boost/geometry/srs/projections/proj/lagrng.hpp
+++ b/include/boost/geometry/srs/projections/proj/lagrng.hpp
@@ -122,13 +122,13 @@ namespace projections
             {
                 T phi1;
 
-                proj_parm.rw = pj_param(par.params, "dW").f;
+                proj_parm.rw = pj_get_param_f(par.params, "W");
                 if (proj_parm.rw <= 0)
                     BOOST_THROW_EXCEPTION( projection_exception(-27) );
 
                 proj_parm.rw = 1. / proj_parm.rw;
                 proj_parm.hrw = 0.5 * proj_parm.rw;
-                phi1 = pj_param(par.params, "rlat_1").f;
+                phi1 = pj_get_param_r(par.params, "lat_1");
                 if (fabs(fabs(phi1 = sin(phi1)) - 1.) < TOL)
                     BOOST_THROW_EXCEPTION( projection_exception(-22) );
 

--- a/include/boost/geometry/srs/projections/proj/lcc.hpp
+++ b/include/boost/geometry/srs/projections/proj/lcc.hpp
@@ -167,12 +167,12 @@ namespace projections
                 T cosphi, sinphi;
                 int secant;
 
-                proj_parm.phi1 = pj_param(par.params, "rlat_1").f;
-                if (pj_param(par.params, "tlat_2").i)
-                    proj_parm.phi2 = pj_param(par.params, "rlat_2").f;
-                else {
+                proj_parm.phi1 = pj_get_param_r(par.params, "lat_1");
+                if (pj_param_r(par.params, "lat_2", proj_parm.phi2)) {
+                    /* empty */
+                } else {
                     proj_parm.phi2 = proj_parm.phi1;
-                    if (!pj_param(par.params, "tlat_0").i)
+                    if (!pj_param_exists(par.params, "lat_0"))
                         par.phi0 = proj_parm.phi1;
                 }
                 if (fabs(proj_parm.phi1 + proj_parm.phi2) < EPS10)

--- a/include/boost/geometry/srs/projections/proj/loxim.hpp
+++ b/include/boost/geometry/srs/projections/proj/loxim.hpp
@@ -137,7 +137,7 @@ namespace projections
             {
                 static const T FORTPI = detail::FORTPI<T>();
 
-                proj_parm.phi1 = pj_param(par.params, "rlat_1").f;
+                proj_parm.phi1 = pj_get_param_r(par.params, "lat_1");
                 proj_parm.cosphi1 = cos(proj_parm.phi1);
                 if (proj_parm.cosphi1 < EPS)
                     BOOST_THROW_EXCEPTION( projection_exception(-22) );

--- a/include/boost/geometry/srs/projections/proj/lsat.hpp
+++ b/include/boost/geometry/srs/projections/proj/lsat.hpp
@@ -247,11 +247,11 @@ namespace projections
                 int land, path;
                 T lam, alf, esc, ess;
 
-                land = pj_param(par.params, "ilsat").i;
+                land = pj_get_param_i(par.params, "lsat");
                 if (land <= 0 || land > 5)
                     BOOST_THROW_EXCEPTION( projection_exception(-28) );
 
-                path = pj_param(par.params, "ipath").i;
+                path = pj_get_param_i(par.params, "path");
                 if (path <= 0 || path > (land <= 3 ? 251 : 233))
                     BOOST_THROW_EXCEPTION( projection_exception(-29) );
 

--- a/include/boost/geometry/srs/projections/proj/merc.hpp
+++ b/include/boost/geometry/srs/projections/proj/merc.hpp
@@ -166,8 +166,8 @@ namespace projections
                 calc_t phits=0.0;
                 int is_phits;
 
-                if( (is_phits = pj_param(par.params, "tlat_ts").i) ) {
-                    phits = fabs(pj_param(par.params, "rlat_ts").f);
+                if( (is_phits = pj_param_r(par.params, "lat_ts", phits)) ) {
+                    phits = fabs(phits);
                     if (phits >= HALFPI)
                         BOOST_THROW_EXCEPTION( projection_exception(-24) );
                 }

--- a/include/boost/geometry/srs/projections/proj/nsper.hpp
+++ b/include/boost/geometry/srs/projections/proj/nsper.hpp
@@ -218,7 +218,7 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup(Parameters& par, par_nsper<T>& proj_parm) 
             {
-                if ((proj_parm.height = pj_param(par.params, "dh").f) <= 0.)
+                if ((proj_parm.height = pj_get_param_f(par.params, "h")) <= 0.)
                     BOOST_THROW_EXCEPTION( projection_exception(-30) );
 
                 if (fabs(fabs(par.phi0) - geometry::math::half_pi<T>()) < EPS10)
@@ -254,8 +254,8 @@ namespace projections
             {
                 T omega, gamma;
 
-                omega = pj_param(par.params, "dtilt").f * geometry::math::d2r<T>();
-                gamma = pj_param(par.params, "dazi").f * geometry::math::d2r<T>();
+                omega = pj_get_param_r(par.params, "tilt");
+                gamma = pj_get_param_r(par.params, "azi");
                 proj_parm.tilt = 1;
                 proj_parm.cg = cos(gamma); proj_parm.sg = sin(gamma);
                 proj_parm.cw = cos(omega); proj_parm.sw = sin(omega);

--- a/include/boost/geometry/srs/projections/proj/ob_tran.hpp
+++ b/include/boost/geometry/srs/projections/proj/ob_tran.hpp
@@ -84,7 +84,7 @@ namespace projections
                 Parameters pj = par;
 
                 /* get name of projection to be translated */
-                pj.name = pj_param(par.params, "so_proj").s;
+                pj.name = pj_get_param_s(par.params, "o_proj");
                 if (pj.name.empty())
                     BOOST_THROW_EXCEPTION( projection_exception(-26) );
 
@@ -233,34 +233,34 @@ namespace projections
             {
                 static const CalculationType HALFPI = detail::HALFPI<CalculationType>();
 
-                CalculationType phip;
+                CalculationType phip, alpha;
 
                 par.es = 0.; /* force to spherical */
 
                 // proj_parm.link should be created at this point
 
-                if (pj_param(par.params, "to_alpha").i) {
-                    CalculationType lamc, phic, alpha;
+                if (pj_param_r(par.params, "o_alpha", alpha)) {
+                    CalculationType lamc, phic;
 
-                    lamc    = pj_param(par.params, "ro_lon_c").f;
-                    phic    = pj_param(par.params, "ro_lat_c").f;
-                    alpha    = pj_param(par.params, "ro_alpha").f;
+                    lamc    = pj_get_param_r(par.params, "o_lon_c");
+                    phic    = pj_get_param_r(par.params, "o_lat_c");
+                    //alpha   = pj_get_param_r(par.params, "o_alpha");
             
                     if (fabs(fabs(phic) - HALFPI) <= TOL)
                         BOOST_THROW_EXCEPTION( projection_exception(-33) );
 
                     proj_parm.lamp = lamc + aatan2(-cos(alpha), -sin(alpha) * sin(phic));
                     phip = aasin(cos(phic) * sin(alpha));
-                } else if (pj_param(par.params, "to_lat_p").i) { /* specified new pole */
-                    proj_parm.lamp = pj_param(par.params, "ro_lon_p").f;
-                    phip = pj_param(par.params, "ro_lat_p").f;
+                } else if (pj_param_r(par.params, "o_lat_p", phip)) { /* specified new pole */
+                    proj_parm.lamp = pj_get_param_r(par.params, "o_lon_p");
+                    //phip = pj_param_r(par.params, "o_lat_p");
                 } else { /* specified new "equator" points */
                     CalculationType lam1, lam2, phi1, phi2, con;
 
-                    lam1 = pj_param(par.params, "ro_lon_1").f;
-                    phi1 = pj_param(par.params, "ro_lat_1").f;
-                    lam2 = pj_param(par.params, "ro_lon_2").f;
-                    phi2 = pj_param(par.params, "ro_lat_2").f;
+                    lam1 = pj_get_param_r(par.params, "o_lon_1");
+                    phi1 = pj_get_param_r(par.params, "o_lat_1");
+                    lam2 = pj_get_param_r(par.params, "o_lon_2");
+                    phi2 = pj_get_param_r(par.params, "o_lat_2");
                     if (fabs(phi1 - phi2) <= TOL || (con = fabs(phi1)) <= TOL ||
                         fabs(con - HALFPI) <= TOL || fabs(fabs(phi2) - HALFPI) <= TOL)
                         BOOST_THROW_EXCEPTION( projection_exception(-32) );

--- a/include/boost/geometry/srs/projections/proj/ocea.hpp
+++ b/include/boost/geometry/srs/projections/proj/ocea.hpp
@@ -136,10 +136,10 @@ namespace projections
                 proj_parm.rok = 1. / par.k0;
                 proj_parm.rtk = par.k0;
                 /*If the keyword "alpha" is found in the sentence then use 1point+1azimuth*/
-                if ( pj_param(par.params, "talpha").i) {
+                if ( pj_param_r(par.params, "alpha", alpha)) {
                     /*Define Pole of oblique transformation from 1 point & 1 azimuth*/
-                    alpha    = pj_param(par.params, "ralpha").f;
-                    lonz = pj_param(par.params, "rlonc").f;
+                    //alpha = pj_get_param_r(par.params, "alpha"); // set above
+                    lonz = pj_get_param_r(par.params, "lonc");
                     /*Equation 9-8 page 80 (http://pubs.usgs.gov/pp/1395/report.pdf)*/
                     proj_parm.singam = atan(-cos(alpha)/(-sin(phi_0) * sin(alpha))) + lonz;
                     /*Equation 9-7 page 80 (http://pubs.usgs.gov/pp/1395/report.pdf)*/
@@ -147,10 +147,10 @@ namespace projections
                 /*If the keyword "alpha" is NOT found in the sentence then use 2points*/
                 } else {
                     /*Define Pole of oblique transformation from 2 points*/
-                    phi_1 = pj_param(par.params, "rlat_1").f;
-                    phi_2 = pj_param(par.params, "rlat_2").f;
-                    lam_1 = pj_param(par.params, "rlon_1").f;
-                    lam_2 = pj_param(par.params, "rlon_2").f;
+                    phi_1 = pj_get_param_r(par.params, "lat_1");
+                    phi_2 = pj_get_param_r(par.params, "lat_2");
+                    lam_1 = pj_get_param_r(par.params, "lon_1");
+                    lam_2 = pj_get_param_r(par.params, "lon_2");
                     /*Equation 9-1 page 80 (http://pubs.usgs.gov/pp/1395/report.pdf)*/
                     proj_parm.singam = atan2(cos(phi_1) * sin(phi_2) * cos(lam_1) -
                         sin(phi_1) * cos(phi_2) * cos(lam_2),

--- a/include/boost/geometry/srs/projections/proj/oea.hpp
+++ b/include/boost/geometry/srs/projections/proj/oea.hpp
@@ -133,11 +133,11 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_oea(Parameters& par, par_oea<T>& proj_parm)
             {
-                if (((proj_parm.n = pj_param(par.params, "dn").f) <= 0.) ||
-                    ((proj_parm.m = pj_param(par.params, "dm").f) <= 0.)) {
+                if (((proj_parm.n = pj_get_param_f(par.params, "n")) <= 0.) ||
+                    ((proj_parm.m = pj_get_param_f(par.params, "m")) <= 0.)) {
                     BOOST_THROW_EXCEPTION( projection_exception(-39) );
                 } else {
-                    proj_parm.theta = pj_param(par.params, "rtheta").f;
+                    proj_parm.theta = pj_get_param_r(par.params, "theta");
                     proj_parm.sp0 = sin(par.phi0);
                     proj_parm.cp0 = cos(par.phi0);
                     proj_parm.rn = 1./ proj_parm.n;

--- a/include/boost/geometry/srs/projections/proj/omerc.hpp
+++ b/include/boost/geometry/srs/projections/proj/omerc.hpp
@@ -183,29 +183,28 @@ namespace projections
                   gamma0, lamc=0, lam1=0, lam2=0, phi1=0, phi2=0, alpha_c=0;
                 int alp, gam, no_off = 0;
 
-                proj_parm.no_rot = pj_param(par.params, "tno_rot").i;
-                if ((alp = pj_param(par.params, "talpha").i) != 0)
-                    alpha_c = pj_param(par.params, "ralpha").f;
-                if ((gam = pj_param(par.params, "tgamma").i) != 0)
-                    gamma = pj_param(par.params, "rgamma").f;
+                proj_parm.no_rot = pj_get_param_b(par.params, "no_rot");
+                alp = pj_param_r(par.params, "alpha", alpha_c);
+                gam = pj_param_r(par.params, "gamma", gamma);
                 if (alp || gam) {
-                    lamc    = pj_param(par.params, "rlonc").f;
-                    no_off =
-                                /* For libproj4 compatability */
-                                pj_param(par.params, "tno_off").i
-                                /* for backward compatibility */
-                                || pj_param(par.params, "tno_uoff").i;
-                    if( no_off )
-                    {
-                        /* Mark the parameter as used, so that the pj_get_def() return them */
-                        pj_param(par.params, "sno_uoff");
-                        pj_param(par.params, "sno_off");
-                    }
+                    lamc = pj_get_param_r(par.params, "lonc");
+                    // NOTE: This is not needed in Boost.Geometry
+                    //no_off =
+                    //            /* For libproj4 compatability */
+                    //            pj_param_exists(par.params, "no_off")
+                    //            /* for backward compatibility */
+                    //            || pj_param_exists(par.params, "no_uoff");
+                    //if( no_off )
+                    //{
+                    //    /* Mark the parameter as used, so that the pj_get_def() return them */
+                    //    pj_get_param_s(par.params, "no_uoff");
+                    //    pj_get_param_s(par.params, "no_off");
+                    //}
                 } else {
-                    lam1 = pj_param(par.params, "rlon_1").f;
-                    phi1 = pj_param(par.params, "rlat_1").f;
-                    lam2 = pj_param(par.params, "rlon_2").f;
-                    phi2 = pj_param(par.params, "rlat_2").f;
+                    lam1 = pj_get_param_r(par.params, "lon_1");
+                    phi1 = pj_get_param_r(par.params, "lat_1");
+                    lam2 = pj_get_param_r(par.params, "lon_2");
+                    phi2 = pj_get_param_r(par.params, "lat_2");
                     if (fabs(phi1 - phi2) <= TOL ||
                         (con = fabs(phi1)) <= TOL ||
                         fabs(con - HALFPI) <= TOL ||

--- a/include/boost/geometry/srs/projections/proj/rpoly.hpp
+++ b/include/boost/geometry/srs/projections/proj/rpoly.hpp
@@ -117,7 +117,7 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_rpoly(Parameters& par, par_rpoly<T>& proj_parm)
             {
-                if ((proj_parm.mode = (proj_parm.phi1 = fabs(pj_param(par.params, "rlat_ts").f)) > EPS)) {
+                if ((proj_parm.mode = (proj_parm.phi1 = fabs(pj_get_param_r(par.params, "lat_ts"))) > EPS)) {
                     proj_parm.fxb = 0.5 * sin(proj_parm.phi1);
                     proj_parm.fxa = 0.5 / proj_parm.fxb;
                 }

--- a/include/boost/geometry/srs/projections/proj/sconics.hpp
+++ b/include/boost/geometry/srs/projections/proj/sconics.hpp
@@ -100,12 +100,12 @@ namespace projections
                 T p1, p2;
                 int err = 0;
 
-                if (!pj_param(par.params, "tlat_1").i ||
-                    !pj_param(par.params, "tlat_2").i) {
+                if (!pj_param_r(par.params, "lat_1", p1) ||
+                    !pj_param_r(par.params, "lat_2", p2)) {
                     err = -41;
                 } else {
-                    p1 = pj_param(par.params, "rlat_1").f;
-                    p2 = pj_param(par.params, "rlat_2").f;
+                    //p1 = pj_get_param_r(par.params, "lat_1"); // set above
+                    //p2 = pj_get_param_r(par.params, "lat_2"); // set above
                     *del = 0.5 * (p2 - p1);
                     proj_parm.sig = 0.5 * (p2 + p1);
                     err = (fabs(*del) < EPS || fabs(proj_parm.sig) < EPS) ? -42 : 0;

--- a/include/boost/geometry/srs/projections/proj/stere.hpp
+++ b/include/boost/geometry/srs/projections/proj/stere.hpp
@@ -385,8 +385,8 @@ namespace projections
             {
                 static const T HALFPI = detail::HALFPI<T>();
 
-                proj_parm.phits = pj_param(par.params, "tlat_ts").i ?
-                                  pj_param(par.params, "rlat_ts").f : HALFPI;
+                if (! pj_param_r(par.params, "lat_ts", proj_parm.phits))
+                    proj_parm.phits = HALFPI;
 
                 setup(par, proj_parm);
             }
@@ -398,7 +398,7 @@ namespace projections
                 static const T HALFPI = detail::HALFPI<T>();
 
                 /* International Ellipsoid */
-                par.phi0 = pj_param(par.params, "bsouth").i ? -HALFPI: HALFPI;
+                par.phi0 = pj_get_param_b(par.params, "south") ? -HALFPI: HALFPI;
                 if (par.es == 0.0) {
                     BOOST_THROW_EXCEPTION( projection_exception(-34) );
                 }

--- a/include/boost/geometry/srs/projections/proj/tpeqd.hpp
+++ b/include/boost/geometry/srs/projections/proj/tpeqd.hpp
@@ -140,10 +140,10 @@ namespace projections
                 T lam_1, lam_2, phi_1, phi_2, A12, pp;
 
                 /* get control point locations */
-                phi_1 = pj_param(par.params, "rlat_1").f;
-                lam_1 = pj_param(par.params, "rlon_1").f;
-                phi_2 = pj_param(par.params, "rlat_2").f;
-                lam_2 = pj_param(par.params, "rlon_2").f;
+                phi_1 = pj_get_param_r(par.params, "lat_1");
+                lam_1 = pj_get_param_r(par.params, "lon_1");
+                phi_2 = pj_get_param_r(par.params, "lat_2");
+                lam_2 = pj_get_param_r(par.params, "lon_2");
 
                 if (phi_1 == phi_2 && lam_1 == lam_2)
                     BOOST_THROW_EXCEPTION( projection_exception(-25) );

--- a/include/boost/geometry/srs/projections/proj/urm5.hpp
+++ b/include/boost/geometry/srs/projections/proj/urm5.hpp
@@ -106,15 +106,14 @@ namespace projections
             {
                 T alpha, t;
 
-                if (pj_param(par.params, "tn").i) {
-                    proj_parm.n = pj_param(par.params, "dn").f;
+                if (pj_param_f(par.params, "n", proj_parm.n)) {
                     if (proj_parm.n <= 0. || proj_parm.n > 1.)
                         BOOST_THROW_EXCEPTION( projection_exception(-40) );
                 } else {
                     BOOST_THROW_EXCEPTION( projection_exception(-40) );
                 }
-                proj_parm.q3 = pj_param(par.params, "dq").f / 3.;
-                alpha = pj_param(par.params, "ralpha").f;
+                proj_parm.q3 = pj_get_param_f(par.params, "q") / 3.;
+                alpha = pj_get_param_r(par.params, "alpha");
                 t = proj_parm.n * sin(alpha);
                 proj_parm.m = cos(alpha) / sqrt(1. - t * t);
                 proj_parm.rmn = 1. / (proj_parm.m * proj_parm.n);

--- a/include/boost/geometry/srs/projections/proj/urmfps.hpp
+++ b/include/boost/geometry/srs/projections/proj/urmfps.hpp
@@ -123,8 +123,7 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_urmfps(Parameters& par, par_urmfps<T>& proj_parm)
             {
-                if (pj_param(par.params, "tn").i) {
-                    proj_parm.n = pj_param(par.params, "dn").f;
+                if (pj_param_f(par.params, "n", proj_parm.n)) {
                     if (proj_parm.n <= 0. || proj_parm.n > 1.)
                         BOOST_THROW_EXCEPTION( projection_exception(-40) );
                 } else

--- a/include/boost/geometry/srs/projections/proj/wag3.hpp
+++ b/include/boost/geometry/srs/projections/proj/wag3.hpp
@@ -113,7 +113,7 @@ namespace projections
             {
                 T ts;
 
-                ts = pj_param(par.params, "rlat_ts").f;
+                ts = pj_get_param_r(par.params, "lat_ts");
                 proj_parm.C_x = cos(ts) / cos(2.*ts/3.);
                 par.es = 0.;
             }

--- a/include/boost/geometry/srs/projections/proj/wink1.hpp
+++ b/include/boost/geometry/srs/projections/proj/wink1.hpp
@@ -108,7 +108,7 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_wink1(Parameters& par, par_wink1<T>& proj_parm)
             {
-                proj_parm.cosphi1 = cos(pj_param(par.params, "rlat_ts").f);
+                proj_parm.cosphi1 = cos(pj_get_param_r(par.params, "lat_ts"));
                 par.es = 0.;
             }
 

--- a/include/boost/geometry/srs/projections/proj/wink2.hpp
+++ b/include/boost/geometry/srs/projections/proj/wink2.hpp
@@ -126,7 +126,7 @@ namespace projections
             template <typename Parameters, typename T>
             inline void setup_wink2(Parameters& par, par_wink2<T>& proj_parm)
             {
-                proj_parm.cosphi1 = cos(pj_param(par.params, "rlat_1").f);
+                proj_parm.cosphi1 = cos(pj_get_param_r(par.params, "lat_1"));
                 par.es = 0.;
             }
 

--- a/include/boost/geometry/srs/projections/shared_grids.hpp
+++ b/include/boost/geometry/srs/projections/shared_grids.hpp
@@ -1,0 +1,95 @@
+// Boost.Geometry
+
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018, Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_SRS_PROJECTIONS_SHARED_GRIDS_HPP
+#define BOOST_GEOMETRY_SRS_PROJECTIONS_SHARED_GRIDS_HPP
+
+
+#include <boost/geometry/srs/projections/impl/pj_gridinfo.hpp>
+
+#include <boost/thread.hpp>
+
+#include <vector>
+
+
+namespace boost { namespace geometry
+{
+    
+
+// Forward declarations
+namespace srs
+{
+
+// Forward declaration for functions declarations below
+class shared_grids;
+
+} // namespace srs
+namespace projections { namespace detail
+{
+
+// Forward declaratios of shared_grids friends
+template <typename StreamPolicy>
+inline bool pj_gridlist_merge_gridfile(std::string const& gridname,
+                                       StreamPolicy const& stream_policy,
+                                       srs::shared_grids & grids,
+                                       std::vector<std::size_t> & gridindexes);
+template <bool Inverse, typename CalcT, typename StreamPolicy, typename Range>
+inline bool pj_apply_gridshift_3(StreamPolicy const& stream_policy,
+                                 Range & range,
+                                 srs::shared_grids & grids,
+                                 std::vector<std::size_t> const& gridindexes);
+
+}} // namespace projections::detail
+
+
+namespace srs
+{
+
+
+class shared_grids
+{
+public:
+    std::size_t size() const
+    {
+        boost::shared_lock<boost::shared_mutex> lock(mutex);
+        return gridinfo.size();
+    }
+
+    bool empty() const
+    {
+        boost::shared_lock<boost::shared_mutex> lock(mutex);
+        return gridinfo.empty();
+    }
+
+private:
+    template <typename StreamPolicy>
+    friend inline bool projections::detail::pj_gridlist_merge_gridfile(
+                            std::string const& gridname,
+                            StreamPolicy const& stream_policy,
+                            srs::shared_grids & grids,
+                            std::vector<std::size_t> & gridindexes);
+    template <bool Inverse, typename CalcT, typename StreamPolicy, typename Range>
+    friend inline bool projections::detail::pj_apply_gridshift_3(
+                            StreamPolicy const& stream_policy,
+                            Range & range,
+                            srs::shared_grids & grids,
+                            std::vector<std::size_t> const& gridindexes);
+
+    projections::detail::pj_gridinfo gridinfo;
+    mutable boost::shared_mutex mutex;
+};
+
+
+} // namespace srs
+
+}} // namespace boost::geometry
+
+
+#endif // BOOST_GEOMETRY_SRS_PROJECTIONS_SHARED_GRIDS_HPP

--- a/include/boost/geometry/srs/shared_grids.hpp
+++ b/include/boost/geometry/srs/shared_grids.hpp
@@ -1,0 +1,20 @@
+// Boost.Geometry
+
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018, Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_SRS_SHARED_GRIDS_HPP
+#define BOOST_GEOMETRY_SRS_SHARED_GRIDS_HPP
+
+
+#include <boost/geometry/srs/projections/impl/pj_apply_gridshift_shared.hpp>
+#include <boost/geometry/srs/projections/impl/pj_gridlist_shared.hpp>
+#include <boost/geometry/srs/projections/shared_grids.hpp>
+
+
+#endif // BOOST_GEOMETRY_SRS_SHARED_GRIDS_HPP


### PR DESCRIPTION
This PR adds support for nadgrids. Relevant proj4 code was converted to C++ and Boostified. So all grids formats are supported (ctable, ctable2, ntv1, ntv2), also vertical geoid grid GTX format but it is not used right now. There are some differences though:
- proj4 stores loaded grids in global storage and pointers to a relevant subset of grids in projection parameters structure. In Boost.Geometry grids are moved outside transformation to allow users to place grids storage(s) wherever they like.
- in proj4 the grids are loaded implicitly when there is `+nadgrids` parameter passed. In Boost.Geometry an object representing a subset of grids explicitly has to be initialized and then passed into transforming function.
- in proj4 grids has to be "installed" into certain directories. In Boost.Geometry the user can implement StreamPolicy opening any input stream having unformatted input interface. The default one uses `std::ifstream` opening files having the same names as the ones in `+nadgrids` parameter in working directory.

I'm open to suggestion, in particular regarding the interface, names, etc.

This is how it looks like right now by default:

    std::string from = "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs";
    std::string to = "+proj=aea +lat_1=34 +lat_2=40.5 +lat_0=0 +lon_0=-120 +x_0=0 +y_0=-4000000 +ellps=clrk66 +datum=NAD27 +units=m +no_defs";
    // +datum=NAD27 uses +nadgrids=@conus,@alaska,@ntv2_0.gsb,@ntv1_can.dat

    bg::srs::transformation<> tr = {bg::srs::proj4(from), bg::srs::proj4(to)};

    bg::srs::grids_storage<> gs;

    // reads headers of grids, adds them to grids_storage
    // and creates representation of grids that are used by this transformation
    bg::srs::transformation_grids<> tg = tr.initialize_grids(gs);

    point_geo san_fran(-122.419167, 37.779167);
    point_xy xy;

    tr.forward(san_fran, xy);
    std::cout << "without grids: " << bg::wkt(xy) << std::endl;

    // loads content of relevant grid if needed and stores it in grids_storage
    tr.forward(san_fran, xy, tg);
    std::cout << "with grids: " << bg::wkt(xy) << std::endl;

Now let's say a user wants to pass his own StreamPolicy opening files from directory "/abc" and share single grid storage between multiple threads:

    struct my_stream_policy
    {
        typedef std::ifstream stream_type;

        static inline void open(stream_type & is, std::string const& gridname)
        {
            is.open(std::string("/abc/") + gridname, std::ios::binary);
        }
    };

    typedef bg::srs::grids_storage
        <
            my_stream_policy,
            bg::srs::shared_grids
        > my_grids_storage;

    typedef bg::srs::transformation_grids
        <
            my_grids_storage
        > my_transformation_grids;

    // the rest is similar
    my_grids_storage gs;

    boost::thread t1{[&](){
        bg::srs::transformation<> tr = {bg::srs::proj4(from1), bg::srs::proj4(to1)};
        my_transformation_grids tg = tr.initialize_grids(gs);    
        for (int i = 0 ; i < 1000 ; ++i)
            tr.forward(san_fran, xy, tg);
    }};
    boost::thread t2{[&](){
        bg::srs::transformation<> tr = {bg::srs::proj4(from2), bg::srs::proj4(to2)};
        my_transformation_grids tg = tr.initialize_grids(gs);
        for (int i = 0 ; i < 1000 ; ++i)
            tr.forward(san_fran, xy, tg);
    }};
    t1.join();
    t2.join();

Note that sharing the same transformation object between threads should work too because neither `transformation` nor `transformation_grids` do not change while the transformation is performed:

    my_grids_storage gs;
    bg::srs::transformation<> tr = {bg::srs::proj4(from), bg::srs::proj4(to)};
    my_transformation_grids tg = tr.initialize_grids(gs);
    boost::thread t1{[&](){
        for (int i = 0 ; i < 1000 ; ++i)
            tr.forward(san_fran, xy, tg);
    }};
    boost::thread t2{[&](){
        for (int i = 0 ; i < 1000 ; ++i)
            tr.forward(san_fran, xy, tg);
    }};
    t1.join();
    t2.join();

This PR is implemented on top of https://github.com/boostorg/geometry/pull/468 and while the other PR is not merged this one will contain some unrelated changes.