### PR TITLE
Fix potential unsigned integer overflow in find_polygons_for_source

### DIFF
--- a/include/boost/geometry/algorithms/detail/overlay/sort_by_side.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/sort_by_side.hpp
@@ -521,7 +521,7 @@ private :
         {
             rp& ranked = m_ranked_points[index];
 
-            if (ranked.rank != previous_rank && ! in_polygon)
+            if (previous_rank > 0 && ranked.rank != previous_rank && ! in_polygon)
             {
                 assign_ranks(last_from_rank, previous_rank - 1, 1);
                 assign_ranks(last_from_rank + 1, previous_rank, 2);


### PR DESCRIPTION
An invalid polygon will trigger overflow when `previous_rank` is `0` as `previous_rank - 1` will overflow. This can be detected by passing an invalid polygon like `[[8128,3600],[8224,3664],[8128,3600]]` into `boost::geometry::intersection` and compiling with `-fsanitize=undefined`.

I'm aware that `boost::geometry::intersection` is not meant to be used with invalid polygons. However I still think that an overflow is not desirable. Better to prevent it or (if others think this fix is incorrect) perhaps an exception would be better?