### PR TITLE
Replace boost::ignore_unused_variable_warning with boost::ignore_unused

### DIFF
--- a/doc/src/examples/algorithms/create_svg_overlay.hpp
+++ b/doc/src/examples/algorithms/create_svg_overlay.hpp
@@ -14,6 +14,7 @@
 #include <fstream>
 
 #include <boost/foreach.hpp>
+#include <boost/core/ignore_unused.hpp>
 #include <boost/algorithm/string.hpp>
 
 #if defined(HAVE_SVG)
@@ -45,10 +46,7 @@ void create_svg(std::string const& filename, Geometry const& a, Geometry const& 
                     "fill:rgb(0,0,0);font-family:Arial;font-size:10px");
     }
 #else
-    boost::ignore_unused_variable_warning(filename);
-    boost::ignore_unused_variable_warning(a);
-    boost::ignore_unused_variable_warning(b);
-    boost::ignore_unused_variable_warning(range);
+    boost::ignore_unused(filename, a, b, range);
 #endif
 }
 

--- a/doc/src/examples/algorithms/create_svg_two.hpp
+++ b/doc/src/examples/algorithms/create_svg_two.hpp
@@ -13,7 +13,7 @@
 
 #include <fstream>
 #include <boost/algorithm/string.hpp>
-
+#include <boost/core/ignore_unused.hpp>
 #if defined(HAVE_SVG)
 #  include <boost/geometry/io/svg/svg_mapper.hpp>
 #endif
@@ -41,9 +41,7 @@ void create_svg(std::string const& filename, Geometry1 const& a, Geometry2 const
         mapper.map(b, "opacity:0.8;fill:none;stroke:rgb(255,128,0);stroke-width:4;stroke-dasharray:1,7;stroke-linecap:round");
     }
 #else
-    boost::ignore_unused_variable_warning(filename);
-    boost::ignore_unused_variable_warning(a);
-    boost::ignore_unused_variable_warning(b);
+    boost::ignore_unused(filename, a, b);
 #endif
 }
 

--- a/doc/src/examples/examples_utils/create_svg_buffer.hpp
+++ b/doc/src/examples/examples_utils/create_svg_buffer.hpp
@@ -12,7 +12,7 @@
 #define CREATE_SVG_BUFFER_HPP
 
 #include <fstream>
-
+#include <boost/core/ignore_unused.hpp>
 #if defined(HAVE_SVG)
 #  include <boost/geometry/io/svg/svg_mapper.hpp>
 #endif
@@ -35,9 +35,7 @@ void create_svg_buffer(std::string const& filename, Geometry1 const& original, G
     mapper.map(original, "fill-opacity:0.6;fill:rgb(51,51,153);stroke:rgb(51,51,153);stroke-width:2");
 
 #else
-    boost::ignore_unused_variable_warning(filename);
-    boost::ignore_unused_variable_warning(original);
-    boost::ignore_unused_variable_warning(buffer);
+    boost::ignore_unused(filename, original, buffer);
 #endif
 }
 

