### PR TITLE
[srs] Add missing cstring include.

### DIFF
--- a/include/boost/geometry/algorithms/detail/relate/result.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/result.hpp
@@ -16,6 +16,7 @@
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_RELATE_RESULT_HPP
 
 #include <cstddef>
+#include <cstring>
 
 #include <boost/mpl/assert.hpp>
 #include <boost/mpl/at.hpp>


### PR DESCRIPTION
`geometry/algorithms/detail/relate/result.hpp` uses `memset` and `memcpy` but `cstring` is not included.