### PR TITLE
Fix make_inverse and expand issue 

### DIFF
--- a/include/boost/geometry/algorithms/detail/assign_values.hpp
+++ b/include/boost/geometry/algorithms/detail/assign_values.hpp
@@ -7,6 +7,11 @@
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -34,7 +39,7 @@
 #include <boost/geometry/geometries/concepts/check.hpp>
 
 
-#include <boost/geometry/util/is_inverse.hpp>
+#include <boost/geometry/util/is_inverse_spheroidal_coordinates.hpp>
 #include <boost/geometry/util/for_each_coordinate.hpp>
 
 

--- a/include/boost/geometry/algorithms/detail/assign_values.hpp
+++ b/include/boost/geometry/algorithms/detail/assign_values.hpp
@@ -34,6 +34,7 @@
 #include <boost/geometry/geometries/concepts/check.hpp>
 
 
+#include <boost/geometry/util/is_inverse.hpp>
 #include <boost/geometry/util/for_each_coordinate.hpp>
 
 
@@ -86,10 +87,10 @@ struct assign_inverse_box_or_segment
         typedef typename coordinate_type<point_type>::type bound_type;
 
         initialize<0, 0, dimension<BoxOrSegment>::type::value>::apply(
-            geometry, boost::numeric::bounds<bound_type>::highest()
+            geometry, geometry::bounds<bound_type>::highest()
         );
         initialize<1, 0, dimension<BoxOrSegment>::type::value>::apply(
-            geometry, boost::numeric::bounds<bound_type>::lowest()
+            geometry, geometry::bounds<bound_type>::lowest()
         );
     }
 };

--- a/include/boost/geometry/algorithms/detail/envelope/box.hpp
+++ b/include/boost/geometry/algorithms/detail/envelope/box.hpp
@@ -4,8 +4,8 @@
 // Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2015, 2016, 2017.
