### PR TITLE
Fix/closing iterator returns reference to temp

### DIFF
--- a/include/boost/geometry/iterators/closing_iterator.hpp
+++ b/include/boost/geometry/iterators/closing_iterator.hpp
@@ -39,7 +39,7 @@ struct closing_iterator
         closing_iterator<Range>,
         typename boost::range_value<Range>::type const,
         boost::random_access_traversal_tag,
-        typename boost::range_reference<Range>::type const,
+        typename boost::range_reference<Range const>::type,
         typename boost::range_difference<Range>::type
     >
 {
@@ -49,7 +49,7 @@ private:
             closing_iterator<Range>,
             typename boost::range_value<Range>::type const,
             boost::random_access_traversal_tag,
-            typename boost::range_reference<Range>::type const,
+            typename boost::range_reference<Range const>::type,
             typename boost::range_difference<Range>::type
         > base_type;
 

--- a/include/boost/geometry/iterators/closing_iterator.hpp
+++ b/include/boost/geometry/iterators/closing_iterator.hpp
@@ -38,9 +38,12 @@ struct closing_iterator
     <
         closing_iterator<Range>,
         typename boost::range_value<Range>::type const,
-        boost::random_access_traversal_tag
+        boost::random_access_traversal_tag,
+        typename boost::range_reference<Range>::type const,
+        typename boost::range_difference<Range>::type
     >
 {
+    typedef typename boost::range_reference<Range>::type const reference_type;
     typedef typename boost::range_difference<Range>::type difference_type;
 
     /// Constructor including the range it is based on
@@ -71,7 +74,7 @@ struct closing_iterator
 private:
     friend class boost::iterator_core_access;
 
-    inline typename boost::range_value<Range>::type const& dereference() const
+    inline reference_type dereference() const
     {
         return *m_iterator;
     }

--- a/include/boost/geometry/iterators/closing_iterator.hpp
+++ b/include/boost/geometry/iterators/closing_iterator.hpp
@@ -43,8 +43,19 @@ struct closing_iterator
         typename boost::range_difference<Range>::type
     >
 {
-    typedef typename boost::range_reference<Range>::type const reference_type;
-    typedef typename boost::range_difference<Range>::type difference_type;
+private:
+    typedef boost::iterator_facade
+        <
+            closing_iterator<Range>,
+            typename boost::range_value<Range>::type const,
+            boost::random_access_traversal_tag,
+            typename boost::range_reference<Range>::type const,
+            typename boost::range_difference<Range>::type
+        > base_type;
+
+public:
+    typedef typename base_type::reference reference;
+    typedef typename base_type::difference_type difference_type;
 
     /// Constructor including the range it is based on
     explicit inline closing_iterator(Range& range)
@@ -74,7 +85,7 @@ struct closing_iterator
 private:
     friend class boost::iterator_core_access;
 
-    inline reference_type dereference() const
+    inline reference dereference() const
     {
         return *m_iterator;
     }

--- a/include/boost/geometry/iterators/ever_circling_iterator.hpp
+++ b/include/boost/geometry/iterators/ever_circling_iterator.hpp
@@ -105,6 +105,17 @@ struct ever_circling_range_iterator
         typename boost::range_difference<Range>::type
     >
 {
+private:
+    typedef boost::iterator_facade
+        <
+            ever_circling_range_iterator<Range>,
+            typename boost::range_value<Range>::type const,
+            boost::random_access_traversal_tag,
+            typename boost::range_reference<Range>::type const,
+            typename boost::range_difference<Range>::type
+        > base_type;
+
+public:
     /// Constructor including the range it is based on
     explicit inline ever_circling_range_iterator(Range& range)
         : m_range(&range)
@@ -120,13 +131,13 @@ struct ever_circling_range_iterator
         , m_index(0)
     {}
 
-    typedef typename boost::range_reference<Range>::type const reference_type;
-    typedef typename boost::range_difference<Range>::type difference_type;
+    typedef typename base_type::reference reference;
+    typedef typename base_type::difference_type difference_type;
 
 private:
     friend class boost::iterator_core_access;
 
-    inline reference_type dereference() const
+    inline reference dereference() const
     {
         return *m_iterator;
     }

--- a/include/boost/geometry/iterators/ever_circling_iterator.hpp
+++ b/include/boost/geometry/iterators/ever_circling_iterator.hpp
@@ -101,7 +101,7 @@ struct ever_circling_range_iterator
         ever_circling_range_iterator<Range>,
         typename boost::range_value<Range>::type const,
         boost::random_access_traversal_tag,
-        typename boost::range_reference<Range>::type const,
+        typename boost::range_reference<Range const>::type,
         typename boost::range_difference<Range>::type
     >
 {
@@ -111,7 +111,7 @@ private:
             ever_circling_range_iterator<Range>,
             typename boost::range_value<Range>::type const,
             boost::random_access_traversal_tag,
-            typename boost::range_reference<Range>::type const,
+            typename boost::range_reference<Range const>::type,
             typename boost::range_difference<Range>::type
         > base_type;
 

--- a/include/boost/geometry/iterators/ever_circling_iterator.hpp
+++ b/include/boost/geometry/iterators/ever_circling_iterator.hpp
@@ -100,7 +100,9 @@ struct ever_circling_range_iterator
     <
         ever_circling_range_iterator<Range>,
         typename boost::range_value<Range>::type const,
-        boost::random_access_traversal_tag
+        boost::random_access_traversal_tag,
+        typename boost::range_reference<Range>::type const,
+        typename boost::range_difference<Range>::type
     >
 {
     /// Constructor including the range it is based on
@@ -118,12 +120,13 @@ struct ever_circling_range_iterator
         , m_index(0)
     {}
 
-    typedef std::ptrdiff_t difference_type;
+    typedef typename boost::range_reference<Range>::type const reference_type;
+    typedef typename boost::range_difference<Range>::type difference_type;
 
 private:
     friend class boost::iterator_core_access;
 
-    inline typename boost::range_value<Range>::type const& dereference() const
+    inline reference_type dereference() const
     {
         return *m_iterator;
     }

--- a/test/iterators/closing_iterator.cpp
+++ b/test/iterators/closing_iterator.cpp
@@ -26,6 +26,8 @@
 #include <boost/geometry/geometries/geometries.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
 
+#include <boost/range/adaptor/transformed.hpp>
+
 
 // The closing iterator should also work on normal std:: containers
 void test_empty_non_geometry()
@@ -64,6 +66,36 @@ void test_non_geometry()
 
     closing_iterator it(v);
     closing_iterator end(v, true);
+
+    std::ostringstream out;
+    for (; it != end; ++it)
+    {
+        out << *it;
+    }
+    BOOST_CHECK_EQUAL(out.str(), "1231");
+}
+
+void test_transformed_non_geometry()
+{
+    std::vector<int> v;
+    v.push_back(-1);
+    v.push_back(-2);
+    v.push_back(-3);
+
+    typedef boost::transformed_range
+        <
+            std::negate<int>,
+            std::vector<int>
+        > transformed_range;
+
+    typedef bg::closing_iterator
+        <
+            transformed_range const
+        > closing_iterator;
+
+    transformed_range v2 = v | boost::adaptors::transformed(std::negate<int>());
+    closing_iterator it(v2);
+    closing_iterator end(v2, true);
 
     std::ostringstream out;
     for (; it != end; ++it)
@@ -129,6 +161,7 @@ void test_all()
 {
     test_empty_non_geometry();
     test_non_geometry();
+    test_transformed_non_geometry();
     test_geometry<bg::model::ring<P> >("POLYGON((1 1,1 4,4 4,4 1))");
 }
 

--- a/test/iterators/ever_circling_iterator.cpp
+++ b/test/iterators/ever_circling_iterator.cpp
@@ -23,12 +23,14 @@
 #include <boost/geometry/io/wkt/read.hpp>
 #include <boost/geometry/geometries/geometries.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
+#include <boost/geometry/geometries/register/linestring.hpp>
+
+#include <boost/range/adaptor/transformed.hpp>
+
 
 template <typename G>
-void test_geometry(std::string const& wkt)
+void test_geometry(G const& geo)
 {
-    G geo;
-    bg::read_wkt(wkt, geo);
     typedef typename boost::range_iterator<G const>::type iterator_type;
 
 
@@ -74,7 +76,7 @@ void test_geometry(std::string const& wkt)
     // Check the range_iterator-one
     {
         std::ostringstream out;
-        bg::ever_circling_range_iterator<G> it(geo);
+        bg::ever_circling_range_iterator<G const> it(geo);
         for (std::size_t i = 0; i < n; ++i, ++it)
         {
             out << bg::get<0>(*it);
@@ -83,10 +85,54 @@ void test_geometry(std::string const& wkt)
     }
 }
 
+template <typename G>
+void test_geometry(std::string const& wkt)
+{
+    G geo;
+    bg::read_wkt(wkt, geo);
+    test_geometry(geo);
+}
+
+
+template <typename P>
+P transform_point(P const& p)
+{
+    P result;
+    bg::set<0>(result, bg::get<0>(p) + 1);
+    bg::set<1>(result, bg::get<1>(p) + 1);
+    return result;
+}
+
+template <typename G>
+struct transformed_geometry_type
+{
+    typedef typename bg::point_type<G>::type point_type;
+    typedef boost::transformed_range<point_type(*)(point_type const&), G> type;
+};
+
+template <typename G>
+void test_transformed_geometry(G const& geo)
+{
+    typedef typename bg::point_type<G>::type point_type;
+    test_geometry(geo | boost::adaptors::transformed(&transform_point<point_type>));
+}
+
+template <typename G>
+void test_transformed_geometry(std::string const& wkt)
+{
+    G geo;
+    bg::read_wkt(wkt, geo);
+    test_transformed_geometry(geo);
+}
+
+
+BOOST_GEOMETRY_REGISTER_LINESTRING(typename transformed_geometry_type< bg::model::linestring< bg::model::d2::point_xy<double> > >::type)
+
 template <typename P>
 void test_all()
 {
     test_geometry<bg::model::linestring<P> >("linestring(1 1,2 2,3 3,4 4,5 5)");
+    test_transformed_geometry<bg::model::linestring<P> >("linestring(0 0,1 1,2 2,3 3,4 4)");
 }
 
 int test_main(int, char* [])


### PR DESCRIPTION
This PR addresses an issue with both closing_iterator and ever_circling_range_iterator where they can return a reference to a temporary object. This happens when using a range where Range::reference is a value type (in my particular case, I hit this with boost::transformed_range). This happens because neither of them were honoring the range's reference type, they were assuming it was 'value_type const&'.

The first commit adds the tests, both of which fail with a SEGFAULT, and the second commit fixes the iterators.

Built and tested on Ubuntu 16.04 with gcc 5.4:
gcc (Ubuntu 5.4.0-6ubuntu1~16.04.9) 5.4.0 20160609