### PR TITLE
Add compile-only tests verifying headers are self-contained

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 # Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
-# Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
+# Copyright (c) 2009-2018 Mateusz Loskot, London, UK.
 #
 # This file was modified by Oracle on 2017, 2018.
 # Modifications copyright (c) 2017-2018 Oracle and/or its affiliates.
@@ -27,6 +27,13 @@ project boost-geometry-test
         <host-os>windows,<toolset>intel:<cxxflags>/bigobj
         <define>BOOST_NO_AUTO_PTR # disable the deprecated std::auto_ptr support in SmartPtr and Core
     ;
+
+# Rest self-contained headers on-demand only to avoid build timeouts on CI services.
+# The CI environment is common for Travis CI, AppVeyor, CircleCI, etc.
+if ! [ os.environ CI ] || [ os.environ TEST_HEADERS ]
+{
+    build-project self_contained_headers ;
+}
 
 # Run minimal testset
 test-suite boost-geometry-minimal
@@ -53,3 +60,4 @@ build-project util ;
 build-project views ;
 
 }
+

--- a/test/self_contained_headers/Jamfile
+++ b/test/self_contained_headers/Jamfile
@@ -1,0 +1,65 @@
+# Boost.Geometry (aka GGL, Generic Geometry Library)
+#
+# Copyright (c) 2018 Mateusz Loskot <mateusz@loskot.net>
+#
+# Use, modification and distribution is subject to the Boost Software License,
+# Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import os ;
+import path ;
+import regex ;
+
+rule generate_self_contained_headers ( headers_subpath )
+{
+    # This rule is based on script copied from similar rule in Boost.GIL
+    # On CI services, test the self-contained headers on-demand only to avoid build timeouts
+    # CI environment is common for Travis CI, AppVeyor, CircleCI, etc.
+    # For example:
+    # if ! [ os.environ CI ] || [ os.environ TEST_HEADERS ] {
+    #    alias self_contained_headers : [ generate_self_contained_headers ] ;
+    # }
+
+    local targets ;
+
+    # NOTE: All '/' in test names are replaced with '-' because apparently
+    #       test scripts have a problem with test names containing slashes.
+
+    local top_headers_path = [ path.make $(BOOST_ROOT)/libs/geometry/include/boost/geometry ] ;
+
+    for local file in [ path.glob-tree $(top_headers_path)/$(headers_subpath) : *.hpp ]
+    {
+        local rel_file = [ path.relative-to $(top_headers_path) $(file) ] ;
+        local target_name = [ regex.replace self-contained/$(rel_file) "/" "-" ] ;
+        targets += [
+            compile $(BOOST_ROOT)/libs/geometry/test/self_contained_headers/main.cpp
+            : <define>"BOOST_GEOMETRY_TEST_HEADER=$(rel_file)" <dependency>$(file)
+            : $(target_name)
+        ] ;
+    }
+
+    return $(targets) ;
+}
+
+# TODO: Review sorting to get as close as possible from general to specific
+
+# Core
+alias core : [ generate_self_contained_headers core ] ;
+alias util : [ generate_self_contained_headers util ] ;
+alias policies : [ generate_self_contained_headers policies ] ;
+alias geometries : [ generate_self_contained_headers geometries ] ;
+alias concepts : [ generate_self_contained_headers concepts ] ;
+alias arithmetic : [ generate_self_contained_headers arithmetic ] ;
+alias formulas : [ generate_self_contained_headers formulas ] ;
+alias iterators : [ generate_self_contained_headers iterators ] ;
+alias strategies : [ generate_self_contained_headers strategies ] ;
+alias srs : [ generate_self_contained_headers srs ] ;
+alias algorithms : [ generate_self_contained_headers algorithms ] ;
+alias views : [ generate_self_contained_headers views ] ;
+alias index : [ generate_self_contained_headers index ] ;
+
+# Extensions
+alias ext_algebra : [ generate_self_contained_headers extensions/algebra ] ;
+alias ext_algorithms : [ generate_self_contained_headers extensions/algorithms ] ;
+alias ext_index : [ generate_self_contained_headers extensions/index ] ;
+alias ext_gis : [ generate_self_contained_headers extensions/gis ] ;

--- a/test/self_contained_headers/main.cpp
+++ b/test/self_contained_headers/main.cpp
@@ -1,0 +1,19 @@
+//
+// Copyright (c) 2018 Mateusz Loskot <mateusz@loskot.net>
+// Copyright (c) 2007-2015 Andrey Semashev
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+// This file contains a test boilerplate for checking that every public header
+// is self-contained and does not have any missing #include-s.
+
+#define BOOST_GEOMETRY_TEST_INCLUDE_HEADER() <boost/geometry/BOOST_GEOMETRY_TEST_HEADER>
+
+#include BOOST_GEOMETRY_TEST_INCLUDE_HEADER()
+
+int main()
+{
+    return 0;
+}


### PR DESCRIPTION
Add Boost.Jam rule generating test target for each header found in specified location.
List test suites (target aliases) for groups of headers.
Build self_contained_headers test only if `CI` environment variable is NOT defined or on-demand, if `TEST_HEADERS` environment variable is defined, or if `b2 test/self_contained_headers` is requested from command line.

Related to issue #523

-----

First, this PR does not attempt to fix any headers, not yet.

I've run all the headers tests on 24 CPUs (48 logical cores) as follows:

```shell
cd libs/geometry
b2 -j 16 test/self_contained_headers >build.log 2>&1
```

AFAICT, it compile-tests *~900* headers in less than *4 minutes*:

```shell
cat build.log | grep -E -o "c\+\+.+\~hpp\.test" | sort | uniq | wc -l
898
cat build.log | grep -E -o "passed.+~hpp\.test" | wc -l
547
cat build.log | grep -E -o "failed.+~hpp\.test" | wc -l
350
```

And, I have only included several extensions, see `alias`-es  and comments in `test/self_contained_headers/Jamfile`.

-----

To run the tests on CI services, it should be enough to define environment variable `TEST_HEADERS=1`  for one just build job. For example, Boost.GIL defines it for first job only https://travis-ci.org/boostorg/gil/jobs/447353675