-// Modifications copyright (c) 2015-2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2015-2018.
+// Modifications copyright (c) 2015-2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
@@ -126,7 +126,7 @@ struct envelope_box_on_spheroid
     {
         BoxIn box_in_normalized = box_in;
 
-        if (!is_inverse(box_in))
+        if (!is_inverse_spheroidal_coordinates(box_in))
         {
             box_in_normalized = detail::return_normalized<BoxIn>(box_in);
         }

--- a/include/boost/geometry/algorithms/detail/envelope/box.hpp
+++ b/include/boost/geometry/algorithms/detail/envelope/box.hpp
@@ -126,15 +126,7 @@ struct envelope_box_on_spheroid
     {
         BoxIn box_in_normalized = box_in;
 
-        typedef typename point_type<BoxIn>::type point_type;
-        typedef typename coordinate_type<point_type>::type bound_type;
-
-        // normalize input box (except from special boxes come from make_inverse)
-        bound_type high = boost::numeric::bounds<bound_type>::highest();
-        bound_type low = boost::numeric::bounds<bound_type>::lowest();
-
-        if (geometry::get<0, 0>(box_in) != high || geometry::get<0, 1>(box_in) != high
-            || geometry::get<1, 0>(box_in) != low  || geometry::get<1, 1>(box_in) != low)
+        if (!is_inverse(box_in))
         {
             box_in_normalized = detail::return_normalized<BoxIn>(box_in);
         }

--- a/include/boost/geometry/algorithms/detail/envelope/box.hpp
+++ b/include/boost/geometry/algorithms/detail/envelope/box.hpp
@@ -124,7 +124,20 @@ struct envelope_box_on_spheroid
                              BoxOut& mbr,
                              Strategy const&)
     {
-        BoxIn box_in_normalized = detail::return_normalized<BoxIn>(box_in);
+        BoxIn box_in_normalized = box_in;
+
+        typedef typename point_type<BoxIn>::type point_type;
+        typedef typename coordinate_type<point_type>::type bound_type;
+
+        // normalize input box (except from special boxes come from make_inverse)
+        bound_type high = boost::numeric::bounds<bound_type>::highest();
+        bound_type low = boost::numeric::bounds<bound_type>::lowest();
+
+        if (geometry::get<0, 0>(box_in) != high || geometry::get<0, 1>(box_in) != high
+            || geometry::get<1, 0>(box_in) != low  || geometry::get<1, 1>(box_in) != low)
+        {
+            box_in_normalized = detail::return_normalized<BoxIn>(box_in);
+        }
 
         envelope_indexed_box_on_spheroid
             <

--- a/include/boost/geometry/algorithms/detail/envelope/range_of_boxes.hpp
+++ b/include/boost/geometry/algorithms/detail/envelope/range_of_boxes.hpp
@@ -272,11 +272,7 @@ struct envelope_range_of_boxes
              it != boost::end(range_of_boxes);
              ++it)
         {
-            coordinate_type high = boost::numeric::bounds<coordinate_type>::highest();
-            coordinate_type low = boost::numeric::bounds<coordinate_type>::lowest();
-
-            if (geometry::get<0, 0>(*it) == high && geometry::get<0, 1>(*it) == high
-                && geometry::get<1, 0>(*it) == low  && geometry::get<1, 1>(*it) == low)
+            if (is_inverse(*it))
             {
                 continue;
             }

--- a/include/boost/geometry/algorithms/detail/envelope/range_of_boxes.hpp
+++ b/include/boost/geometry/algorithms/detail/envelope/range_of_boxes.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2015-2017, Oracle and/or its affiliates.
+// Copyright (c) 2015-2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
@@ -272,7 +272,7 @@ struct envelope_range_of_boxes
              it != boost::end(range_of_boxes);
              ++it)
         {
-            if (is_inverse(*it))
+            if (is_inverse_spheroidal_coordinates(*it))
             {
                 continue;
             }

--- a/include/boost/geometry/algorithms/detail/envelope/range_of_boxes.hpp
+++ b/include/boost/geometry/algorithms/detail/envelope/range_of_boxes.hpp
@@ -272,6 +272,15 @@ struct envelope_range_of_boxes
              it != boost::end(range_of_boxes);
              ++it)
         {
+            coordinate_type high = boost::numeric::bounds<coordinate_type>::highest();
+            coordinate_type low = boost::numeric::bounds<coordinate_type>::lowest();
+
+            if (geometry::get<0, 0>(*it) == high && geometry::get<0, 1>(*it) == high
+                && geometry::get<1, 0>(*it) == low  && geometry::get<1, 1>(*it) == low)
+            {
+                continue;
+            }
+
             coordinate_type lat_min = geometry::get<min_corner, 1>(*it);
             coordinate_type lat_max = geometry::get<max_corner, 1>(*it);
             if (math::equals(lat_min, constants::max_latitude())

--- a/include/boost/geometry/algorithms/detail/expand/point.hpp
+++ b/include/boost/geometry/algorithms/detail/expand/point.hpp
@@ -43,6 +43,7 @@
 
 #include <boost/geometry/algorithms/dispatch/expand.hpp>
 
+#include <boost/geometry/algorithms/make.hpp>
 
 namespace boost { namespace geometry
 {
@@ -112,95 +113,113 @@ struct point_loop_on_spheroid
 
         // normalize input point and input box
         Point p_normalized = detail::return_normalized<Point>(point);
-        detail::normalize(box, box);
 
         // transform input point to be of the same type as the box point
         box_point_type box_point;
         detail::envelope::transform_units(p_normalized, box_point);
 
-        box_coordinate_type p_lon = geometry::get<0>(box_point);
-        box_coordinate_type p_lat = geometry::get<1>(box_point);
+        // normalize input box (except from special boxes come from make_inverse)
+        box_coordinate_type high = boost::numeric::bounds<box_coordinate_type>::highest();
+        box_coordinate_type low = boost::numeric::bounds<box_coordinate_type>::lowest();
 
-        typename coordinate_type<Box>::type
-            b_lon_min = geometry::get<min_corner, 0>(box),
-            b_lat_min = geometry::get<min_corner, 1>(box),
-            b_lon_max = geometry::get<max_corner, 0>(box),
-            b_lat_max = geometry::get<max_corner, 1>(box);
-
-        if (math::is_latitude_pole<units_type, IsEquatorial>(p_lat))
+        if (math::equals(geometry::get<0, 0>(box), high)
+         && math::equals(geometry::get<0, 1>(box), high)
+         && math::equals(geometry::get<1, 0>(box), low)
+         && math::equals(geometry::get<1, 1>(box), low))
         {
-            // the point of expansion is the either the north or the
-            // south pole; the only important coordinate here is the
-            // pole's latitude, as the longitude can be anything;
-            // we, thus, take into account the point's latitude only and return
-            geometry::set<min_corner, 1>(box, (std::min)(p_lat, b_lat_min));
-            geometry::set<max_corner, 1>(box, (std::max)(p_lat, b_lat_max));
-            return;
-        }
+            geometry::set_from_radian<min_corner, 0>(box, geometry::get_as_radian<0>(p_normalized));
+            geometry::set_from_radian<min_corner, 1>(box, geometry::get_as_radian<1>(p_normalized));
+            geometry::set_from_radian<max_corner, 0>(box, geometry::get_as_radian<0>(p_normalized));
+            geometry::set_from_radian<max_corner, 1>(box, geometry::get_as_radian<1>(p_normalized));
 
-        if (math::equals(b_lat_min, b_lat_max)
-            && math::is_latitude_pole<units_type, IsEquatorial>(b_lat_min))
-        {
-            // the box degenerates to either the north or the south pole;
-            // the only important coordinate here is the pole's latitude, 
-            // as the longitude can be anything;
-            // we thus take into account the box's latitude only and return
-            geometry::set<min_corner, 0>(box, p_lon);
-            geometry::set<min_corner, 1>(box, (std::min)(p_lat, b_lat_min));
-            geometry::set<max_corner, 0>(box, p_lon);
-            geometry::set<max_corner, 1>(box, (std::max)(p_lat, b_lat_max));
-            return;
-        }
+        } else {
 
-        // update latitudes
-        b_lat_min = (std::min)(b_lat_min, p_lat);
-        b_lat_max = (std::max)(b_lat_max, p_lat);
+            detail::normalize(box, box);
 
-        // update longitudes
-        if (math::smaller(p_lon, b_lon_min))
-        {
-            box_coordinate_type p_lon_shifted = p_lon + constants::period();
+            box_coordinate_type p_lon = geometry::get<0>(box_point);
+            box_coordinate_type p_lat = geometry::get<1>(box_point);
 
-            if (math::larger(p_lon_shifted, b_lon_max))
+            typename coordinate_type<Box>::type
+                    b_lon_min = geometry::get<min_corner, 0>(box),
+                    b_lat_min = geometry::get<min_corner, 1>(box),
+                    b_lon_max = geometry::get<max_corner, 0>(box),
+                    b_lat_max = geometry::get<max_corner, 1>(box);
+
+            if (math::is_latitude_pole<units_type, IsEquatorial>(p_lat))
             {
-                // here we could check using: ! math::larger(.., ..)
-                if (math::smaller(b_lon_min - p_lon, p_lon_shifted - b_lon_max))
+                // the point of expansion is the either the north or the
+                // south pole; the only important coordinate here is the
+                // pole's latitude, as the longitude can be anything;
+                // we, thus, take into account the point's latitude only and return
+                geometry::set<min_corner, 1>(box, (std::min)(p_lat, b_lat_min));
+                geometry::set<max_corner, 1>(box, (std::max)(p_lat, b_lat_max));
+                return;
+            }
+
+            if (math::equals(b_lat_min, b_lat_max)
+                    && math::is_latitude_pole<units_type, IsEquatorial>(b_lat_min))
+            {
+                // the box degenerates to either the north or the south pole;
+                // the only important coordinate here is the pole's latitude,
+                // as the longitude can be anything;
+                // we thus take into account the box's latitude only and return
+                geometry::set<min_corner, 0>(box, p_lon);
+                geometry::set<min_corner, 1>(box, (std::min)(p_lat, b_lat_min));
+                geometry::set<max_corner, 0>(box, p_lon);
+                geometry::set<max_corner, 1>(box, (std::max)(p_lat, b_lat_max));
+                return;
+            }
+
+            // update latitudes
+            b_lat_min = (std::min)(b_lat_min, p_lat);
+            b_lat_max = (std::max)(b_lat_max, p_lat);
+
+            // update longitudes
+            if (math::smaller(p_lon, b_lon_min))
+            {
+                box_coordinate_type p_lon_shifted = p_lon + constants::period();
+
+                if (math::larger(p_lon_shifted, b_lon_max))
+                {
+                    // here we could check using: ! math::larger(.., ..)
+                    if (math::smaller(b_lon_min - p_lon, p_lon_shifted - b_lon_max))
+                    {
+                        b_lon_min = p_lon;
+                    }
+                    else
+                    {
+                        b_lon_max = p_lon_shifted;
+                    }
+                }
+            }
+            else if (math::larger(p_lon, b_lon_max))
+            {
+                // in this case, and since p_lon is normalized in the range
+                // (-180, 180], we must have that b_lon_max <= 180
+                if (b_lon_min < 0
+                        && math::larger(p_lon - b_lon_max,
+                                        constants::period() - p_lon + b_lon_min))
                 {
                     b_lon_min = p_lon;
+                    b_lon_max += constants::period();
                 }
                 else
                 {
-                    b_lon_max = p_lon_shifted;
+                    b_lon_max = p_lon;
                 }
             }
-        }
-        else if (math::larger(p_lon, b_lon_max))
-        {
-            // in this case, and since p_lon is normalized in the range
-            // (-180, 180], we must have that b_lon_max <= 180
-            if (b_lon_min < 0
-                && math::larger(p_lon - b_lon_max,
-                                constants::period() - p_lon + b_lon_min))
-            {
-                b_lon_min = p_lon;
-                b_lon_max += constants::period();
-            }
-            else
-            {
-                b_lon_max = p_lon;
-            }
-        }
 
-        geometry::set<min_corner, 0>(box, b_lon_min);
-        geometry::set<min_corner, 1>(box, b_lat_min);
-        geometry::set<max_corner, 0>(box, b_lon_max);
-        geometry::set<max_corner, 1>(box, b_lat_max);
+            geometry::set<min_corner, 0>(box, b_lon_min);
+            geometry::set<min_corner, 1>(box, b_lat_min);
+            geometry::set<max_corner, 0>(box, b_lon_max);
+            geometry::set<max_corner, 1>(box, b_lat_max);
+        }
 
         point_loop
             <
                 2, DimensionCount
             >::apply(box, point, strategy);
-    }
+        }
 };
 
 

--- a/include/boost/geometry/algorithms/detail/expand/point.hpp
+++ b/include/boost/geometry/algorithms/detail/expand/point.hpp
@@ -5,8 +5,8 @@
 // Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 // Copyright (c) 2014-2015 Samuel Debionne, Grenoble, France.
 
-// This file was modified by Oracle on 2015, 2016, 2017.
-// Modifications copyright (c) 2015-2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2015-2018.
+// Modifications copyright (c) 2015-2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
@@ -35,7 +35,7 @@
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/tags.hpp>
 
-#include <boost/geometry/util/is_inverse.hpp>
+#include <boost/geometry/util/is_inverse_spheroidal_coordinates.hpp>
 #include <boost/geometry/util/math.hpp>
 #include <boost/geometry/util/select_coordinate_type.hpp>
 
@@ -117,7 +117,7 @@ struct point_loop_on_spheroid
         box_point_type box_point;
         detail::envelope::transform_units(p_normalized, box_point);
 
-        if (is_inverse(box))
+        if (is_inverse_spheroidal_coordinates(box))
         {
             geometry::set_from_radian<min_corner, 0>(box, geometry::get_as_radian<0>(p_normalized));
             geometry::set_from_radian<min_corner, 1>(box, geometry::get_as_radian<1>(p_normalized));

--- a/include/boost/geometry/algorithms/detail/expand/point.hpp
+++ b/include/boost/geometry/algorithms/detail/expand/point.hpp
@@ -44,8 +44,6 @@
 
 #include <boost/geometry/algorithms/dispatch/expand.hpp>
 
-#include <boost/geometry/algorithms/make.hpp>
-
 namespace boost { namespace geometry
 {
 

--- a/include/boost/geometry/algorithms/detail/expand/point.hpp
+++ b/include/boost/geometry/algorithms/detail/expand/point.hpp
@@ -35,6 +35,7 @@
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/tags.hpp>
 
+#include <boost/geometry/util/is_inverse.hpp>
 #include <boost/geometry/util/math.hpp>
 #include <boost/geometry/util/select_coordinate_type.hpp>
 
@@ -118,14 +119,7 @@ struct point_loop_on_spheroid
         box_point_type box_point;
         detail::envelope::transform_units(p_normalized, box_point);
 
-        // normalize input box (except from special boxes come from make_inverse)
-        box_coordinate_type high = boost::numeric::bounds<box_coordinate_type>::highest();
-        box_coordinate_type low = boost::numeric::bounds<box_coordinate_type>::lowest();
-
-        if (math::equals(geometry::get<0, 0>(box), high)
-         && math::equals(geometry::get<0, 1>(box), high)
-         && math::equals(geometry::get<1, 0>(box), low)
-         && math::equals(geometry::get<1, 1>(box), low))
+        if (is_inverse(box))
         {
             geometry::set_from_radian<min_corner, 0>(box, geometry::get_as_radian<0>(p_normalized));
             geometry::set_from_radian<min_corner, 1>(box, geometry::get_as_radian<1>(p_normalized));

--- a/include/boost/geometry/util/is_inverse.hpp
+++ b/include/boost/geometry/util/is_inverse.hpp
@@ -32,10 +32,10 @@ bool is_inverse(Box const& box)
     bound_type high = bounds<bound_type>::highest();
     bound_type low = bounds<bound_type>::lowest();
 
-    return math::equals(geometry::get<0, 0>(box), high) &&
-           math::equals(geometry::get<0, 1>(box), high) &&
-           math::equals(geometry::get<1, 0>(box), low) &&
-           math::equals(geometry::get<1, 1>(box), low);
+    return (geometry::get<0, 0>(box) == high) &&
+           (geometry::get<0, 1>(box) == high) &&
+           (geometry::get<1, 0>(box) == low) &&
+           (geometry::get<1, 1>(box) == low);
 }
 
 }} // namespace boost::geometry

--- a/include/boost/geometry/util/is_inverse.hpp
+++ b/include/boost/geometry/util/is_inverse.hpp
@@ -1,0 +1,43 @@
+// Boost.Geometry
+
+// Copyright (c) 2018 Oracle and/or its affiliates.
+
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_UTIL_IS_INVERSE_HPP
+#define BOOST_GEOMETRY_UTIL_IS_INVERSE_HPP
+
+#include <boost/geometry/util/math.hpp>
+
+namespace boost { namespace geometry
+{
+
+template<class CT>
+struct bounds
+{
+  static CT lowest  () { return boost::numeric::bounds<CT>::lowest(); }
+  static CT highest () { return boost::numeric::bounds<CT>::highest(); }
+};
+
+template <typename Box>
+bool is_inverse(Box const& box)
+{
+    typedef typename point_type<Box>::type point_type;
+    typedef typename coordinate_type<point_type>::type bound_type;
+
+    bound_type high = bounds<bound_type>::highest();
+    bound_type low = bounds<bound_type>::lowest();
+
+    return math::equals(geometry::get<0, 0>(box), high) &&
+           math::equals(geometry::get<0, 1>(box), high) &&
+           math::equals(geometry::get<1, 0>(box), low) &&
+           math::equals(geometry::get<1, 1>(box), low);
+}
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_UTIL_IS_INVERSE_HPP

--- a/include/boost/geometry/util/is_inverse_spheroidal_coordinates.hpp
+++ b/include/boost/geometry/util/is_inverse_spheroidal_coordinates.hpp
@@ -8,8 +8,8 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef BOOST_GEOMETRY_UTIL_IS_INVERSE_HPP
-#define BOOST_GEOMETRY_UTIL_IS_INVERSE_HPP
+#ifndef BOOST_GEOMETRY_UTIL_IS_INVERSE_SPHEROIDAL_COORDINATES_HPP
+#define BOOST_GEOMETRY_UTIL_IS_INVERSE_SPHEROIDAL_COORDINATES_HPP
 
 #include <boost/geometry/util/math.hpp>
 
@@ -24,7 +24,7 @@ struct bounds
 };
 
 template <typename Box>
-bool is_inverse(Box const& box)
+bool is_inverse_spheroidal_coordinates(Box const& box)
 {
     typedef typename point_type<Box>::type point_type;
     typedef typename coordinate_type<point_type>::type bound_type;
@@ -40,4 +40,4 @@ bool is_inverse(Box const& box)
 
 }} // namespace boost::geometry
 
-#endif // BOOST_GEOMETRY_UTIL_IS_INVERSE_HPP
+#endif // BOOST_GEOMETRY_UTIL_IS_INVERSE_SPHEROIDAL_COORDINATES_HPP

--- a/test/algorithms/envelope_expand/expand_on_spheroid.cpp
+++ b/test/algorithms/envelope_expand/expand_on_spheroid.cpp
@@ -244,11 +244,7 @@ private:
 
             //if the input box is the special one made from make_inverse
             //do not convert coordinates
-            double high = boost::numeric::bounds<double>::highest();
-            double low = boost::numeric::bounds<double>::lowest();
-
-            if (bg::get<0, 0>(box) != high || bg::get<0, 1>(box) != high
-                || bg::get<1, 0>(box) != low  || bg::get<1, 1>(box) != low)
+            if (!is_inverse(box))
             {
                 bg::detail::indexed_point_view<Box const, 0> p_min(box);
                 bg::detail::indexed_point_view<Box const, 1> p_max(box);

--- a/test/algorithms/envelope_expand/expand_on_spheroid.cpp
+++ b/test/algorithms/envelope_expand/expand_on_spheroid.cpp
@@ -1,7 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 // Unit Test
 
-// Copyright (c) 2015-2017, Oracle and/or its affiliates.
+// Copyright (c) 2015-2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
@@ -245,7 +245,7 @@ private:
 
             //if the input box is the special one made from make_inverse
             //do not convert coordinates
-            if (!is_inverse(box))
+            if (!is_inverse_spheroidal_coordinates(box))
             {
                 bg::detail::indexed_point_view<Box const, 0> p_min(box);
                 bg::detail::indexed_point_view<Box const, 1> p_max(box);

--- a/test/algorithms/envelope_expand/expand_on_spheroid.cpp
+++ b/test/algorithms/envelope_expand/expand_on_spheroid.cpp
@@ -42,6 +42,7 @@
 #include <boost/geometry/algorithms/assign.hpp>
 #include <boost/geometry/algorithms/envelope.hpp>
 #include <boost/geometry/algorithms/expand.hpp>
+#include <boost/geometry/algorithms/make.hpp>
 #include <boost/geometry/algorithms/transform.hpp>
 
 #include "test_envelope_expand_on_spheroid.hpp"


### PR DESCRIPTION
This PR proposes a fix for issue https://github.com/boostorg/geometry/issues/498 by avoiding normalization for boxes created by ```make_inverse``` in spherical and geographic coordinate systems. 