--- a/extensions/test/algorithms/is_convex.cpp
+++ b/extensions/test/algorithms/is_convex.cpp
@@ -50,7 +50,7 @@ void test_geometry(std::string const& wkt,
             typename bg::cs_tag<P>::type
         >::type side;
 
-    boost::ignore_unused_variable_warning(side);
+    boost::ignore_unused(side);
 
     typedef typename bg::range_type<Geometry>::type range_type;
     typedef typename boost::range_const_iterator<range_type>::type iterator;

--- a/include/boost/geometry/algorithms/area.hpp
+++ b/include/boost/geometry/algorithms/area.hpp
@@ -20,6 +20,7 @@
 #define BOOST_GEOMETRY_ALGORITHMS_AREA_HPP
 
 #include <boost/concept_check.hpp>
+#include <boost/core/ignore_unused.hpp>
 #include <boost/range/functions.hpp>
 #include <boost/range/metafunctions.hpp>
 
@@ -93,7 +94,7 @@ struct ring_area
         assert_dimension<Ring, 2>();
 
         // Ignore warning (because using static method sometimes) on strategy
-        boost::ignore_unused_variable_warning(strategy);
+        boost::ignore_unused(strategy);
 
         // An open ring has at least three points,
         // A closed ring has at least four points,

--- a/include/boost/geometry/algorithms/detail/buffer/get_piece_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/get_piece_turns.hpp
@@ -14,6 +14,7 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_BUFFER_GET_PIECE_TURNS_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_BUFFER_GET_PIECE_TURNS_HPP
 
+#include <boost/core/ignore_unused.hpp>
 #include <boost/range.hpp>
 
 #include <boost/geometry/algorithms/equals.hpp>
@@ -281,7 +282,7 @@ public:
     inline bool apply(Section const& section1, Section const& section2,
                     bool first = true)
     {
-        boost::ignore_unused_variable_warning(first);
+        boost::ignore_unused(first);
 
         typedef typename boost::range_value<Pieces const>::type piece_type;
         piece_type const& piece1 = m_pieces[section1.ring_id.source_index];

--- a/include/boost/geometry/algorithms/detail/buffer/turn_in_original_visitor.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/turn_in_original_visitor.hpp
@@ -214,7 +214,7 @@ public:
     template <typename Turn, typename Original>
     inline bool apply(Turn const& turn, Original const& original, bool first = true)
     {
-        boost::ignore_unused_variable_warning(first);
+        boost::ignore_unused(first);
 
         if (turn.location != location_ok || turn.within_original)
         {

--- a/include/boost/geometry/algorithms/detail/buffer/turn_in_piece_visitor.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/turn_in_piece_visitor.hpp
@@ -706,7 +706,7 @@ public:
     template <typename Turn, typename Piece>
     inline bool apply(Turn const& turn, Piece const& piece, bool first = true)
     {
-        boost::ignore_unused_variable_warning(first);
+        boost::ignore_unused(first);
 
         if (turn.count_within > 0)
         {

--- a/include/boost/geometry/algorithms/detail/covered_by/implementation.hpp
+++ b/include/boost/geometry/algorithms/detail/covered_by/implementation.hpp
@@ -19,9 +19,8 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_COVERED_BY_IMPLEMENTATION_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_COVERED_BY_IMPLEMENTATION_HPP
 
-
 #include <cstddef>
-
+#include <boost/core/ignore_unused.hpp>
 #include <boost/geometry/algorithms/detail/covered_by/interface.hpp>
 #include <boost/geometry/algorithms/detail/within/implementation.hpp>
 
@@ -67,7 +66,7 @@ struct covered_by<Point, Box, point_tag, box_tag>
     template <typename Strategy>
     static inline bool apply(Point const& point, Box const& box, Strategy const& strategy)
     {
-        ::boost::ignore_unused_variable_warning(strategy);
+        ::boost::ignore_unused(strategy);
         return strategy.apply(point, box);
     }
 };
@@ -79,7 +78,7 @@ struct covered_by<Box1, Box2, box_tag, box_tag>
     static inline bool apply(Box1 const& box1, Box2 const& box2, Strategy const& strategy)
     {
         assert_dimension_equal<Box1, Box2>();
-        ::boost::ignore_unused_variable_warning(strategy);
+        ::boost::ignore_unused(strategy);
         return strategy.apply(box1, box2);
     }
 };

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
@@ -14,6 +14,7 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_TURN_INFO_FOR_ENDPOINT_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_TURN_INFO_FOR_ENDPOINT_HPP
 
+#include <boost/core/ignore_unused.hpp>
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/algorithms/detail/overlay/get_turn_info.hpp>
 #include <boost/geometry/policies/robustness/no_rescale_policy.hpp>
@@ -402,10 +403,7 @@ struct get_turn_info_for_endpoint
     {
         typedef typename cs_tag<typename TurnInfo::point_type>::type cs_tag;
 
-        boost::ignore_unused_variable_warning(i2);
-        boost::ignore_unused_variable_warning(j2);
-        boost::ignore_unused_variable_warning(ip_index);
-        boost::ignore_unused_variable_warning(tp_model);
+        boost::ignore_unused(i2, j2, ip_index, tp_model);
 
         if ( !first2 && !last2 )
         {

--- a/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
@@ -21,6 +21,7 @@
 
 #include <boost/array.hpp>
 #include <boost/concept_check.hpp>
+#include <boost/core/ignore_unused.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/vector_c.hpp>
 #include <boost/range.hpp>
@@ -155,9 +156,7 @@ class get_turns_in_sections
         // It checks if it is areal (box, ring, (multi)polygon)
         signed_size_type const n = static_cast<signed_size_type>(section.range_count);
 
-        boost::ignore_unused_variable_warning(n);
-        boost::ignore_unused_variable_warning(index1);
-        boost::ignore_unused_variable_warning(index2);
+        boost::ignore_unused(n, index1, index2);
 
         return boost::is_same
                     <
@@ -186,7 +185,7 @@ public :
             Turns& turns,
             InterruptPolicy& interrupt_policy)
     {
-        boost::ignore_unused_variable_warning(interrupt_policy);
+        boost::ignore_unused(interrupt_policy);
 
         if ((sec1.duplicate && (sec1.count + 1) < sec1.range_count)
            || (sec2.duplicate && (sec2.count + 1) < sec2.range_count))
@@ -667,7 +666,7 @@ private:
             Turns& turns,
             InterruptPolicy& interrupt_policy)
     {
-        boost::ignore_unused_variable_warning(interrupt_policy);
+        boost::ignore_unused(interrupt_policy);
 
         // Depending on code some relations can be left out
 

--- a/include/boost/geometry/algorithms/detail/relate/boundary_checker.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/boundary_checker.hpp
@@ -11,6 +11,7 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_RELATE_BOUNDARY_CHECKER_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_RELATE_BOUNDARY_CHECKER_HPP
 
+#include <boost/core/ignore_unused.hpp>
 #include <boost/geometry/util/range.hpp>
 #include <boost/geometry/algorithms/num_points.hpp>
 #include <boost/geometry/algorithms/detail/sub_range.hpp>
@@ -46,7 +47,7 @@ public:
     template <boundary_query BoundaryQuery>
     bool is_endpoint_boundary(point_type const& pt) const
     {
-        boost::ignore_unused_variable_warning(pt);
+        boost::ignore_unused(pt);
 #ifdef BOOST_GEOMETRY_DEBUG_RELATE_BOUNDARY_CHECKER
         // may give false positives for INT
         BOOST_GEOMETRY_ASSERT( (BoundaryQuery == boundary_front || BoundaryQuery == boundary_any)

--- a/include/boost/geometry/algorithms/detail/relate/follow_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/follow_helpers.hpp
@@ -14,6 +14,8 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_RELATE_FOLLOW_HELPERS_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_RELATE_FOLLOW_HELPERS_HPP
 
+#include <boost/core/ignore_unused.hpp>
+
 #include <boost/geometry/core/assert.hpp>
 
 #include <boost/geometry/util/condition.hpp>
@@ -94,7 +96,7 @@ struct for_each_disjoint_geometry_if<OpId, Geometry, Tag, true>
         BOOST_GEOMETRY_ASSERT(first != last);
 
         const std::size_t count = boost::size(geometry);
-        boost::ignore_unused_variable_warning(count);
+        boost::ignore_unused(count);
 
         // O(I)
         // gather info about turns generated for contained geometries
@@ -373,7 +375,7 @@ static inline bool is_ip_on_boundary(IntersectionPoint const& ip,
                                      BoundaryChecker & boundary_checker,
                                      segment_identifier const& seg_id)
 {
-    boost::ignore_unused_variable_warning(seg_id);
+    boost::ignore_unused(seg_id);
 
     bool res = false;
 

--- a/include/boost/geometry/algorithms/detail/sections/sectionalize.hpp
+++ b/include/boost/geometry/algorithms/detail/sections/sectionalize.hpp
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include <boost/concept/requires.hpp>
+#include <boost/core/ignore_unused.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/mpl/vector_c.hpp>
 #include <boost/range.hpp>
@@ -420,7 +421,7 @@ struct sectionalize_part
                              ring_identifier ring_id,
                              std::size_t max_count)
     {
-        boost::ignore_unused_variable_warning(robust_policy);
+        boost::ignore_unused(robust_policy);
 
         typedef typename boost::range_value<Sections>::type section_type;
         BOOST_STATIC_ASSERT

--- a/include/boost/geometry/algorithms/detail/within/implementation.hpp
+++ b/include/boost/geometry/algorithms/detail/within/implementation.hpp
@@ -19,9 +19,9 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_WITHIN_IMPLEMENTATION_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_WITHIN_IMPLEMENTATION_HPP
 
-
 #include <cstddef>
 
+#include <boost/core/ignore_unused.hpp>
 #include <boost/range.hpp>
 
 #include <boost/geometry/algorithms/detail/within/interface.hpp>
@@ -91,7 +91,7 @@ struct within<Point, Box, point_tag, box_tag>
     template <typename Strategy>
     static inline bool apply(Point const& point, Box const& box, Strategy const& strategy)
     {
-        boost::ignore_unused_variable_warning(strategy);
+        boost::ignore_unused(strategy);
         return strategy.apply(point, box);
     }
 };
@@ -103,7 +103,7 @@ struct within<Box1, Box2, box_tag, box_tag>
     static inline bool apply(Box1 const& box1, Box2 const& box2, Strategy const& strategy)
     {
         assert_dimension_equal<Box1, Box2>();
-        boost::ignore_unused_variable_warning(strategy);
+        boost::ignore_unused(strategy);
         return strategy.apply(box1, box2);
     }
 };

--- a/include/boost/geometry/extensions/algebra/geometries/concepts/matrix_concept.hpp
+++ b/include/boost/geometry/extensions/algebra/geometries/concepts/matrix_concept.hpp
@@ -16,7 +16,7 @@
 #define BOOST_GEOMETRY_EXTENSIONS_ALGEBRA_GEOMETRIES_CONCEPTS_MATRIX_CONCEPT_HPP
 
 #include <boost/concept_check.hpp>
-
+#include <boost/core/ignore_unused.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/access.hpp>
 
@@ -96,7 +96,7 @@ class ConstMatrix
         {
             const G* g = 0;
             ctype coord(geometry::get<I, J>(*g));
-            boost::ignore_unused_variable_warning(coord);
+            boost::ignore_unused(coord);
             dimension_checker_row<G, I, J+1, N>::apply();
         }
     };

--- a/include/boost/geometry/extensions/algebra/geometries/concepts/quaternion_concept.hpp
+++ b/include/boost/geometry/extensions/algebra/geometries/concepts/quaternion_concept.hpp
@@ -16,7 +16,7 @@
 #define BOOST_GEOMETRY_EXTENSIONS_ALGEBRA_GEOMETRIES_CONCEPTS_QUATERNION_CONCEPT_HPP
 
 #include <boost/concept_check.hpp>
-
+#include <boost/core/ignore_unused.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/access.hpp>
 
@@ -79,7 +79,7 @@ class ConstQuaternion
         {
             const G* g = 0;
             ctype coord(geometry::get<I>(*g));
-            boost::ignore_unused_variable_warning(coord);
+            boost::ignore_unused(coord);
             dimension_checker<G, I+1, N>::apply();
         }
     };

--- a/include/boost/geometry/extensions/algebra/geometries/concepts/rotation_matrix_concept.hpp
+++ b/include/boost/geometry/extensions/algebra/geometries/concepts/rotation_matrix_concept.hpp
@@ -16,7 +16,7 @@
 #define BOOST_GEOMETRY_EXTENSIONS_ALGEBRA_GEOMETRIES_CONCEPTS_ROTATION_MATRIX_CONCEPT_HPP
 
 #include <boost/concept_check.hpp>
-
+#include <boost/core/ignore_unused.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/access.hpp>
 
@@ -96,7 +96,7 @@ class ConstRotationMatrix
         {
             const G* g = 0;
             ctype coord(geometry::get<I, J>(*g));
-            boost::ignore_unused_variable_warning(coord);
+            boost::ignore_unused(coord);
             dimension_checker_row<G, I, J+1, N>::apply();
         }
     };

--- a/include/boost/geometry/extensions/algebra/geometries/concepts/rotation_quaternion_concept.hpp
+++ b/include/boost/geometry/extensions/algebra/geometries/concepts/rotation_quaternion_concept.hpp
@@ -16,7 +16,7 @@
 #define BOOST_GEOMETRY_EXTENSIONS_ALGEBRA_GEOMETRIES_CONCEPTS_ROTATION_QUATERNION_CONCEPT_HPP
 
 #include <boost/concept_check.hpp>
-
+#include <boost/core/ignore_unused.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/access.hpp>
 
@@ -79,7 +79,7 @@ class ConstRotationQuaternion
         {
             const G* g = 0;
             ctype coord(geometry::get<I>(*g));
-            boost::ignore_unused_variable_warning(coord);
+            boost::ignore_unused(coord);
             dimension_checker<G, I+1, N>::apply();
         }
     };

--- a/include/boost/geometry/extensions/algebra/geometries/concepts/vector_concept.hpp
+++ b/include/boost/geometry/extensions/algebra/geometries/concepts/vector_concept.hpp
@@ -16,7 +16,7 @@
 #define BOOST_GEOMETRY_EXTENSIONS_ALGEBRA_GEOMETRIES_CONCEPTS_VECTOR_CONCEPT_HPP
 
 #include <boost/concept_check.hpp>
-
+#include <boost/core/ignore_unused.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/access.hpp>
 
@@ -82,7 +82,7 @@ class ConstVector
         {
             const V* v = 0;
             ctype coord(geometry::get<Dimension>(*v));
-            boost::ignore_unused_variable_warning(coord);
+            boost::ignore_unused(coord);
             dimension_checker<V, Dimension+1, DimensionCount>::apply();
         }
     };

--- a/include/boost/geometry/extensions/index/rtree/rtree.hpp
+++ b/include/boost/geometry/extensions/index/rtree/rtree.hpp
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include <boost/concept_check.hpp>
+#include <boost/core/ignore_unused.hpp>
 #include <boost/shared_ptr.hpp>
 
 #include <boost/geometry/algorithms/area.hpp>
@@ -56,7 +57,7 @@ public:
         , m_max_elems_per_node(maximum)
         , m_root(new rtree_node<Box, Value>(node_pointer(), 1))
     {
-        boost::ignore_unused_variable_warning(box);
+        boost::ignore_unused(box);
     }
 
     /**

--- a/include/boost/geometry/extensions/nsphere/algorithms/covered_by.hpp
+++ b/include/boost/geometry/extensions/nsphere/algorithms/covered_by.hpp
@@ -15,6 +15,7 @@
 #ifndef BOOST_GEOMETRY_EXTENSIONS_NSPHERE_ALGORITHMS_COVERED_BY_HPP
 #define BOOST_GEOMETRY_EXTENSIONS_NSPHERE_ALGORITHMS_COVERED_BY_HPP
 
+#include <boost/core/ignore_unused.hpp>
 
 #include <boost/geometry/algorithms/covered_by.hpp>
 
@@ -36,7 +37,7 @@ struct covered_by<NSphere, Box, nsphere_tag, box_tag>
     static inline bool apply(NSphere const& nsphere, Box const& box, Strategy const& strategy)
     {
         assert_dimension_equal<NSphere, Box>();
-        boost::ignore_unused_variable_warning(strategy);
+        boost::ignore_unused(strategy);
         return strategy.apply(nsphere, box);
     }
 };
@@ -48,7 +49,7 @@ struct covered_by<Point, NSphere, point_tag, nsphere_tag>
     static inline bool apply(Point const& point, NSphere const& nsphere, Strategy const& strategy)
     {
         assert_dimension_equal<Point, NSphere>();
-        boost::ignore_unused_variable_warning(strategy);
+        boost::ignore_unused(strategy);
         return strategy.apply(point, nsphere);
     }
 };

--- a/include/boost/geometry/extensions/nsphere/algorithms/within.hpp
+++ b/include/boost/geometry/extensions/nsphere/algorithms/within.hpp
@@ -15,6 +15,7 @@
 #ifndef BOOST_GEOMETRY_EXTENSIONS_NSPHERE_ALGORITHMS_WITHIN_HPP
 #define BOOST_GEOMETRY_EXTENSIONS_NSPHERE_ALGORITHMS_WITHIN_HPP
 
+#include <boost/core/ignore_unused.hpp>
 
 #include <boost/geometry/algorithms/distance.hpp>
 #include <boost/geometry/algorithms/make.hpp>
@@ -153,7 +154,7 @@ struct within<P, Circle, point_tag, nsphere_tag>
     template <typename Strategy>
     static inline bool apply(P const& p, Circle const& c, Strategy const& strategy)
     {
-        ::boost::ignore_unused_variable_warning(strategy);
+        ::boost::ignore_unused(strategy);
         return strategy.apply(p, c);
         //return detail::within::point_in_circle(p, c);
     }
@@ -218,7 +219,7 @@ struct within<NSphere, Box, nsphere_tag, box_tag>
     static inline bool apply(NSphere const& nsphere, Box const& box, Strategy const& strategy)
     {
         assert_dimension_equal<NSphere, Box>();
-        boost::ignore_unused_variable_warning(strategy);
+        boost::ignore_unused(strategy);
         return strategy.apply(nsphere, box);
     }
 };

--- a/include/boost/geometry/extensions/nsphere/geometries/concepts/nsphere_concept.hpp
+++ b/include/boost/geometry/extensions/nsphere/geometries/concepts/nsphere_concept.hpp
@@ -15,6 +15,7 @@
 #define BOOST_GEOMETRY_EXTENSIONS_NSPHERE_GEOMETRIES_CONCEPTS_NSPHERE_CONCEPT_HPP
 
 #include <boost/concept_check.hpp>
+#include <boost/core/ignore_unused.hpp>
 
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/access.hpp>
@@ -44,7 +45,7 @@ class ConstNsphere
             typedef typename coordinate_type<Geometry>::type coordinate_type;
             const Geometry* s = 0;
             coordinate_type coord(geometry::get<Dimension>(*s));
-            boost::ignore_unused_variable_warning(coord);
+            boost::ignore_unused(coord);
             dimension_checker<Dimension + 1, DimensionCount>::apply();
         }
     };
@@ -66,7 +67,7 @@ public :
         // Check radius access
         Geometry const* s = 0;
         radius_type coord(geometry::get_radius<0>(*s));
-        boost::ignore_unused_variable_warning(coord);
+        boost::ignore_unused(coord);
     }
 };
 

--- a/include/boost/geometry/extensions/nsphere/index/detail/rtree/linear/redistribute_elements.hpp
+++ b/include/boost/geometry/extensions/nsphere/index/detail/rtree/linear/redistribute_elements.hpp
@@ -12,6 +12,8 @@
 #ifndef BOOST_GEOMETRY_EXTENSIONS_NSPHERE_INDEX_DETAIL_RTREE_LINEAR_REDISTRIBUTE_ELEMENTS_HPP
 #define BOOST_GEOMETRY_EXTENSIONS_NSPHERE_INDEX_DETAIL_RTREE_LINEAR_REDISTRIBUTE_ELEMENTS_HPP
 
+#include <boost/core/ignore_unused.hpp>
+
 #include <boost/geometry/index/detail/rtree/linear/redistribute_elements.hpp>
 
 namespace boost { namespace geometry { namespace index {
@@ -98,7 +100,7 @@ struct find_greatest_normalized_separation<Elements, Parameters, Translator, nsp
         seed1 = highest_low_index;
         seed2 = lowest_high_index;
 
-        ::boost::ignore_unused_variable_warning(parameters);
+        ::boost::ignore_unused(parameters);
     }
 };
 

--- a/include/boost/geometry/extensions/strategies/cartesian/distance_info.hpp
+++ b/include/boost/geometry/extensions/strategies/cartesian/distance_info.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_GEOMETRY_STRATEGY_CARTESIAN_DISTANCE_INFO_HPP
 #define BOOST_GEOMETRY_STRATEGY_CARTESIAN_DISTANCE_INFO_HPP
 
+#include <boost/core/ignore_unused.hpp>
 #include <boost/type_traits/remove_const.hpp>
 
 #include <boost/geometry/core/access.hpp>
@@ -103,7 +104,7 @@ public :
     apply_point_point(Point1 const& p1, Point2 const& p2) const
     {
         Strategy point_point_strategy;
-        boost::ignore_unused_variable_warning(point_point_strategy);
+        boost::ignore_unused(point_point_strategy);
         return point_point_strategy.apply(p1, p2);
     }
 
@@ -146,7 +147,7 @@ public :
         result.on_segment = c1 >= zero && c1 <= c2;
 
         Strategy point_point_strategy;
-        boost::ignore_unused_variable_warning(point_point_strategy);
+        boost::ignore_unused(point_point_strategy);
 
         if (geometry::math::equals(c2, zero))
         {

--- a/include/boost/geometry/geometries/concepts/box_concept.hpp
+++ b/include/boost/geometry/geometries/concepts/box_concept.hpp
@@ -15,11 +15,10 @@
 #ifndef BOOST_GEOMETRY_GEOMETRIES_CONCEPTS_BOX_CONCEPT_HPP
 #define BOOST_GEOMETRY_GEOMETRIES_CONCEPTS_BOX_CONCEPT_HPP
 
-
 #include <cstddef>
 
 #include <boost/concept_check.hpp>
-
+#include <boost/core/ignore_unused.hpp>
 
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
@@ -109,7 +108,7 @@ class ConstBox
         {
             const Geometry* b = 0;
             coordinate_type coord(geometry::get<Index, Dimension>(*b));
-            boost::ignore_unused_variable_warning(coord);
+            boost::ignore_unused(coord);
             dimension_checker<Index, Dimension + 1, DimensionCount>::apply();
         }
     };

--- a/include/boost/geometry/geometries/concepts/check.hpp
+++ b/include/boost/geometry/geometries/concepts/check.hpp
@@ -18,6 +18,7 @@
 
 #include <boost/concept_check.hpp>
 #include <boost/concept/requires.hpp>
+#include <boost/core/ignore_unused.hpp>
 #include <boost/type_traits/is_const.hpp>
 #include <boost/variant/variant_fwd.hpp>
 
@@ -216,7 +217,7 @@ template <typename Geometry>
 inline void check()
 {
     detail::checker<Geometry> c;
-    boost::ignore_unused_variable_warning(c);
+    boost::ignore_unused(c);
 }
 
 

--- a/include/boost/geometry/geometries/concepts/polygon_concept.hpp
+++ b/include/boost/geometry/geometries/concepts/polygon_concept.hpp
@@ -15,6 +15,7 @@
 #define BOOST_GEOMETRY_GEOMETRIES_CONCEPTS_POLYGON_CONCEPT_HPP
 
 #include <boost/concept_check.hpp>
+#include <boost/core/ignore_unused.hpp>
 #include <boost/range/concepts.hpp>
 
 #include <boost/geometry/core/access.hpp>
@@ -65,12 +66,8 @@ class Polygon
             ring_const_type ce = traits::exterior_ring<PolygonType>::get(*cpoly);
             interior_const_type ci = traits::interior_rings<PolygonType>::get(*cpoly);
 
-            boost::ignore_unused_variable_warning(e);
-            boost::ignore_unused_variable_warning(i);
-            boost::ignore_unused_variable_warning(ce);
-            boost::ignore_unused_variable_warning(ci);
-            boost::ignore_unused_variable_warning(poly);
-            boost::ignore_unused_variable_warning(cpoly);
+            boost::ignore_unused(poly, cpoly);
+            boost::ignore_unused(e, i, ce, ci);
         }
     };
 
@@ -115,9 +112,7 @@ class ConstPolygon
             ring_const_type ce = traits::exterior_ring<const_polygon_type>::get(*cpoly);
             interior_const_type ci = traits::interior_rings<const_polygon_type>::get(*cpoly);
 
-            boost::ignore_unused_variable_warning(ce);
-            boost::ignore_unused_variable_warning(ci);
-            boost::ignore_unused_variable_warning(cpoly);
+            boost::ignore_unused(ce, ci, cpoly);
         }
     };
 

--- a/include/boost/geometry/geometries/concepts/segment_concept.hpp
+++ b/include/boost/geometry/geometries/concepts/segment_concept.hpp
@@ -14,8 +14,8 @@
 #ifndef BOOST_GEOMETRY_GEOMETRIES_CONCEPTS_SEGMENT_CONCEPT_HPP
 #define BOOST_GEOMETRY_GEOMETRIES_CONCEPTS_SEGMENT_CONCEPT_HPP
 
-
 #include <boost/concept_check.hpp>
+#include <boost/core/ignore_unused.hpp>
 
 #include <boost/geometry/geometries/concepts/point_concept.hpp>
 
@@ -106,7 +106,7 @@ class ConstSegment
         {
             const Geometry* s = 0;
             coordinate_type coord(geometry::get<Index, Dimension>(*s));
-            boost::ignore_unused_variable_warning(coord);
+            boost::ignore_unused(coord);
             dimension_checker<Index, Dimension + 1, DimensionCount>::apply();
         }
     };

--- a/include/boost/geometry/index/detail/rtree/linear/redistribute_elements.hpp
+++ b/include/boost/geometry/index/detail/rtree/linear/redistribute_elements.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_RTREE_LINEAR_REDISTRIBUTE_ELEMENTS_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_RTREE_LINEAR_REDISTRIBUTE_ELEMENTS_HPP
 
+#include <boost/core/ignore_unused.hpp>
 #include <boost/type_traits/is_unsigned.hpp>
 
 #include <boost/geometry/index/detail/algorithms/content.hpp>
@@ -156,7 +157,7 @@ struct find_greatest_normalized_separation
         seed1 = highest_low_index;
         seed2 = lowest_high_index;
 
-        ::boost::ignore_unused_variable_warning(parameters);
+        ::boost::ignore_unused(parameters);
     }
 };
 
@@ -211,7 +212,7 @@ struct find_greatest_normalized_separation<Elements, Parameters, Translator, poi
         if ( lowest_index == highest_index )
             seed2 = (lowest_index + 1) % elements_count; // % is just in case since if this is true lowest_index is 0
 
-        ::boost::ignore_unused_variable_warning(parameters);
+        ::boost::ignore_unused(parameters);
     }
 };
 

--- a/include/boost/geometry/index/detail/rtree/pack_create.hpp
+++ b/include/boost/geometry/index/detail/rtree/pack_create.hpp
@@ -11,6 +11,8 @@
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_RTREE_PACK_CREATE_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_RTREE_PACK_CREATE_HPP
 
+#include <boost/core/ignore_unused.hpp>
+
 #include <boost/geometry/algorithms/expand.hpp>
 #include <boost/geometry/index/detail/algorithms/bounds.hpp>
 #include <boost/geometry/index/detail/algorithms/nth_element.hpp>
@@ -383,7 +385,7 @@ private:
     inline static
     subtree_elements_counts calculate_subtree_elements_counts(std::size_t elements_count, parameters_type const& parameters, size_type & leafs_level)
     {
-        boost::ignore_unused_variable_warning(parameters);
+        boost::ignore_unused(parameters);
 
         subtree_elements_counts res(1, 1);
         leafs_level = 0;

--- a/include/boost/geometry/index/detail/rtree/quadratic/redistribute_elements.hpp
+++ b/include/boost/geometry/index/detail/rtree/quadratic/redistribute_elements.hpp
@@ -13,6 +13,8 @@
 
 #include <algorithm>
 
+#include <boost/core/ignore_unused.hpp>
+
 #include <boost/geometry/index/detail/algorithms/content.hpp>
 #include <boost/geometry/index/detail/algorithms/union_content.hpp>
 
@@ -75,7 +77,7 @@ inline void pick_seeds(Elements const& elements,
         }
     }
 
-    ::boost::ignore_unused_variable_warning(parameters);
+    ::boost::ignore_unused(parameters);
 }
 
 } // namespace quadratic

--- a/include/boost/geometry/index/detail/rtree/rstar/choose_next_node.hpp
+++ b/include/boost/geometry/index/detail/rtree/rstar/choose_next_node.hpp
@@ -13,6 +13,8 @@
 
 #include <algorithm>
 
+#include <boost/core/ignore_unused.hpp>
+
 #include <boost/geometry/algorithms/expand.hpp>
 
 #include <boost/geometry/index/detail/algorithms/content.hpp>
@@ -48,7 +50,7 @@ public:
                                parameters_type const& parameters,
                                size_t node_relative_level)
     {
-        ::boost::ignore_unused_variable_warning(parameters);
+        ::boost::ignore_unused(parameters);
 
         children_type & children = rtree::elements(n);
         

--- a/include/boost/geometry/index/detail/rtree/rstar/insert.hpp
+++ b/include/boost/geometry/index/detail/rtree/rstar/insert.hpp
@@ -11,6 +11,8 @@
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_RTREE_RSTAR_INSERT_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_RTREE_RSTAR_INSERT_HPP
 
+#include <boost/core/ignore_unused.hpp>
+
 #include <boost/geometry/index/detail/algorithms/content.hpp>
 
 namespace boost { namespace geometry { namespace index {
@@ -123,7 +125,7 @@ public:
         }
         BOOST_CATCH_END
 
-        ::boost::ignore_unused_variable_warning(parameters);
+        ::boost::ignore_unused(parameters);
     }
 
 private:

--- a/include/boost/geometry/index/detail/rtree/rstar/redistribute_elements.hpp
+++ b/include/boost/geometry/index/detail/rtree/rstar/redistribute_elements.hpp
@@ -11,6 +11,8 @@
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_RTREE_RSTAR_REDISTRIBUTE_ELEMENTS_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_RTREE_RSTAR_REDISTRIBUTE_ELEMENTS_HPP
 
+#include <boost/core/ignore_unused.hpp>
+
 #include <boost/geometry/index/detail/algorithms/intersection_content.hpp>
 #include <boost/geometry/index/detail/algorithms/margin.hpp>
 #include <boost/geometry/index/detail/algorithms/nth_element.hpp>
@@ -158,7 +160,7 @@ struct choose_split_axis_and_index_for_corner
             }
         }
 
-        ::boost::ignore_unused_variable_warning(parameters);
+        ::boost::ignore_unused(parameters);
     }
 };
 

--- a/include/boost/geometry/index/detail/varray.hpp
+++ b/include/boost/geometry/index/detail/varray.hpp
@@ -19,6 +19,7 @@
 #endif
 
 #include <boost/config.hpp>
+#include <boost/core/ignore_unused.hpp>
 #include <boost/swap.hpp>
 #include <boost/integer.hpp>
 
@@ -75,8 +76,7 @@ struct checker
     {
         BOOST_GEOMETRY_INDEX_ASSERT(s <= v.capacity(), "size too big");
 
-        ::boost::ignore_unused_variable_warning(v);
-        ::boost::ignore_unused_variable_warning(s);
+        ::boost::ignore_unused(v, s);
     }
 
     static inline void throw_out_of_bounds(Varray const& v, size_type i)
@@ -84,39 +84,35 @@ struct checker
         if ( v.size() <= i )
             throw_out_of_range("index out of bounds");
 
-        ::boost::ignore_unused_variable_warning(v);
-        ::boost::ignore_unused_variable_warning(i);
+        ::boost::ignore_unused(v, i);
     }
 
     static inline void check_index(Varray const& v, size_type i)
     {
         BOOST_GEOMETRY_INDEX_ASSERT(i < v.size(), "index out of bounds");
 
-        ::boost::ignore_unused_variable_warning(v);
-        ::boost::ignore_unused_variable_warning(i);
+        ::boost::ignore_unused(v, i);
     }
 
     static inline void check_not_empty(Varray const& v)
     {
         BOOST_GEOMETRY_INDEX_ASSERT(!v.empty(), "the container is empty");
         
-        ::boost::ignore_unused_variable_warning(v);
+        ::boost::ignore_unused(v);
     }
 
     static inline void check_iterator_end_neq(Varray const& v, const_iterator position)
     {
         BOOST_GEOMETRY_INDEX_ASSERT(v.begin() <= position && position < v.end(), "iterator out of bounds");
 
-        ::boost::ignore_unused_variable_warning(v);
-        ::boost::ignore_unused_variable_warning(position);
+        ::boost::ignore_unused(v, position);
     }
 
     static inline void check_iterator_end_eq(Varray const& v, const_iterator position)
     {
         BOOST_GEOMETRY_INDEX_ASSERT(v.begin() <= position && position <= v.end(), "iterator out of bounds");
 
-        ::boost::ignore_unused_variable_warning(v);
-        ::boost::ignore_unused_variable_warning(position);
+        ::boost::ignore_unused(v, position);
     }
 };
 

--- a/include/boost/geometry/strategies/agnostic/point_in_box_by_side.hpp
+++ b/include/boost/geometry/strategies/agnostic/point_in_box_by_side.hpp
@@ -15,6 +15,7 @@
 #define BOOST_GEOMETRY_STRATEGIES_AGNOSTIC_POINT_IN_BOX_BY_SIDE_HPP
 
 #include <boost/array.hpp>
+#include <boost/core/ignore_unused.hpp>
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/algorithms/assign.hpp>
@@ -78,7 +79,7 @@ struct point_in_box_by_side
 
         bool result = true;
         side_strategy_type strategy;
-        boost::ignore_unused_variable_warning(strategy);
+        boost::ignore_unused(strategy);
 
         for (int i = 1; i < 5; i++)
         {

--- a/include/boost/geometry/strategies/cartesian/distance_projected_point.hpp
+++ b/include/boost/geometry/strategies/cartesian/distance_projected_point.hpp
@@ -21,6 +21,7 @@
 
 
 #include <boost/concept_check.hpp>
+#include <boost/core/ignore_unused.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/type_traits/is_void.hpp>
 
@@ -135,7 +136,7 @@ public :
         subtract_point(w, projected);
 
         Strategy strategy;
-        boost::ignore_unused_variable_warning(strategy);
+        boost::ignore_unused(strategy);
 
         calculation_type const zero = calculation_type();
         calculation_type const c1 = dot_product(w, v);

--- a/include/boost/geometry/strategies/cartesian/distance_projected_point_ax.hpp
+++ b/include/boost/geometry/strategies/cartesian/distance_projected_point_ax.hpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 
 #include <boost/concept_check.hpp>
+#include <boost/core/ignore_unused.hpp>
 
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/point_type.hpp>
@@ -194,7 +195,7 @@ public :
         subtract_point(w, projected);
 
         Strategy strategy;
-        boost::ignore_unused_variable_warning(strategy);
+        boost::ignore_unused(strategy);
 
         typename result_type<Point, PointOfSegment>::type result;
 

--- a/include/boost/geometry/strategies/concepts/area_concept.hpp
+++ b/include/boost/geometry/strategies/concepts/area_concept.hpp
@@ -17,7 +17,7 @@
 
 
 #include <boost/concept_check.hpp>
-
+#include <boost/core/ignore_unused.hpp>
 
 namespace boost { namespace geometry { namespace concepts
 {
@@ -52,8 +52,7 @@ class AreaStrategy
             // 4) must implement a static method result with the following signature
             return_type r = str->result(*st);
 
-            boost::ignore_unused_variable_warning(r);
-            boost::ignore_unused_variable_warning(str);
+            boost::ignore_unused(r, str);
         }
     };
 

--- a/include/boost/geometry/strategies/concepts/centroid_concept.hpp
+++ b/include/boost/geometry/strategies/concepts/centroid_concept.hpp
@@ -17,7 +17,7 @@
 
 
 #include <boost/concept_check.hpp>
-
+#include <boost/core/ignore_unused.hpp>
 
 namespace boost { namespace geometry { namespace concepts
 {
@@ -58,8 +58,7 @@ class CentroidStrategy
             point_type *c = 0;
             bool r = str->result(*st, *c);
 
-            boost::ignore_unused_variable_warning(str);
-            boost::ignore_unused_variable_warning(r);
+            boost::ignore_unused(str, r);
         }
     };
 

--- a/include/boost/geometry/strategies/concepts/within_concept.hpp
+++ b/include/boost/geometry/strategies/concepts/within_concept.hpp
@@ -17,6 +17,7 @@
 
 
 #include <boost/concept_check.hpp>
+#include <boost/core/ignore_unused.hpp>
 #include <boost/function_types/result_type.hpp>
 
 #include <boost/geometry/util/parameter_type_of.hpp>
@@ -93,9 +94,7 @@ class WithinStrategyPolygonal
             bool b = str->apply(*p, *sp, *sp, *st);
             int r = str->result(*st);
 
-            boost::ignore_unused_variable_warning(r);
-            boost::ignore_unused_variable_warning(b);
-            boost::ignore_unused_variable_warning(str);
+            boost::ignore_unused(r, b, str);
         }
     };
 
@@ -158,8 +157,7 @@ class WithinStrategyPointBox
 
             bool b = str->apply(*p, *bx);
 
-            boost::ignore_unused_variable_warning(b);
-            boost::ignore_unused_variable_warning(str);
+            boost::ignore_unused(b, str);
         }
     };
 
@@ -222,8 +220,7 @@ class WithinStrategyBoxBox
 
             bool b = str->apply(*b1, *b2);
 
-            boost::ignore_unused_variable_warning(b);
-            boost::ignore_unused_variable_warning(str);
+            boost::ignore_unused(b, str);
         }
     };
 
@@ -281,7 +278,7 @@ template <typename FirstTag, typename SecondTag, typename CastedTag, typename St
 inline void check()
 {
     dispatch::check_within<FirstTag, SecondTag, CastedTag, Strategy> c;
-    boost::ignore_unused_variable_warning(c);
+    boost::ignore_unused(c);
 }
 
 

--- a/index/test/rtree/test_rtree.hpp
+++ b/index/test/rtree/test_rtree.hpp
@@ -1416,7 +1416,7 @@ void copy_swap_move(Rtree const& tree, Box const& qbox)
 
     //TODO - test SWAP
 
-    ::boost::ignore_unused_variable_warning(params);
+    ::boost::ignore_unused(params);
 }
 
 template <typename I, typename O>

--- a/test/algorithms/detail/sections/sectionalize.cpp
+++ b/test/algorithms/detail/sections/sectionalize.cpp
@@ -73,7 +73,7 @@ void test_sectionalize(std::string const& caseid, G const& g, std::size_t sectio
         std::string const& index_check, std::string const& dir_check,
         std::size_t max_count = 10)
 {
-    boost::ignore_unused_variable_warning(caseid);
+    boost::ignore_unused(caseid);
 
     static const std::size_t dimension_count = boost::mpl::size<DimensionVector>::value;
 

--- a/test/geometry_test_common.hpp
+++ b/test/geometry_test_common.hpp
@@ -49,7 +49,7 @@
 
 #include <boost/config.hpp>
 #include <boost/concept_check.hpp>
-
+#include <boost/core/ignore_unused.hpp>
 #include <boost/foreach.hpp>
 
 #include <string_from_type.hpp>
@@ -113,7 +113,7 @@ inline T1 if_typed_tt(T1 value_tt, T2 value)
 #if defined(HAVE_TTMATH)
     return boost::is_same<CoordinateType, ttmath_big>::type::value ? value_tt : value;
 #else
-    boost::ignore_unused_variable_warning(value_tt);
+    boost::ignore_unused(value_tt);
     return value;
 #endif
 }

--- a/test/strategies/projected_point_ax.cpp
+++ b/test/strategies/projected_point_ax.cpp
@@ -36,8 +36,7 @@ void test_all_2d_ax()
 
     strategy_type strategy;
     comparable_strategy_type comparable_strategy;
-    boost::ignore_unused(strategy);
-    boost::ignore_unused(comparable_strategy);
+    boost::ignore_unused(strategy, comparable_strategy);
 
     test_2d<P1, P2>("POINT(1 1)", "POINT(0 0)", "POINT(2 3)",
                     result_type(0, 0.27735203958327),

--- a/test/strategies/segment_intersection_collinear.cpp
+++ b/test/strategies/segment_intersection_collinear.cpp
@@ -62,7 +62,7 @@ static void test_segment_intersection(std::string const& case_id,
                 int expected_x2 = -99, int expected_y2 = -99)
 
 {
-    boost::ignore_unused_variable_warning(case_id);
+    boost::ignore_unused(case_id);
 
     typedef bg::model::referring_segment<const P> segment_type;
 
@@ -125,7 +125,7 @@ static void test_segment_ratio(std::string const& case_id,
                 std::size_t expected_count = 2)
 
 {
-    boost::ignore_unused_variable_warning(case_id);
+    boost::ignore_unused(case_id);
 
     typedef bg::model::referring_segment<const P> segment_type;
 


### PR DESCRIPTION
The former is provided by Boost.ConceptCheck.
The latter is an improved equivalent provided by Boost.Core.

Related to #513