### PR TITLE
Minor fixes for compilation with VxWorks 7

### DIFF
--- a/index/test/rtree/interprocess/Jamfile.v2
+++ b/index/test/rtree/interprocess/Jamfile.v2
@@ -18,13 +18,13 @@ rule test_all
       :  # requirements
         <toolset>acc:<linkflags>-lrt
         <toolset>acc-pa_risc:<linkflags>-lrt
-        <host-os>hpux,<toolset>gcc:<linkflags>"-Wl,+as,mpas"
+        <target-os>hpux,<toolset>gcc:<linkflags>"-Wl,+as,mpas"
 #        <toolset>gcc-mingw:<linkflags>"-lole32 -loleaut32 -lpsapi -ladvapi32"
         <toolset>gcc,<target-os>windows:<linkflags>"-lole32 -loleaut32 -lpsapi -ladvapi32" 
-        <host-os>windows,<toolset>clang:<linkflags>"-lole32 -loleaut32 -lpsapi -ladvapi32"
+        <target-os>windows,<toolset>clang:<linkflags>"-lole32 -loleaut32 -lpsapi -ladvapi32"
         <toolset>msvc:<cxxflags>/bigobj
-        <host-os>windows,<toolset>intel:<cxxflags>/bigobj
-        <host-os>linux:<linkflags>"-lrt"
+        <target-os>windows,<toolset>intel:<cxxflags>/bigobj
+        <target-os>linux:<linkflags>"-lrt"
       ] ;
    }
 

--- a/test/srs/projection_interface.cpp
+++ b/test/srs/projection_interface.cpp
@@ -70,7 +70,7 @@ int test_main(int, char*[])
         point_xy pt_xy(0, 0);
 
         // default WGS84 spheroid
-        projection<static_proj4<proj<tmerc> > > prj;
+        projection<static_proj4<boost::geometry::srs::par4::proj<tmerc> > > prj;
         //projection<static_proj4<proj<tmerc>, ellps<WGS84> > > prj;
 
         prj.forward(pt_ll, pt_xy);
@@ -100,12 +100,12 @@ int test_main(int, char*[])
 
     {
         // static_proj4 constructors
-        projection<static_proj4<proj<tmerc>, ellps<WGS84> > >
+        projection<static_proj4<boost::geometry::srs::par4::proj<tmerc>, ellps<WGS84> > >
             prj1;
-        projection<static_proj4<proj<tmerc>, ellps<WGS84>, datum<WGS84> > >
+        projection<static_proj4<boost::geometry::srs::par4::proj<tmerc>, ellps<WGS84>, datum<WGS84> > >
             prj2;
 #ifdef BOOST_GEOMETRY_SRS_ENABLE_STATIC_PROJECTION_HYBRID_INTERFACE
-        projection<static_proj4<proj<tmerc>, ellps<WGS84>, datum<WGS84> > >
+        projection<static_proj4<boost::geometry::srs::par4::proj<tmerc>, ellps<WGS84>, datum<WGS84> > >
             prj3 = proj4("");
 #endif
     }
@@ -113,7 +113,7 @@ int test_main(int, char*[])
     {
         typedef spheroid<double> sph;
         typedef ellps<sph> ell;
-        typedef proj<tmerc> prj;
+        typedef boost::geometry::srs::par4::proj<tmerc> prj;
         projection<static_proj4<ell, prj> >
             prj1 = static_proj4<ell, prj>(ell(sph(1000, 999)));
 #ifdef BOOST_GEOMETRY_SRS_ENABLE_STATIC_PROJECTION_HYBRID_INTERFACE
@@ -130,7 +130,7 @@ int test_main(int, char*[])
         //projection<static_proj4<int> > prj1;
         //projection<int> prj2;
 
-        projection<static_proj4<proj<bacon> > > prj3;
+        projection<static_proj4<boost::geometry::srs::par4::proj<bacon> > > prj3;
         //projection<static_proj4<proj<bacon>, ellps<WGS84> > > prj3;
         //prj3.inverse(pt_xy, pt_ll);
     }

--- a/test/srs/srs_transformer.cpp
+++ b/test/srs/srs_transformer.cpp
@@ -72,26 +72,26 @@ int test_main(int, char*[])
     {
         srs_forward_transformer
             <
-                projection<static_proj4<proj<tmerc>, ellps<WGS84> > >
+                projection<static_proj4<boost::geometry::srs::par4::proj<tmerc>, ellps<WGS84> > >
             > strategy_pf;
         srs_forward_transformer
             <
-                projection<static_proj4<proj<tmerc>, ellps<WGS84> > >
+                projection<static_proj4<boost::geometry::srs::par4::proj<tmerc>, ellps<WGS84> > >
             > strategy_pi;
         srs_forward_transformer
             <
                 transformation
                     <
-                        static_proj4<proj<tmerc>, ellps<WGS84> >,
-                        static_proj4<proj<tmerc>, ellps<clrk66> >
+                        static_proj4<boost::geometry::srs::par4::proj<tmerc>, ellps<WGS84> >,
+                        static_proj4<boost::geometry::srs::par4::proj<tmerc>, ellps<clrk66> >
                     >
             > strategy_tf;
         srs_forward_transformer
             <
                 transformation
                     <
-                        static_proj4<proj<tmerc>, ellps<WGS84> >,
-                        static_proj4<proj<tmerc>, ellps<clrk66> >
+                        static_proj4<boost::geometry::srs::par4::proj<tmerc>, ellps<WGS84> >,
+                        static_proj4<boost::geometry::srs::par4::proj<tmerc>, ellps<clrk66> >
                     >
             > strategy_ti;
     }


### PR DESCRIPTION
Change \<host-os\> to \<target-os\>  in one Jamfile for cross-compilation.
And change <proj to fully qualified <boost::geometry::srs::par4::proj
to avoid confusing clang when compiling with the Dinkum STL
which has inline proj() in global namespace