### PR TITLE
Feature/get turn info add retrieve policy

### DIFF
--- a/include/boost/geometry/algorithms/detail/buffer/get_piece_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/get_piece_turns.hpp
@@ -253,11 +253,13 @@ class piece_turn_visitor
 #endif
                     > turn_policy;
 
+                overlay::retrieve_null_policy retrieve_policy;
+
                 turn_policy::apply(*prev1, *it1, *next1,
                                     *prev2, *it2, *next2,
-                                    false, false, false, false,
                                     the_model,
                                     m_intersection_strategy,
+                                    retrieve_policy, retrieve_policy,
                                     m_robust_policy,
                                     std::back_inserter(m_turns));
             }

--- a/include/boost/geometry/algorithms/detail/buffer/get_piece_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/get_piece_turns.hpp
@@ -170,6 +170,7 @@ class piece_turn_visitor
         typedef typename boost::range_value<Rings const>::type ring_type;
         typedef typename boost::range_value<Turns const>::type turn_type;
         typedef typename boost::range_iterator<ring_type const>::type iterator;
+        typedef typename point_type<ring_type const>::type point_type;
 
         signed_size_type const piece1_first_index = piece1.first_seg_id.segment_index;
         signed_size_type const piece2_first_index = piece2.first_seg_id.segment_index;
@@ -230,7 +231,9 @@ class piece_turn_visitor
             the_model.operations[1].seg_id = piece2.first_seg_id;
             the_model.operations[1].seg_id.segment_index = index2; // override
 
+            // TODO: next_point can be moved inside a specified retrieve policy for piece points
             iterator next1 = next_point(ring1, it1);
+            overlay::retrieve_null_policy<point_type> retrieve_policy1(*next1);
 
             iterator it2 = it2_first;
             for (iterator prev2 = it2++;
@@ -238,6 +241,7 @@ class piece_turn_visitor
                     prev2 = it2++, the_model.operations[1].seg_id.segment_index++)
             {
                 iterator next2 = next_point(ring2, it2);
+                overlay::retrieve_null_policy<point_type> retrieve_policy2(*next2);
 
                 // TODO: internally get_turn_info calculates robust points.
                 // But they are already calculated.
@@ -253,13 +257,12 @@ class piece_turn_visitor
 #endif
                     > turn_policy;
 
-                overlay::retrieve_null_policy retrieve_policy;
 
-                turn_policy::apply(*prev1, *it1, *next1,
-                                    *prev2, *it2, *next2,
+                turn_policy::apply(*prev1, *it1,
+                                    *prev2, *it2,
                                     the_model,
                                     m_intersection_strategy,
-                                    retrieve_policy, retrieve_policy,
+                                    retrieve_policy1, retrieve_policy2,
                                     m_robust_policy,
                                     std::back_inserter(m_turns));
             }

--- a/include/boost/geometry/algorithms/detail/buffer/get_piece_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/get_piece_turns.hpp
@@ -52,7 +52,8 @@ struct unique_sub_range_from_piece
         , m_point_retrieved(false)
     {}
 
-    static inline bool is_first() { return false; }
+    static inline bool is_first_segment() { return false; }
+    static inline bool is_last_segment() { return false; }
 
     static inline std::size_t size() { return 3u; }
 

--- a/include/boost/geometry/algorithms/detail/buffer/get_piece_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/get_piece_turns.hpp
@@ -17,6 +17,7 @@
 #include <boost/core/ignore_unused.hpp>
 #include <boost/range.hpp>
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/algorithms/equals.hpp>
 #include <boost/geometry/algorithms/expand.hpp>
 #include <boost/geometry/algorithms/detail/disjoint/box_box.hpp>
@@ -57,6 +58,7 @@ struct unique_sub_range_from_piece
 
     inline point_type const& at(std::size_t index) const
     {
+        BOOST_GEOMETRY_ASSERT(index < size());
         switch (index)
         {
             case 0 : return *m_iterator_at_i;

--- a/include/boost/geometry/algorithms/detail/buffer/get_piece_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/get_piece_turns.hpp
@@ -205,7 +205,6 @@ class piece_turn_visitor
         typedef typename boost::range_value<Rings const>::type ring_type;
         typedef typename boost::range_value<Turns const>::type turn_type;
         typedef typename boost::range_iterator<ring_type const>::type iterator;
-        typedef typename point_type<ring_type const>::type point_type;
 
         signed_size_type const piece1_first_index = piece1.first_seg_id.segment_index;
         signed_size_type const piece2_first_index = piece2.first_seg_id.segment_index;

--- a/include/boost/geometry/algorithms/detail/disjoint/linear_linear.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/linear_linear.hpp
@@ -93,18 +93,6 @@ struct assign_disjoint_policy
     static bool const include_no_turn = true;
     static bool const include_degenerate = true;
     static bool const include_opposite = true;
-
-    // We don't assign extra info:
-    template
-    <
-        typename Info,
-        typename Point1,
-        typename Point2,
-        typename IntersectionInfo
-    >
-    static inline void apply(Info& , Point1 const& , Point2 const&,
-                IntersectionInfo const&)
-    {}
 };
 
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_intersection_points.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_intersection_points.hpp
@@ -69,10 +69,10 @@ struct get_turn_without_info
 
         typedef model::referring_segment<Point1 const> segment_type1;
         typedef model::referring_segment<Point2 const> segment_type2;
-        Point1 const& pi = range_p.get_point_i();
-        Point1 const& pj = range_p.get_point_j();
-        Point2 const& qi = range_q.get_point_i();
-        Point2 const& qj = range_q.get_point_j();
+        Point1 const& pi = range_p.at(0);
+        Point1 const& pj = range_p.at(1);
+        Point2 const& qi = range_q.at(0);
+        Point2 const& qj = range_q.at(1);
         segment_type1 p1(pi, pj);
         segment_type2 q1(qi, qj);
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_intersection_points.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_intersection_points.hpp
@@ -44,14 +44,13 @@ template
 >
 struct get_turn_without_info
 {
-    template <typename Strategy, typename RobustPolicy, typename OutputIterator>
+    template <typename Strategy, typename RetrievePolicy, typename RobustPolicy, typename OutputIterator>
     static inline OutputIterator apply(
                 Point1 const& pi, Point1 const& pj, Point1 const& /*pk*/,
                 Point2 const& qi, Point2 const& qj, Point2 const& /*qk*/,
-                bool /*is_p_first*/, bool /*is_p_last*/,
-                bool /*is_q_first*/, bool /*is_q_last*/,
                 TurnInfo const& ,
                 Strategy const& strategy,
+                RetrievePolicy const& ,
                 RobustPolicy const& robust_policy,
                 OutputIterator out)
     {

--- a/include/boost/geometry/algorithms/detail/overlay/get_intersection_points.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_intersection_points.hpp
@@ -46,12 +46,10 @@ struct get_turn_without_info
 {
     template <typename Strategy, typename RetrieveAdditionalInfoPolicy1, typename RetrieveAdditionalInfoPolicy2, typename RobustPolicy, typename OutputIterator>
     static inline OutputIterator apply(
-                Point1 const& pi, Point1 const& pj,
-                Point2 const& qi, Point2 const& qj,
                 TurnInfo const& ,
                 Strategy const& strategy,
-                RetrieveAdditionalInfoPolicy1 const& ,
-                RetrieveAdditionalInfoPolicy2 const& ,
+                RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
+                RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
                 RobustPolicy const& robust_policy,
                 OutputIterator out)
     {
@@ -71,6 +69,10 @@ struct get_turn_without_info
 
         typedef model::referring_segment<Point1 const> segment_type1;
         typedef model::referring_segment<Point2 const> segment_type2;
+        Point1 const& pi = retrieve_policy_p.get_point_i();
+        Point1 const& pj = retrieve_policy_p.get_point_j();
+        Point2 const& qi = retrieve_policy_q.get_point_i();
+        Point2 const& qj = retrieve_policy_q.get_point_j();
         segment_type1 p1(pi, pj);
         segment_type2 q1(qi, qj);
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_intersection_points.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_intersection_points.hpp
@@ -46,8 +46,8 @@ struct get_turn_without_info
 {
     template <typename Strategy, typename RetrievePolicy1, typename RetrievePolicy2, typename RobustPolicy, typename OutputIterator>
     static inline OutputIterator apply(
-                Point1 const& pi, Point1 const& pj, Point1 const& /*pk*/,
-                Point2 const& qi, Point2 const& qj, Point2 const& /*qk*/,
+                Point1 const& pi, Point1 const& pj,
+                Point2 const& qi, Point2 const& qj,
                 TurnInfo const& ,
                 Strategy const& strategy,
                 RetrievePolicy1 const& ,

--- a/include/boost/geometry/algorithms/detail/overlay/get_intersection_points.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_intersection_points.hpp
@@ -44,13 +44,14 @@ template
 >
 struct get_turn_without_info
 {
-    template <typename Strategy, typename RetrievePolicy, typename RobustPolicy, typename OutputIterator>
+    template <typename Strategy, typename RetrievePolicy1, typename RetrievePolicy2, typename RobustPolicy, typename OutputIterator>
     static inline OutputIterator apply(
                 Point1 const& pi, Point1 const& pj, Point1 const& /*pk*/,
                 Point2 const& qi, Point2 const& qj, Point2 const& /*qk*/,
                 TurnInfo const& ,
                 Strategy const& strategy,
-                RetrievePolicy const& ,
+                RetrievePolicy1 const& ,
+                RetrievePolicy2 const& ,
                 RobustPolicy const& robust_policy,
                 OutputIterator out)
     {

--- a/include/boost/geometry/algorithms/detail/overlay/get_intersection_points.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_intersection_points.hpp
@@ -44,12 +44,12 @@ template
 >
 struct get_turn_without_info
 {
-    template <typename Strategy, typename RetrieveAdditionalInfoPolicy1, typename RetrieveAdditionalInfoPolicy2, typename RobustPolicy, typename OutputIterator>
+    template <typename Strategy, typename UniqueSubRange1, typename UniqueSubRange2, typename RobustPolicy, typename OutputIterator>
     static inline OutputIterator apply(
                 TurnInfo const& ,
                 Strategy const& strategy,
-                RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
-                RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
+                UniqueSubRange1 const& range_p,
+                UniqueSubRange2 const& range_q,
                 RobustPolicy const& robust_policy,
                 OutputIterator out)
     {
@@ -69,10 +69,10 @@ struct get_turn_without_info
 
         typedef model::referring_segment<Point1 const> segment_type1;
         typedef model::referring_segment<Point2 const> segment_type2;
-        Point1 const& pi = retrieve_policy_p.get_point_i();
-        Point1 const& pj = retrieve_policy_p.get_point_j();
-        Point2 const& qi = retrieve_policy_q.get_point_i();
-        Point2 const& qj = retrieve_policy_q.get_point_j();
+        Point1 const& pi = range_p.get_point_i();
+        Point1 const& pj = range_p.get_point_j();
+        Point2 const& qi = range_q.get_point_i();
+        Point2 const& qj = range_q.get_point_j();
         segment_type1 p1(pi, pj);
         segment_type2 q1(qi, qj);
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_intersection_points.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_intersection_points.hpp
@@ -44,12 +44,18 @@ template
 >
 struct get_turn_without_info
 {
-    template <typename Strategy, typename UniqueSubRange1, typename UniqueSubRange2, typename RobustPolicy, typename OutputIterator>
-    static inline OutputIterator apply(
+    template
+    <
+        typename UniqueSubRange1,
+        typename UniqueSubRange2,
+        typename Strategy,
+        typename RobustPolicy,
+        typename OutputIterator
+    >
+    static inline OutputIterator apply(UniqueSubRange1 const& range_p,
+                UniqueSubRange2 const& range_q,
                 TurnInfo const& ,
                 Strategy const& strategy,
-                UniqueSubRange1 const& range_p,
-                UniqueSubRange2 const& range_q,
                 RobustPolicy const& robust_policy,
                 OutputIterator out)
     {

--- a/include/boost/geometry/algorithms/detail/overlay/get_intersection_points.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_intersection_points.hpp
@@ -44,14 +44,14 @@ template
 >
 struct get_turn_without_info
 {
-    template <typename Strategy, typename RetrievePolicy1, typename RetrievePolicy2, typename RobustPolicy, typename OutputIterator>
+    template <typename Strategy, typename RetrieveAdditionalInfoPolicy1, typename RetrieveAdditionalInfoPolicy2, typename RobustPolicy, typename OutputIterator>
     static inline OutputIterator apply(
                 Point1 const& pi, Point1 const& pj,
                 Point2 const& qi, Point2 const& qj,
                 TurnInfo const& ,
                 Strategy const& strategy,
-                RetrievePolicy1 const& ,
-                RetrievePolicy2 const& ,
+                RetrieveAdditionalInfoPolicy1 const& ,
+                RetrieveAdditionalInfoPolicy2 const& ,
                 RobustPolicy const& robust_policy,
                 OutputIterator out)
     {

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -921,6 +921,18 @@ struct assign_null_policy
 
 
 /*!
+\brief Retrieve Policy doing nothing
+\details get_turn_info receives a policy indicating if a segment is first or last.
+   By default, all this information is false.
+ */
+struct retrieve_null_policy
+{
+    static inline bool is_first(int) { return false; }
+    static inline bool is_last(int) { return false; }
+};
+
+
+/*!
     \brief Turn information: intersection point, method, and turn information
     \details Information necessary for traversal phase (a phase
         of the overlay process). The information is gathered during the
@@ -946,16 +958,16 @@ struct get_turn_info
         typename Point2,
         typename TurnInfo,
         typename IntersectionStrategy,
+        typename RetrievePolicy,
         typename RobustPolicy,
         typename OutputIterator
     >
     static inline OutputIterator apply(
                 Point1 const& pi, Point1 const& pj, Point1 const& pk,
                 Point2 const& qi, Point2 const& qj, Point2 const& qk,
-                bool /*is_p_first*/, bool /*is_p_last*/,
-                bool /*is_q_first*/, bool /*is_q_last*/,
                 TurnInfo const& tp_model,
                 IntersectionStrategy const& intersection_strategy,
+                RetrievePolicy const& ,
                 RobustPolicy const& robust_policy,
                 OutputIterator out)
     {

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -941,9 +941,6 @@ struct assign_null_policy
     \details Information necessary for traversal phase (a phase
         of the overlay process). The information is gathered during the
         get_turns (segment intersection) phase.
-    \tparam Point1 point type of first segment
-    \tparam Point2 point type of second segment
-    \tparam TurnInfo type of class getting intersection and turn info
     \tparam AssignPolicy policy to assign extra info,
         e.g. to calculate distance from segment's first points
         to intersection points.
@@ -958,8 +955,6 @@ struct get_turn_info
     // about the turn (turn left/right)
     template
     <
-        typename Point1,
-        typename Point2,
         typename TurnInfo,
         typename IntersectionStrategy,
         typename RetrieveAdditionalInfoPolicy1,
@@ -968,8 +963,6 @@ struct get_turn_info
         typename OutputIterator
     >
     static inline OutputIterator apply(
-                Point1 const& pi, Point1 const& pj,
-                Point2 const& qi, Point2 const& qj,
                 TurnInfo const& tp_model,
                 IntersectionStrategy const& intersection_strategy,
                 RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
@@ -979,14 +972,21 @@ struct get_turn_info
     {
         typedef intersection_info
             <
-                Point1, Point2, RetrieveAdditionalInfoPolicy1, RetrieveAdditionalInfoPolicy2,
+                RetrieveAdditionalInfoPolicy1, RetrieveAdditionalInfoPolicy2,
                 typename TurnInfo::point_type,
                 IntersectionStrategy,
                 RobustPolicy
             > inters_info;
 
-        inters_info inters(pi, pj, qi, qj,
-                           retrieve_policy_p, retrieve_policy_q,
+        typedef typename RetrieveAdditionalInfoPolicy1::point_type Point1;
+        typedef typename RetrieveAdditionalInfoPolicy2::point_type Point2;
+
+        Point1 const& pi = retrieve_policy_p.get_point_i();
+        Point1 const& pj = retrieve_policy_p.get_point_j();
+        Point2 const& qi = retrieve_policy_q.get_point_i();
+        Point2 const& qj = retrieve_policy_q.get_point_j();
+
+        inters_info inters(retrieve_policy_p, retrieve_policy_q,
                            intersection_strategy, robust_policy);
 
         char const method = inters.d_info().how;

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -919,29 +919,6 @@ struct assign_null_policy
 
 };
 
-
-/*!
-\brief Retrieve Policy doing nothing
-\details get_turn_info receives a policy indicating if a segment is first or last.
-   By default, all this information is false.
- */
-template <typename Point>
-struct retrieve_null_policy
-{
-    retrieve_null_policy(Point const& point)
-      : m_point(point)
-    {}
-
-    static inline bool is_first() { return false; }
-    static inline bool is_last() { return false; }
-    inline Point const& get() const
-    {
-        return m_point;
-    }
-    Point m_point;
-};
-
-
 /*!
     \brief Turn information: intersection point, method, and turn information
     \details Information necessary for traversal phase (a phase

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -927,8 +927,8 @@ struct assign_null_policy
  */
 struct retrieve_null_policy
 {
-    static inline bool is_first(int) { return false; }
-    static inline bool is_last(int) { return false; }
+    static inline bool is_first() { return false; }
+    static inline bool is_last() { return false; }
 };
 
 
@@ -958,7 +958,8 @@ struct get_turn_info
         typename Point2,
         typename TurnInfo,
         typename IntersectionStrategy,
-        typename RetrievePolicy,
+        typename RetrievePolicy1,
+        typename RetrievePolicy2,
         typename RobustPolicy,
         typename OutputIterator
     >
@@ -967,7 +968,8 @@ struct get_turn_info
                 Point2 const& qi, Point2 const& qj, Point2 const& qk,
                 TurnInfo const& tp_model,
                 IntersectionStrategy const& intersection_strategy,
-                RetrievePolicy const& ,
+                RetrievePolicy1 const& ,
+                RetrievePolicy2 const& ,
                 RobustPolicy const& robust_policy,
                 OutputIterator out)
     {

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -601,8 +601,8 @@ struct collinear : public base_turn_handler
         // Should not be 0, this is checked before
         BOOST_GEOMETRY_ASSERT(arrival != 0);
 
-        bool const has_pk = range_p.size() != 2u;
-        bool const has_qk = range_q.size() != 2u;
+        bool const has_pk = ! range_p.is_last_segment();
+        bool const has_qk = ! range_q.is_last_segment();
         int const side_p = has_pk ? side.pk_wrt_p1() : 0;
         int const side_q = has_qk ? side.qk_wrt_q1() : 0;
 
@@ -794,7 +794,7 @@ public:
 
         // If P arrives within Q, there is a turn dependent on P
         if ( p_arrival == 1
-          && range_p.size() > 2u
+          && ! range_p.is_last_segment()
           && set_tp<0>(side.pk_wrt_p1(), true, side.pk_wrt_q1(), tp, info.i_info()) )
         {
             turn_transformer(tp);
@@ -804,7 +804,7 @@ public:
 
         // If Q arrives within P, there is a turn dependent on Q
         if ( q_arrival == 1
-          && range_q.size() > 2u
+          && ! range_q.is_last_segment()
           && set_tp<1>(side.qk_wrt_q1(), false, side.qk_wrt_p1(), tp, info.i_info()) )
         {
             turn_transformer(tp);

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -997,8 +997,7 @@ struct get_turn_info
                         <
                             TurnInfo,
                             AssignPolicy
-                        >::apply(range_p, range_q,
-                            tp, out, inters);
+                        >::apply(range_p, range_q, tp, out, inters);
                 }
             }
             break;

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -981,7 +981,7 @@ struct get_turn_info
     {
         typedef intersection_info
             <
-                Point1, Point2,
+                Point1, Point2, RetrievePolicy1, RetrievePolicy2,
                 typename TurnInfo::point_type,
                 IntersectionStrategy,
                 RobustPolicy

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -873,23 +873,14 @@ template
 >
 struct crosses : public base_turn_handler
 {
-    template
-    <
-        typename Point1,
-        typename Point2,
-        typename IntersectionInfo,
-        typename DirInfo
-    >
-    static inline void apply(
-                Point1 const& , Point1 const& ,
-                Point2 const& , Point2 const& ,
-                TurnInfo& ti,
+    template <typename IntersectionInfo, typename DirInfo>
+    static inline void apply(TurnInfo& ti,
                 IntersectionInfo const& intersection_info,
                 DirInfo const& dir_info)
     {
         assign_point(ti, method_crosses, intersection_info, 0);
 
-        // In all casees:
+        // In all cases:
         // If Q crosses P from left to right
         // Union: take P
         // Intersection: take Q
@@ -1039,8 +1030,7 @@ struct get_turn_info
             break;
             case 'i' :
             {
-                crosses<TurnInfo>::apply(pi, pj, qi, qj,
-                    tp, inters.i_info(), inters.d_info());
+                crosses<TurnInfo>::apply(tp, inters.i_info(), inters.d_info());
                 AssignPolicy::apply(tp, pi, qi, inters);
                 *out++ = tp;
             }

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -925,10 +925,20 @@ struct assign_null_policy
 \details get_turn_info receives a policy indicating if a segment is first or last.
    By default, all this information is false.
  */
+template <typename Point>
 struct retrieve_null_policy
 {
+    retrieve_null_policy(Point const& point)
+      : m_point(point)
+    {}
+
     static inline bool is_first() { return false; }
     static inline bool is_last() { return false; }
+    inline Point const& get() const
+    {
+        return m_point;
+    }
+    Point m_point;
 };
 
 
@@ -964,12 +974,12 @@ struct get_turn_info
         typename OutputIterator
     >
     static inline OutputIterator apply(
-                Point1 const& pi, Point1 const& pj, Point1 const& pk,
-                Point2 const& qi, Point2 const& qj, Point2 const& qk,
+                Point1 const& pi, Point1 const& pj,
+                Point2 const& qi, Point2 const& qj,
                 TurnInfo const& tp_model,
                 IntersectionStrategy const& intersection_strategy,
-                RetrievePolicy1 const& ,
-                RetrievePolicy2 const& ,
+                RetrievePolicy1 const& retrieve_policy_p,
+                RetrievePolicy2 const& retrieve_policy_q,
                 RobustPolicy const& robust_policy,
                 OutputIterator out)
     {
@@ -980,6 +990,9 @@ struct get_turn_info
                 IntersectionStrategy,
                 RobustPolicy
             > inters_info;
+
+        Point1 const& pk = retrieve_policy_p.get();
+        Point2 const& qk = retrieve_policy_q.get();
 
         inters_info inters(pi, pj, pk, qi, qj, qk, intersection_strategy, robust_policy);
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -1032,19 +1032,9 @@ struct get_turn_info
                 else
                 {
                     // Swap p/q
-                    side_calculator
-                        <
-                            typename inters_info::cs_tag,
-                            typename inters_info::robust_point2_type,
-                            typename inters_info::robust_point1_type,
-                            typename inters_info::side_strategy_type
-                        > swapped_side_calc(inters.rqi(), inters.rqj(), inters.rqk(),
-                                            inters.rpi(), inters.rpj(), inters.rpk(),
-                                            inters.get_side_strategy());
-
                     policy::template apply<1>(qi, qj, pi, pj,
                                 tp, inters.i_info(), inters.d_info(),
-                                swapped_side_calc);
+                                inters.get_swapped_sides());
                 }
                 AssignPolicy::apply(tp, pi, qi, inters);
                 *out++ = tp;

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -534,7 +534,7 @@ struct equal_opposite : public base_turn_handler
             for (unsigned int i = 0; i < intersection_info.i_info().count; i++)
             {
                 assign_point(tp, method_none, intersection_info.i_info(), i);
-                AssignPolicy::apply(tp, range_p.get_point_i(), range_q.get_point_i(), intersection_info);
+                AssignPolicy::apply(tp, range_p.at(0), range_q.at(0), intersection_info);
                 *out++ = tp;
             }
         }
@@ -631,12 +631,12 @@ struct collinear : public base_turn_handler
         // measured until the end of the next segment
         ti.operations[0].remaining_distance
                 = side_p == 0
-                ? distance_measure(ti.point, range_p.get_point_k())
-                : distance_measure(ti.point, range_p.get_point_j());
+                ? distance_measure(ti.point, range_p.at(2))
+                : distance_measure(ti.point, range_p.at(1));
         ti.operations[1].remaining_distance
                 = side_q == 0
-                ? distance_measure(ti.point, range_q.get_point_k())
-                : distance_measure(ti.point, range_q.get_point_j());
+                ? distance_measure(ti.point, range_q.at(2))
+                : distance_measure(ti.point, range_q.at(1));
     }
 
     template <typename Point1, typename Point2>
@@ -775,7 +775,7 @@ public:
                 UniqueSubRange2 const& range_q,
                 IntersectionInfo const& info)
     {
-        AssignPolicy::apply(tp, range_p.get_point_i(), range_q.get_point_i(), info);
+        AssignPolicy::apply(tp, range_p.at(0), range_q.at(0), info);
     }
 
     template
@@ -806,7 +806,7 @@ public:
 
         // If P arrives within Q, there is a turn dependent on P
         if ( p_arrival == 1
-          && range_p.has_k()
+          && range_p.size() > 2u
           && set_tp<0>(side.pk_wrt_p1(), true, side.pk_wrt_q1(), tp, info.i_info()) )
         {
             turn_transformer(tp);
@@ -817,7 +817,7 @@ public:
 
         // If Q arrives within P, there is a turn dependent on Q
         if ( q_arrival == 1
-          && range_q.has_k()
+          && range_q.size() > 2u
           && set_tp<1>(side.qk_wrt_q1(), false, side.qk_wrt_p1(), tp, info.i_info()) )
         {
             turn_transformer(tp);
@@ -935,7 +935,7 @@ struct get_turn_info
                 UniqueSubRange2 const& range_q,
                 IntersectionInfo const& info)
     {
-        AssignPolicy::apply(tp, range_p.get_point_i(), range_q.get_point_i(), info);
+        AssignPolicy::apply(tp, range_p.at(0), range_q.at(0), info);
     }
 
     // Intersect pi-pj with qi-qj

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -595,8 +595,8 @@ struct collinear : public base_turn_handler
     <
         typename Point1,
         typename Point2,
-        typename RetrievePolicy1,
-        typename RetrievePolicy2,
+        typename RetrieveAdditionalInfoPolicy1,
+        typename RetrieveAdditionalInfoPolicy2,
         typename IntersectionInfo,
         typename DirInfo,
         typename SidePolicy
@@ -604,8 +604,8 @@ struct collinear : public base_turn_handler
     static inline void apply(
                 Point1 const& , Point1 const& pj,
                 Point2 const& , Point2 const& qj,
-                RetrievePolicy1 const& retrieve_policy_p,
-                RetrievePolicy2 const& retrieve_policy_q,
+                RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
+                RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
                 TurnInfo& ti,
                 IntersectionInfo const& info,
                 DirInfo const& dir_info,
@@ -643,8 +643,8 @@ struct collinear : public base_turn_handler
             ui_else_iu(product == 1, ti);
         }
 
-        Point1 const& pk = retrieve_policy_p.get();
-        Point2 const& qk = retrieve_policy_q.get();
+        Point1 const& pk = retrieve_policy_p.get_point_k();
+        Point2 const& qk = retrieve_policy_q.get_point_k();
 
         // Calculate remaining distance. If it continues collinearly it is
         // measured until the end of the next segment
@@ -766,8 +766,8 @@ public:
     <
         typename Point1,
         typename Point2,
-        typename RetrievePolicy1,
-        typename RetrievePolicy2,
+        typename RetrieveAdditionalInfoPolicy1,
+        typename RetrieveAdditionalInfoPolicy2,
         typename OutputIterator,
         typename IntersectionInfo,
         typename SidePolicy
@@ -775,8 +775,8 @@ public:
     static inline void apply(
                 Point1 const& pi, Point1 const& pj,
                 Point2 const& qi, Point2 const& qj,
-                RetrievePolicy1 const& retrieve_policy_p,
-                RetrievePolicy2 const& retrieve_policy_q,
+                RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
+                RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
 
                 // Opposite collinear can deliver 2 intersection points,
                 TurnInfo const& tp_model,
@@ -794,8 +794,8 @@ public:
     <
         typename Point1,
         typename Point2,
-        typename RetrievePolicy1,
-        typename RetrievePolicy2,
+        typename RetrieveAdditionalInfoPolicy1,
+        typename RetrieveAdditionalInfoPolicy2,
         typename OutputIterator,
         typename IntersectionInfo,
         typename SidePolicy,
@@ -804,8 +804,8 @@ public:
     static inline void apply(
                 Point1 const& pi, Point1 const& pj,
                 Point2 const& qi, Point2 const& qj,
-                RetrievePolicy1 const& retrieve_policy_p,
-                RetrievePolicy2 const& retrieve_policy_q,
+                RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
+                RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
 
                 // Opposite collinear can deliver 2 intersection points,
                 TurnInfo const& tp_model,
@@ -813,21 +813,18 @@ public:
 
                 IntersectionInfo const& info,
                 SidePolicy const& side,
-                TurnTransformer turn_transformer,
-                bool const is_pk_valid = true, bool const is_qk_valid = true)
+                TurnTransformer turn_transformer)
     {
         TurnInfo tp = tp_model;
 
         int const p_arrival = info.d_info().arrival[0];
         int const q_arrival = info.d_info().arrival[1];
 
-        Point1 const& pk = retrieve_policy_p.get();
-        Point2 const& qk = retrieve_policy_q.get();
-
         // If P arrives within Q, there is a turn dependent on P
         if ( p_arrival == 1
-          && is_pk_valid
-          && set_tp<0>(pi, pj, pk, side.pk_wrt_p1(), true, qi, qj, side.pk_wrt_q1(), tp, info.i_info()) )
+          && retrieve_policy_p.has_k()
+          && set_tp<0>(pi, pj, retrieve_policy_p.get_point_k(),
+                       side.pk_wrt_p1(), true, qi, qj, side.pk_wrt_q1(), tp, info.i_info()) )
         {
             turn_transformer(tp);
 
@@ -837,8 +834,9 @@ public:
 
         // If Q arrives within P, there is a turn dependent on Q
         if ( q_arrival == 1
-          && is_qk_valid
-          && set_tp<1>(qi, qj, qk, side.qk_wrt_q1(), false, pi, pj, side.qk_wrt_p1(), tp, info.i_info()) )
+          && retrieve_policy_q.has_k()
+          && set_tp<1>(qi, qj, retrieve_policy_q.get_point_k(),
+                       side.qk_wrt_q1(), false, pi, pj, side.qk_wrt_p1(), tp, info.i_info()) )
         {
             turn_transformer(tp);
 
@@ -964,8 +962,8 @@ struct get_turn_info
         typename Point2,
         typename TurnInfo,
         typename IntersectionStrategy,
-        typename RetrievePolicy1,
-        typename RetrievePolicy2,
+        typename RetrieveAdditionalInfoPolicy1,
+        typename RetrieveAdditionalInfoPolicy2,
         typename RobustPolicy,
         typename OutputIterator
     >
@@ -974,14 +972,14 @@ struct get_turn_info
                 Point2 const& qi, Point2 const& qj,
                 TurnInfo const& tp_model,
                 IntersectionStrategy const& intersection_strategy,
-                RetrievePolicy1 const& retrieve_policy_p,
-                RetrievePolicy2 const& retrieve_policy_q,
+                RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
+                RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
                 RobustPolicy const& robust_policy,
                 OutputIterator out)
     {
         typedef intersection_info
             <
-                Point1, Point2, RetrievePolicy1, RetrievePolicy2,
+                Point1, Point2, RetrieveAdditionalInfoPolicy1, RetrieveAdditionalInfoPolicy2,
                 typename TurnInfo::point_type,
                 IntersectionStrategy,
                 RobustPolicy

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -601,8 +601,10 @@ struct collinear : public base_turn_handler
         // Should not be 0, this is checked before
         BOOST_GEOMETRY_ASSERT(arrival != 0);
 
-        int const side_p = side.pk_wrt_p1();
-        int const side_q = side.qk_wrt_q1();
+        bool const has_pk = range_p.size() != 2u;
+        bool const has_qk = range_q.size() != 2u;
+        int const side_p = has_pk ? side.pk_wrt_p1() : 0;
+        int const side_q = has_qk ? side.qk_wrt_q1() : 0;
 
         // If p arrives, use p, else use q
         int const side_p_or_q = arrival == 1
@@ -629,11 +631,11 @@ struct collinear : public base_turn_handler
         // Calculate remaining distance. If it continues collinearly it is
         // measured until the end of the next segment
         ti.operations[0].remaining_distance
-                = side_p == 0
+                = side_p == 0 && has_pk
                 ? distance_measure(ti.point, range_p.at(2))
                 : distance_measure(ti.point, range_p.at(1));
         ti.operations[1].remaining_distance
-                = side_q == 0
+                = side_q == 0 && has_qk
                 ? distance_measure(ti.point, range_q.at(2))
                 : distance_measure(ti.point, range_q.at(1));
     }

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -534,7 +534,6 @@ struct equal_opposite : public base_turn_handler
             for (unsigned int i = 0; i < intersection_info.i_info().count; i++)
             {
                 assign_point(tp, method_none, intersection_info.i_info(), i);
-                AssignPolicy::apply(tp, range_p.at(0), range_q.at(0), intersection_info);
                 *out++ = tp;
             }
         }
@@ -764,19 +763,6 @@ public:
     }
 
 public:
-    template
-    <
-        typename UniqueSubRange1,
-        typename UniqueSubRange2,
-        typename IntersectionInfo
-    >
-    static inline void assign(TurnInfo const& tp,
-                UniqueSubRange1 const& range_p,
-                UniqueSubRange2 const& range_q,
-                IntersectionInfo const& info)
-    {
-        AssignPolicy::apply(tp, range_p.at(0), range_q.at(0), info);
-    }
 
     template
     <
@@ -811,7 +797,6 @@ public:
         {
             turn_transformer(tp);
 
-            assign(tp, range_p, range_q, info);
             *out++ = tp;
         }
 
@@ -822,7 +807,6 @@ public:
         {
             turn_transformer(tp);
 
-            assign(tp, range_p, range_q, info);
             *out++ = tp;
         }
 
@@ -839,7 +823,6 @@ public:
                 for (unsigned int i = 0; i < info.i_info().count; i++)
                 {
                     assign_point(tp, method_collinear, info.i_info(), i);
-                    assign(tp, range_p, range_q, info);
                     *out++ = tp;
                 }
             }
@@ -887,26 +870,14 @@ struct only_convert : public base_turn_handler
 
 /*!
 \brief Policy doing nothing
-\details get_turn_info can have an optional policy to get/assign some
-    extra information. By default it does not, and this class
-    is that default.
+\details get_turn_info can have an optional policy include extra
+    truns. By default it does not, and this class is that default.
  */
 struct assign_null_policy
 {
     static bool const include_no_turn = false;
     static bool const include_degenerate = false;
     static bool const include_opposite = false;
-
-    template
-    <
-        typename Info,
-        typename Point1,
-        typename Point2,
-        typename IntersectionInfo
-    >
-    static inline void apply(Info& , Point1 const& , Point2 const&, IntersectionInfo const&)
-    {}
-
 };
 
 /*!
@@ -923,21 +894,6 @@ struct assign_null_policy
 template<typename AssignPolicy>
 struct get_turn_info
 {
-    template
-    <
-        typename TurnInfo,
-        typename UniqueSubRange1,
-        typename UniqueSubRange2,
-        typename IntersectionInfo
-    >
-    static inline void assign(TurnInfo const& tp,
-                UniqueSubRange1 const& range_p,
-                UniqueSubRange2 const& range_q,
-                IntersectionInfo const& info)
-    {
-        AssignPolicy::apply(tp, range_p.at(0), range_q.at(0), info);
-    }
-
     // Intersect pi-pj with qi-qj
     // The points pk and qk are used do determine more information
     // about the turn (turn left/right)
@@ -984,7 +940,6 @@ struct get_turn_info
                     && inters.i_info().count > 0)
                 {
                     only_convert::apply(tp, inters.i_info());
-                    assign(tp, range_p, range_q, inters);
                     *out++ = tp;
                 }
                 break;
@@ -1011,14 +966,12 @@ struct get_turn_info
                     policy::template apply<1>(tp, inters.i_info(), inters.d_info(),
                                 inters.get_swapped_sides());
                 }
-                assign(tp, range_p, range_q, inters);
                 *out++ = tp;
             }
             break;
             case 'i' :
             {
                 crosses<TurnInfo>::apply(tp, inters.i_info(), inters.d_info());
-                assign(tp, range_p, range_q, inters);
                 *out++ = tp;
             }
             break;
@@ -1026,7 +979,6 @@ struct get_turn_info
             {
                 // Both touch (both arrive there)
                 touch<TurnInfo>::apply(tp, inters.i_info(), inters.d_info(), inters.sides());
-                assign(tp, range_p, range_q, inters);
                 *out++ = tp;
             }
             break;
@@ -1037,7 +989,6 @@ struct get_turn_info
                     // Both equal
                     // or collinear-and-ending at intersection point
                     equal<TurnInfo>::apply(tp, inters.i_info(), inters.d_info(), inters.sides());
-                    assign(tp, range_p, range_q, inters);
                     *out++ = tp;
                 }
                 else
@@ -1071,7 +1022,6 @@ struct get_turn_info
                                 tp, inters.i_info(), inters.d_info(), inters.sides());
                     }
 
-                    assign(tp, range_p, range_q, inters);
                     *out++ = tp;
                 }
                 else
@@ -1091,7 +1041,6 @@ struct get_turn_info
                 if (AssignPolicy::include_degenerate)
                 {
                     only_convert::apply(tp, inters.i_info());
-                    assign(tp, range_p, range_q, inters);
                     *out++ = tp;
                 }
             }

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -511,14 +511,14 @@ struct equal_opposite : public base_turn_handler
 {
     template
     <
-        typename RetrieveAdditionalInfoPolicy1,
-        typename RetrieveAdditionalInfoPolicy2,
+        typename UniqueSubRange1,
+        typename UniqueSubRange2,
         typename OutputIterator,
         typename IntersectionInfo
     >
     static inline void apply(
-                RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
-                RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
+                UniqueSubRange1 const& range_p,
+                UniqueSubRange2 const& range_q,
                 /* by value: */ TurnInfo tp,
                 OutputIterator& out,
                 IntersectionInfo const& intersection_info)
@@ -534,7 +534,7 @@ struct equal_opposite : public base_turn_handler
             for (unsigned int i = 0; i < intersection_info.i_info().count; i++)
             {
                 assign_point(tp, method_none, intersection_info.i_info(), i);
-                AssignPolicy::apply(tp, retrieve_policy_p.get_point_i(), retrieve_policy_q.get_point_i(), intersection_info);
+                AssignPolicy::apply(tp, range_p.get_point_i(), range_q.get_point_i(), intersection_info);
                 *out++ = tp;
             }
         }
@@ -581,15 +581,15 @@ struct collinear : public base_turn_handler
     */
     template
     <
-        typename RetrieveAdditionalInfoPolicy1,
-        typename RetrieveAdditionalInfoPolicy2,
+        typename UniqueSubRange1,
+        typename UniqueSubRange2,
         typename IntersectionInfo,
         typename DirInfo,
         typename SidePolicy
     >
     static inline void apply(
-                RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
-                RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
+                UniqueSubRange1 const& range_p,
+                UniqueSubRange2 const& range_q,
                 TurnInfo& ti,
                 IntersectionInfo const& info,
                 DirInfo const& dir_info,
@@ -631,12 +631,12 @@ struct collinear : public base_turn_handler
         // measured until the end of the next segment
         ti.operations[0].remaining_distance
                 = side_p == 0
-                ? distance_measure(ti.point, retrieve_policy_p.get_point_k())
-                : distance_measure(ti.point, retrieve_policy_p.get_point_j());
+                ? distance_measure(ti.point, range_p.get_point_k())
+                : distance_measure(ti.point, range_p.get_point_j());
         ti.operations[1].remaining_distance
                 = side_q == 0
-                ? distance_measure(ti.point, retrieve_policy_q.get_point_k())
-                : distance_measure(ti.point, retrieve_policy_q.get_point_j());
+                ? distance_measure(ti.point, range_q.get_point_k())
+                : distance_measure(ti.point, range_q.get_point_j());
     }
 
     template <typename Point1, typename Point2>
@@ -742,15 +742,15 @@ public:
 
     template
     <
-        typename RetrieveAdditionalInfoPolicy1,
-        typename RetrieveAdditionalInfoPolicy2,
+        typename UniqueSubRange1,
+        typename UniqueSubRange2,
         typename OutputIterator,
         typename IntersectionInfo,
         typename SidePolicy
     >
     static inline void apply(
-                RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
-                RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
+                UniqueSubRange1 const& range_p,
+                UniqueSubRange2 const& range_q,
 
                 // Opposite collinear can deliver 2 intersection points,
                 TurnInfo const& tp_model,
@@ -759,37 +759,37 @@ public:
                 IntersectionInfo const& intersection_info,
                 SidePolicy const& side)
     {
-        apply(retrieve_policy_p, retrieve_policy_q,
+        apply(range_p, range_q,
               tp_model, out, intersection_info, side, empty_transformer);
     }
 
 public:
     template
     <
-        typename RetrieveAdditionalInfoPolicy1,
-        typename RetrieveAdditionalInfoPolicy2,
+        typename UniqueSubRange1,
+        typename UniqueSubRange2,
         typename IntersectionInfo
     >
     static inline void assign(TurnInfo const& tp,
-                RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
-                RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
+                UniqueSubRange1 const& range_p,
+                UniqueSubRange2 const& range_q,
                 IntersectionInfo const& info)
     {
-        AssignPolicy::apply(tp, retrieve_policy_p.get_point_i(), retrieve_policy_q.get_point_i(), info);
+        AssignPolicy::apply(tp, range_p.get_point_i(), range_q.get_point_i(), info);
     }
 
     template
     <
-        typename RetrieveAdditionalInfoPolicy1,
-        typename RetrieveAdditionalInfoPolicy2,
+        typename UniqueSubRange1,
+        typename UniqueSubRange2,
         typename OutputIterator,
         typename IntersectionInfo,
         typename SidePolicy,
         typename TurnTransformer
     >
     static inline void apply(
-                RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
-                RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
+                UniqueSubRange1 const& range_p,
+                UniqueSubRange2 const& range_q,
 
                 // Opposite collinear can deliver 2 intersection points,
                 TurnInfo const& tp_model,
@@ -806,23 +806,23 @@ public:
 
         // If P arrives within Q, there is a turn dependent on P
         if ( p_arrival == 1
-          && retrieve_policy_p.has_k()
+          && range_p.has_k()
           && set_tp<0>(side.pk_wrt_p1(), true, side.pk_wrt_q1(), tp, info.i_info()) )
         {
             turn_transformer(tp);
 
-            assign(tp, retrieve_policy_p, retrieve_policy_q, info);
+            assign(tp, range_p, range_q, info);
             *out++ = tp;
         }
 
         // If Q arrives within P, there is a turn dependent on Q
         if ( q_arrival == 1
-          && retrieve_policy_q.has_k()
+          && range_q.has_k()
           && set_tp<1>(side.qk_wrt_q1(), false, side.qk_wrt_p1(), tp, info.i_info()) )
         {
             turn_transformer(tp);
 
-            assign(tp, retrieve_policy_p, retrieve_policy_q, info);
+            assign(tp, range_p, range_q, info);
             *out++ = tp;
         }
 
@@ -839,7 +839,7 @@ public:
                 for (unsigned int i = 0; i < info.i_info().count; i++)
                 {
                     assign_point(tp, method_collinear, info.i_info(), i);
-                    assign(tp, retrieve_policy_p, retrieve_policy_q, info);
+                    assign(tp, range_p, range_q, info);
                     *out++ = tp;
                 }
             }
@@ -926,16 +926,16 @@ struct get_turn_info
     template
     <
         typename TurnInfo,
-        typename RetrieveAdditionalInfoPolicy1,
-        typename RetrieveAdditionalInfoPolicy2,
+        typename UniqueSubRange1,
+        typename UniqueSubRange2,
         typename IntersectionInfo
     >
     static inline void assign(TurnInfo const& tp,
-                RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
-                RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
+                UniqueSubRange1 const& range_p,
+                UniqueSubRange2 const& range_q,
                 IntersectionInfo const& info)
     {
-        AssignPolicy::apply(tp, retrieve_policy_p.get_point_i(), retrieve_policy_q.get_point_i(), info);
+        AssignPolicy::apply(tp, range_p.get_point_i(), range_q.get_point_i(), info);
     }
 
     // Intersect pi-pj with qi-qj
@@ -945,28 +945,28 @@ struct get_turn_info
     <
         typename TurnInfo,
         typename IntersectionStrategy,
-        typename RetrieveAdditionalInfoPolicy1,
-        typename RetrieveAdditionalInfoPolicy2,
+        typename UniqueSubRange1,
+        typename UniqueSubRange2,
         typename RobustPolicy,
         typename OutputIterator
     >
     static inline OutputIterator apply(
                 TurnInfo const& tp_model,
                 IntersectionStrategy const& intersection_strategy,
-                RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
-                RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
+                UniqueSubRange1 const& range_p,
+                UniqueSubRange2 const& range_q,
                 RobustPolicy const& robust_policy,
                 OutputIterator out)
     {
         typedef intersection_info
             <
-                RetrieveAdditionalInfoPolicy1, RetrieveAdditionalInfoPolicy2,
+                UniqueSubRange1, UniqueSubRange2,
                 typename TurnInfo::point_type,
                 IntersectionStrategy,
                 RobustPolicy
             > inters_info;
 
-        inters_info inters(retrieve_policy_p, retrieve_policy_q,
+        inters_info inters(range_p, range_q,
                            intersection_strategy, robust_policy);
 
         char const method = inters.d_info().how;
@@ -984,7 +984,7 @@ struct get_turn_info
                     && inters.i_info().count > 0)
                 {
                     only_convert::apply(tp, inters.i_info());
-                    assign(tp, retrieve_policy_p, retrieve_policy_q, inters);
+                    assign(tp, range_p, range_q, inters);
                     *out++ = tp;
                 }
                 break;
@@ -1011,14 +1011,14 @@ struct get_turn_info
                     policy::template apply<1>(tp, inters.i_info(), inters.d_info(),
                                 inters.get_swapped_sides());
                 }
-                assign(tp, retrieve_policy_p, retrieve_policy_q, inters);
+                assign(tp, range_p, range_q, inters);
                 *out++ = tp;
             }
             break;
             case 'i' :
             {
                 crosses<TurnInfo>::apply(tp, inters.i_info(), inters.d_info());
-                assign(tp, retrieve_policy_p, retrieve_policy_q, inters);
+                assign(tp, range_p, range_q, inters);
                 *out++ = tp;
             }
             break;
@@ -1026,7 +1026,7 @@ struct get_turn_info
             {
                 // Both touch (both arrive there)
                 touch<TurnInfo>::apply(tp, inters.i_info(), inters.d_info(), inters.sides());
-                assign(tp, retrieve_policy_p, retrieve_policy_q, inters);
+                assign(tp, range_p, range_q, inters);
                 *out++ = tp;
             }
             break;
@@ -1037,7 +1037,7 @@ struct get_turn_info
                     // Both equal
                     // or collinear-and-ending at intersection point
                     equal<TurnInfo>::apply(tp, inters.i_info(), inters.d_info(), inters.sides());
-                    assign(tp, retrieve_policy_p, retrieve_policy_q, inters);
+                    assign(tp, range_p, range_q, inters);
                     *out++ = tp;
                 }
                 else
@@ -1046,7 +1046,7 @@ struct get_turn_info
                         <
                             TurnInfo,
                             AssignPolicy
-                        >::apply(retrieve_policy_p, retrieve_policy_q,
+                        >::apply(range_p, range_q,
                             tp, out, inters);
                 }
             }
@@ -1067,11 +1067,11 @@ struct get_turn_info
                     }
                     else
                     {
-                        collinear<TurnInfo>::apply(retrieve_policy_p, retrieve_policy_q,
+                        collinear<TurnInfo>::apply(range_p, range_q,
                                 tp, inters.i_info(), inters.d_info(), inters.sides());
                     }
 
-                    assign(tp, retrieve_policy_p, retrieve_policy_q, inters);
+                    assign(tp, range_p, range_q, inters);
                     *out++ = tp;
                 }
                 else
@@ -1080,7 +1080,7 @@ struct get_turn_info
                         <
                             TurnInfo,
                             AssignPolicy
-                        >::apply(retrieve_policy_p, retrieve_policy_q,
+                        >::apply(range_p, range_q,
                             tp, out, inters, inters.sides());
                 }
             }
@@ -1091,7 +1091,7 @@ struct get_turn_info
                 if (AssignPolicy::include_degenerate)
                 {
                     only_convert::apply(tp, inters.i_info());
-                    assign(tp, retrieve_policy_p, retrieve_policy_q, inters);
+                    assign(tp, range_p, range_q, inters);
                     *out++ = tp;
                 }
             }

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -987,10 +987,9 @@ struct get_turn_info
                 RobustPolicy
             > inters_info;
 
-        Point1 const& pk = retrieve_policy_p.get();
-        Point2 const& qk = retrieve_policy_q.get();
-
-        inters_info inters(pi, pj, pk, qi, qj, qk, intersection_strategy, robust_policy);
+        inters_info inters(pi, pj, qi, qj,
+                           retrieve_policy_p, retrieve_policy_q,
+                           intersection_strategy, robust_policy);
 
         char const method = inters.d_info().how;
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -894,23 +894,23 @@ struct assign_null_policy
 template<typename AssignPolicy>
 struct get_turn_info
 {
-    // Intersect pi-pj with qi-qj
-    // The points pk and qk are used do determine more information
-    // about the turn (turn left/right)
+    // Intersect a segment p with a segment q
+    // Both p and q are modelled as sub_ranges to provide more points
+    // to be able to give more information about the turn (left/right)
     template
     <
-        typename TurnInfo,
-        typename IntersectionStrategy,
         typename UniqueSubRange1,
         typename UniqueSubRange2,
+        typename TurnInfo,
+        typename IntersectionStrategy,
         typename RobustPolicy,
         typename OutputIterator
     >
     static inline OutputIterator apply(
-                TurnInfo const& tp_model,
-                IntersectionStrategy const& intersection_strategy,
                 UniqueSubRange1 const& range_p,
                 UniqueSubRange2 const& range_q,
+                TurnInfo const& tp_model,
+                IntersectionStrategy const& intersection_strategy,
                 RobustPolicy const& robust_policy,
                 OutputIterator out)
     {

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -143,15 +143,11 @@ struct touch_interior : public base_turn_handler
     template
     <
         unsigned int Index,
-        typename Point1,
-        typename Point2,
         typename IntersectionInfo,
         typename DirInfo,
         typename SidePolicy
     >
     static inline void apply(
-                Point1 const& , Point1 const& ,
-                Point2 const& , Point2 const& ,
                 TurnInfo& ti,
                 IntersectionInfo const& intersection_info,
                 DirInfo const& dir_info,
@@ -266,16 +262,11 @@ struct touch : public base_turn_handler
 
     template
     <
-        typename Point1,
-        typename Point2,
         typename IntersectionInfo,
         typename DirInfo,
         typename SidePolicy
     >
-    static inline void apply(
-                Point1 const& , Point1 const& ,
-                Point2 const& , Point2 const& ,
-                TurnInfo& ti,
+    static inline void apply(TurnInfo& ti,
                 IntersectionInfo const& intersection_info,
                 DirInfo const& dir_info,
                 SidePolicy const& side)
@@ -466,16 +457,11 @@ struct equal : public base_turn_handler
 {
     template
     <
-        typename Point1,
-        typename Point2,
         typename IntersectionInfo,
         typename DirInfo,
         typename SidePolicy
     >
-    static inline void apply(
-                Point1 const& , Point1 const& ,
-                Point2 const& , Point2 const& ,
-                TurnInfo& ti,
+    static inline void apply(TurnInfo& ti,
                 IntersectionInfo const& info,
                 DirInfo const&  ,
                 SidePolicy const& side)
@@ -525,12 +511,14 @@ struct equal_opposite : public base_turn_handler
 {
     template
     <
-        typename Point1,
-        typename Point2,
+        typename RetrieveAdditionalInfoPolicy1,
+        typename RetrieveAdditionalInfoPolicy2,
         typename OutputIterator,
         typename IntersectionInfo
     >
-    static inline void apply(Point1 const& pi, Point2 const& qi,
+    static inline void apply(
+                RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
+                RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
                 /* by value: */ TurnInfo tp,
                 OutputIterator& out,
                 IntersectionInfo const& intersection_info)
@@ -546,7 +534,7 @@ struct equal_opposite : public base_turn_handler
             for (unsigned int i = 0; i < intersection_info.i_info().count; i++)
             {
                 assign_point(tp, method_none, intersection_info.i_info(), i);
-                AssignPolicy::apply(tp, pi, qi, intersection_info);
+                AssignPolicy::apply(tp, retrieve_policy_p.get_point_i(), retrieve_policy_q.get_point_i(), intersection_info);
                 *out++ = tp;
             }
         }
@@ -593,8 +581,6 @@ struct collinear : public base_turn_handler
     */
     template
     <
-        typename Point1,
-        typename Point2,
         typename RetrieveAdditionalInfoPolicy1,
         typename RetrieveAdditionalInfoPolicy2,
         typename IntersectionInfo,
@@ -602,8 +588,6 @@ struct collinear : public base_turn_handler
         typename SidePolicy
     >
     static inline void apply(
-                Point1 const& , Point1 const& pj,
-                Point2 const& , Point2 const& qj,
                 RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
                 RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
                 TurnInfo& ti,
@@ -643,19 +627,16 @@ struct collinear : public base_turn_handler
             ui_else_iu(product == 1, ti);
         }
 
-        Point1 const& pk = retrieve_policy_p.get_point_k();
-        Point2 const& qk = retrieve_policy_q.get_point_k();
-
         // Calculate remaining distance. If it continues collinearly it is
         // measured until the end of the next segment
         ti.operations[0].remaining_distance
                 = side_p == 0
-                ? distance_measure(ti.point, pk)
-                : distance_measure(ti.point, pj);
+                ? distance_measure(ti.point, retrieve_policy_p.get_point_k())
+                : distance_measure(ti.point, retrieve_policy_p.get_point_j());
         ti.operations[1].remaining_distance
                 = side_q == 0
-                ? distance_measure(ti.point, qk)
-                : distance_measure(ti.point, qj);
+                ? distance_measure(ti.point, retrieve_policy_q.get_point_k())
+                : distance_measure(ti.point, retrieve_policy_q.get_point_j());
     }
 
     template <typename Point1, typename Point2>
@@ -706,13 +687,10 @@ private :
     template
     <
         unsigned int Index,
-        typename Point1,
-        typename Point2,
         typename IntersectionInfo
     >
-    static inline bool set_tp(Point1 const& , Point1 const& , Point1 const& , int side_rk_r,
-                bool const handle_robustness,
-                Point2 const& , Point2 const& , int side_rk_s,
+    static inline bool set_tp(int side_rk_r, bool handle_robustness,
+                int side_rk_s,
                 TurnInfo& tp, IntersectionInfo const& intersection_info)
     {
         BOOST_STATIC_ASSERT(Index <= 1);
@@ -764,8 +742,6 @@ public:
 
     template
     <
-        typename Point1,
-        typename Point2,
         typename RetrieveAdditionalInfoPolicy1,
         typename RetrieveAdditionalInfoPolicy2,
         typename OutputIterator,
@@ -773,8 +749,6 @@ public:
         typename SidePolicy
     >
     static inline void apply(
-                Point1 const& pi, Point1 const& pj,
-                Point2 const& qi, Point2 const& qj,
                 RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
                 RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
 
@@ -785,15 +759,27 @@ public:
                 IntersectionInfo const& intersection_info,
                 SidePolicy const& side)
     {
-        apply(pi, pj, qi, qj, retrieve_policy_p, retrieve_policy_q,
+        apply(retrieve_policy_p, retrieve_policy_q,
               tp_model, out, intersection_info, side, empty_transformer);
     }
 
 public:
     template
     <
-        typename Point1,
-        typename Point2,
+        typename RetrieveAdditionalInfoPolicy1,
+        typename RetrieveAdditionalInfoPolicy2,
+        typename IntersectionInfo
+    >
+    static inline void assign(TurnInfo const& tp,
+                RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
+                RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
+                IntersectionInfo const& info)
+    {
+        AssignPolicy::apply(tp, retrieve_policy_p.get_point_i(), retrieve_policy_q.get_point_i(), info);
+    }
+
+    template
+    <
         typename RetrieveAdditionalInfoPolicy1,
         typename RetrieveAdditionalInfoPolicy2,
         typename OutputIterator,
@@ -802,8 +788,6 @@ public:
         typename TurnTransformer
     >
     static inline void apply(
-                Point1 const& pi, Point1 const& pj,
-                Point2 const& qi, Point2 const& qj,
                 RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
                 RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
 
@@ -823,24 +807,22 @@ public:
         // If P arrives within Q, there is a turn dependent on P
         if ( p_arrival == 1
           && retrieve_policy_p.has_k()
-          && set_tp<0>(pi, pj, retrieve_policy_p.get_point_k(),
-                       side.pk_wrt_p1(), true, qi, qj, side.pk_wrt_q1(), tp, info.i_info()) )
+          && set_tp<0>(side.pk_wrt_p1(), true, side.pk_wrt_q1(), tp, info.i_info()) )
         {
             turn_transformer(tp);
 
-            AssignPolicy::apply(tp, pi, qi, info);
+            assign(tp, retrieve_policy_p, retrieve_policy_q, info);
             *out++ = tp;
         }
 
         // If Q arrives within P, there is a turn dependent on Q
         if ( q_arrival == 1
           && retrieve_policy_q.has_k()
-          && set_tp<1>(qi, qj, retrieve_policy_q.get_point_k(),
-                       side.qk_wrt_q1(), false, pi, pj, side.qk_wrt_p1(), tp, info.i_info()) )
+          && set_tp<1>(side.qk_wrt_q1(), false, side.qk_wrt_p1(), tp, info.i_info()) )
         {
             turn_transformer(tp);
 
-            AssignPolicy::apply(tp, pi, qi, info);
+            assign(tp, retrieve_policy_p, retrieve_policy_q, info);
             *out++ = tp;
         }
 
@@ -857,7 +839,7 @@ public:
                 for (unsigned int i = 0; i < info.i_info().count; i++)
                 {
                     assign_point(tp, method_collinear, info.i_info(), i);
-                    AssignPolicy::apply(tp, pi, qi, info);
+                    assign(tp, retrieve_policy_p, retrieve_policy_q, info);
                     *out++ = tp;
                 }
             }
@@ -941,6 +923,21 @@ struct assign_null_policy
 template<typename AssignPolicy>
 struct get_turn_info
 {
+    template
+    <
+        typename TurnInfo,
+        typename RetrieveAdditionalInfoPolicy1,
+        typename RetrieveAdditionalInfoPolicy2,
+        typename IntersectionInfo
+    >
+    static inline void assign(TurnInfo const& tp,
+                RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
+                RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
+                IntersectionInfo const& info)
+    {
+        AssignPolicy::apply(tp, retrieve_policy_p.get_point_i(), retrieve_policy_q.get_point_i(), info);
+    }
+
     // Intersect pi-pj with qi-qj
     // The points pk and qk are used do determine more information
     // about the turn (turn left/right)
@@ -969,14 +966,6 @@ struct get_turn_info
                 RobustPolicy
             > inters_info;
 
-        typedef typename RetrieveAdditionalInfoPolicy1::point_type Point1;
-        typedef typename RetrieveAdditionalInfoPolicy2::point_type Point2;
-
-        Point1 const& pi = retrieve_policy_p.get_point_i();
-        Point1 const& pj = retrieve_policy_p.get_point_j();
-        Point2 const& qi = retrieve_policy_q.get_point_i();
-        Point2 const& qj = retrieve_policy_q.get_point_j();
-
         inters_info inters(retrieve_policy_p, retrieve_policy_q,
                            intersection_strategy, robust_policy);
 
@@ -995,7 +984,7 @@ struct get_turn_info
                     && inters.i_info().count > 0)
                 {
                     only_convert::apply(tp, inters.i_info());
-                    AssignPolicy::apply(tp, pi, qi, inters);
+                    assign(tp, retrieve_policy_p, retrieve_policy_q, inters);
                     *out++ = tp;
                 }
                 break;
@@ -1013,34 +1002,31 @@ struct get_turn_info
                 // If Q (1) arrives (1)
                 if ( inters.d_info().arrival[1] == 1 )
                 {
-                    policy::template apply<0>(pi, pj, qi, qj,
-                                tp, inters.i_info(), inters.d_info(),
+                    policy::template apply<0>(tp, inters.i_info(), inters.d_info(),
                                 inters.sides());
                 }
                 else
                 {
                     // Swap p/q
-                    policy::template apply<1>(qi, qj, pi, pj,
-                                tp, inters.i_info(), inters.d_info(),
+                    policy::template apply<1>(tp, inters.i_info(), inters.d_info(),
                                 inters.get_swapped_sides());
                 }
-                AssignPolicy::apply(tp, pi, qi, inters);
+                assign(tp, retrieve_policy_p, retrieve_policy_q, inters);
                 *out++ = tp;
             }
             break;
             case 'i' :
             {
                 crosses<TurnInfo>::apply(tp, inters.i_info(), inters.d_info());
-                AssignPolicy::apply(tp, pi, qi, inters);
+                assign(tp, retrieve_policy_p, retrieve_policy_q, inters);
                 *out++ = tp;
             }
             break;
             case 't' :
             {
                 // Both touch (both arrive there)
-                touch<TurnInfo>::apply(pi, pj, qi, qj,
-                    tp, inters.i_info(), inters.d_info(), inters.sides());
-                AssignPolicy::apply(tp, pi, qi, inters);
+                touch<TurnInfo>::apply(tp, inters.i_info(), inters.d_info(), inters.sides());
+                assign(tp, retrieve_policy_p, retrieve_policy_q, inters);
                 *out++ = tp;
             }
             break;
@@ -1050,9 +1036,8 @@ struct get_turn_info
                 {
                     // Both equal
                     // or collinear-and-ending at intersection point
-                    equal<TurnInfo>::apply(pi, pj, qi, qj,
-                        tp, inters.i_info(), inters.d_info(), inters.sides());
-                    AssignPolicy::apply(tp, pi, qi, inters);
+                    equal<TurnInfo>::apply(tp, inters.i_info(), inters.d_info(), inters.sides());
+                    assign(tp, retrieve_policy_p, retrieve_policy_q, inters);
                     *out++ = tp;
                 }
                 else
@@ -1061,7 +1046,7 @@ struct get_turn_info
                         <
                             TurnInfo,
                             AssignPolicy
-                        >::apply(pi, qi,
+                        >::apply(retrieve_policy_p, retrieve_policy_q,
                             tp, out, inters);
                 }
             }
@@ -1075,20 +1060,18 @@ struct get_turn_info
                     if ( inters.d_info().arrival[0] == 0 )
                     {
                         // Collinear, but similar thus handled as equal
-                        equal<TurnInfo>::apply(pi, pj, qi, qj,
-                                tp, inters.i_info(), inters.d_info(), inters.sides());
+                        equal<TurnInfo>::apply(tp, inters.i_info(), inters.d_info(), inters.sides());
 
                         // override assigned method
                         tp.method = method_collinear;
                     }
                     else
                     {
-                        collinear<TurnInfo>::apply(pi, pj, qi, qj,
-                                retrieve_policy_p, retrieve_policy_q,
+                        collinear<TurnInfo>::apply(retrieve_policy_p, retrieve_policy_q,
                                 tp, inters.i_info(), inters.d_info(), inters.sides());
                     }
 
-                    AssignPolicy::apply(tp, pi, qi, inters);
+                    assign(tp, retrieve_policy_p, retrieve_policy_q, inters);
                     *out++ = tp;
                 }
                 else
@@ -1097,8 +1080,7 @@ struct get_turn_info
                         <
                             TurnInfo,
                             AssignPolicy
-                        >::apply(pi, pj, qi, qj,
-                            retrieve_policy_p, retrieve_policy_q,
+                        >::apply(retrieve_policy_p, retrieve_policy_q,
                             tp, out, inters, inters.sides());
                 }
             }
@@ -1109,7 +1091,7 @@ struct get_turn_info
                 if (AssignPolicy::include_degenerate)
                 {
                     only_convert::apply(tp, inters.i_info());
-                    AssignPolicy::apply(tp, pi, qi, inters);
+                    assign(tp, retrieve_policy_p, retrieve_policy_q, inters);
                     *out++ = tp;
                 }
             }

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
@@ -247,10 +247,10 @@ struct get_turn_info_for_endpoint
             return false;
         }
 
-        if (! range_p.is_first()
-            && ! range_q.is_first()
-            && range_p.size() > 2u
-            && range_q.size() > 2u)
+        if (! range_p.is_first_segment()
+            && ! range_q.is_first_segment()
+            && ! range_p.is_last_segment()
+            && ! range_q.is_last_segment())
         {
             // Not an end-point from segment p or q
             return false;
@@ -259,8 +259,8 @@ struct get_turn_info_for_endpoint
         linear_intersections intersections(range_p.at(0),
                                            range_q.at(0),
                                            inters.result(),
-                                           range_p.size() == 2u,
-                                           range_q.size() == 2u);
+                                           range_p.is_last_segment(),
+                                           range_q.is_last_segment());
 
         bool append0_last
             = analyse_segment_and_assign_ip(range_p, range_q,
@@ -302,10 +302,10 @@ struct get_turn_info_for_endpoint
                                        OutputIterator out)
     {
         // TODO - calculate first/last only if needed
-        bool is_p_first_ip = range_p.is_first() && ip_info.is_pi;
-        bool is_p_last_ip = range_p.size() == 2u && ip_info.is_pj;
-        bool is_q_first_ip = range_q.is_first() && ip_info.is_qi;
-        bool is_q_last_ip = range_q.size() == 2u && ip_info.is_qj;
+        bool is_p_first_ip = range_p.is_first_segment() && ip_info.is_pi;
+        bool is_p_last_ip = range_p.is_last_segment() && ip_info.is_pj;
+        bool is_q_first_ip = range_q.is_first_segment() && ip_info.is_qi;
+        bool is_q_last_ip = range_q.is_last_segment() && ip_info.is_qj;
         bool append_first = EnableFirst && (is_p_first_ip || is_q_first_ip);
         bool append_last = EnableLast && (is_p_last_ip || is_q_last_ip);
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
@@ -230,25 +230,21 @@ template <typename TurnPointCSTag, typename PointP, typename PointQ,
 struct side_calculator_for_endpoint
 {
     inline side_calculator_for_endpoint(Pi const& pi, Pj const& pj, Pk const& pk,
-                           Qi const& qi, Qj const& qj, Qk const& qk,
+                           Qi const& /*qi*/, Qj const& qj, Qk const& qk,
                            SideStrategy const& side_strategy)
         : m_pi(pi), m_pj(pj), m_pk(pk)
-        , m_qi(qi), m_qj(qj), m_qk(qk)
+        ,           m_qj(qj), m_qk(qk)
         , m_side_strategy(side_strategy)
     {}
 
     inline int pk_wrt_p1() const { return m_side_strategy.apply(m_pi, m_pj, m_pk); }
-    inline int pk_wrt_q1() const { return m_side_strategy.apply(m_qi, m_qj, m_pk); }
     inline int qk_wrt_p1() const { return m_side_strategy.apply(m_pi, m_pj, m_qk); }
-    inline int qk_wrt_q1() const { return m_side_strategy.apply(m_qi, m_qj, m_qk); }
-
     inline int pk_wrt_q2() const { return m_side_strategy.apply(m_qj, m_qk, m_pk); }
-    inline int qk_wrt_p2() const { return m_side_strategy.apply(m_pj, m_pk, m_qk); }
 
     Pi const& m_pi;
     Pj const& m_pj;
     Pk const& m_pk;
-    Qi const& m_qi;
+    // Qi is omitted because it is not used
     Qj const& m_qj;
     Qk const& m_qk;
 
@@ -369,7 +365,6 @@ struct get_turn_info_for_endpoint
         if ( append_first || append_last )
         {
             bool handled = handle_internal<0>(pi, pj, qi, qj,
-                                              retrieve_policy_p, retrieve_policy_q,
                                               inters.rpi(), inters.rpj(), inters.rpk(),
                                               inters.rqi(), inters.rqj(), inters.rqk(),
                                               is_p_first_ip, is_p_last_ip,
@@ -380,7 +375,6 @@ struct get_turn_info_for_endpoint
             if ( !handled )
             {
                 handle_internal<1>(qi, qj, pi, pj,
-                                   retrieve_policy_q, retrieve_policy_p,
                                    inters.rqi(), inters.rqj(), inters.rqk(),
                                    inters.rpi(), inters.rpj(), inters.rpk(),
                                    is_q_first_ip, is_q_last_ip,
@@ -441,13 +435,11 @@ struct get_turn_info_for_endpoint
              typename Point2,
              typename RobustPoint1,
              typename RobustPoint2,
-             typename RetrievePolicyP, typename RetrievePolicyQ,
              typename TurnInfo,
              typename IntersectionInfo
     >
     static inline bool handle_internal(Point1 const& /*i1*/, Point1 const& /*j1*/,
                                        Point2 const& i2, Point2 const& j2,
-                                       RetrievePolicyP const& retp, RetrievePolicyQ const& retq,
                                        RobustPoint1 const& ri1, RobustPoint1 const& rj1, RobustPoint1 const& /*rk1*/,
                                        RobustPoint2 const& ri2, RobustPoint2 const& rj2, RobustPoint2 const& rk2,
                                        bool first1, bool last1, bool first2, bool last2,
@@ -483,7 +475,7 @@ struct get_turn_info_for_endpoint
                                     RobustPoint1, RobustPoint2,
                                     typename IntersectionInfo::side_strategy_type,
                                     RobustPoint2>
-                        side_calc(ri2, ri1, rj1, ri2, rj2, rk2, inters.get_side_strategy());
+                        side_calc(ri2, ri1, rj1, ri2, rj2, rk2, inters.get_side_strategy()); // TODO: wrong, ri2/ri1/rj2
 
                     std::pair<operation_type, operation_type>
                         operations = operations_of_equal(side_calc);
@@ -536,7 +528,7 @@ struct get_turn_info_for_endpoint
                     side_calculator_for_endpoint<cs_tag, RobustPoint1, RobustPoint2,
                                     typename IntersectionInfo::side_strategy_type,
                                     RobustPoint2>
-                        side_calc(ri2, rj1, ri1, ri2, rj2, rk2, inters.get_side_strategy());
+                        side_calc(ri2, rj1, ri1, ri2, rj2, rk2, inters.get_side_strategy()); // TODO: wrong, ri2/ri1/rj2
                     
                     std::pair<operation_type, operation_type>
                         operations = operations_of_equal(side_calc);

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
@@ -222,6 +222,40 @@ private:
     ip_info ips[2];
 };
 
+template <typename TurnPointCSTag, typename PointP, typename PointQ,
+          typename SideStrategy,
+          typename Pi = PointP, typename Pj = PointP, typename Pk = PointP,
+          typename Qi = PointQ, typename Qj = PointQ, typename Qk = PointQ
+>
+struct side_calculator_for_endpoint
+{
+    inline side_calculator_for_endpoint(Pi const& pi, Pj const& pj, Pk const& pk,
+                           Qi const& qi, Qj const& qj, Qk const& qk,
+                           SideStrategy const& side_strategy)
+        : m_pi(pi), m_pj(pj), m_pk(pk)
+        , m_qi(qi), m_qj(qj), m_qk(qk)
+        , m_side_strategy(side_strategy)
+    {}
+
+    inline int pk_wrt_p1() const { return m_side_strategy.apply(m_pi, m_pj, m_pk); }
+    inline int pk_wrt_q1() const { return m_side_strategy.apply(m_qi, m_qj, m_pk); }
+    inline int qk_wrt_p1() const { return m_side_strategy.apply(m_pi, m_pj, m_qk); }
+    inline int qk_wrt_q1() const { return m_side_strategy.apply(m_qi, m_qj, m_qk); }
+
+    inline int pk_wrt_q2() const { return m_side_strategy.apply(m_qj, m_qk, m_pk); }
+    inline int qk_wrt_p2() const { return m_side_strategy.apply(m_pj, m_pk, m_qk); }
+
+    Pi const& m_pi;
+    Pj const& m_pj;
+    Pk const& m_pk;
+    Qi const& m_qi;
+    Qj const& m_qj;
+    Qk const& m_qk;
+
+    SideStrategy m_side_strategy;
+};
+
+
 template <typename AssignPolicy, bool EnableFirst, bool EnableLast>
 struct get_turn_info_for_endpoint
 {
@@ -445,7 +479,7 @@ struct get_turn_info_for_endpoint
                 }
                 else if ( ip_j2 )
                 {
-                    side_calculator<cs_tag,
+                    side_calculator_for_endpoint<cs_tag,
                                     RobustPoint1, RobustPoint2,
                                     typename IntersectionInfo::side_strategy_type,
                                     RobustPoint2>
@@ -499,7 +533,7 @@ struct get_turn_info_for_endpoint
                 }
                 else if ( ip_j2 )
                 {
-                    side_calculator<cs_tag, RobustPoint1, RobustPoint2,
+                    side_calculator_for_endpoint<cs_tag, RobustPoint1, RobustPoint2,
                                     typename IntersectionInfo::side_strategy_type,
                                     RobustPoint2>
                         side_calc(ri2, rj1, ri1, ri2, rj2, rk2, inters.get_side_strategy());

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
@@ -257,14 +257,14 @@ struct get_turn_info_for_endpoint
 {
     BOOST_STATIC_ASSERT(EnableFirst || EnableLast);
 
-    template<typename RetrieveAdditionalInfoPolicy1,
-             typename RetrieveAdditionalInfoPolicy2,
+    template<typename UniqueSubRange1,
+             typename UniqueSubRange2,
              typename TurnInfo,
              typename IntersectionInfo,
              typename OutputIterator
     >
-    static inline bool apply(RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
-                             RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
+    static inline bool apply(UniqueSubRange1 const& range_p,
+                             UniqueSubRange2 const& range_q,
                              TurnInfo const& tp_model,
                              IntersectionInfo const& inters,
                              method_type /*method*/,
@@ -277,22 +277,22 @@ struct get_turn_info_for_endpoint
             return false;
         }
 
-        bool const is_p_first = retrieve_policy_p.is_first();
-        bool const is_p_last = ! retrieve_policy_p.has_k();
-        bool const is_q_first = retrieve_policy_q.is_first();
-        bool const is_q_last = ! retrieve_policy_q.has_k();
+        bool const is_p_first = range_p.is_first();
+        bool const is_p_last = ! range_p.has_k();
+        bool const is_q_first = range_q.is_first();
+        bool const is_q_last = ! range_q.has_k();
 
         if (!is_p_first && !is_p_last && !is_q_first && !is_q_last)
         {
             return false;
         }
 
-        linear_intersections intersections(retrieve_policy_p.get_point_i(),
-                                           retrieve_policy_q.get_point_i(),
+        linear_intersections intersections(range_p.get_point_i(),
+                                           range_q.get_point_i(),
                                            inters.result(), is_p_last, is_q_last);
 
         bool append0_last
-            = analyse_segment_and_assign_ip(retrieve_policy_p, retrieve_policy_q,
+            = analyse_segment_and_assign_ip(range_p, range_q,
                                             intersections.template get<0>(),
                                             tp_model, inters, 0, out);
 
@@ -306,7 +306,7 @@ struct get_turn_info_for_endpoint
             return result_ignore_ip0;
         
         bool append1_last
-            = analyse_segment_and_assign_ip(retrieve_policy_p, retrieve_policy_q,
+            = analyse_segment_and_assign_ip(range_p, range_q,
                                             intersections.template get<1>(),
                                             tp_model, inters, 1, out);
 
@@ -316,14 +316,14 @@ struct get_turn_info_for_endpoint
         return result_ignore_ip0 || result_ignore_ip1;
     }
 
-    template <typename RetrieveAdditionalInfoPolicy1,
-              typename RetrieveAdditionalInfoPolicy2,
+    template <typename UniqueSubRange1,
+              typename UniqueSubRange2,
               typename TurnInfo,
               typename IntersectionInfo,
               typename OutputIterator>
     static inline
-    bool analyse_segment_and_assign_ip(RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
-                                       RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
+    bool analyse_segment_and_assign_ip(UniqueSubRange1 const& range_p,
+                                       UniqueSubRange2 const& range_q,
                                        linear_intersections::ip_info const& ip_info,
                                        TurnInfo const& tp_model,
                                        IntersectionInfo const& inters,
@@ -331,10 +331,10 @@ struct get_turn_info_for_endpoint
                                        OutputIterator out)
     {
         // TODO - calculate first/last only if needed
-        bool const is_p_first = retrieve_policy_p.is_first();
-        bool const is_p_last = ! retrieve_policy_p.has_k();
-        bool const is_q_first = retrieve_policy_q.is_first();
-        bool const is_q_last = ! retrieve_policy_q.has_k();
+        bool const is_p_first = range_p.is_first();
+        bool const is_p_last = ! range_p.has_k();
+        bool const is_q_first = range_q.is_first();
+        bool const is_q_last = ! range_q.has_k();
 
         bool is_p_first_ip = is_p_first && ip_info.is_pi;
         bool is_p_last_ip = is_p_last && ip_info.is_pj;
@@ -381,10 +381,10 @@ struct get_turn_info_for_endpoint
                   && inters.i_info().count == 2
                   && inters.is_spike_p() )
                 {
-                    assign(retrieve_policy_q, retrieve_policy_q,
+                    assign(range_q, range_q,
                            inters.result(), ip_index, method, operation_blocked, q_operation,
                            p_pos, q_pos, is_p_first_ip, is_q_first_ip, true, false, tp_model, out);
-                    assign(retrieve_policy_q, retrieve_policy_q,
+                    assign(range_q, range_q,
                            inters.result(), ip_index, method, operation_intersection, q_operation,
                            p_pos, q_pos, is_p_first_ip, is_q_first_ip, true, false, tp_model, out);
                 }
@@ -394,17 +394,17 @@ struct get_turn_info_for_endpoint
                        && inters.i_info().count == 2
                        && inters.is_spike_q() )
                 {
-                    assign(retrieve_policy_q, retrieve_policy_q,
+                    assign(range_q, range_q,
                            inters.result(), ip_index, method, p_operation, operation_blocked,
                            p_pos, q_pos, is_p_first_ip, is_q_first_ip, false, true, tp_model, out);
-                    assign(retrieve_policy_q, retrieve_policy_q,
+                    assign(range_q, range_q,
                            inters.result(), ip_index, method, p_operation, operation_intersection,
                            p_pos, q_pos, is_p_first_ip, is_q_first_ip, false, true, tp_model, out);
                 }
                 // no spikes
                 else
                 {
-                    assign(retrieve_policy_q, retrieve_policy_q,
+                    assign(range_q, range_q,
                            inters.result(), ip_index, method, p_operation, q_operation,
                            p_pos, q_pos, is_p_first_ip, is_q_first_ip, false, false, tp_model, out);
                 }
@@ -563,13 +563,13 @@ struct get_turn_info_for_endpoint
                ( is_ip_last_j ? position_back : position_middle );
     }
 
-    template <typename RetrieveAdditionalInfoPolicy1,
-              typename RetrieveAdditionalInfoPolicy2,
+    template <typename UniqueSubRange1,
+              typename UniqueSubRange2,
               typename IntersectionResult,
               typename TurnInfo,
               typename OutputIterator>
-    static inline void assign(RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
-                              RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
+    static inline void assign(UniqueSubRange1 const& range_p,
+                              UniqueSubRange2 const& range_q,
                               IntersectionResult const& result,
                               unsigned int ip_index,
                               method_type method,
@@ -623,7 +623,7 @@ struct get_turn_info_for_endpoint
 
         // TODO: this should get an intersection_info, which is unavailable here
         // Because the assign_null policy accepts any structure, we pass the result instead for now
-        AssignPolicy::apply(tp, retrieve_policy_p.get_point_i(), retrieve_policy_q.get_point_i(), result);
+        AssignPolicy::apply(tp, range_p.get_point_i(), range_q.get_point_i(), result);
         *out++ = tp;
     }
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
@@ -582,27 +582,29 @@ struct get_turn_info_for_endpoint
         BOOST_STATIC_ASSERT(Index2 <= 1);
         BOOST_STATIC_ASSERT(Index1 + Index2 == 1);
 
-        // This code assumes that range 2 (aka "q") has at least 3 points
+        // This code assumes that range 2 has at least 3 points
         BOOST_GEOMETRY_ASSERT(range2.size() >= 3);
 
-        int const side_pk_q2 = side.apply(range2.at(1), range2.at(2), range1.at(Index2));
-        int const side_pk_p = side.apply(range2.at(0), range1.at(Index1), range1.at(Index2));
-        int const side_qk_p = side.apply(range2.at(0), range1.at(Index1), range2.at(2));
+        // Calculate three relevant sides (to be documented, originally they were named
+        // but because ranges and indices are swapped, this was confusing)
+        int const side_1 = side.apply(range2.at(1), range2.at(2), range1.at(Index2));
+        int const side_2 = side.apply(range2.at(0), range1.at(Index1), range1.at(Index2));
+        int const side_3 = side.apply(range2.at(0), range1.at(Index1), range2.at(2));
 
         // If pk is collinear with qj-qk, they continue collinearly.
         // This can be on either side of p1 (== q1), or collinear
         // The second condition checks if they do not continue
         // oppositely
-        if ( side_pk_q2 == 0 && side_pk_p == side_qk_p )
+        if ( side_1 == 0 && side_2 == side_3 )
         {
             return std::make_pair(operation_continue, operation_continue);
         }
 
         // If they turn to same side (not opposite sides)
-        if ( ! base_turn_handler::opposite(side_pk_p, side_qk_p) )
+        if ( ! base_turn_handler::opposite(side_2, side_3) )
         {
             // If pk is left of q2 or collinear: p: union, q: intersection
-            if ( side_pk_q2 != -1 )
+            if ( side_1 != -1 )
             {
                 return std::make_pair(operation_union, operation_intersection);
             }
@@ -615,7 +617,7 @@ struct get_turn_info_for_endpoint
         {
             // They turn opposite sides. If p turns left (or collinear),
            // p: union, q: intersection
-            if ( side_pk_p != -1 )
+            if ( side_2 != -1 )
             {
                 return std::make_pair(operation_union, operation_intersection);
             }

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
@@ -198,23 +198,23 @@ public:
 private:
 
     // only if collinear (same_dirs)
-    static inline operation_type union_or_blocked_same_dirs(int arrival, bool is_last)
+    static inline operation_type union_or_blocked_same_dirs(int arrival, bool has_k)
     {
         if ( arrival == 1 )
             return operation_blocked;
         else if ( arrival == -1 )
             return operation_union;
         else
-            return is_last ? operation_blocked : operation_union;
+            return has_k ? operation_blocked : operation_union;
             //return operation_blocked;
     }
 
     // only if not collinear (!same_dirs)
-    static inline operation_type union_or_blocked_different_dirs(int arrival, bool is_last)
+    static inline operation_type union_or_blocked_different_dirs(int arrival, bool has_k)
     {
         if ( arrival == 1 )
             //return operation_blocked;
-            return is_last ? operation_blocked : operation_union;
+            return has_k ? operation_blocked : operation_union;
         else
             return operation_union;
     }
@@ -259,16 +259,16 @@ struct get_turn_info_for_endpoint
 
     template<typename Point1,
              typename Point2,
-             typename RetrievePolicy1,
-             typename RetrievePolicy2,
+             typename RetrieveAdditionalInfoPolicy1,
+             typename RetrieveAdditionalInfoPolicy2,
              typename TurnInfo,
              typename IntersectionInfo,
              typename OutputIterator
     >
     static inline bool apply(Point1 const& pi, Point1 const& pj,
                              Point2 const& qi, Point2 const& qj,
-                             RetrievePolicy1 const& retrieve_policy_p,
-                             RetrievePolicy2 const& retrieve_policy_q,
+                             RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
+                             RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
                              TurnInfo const& tp_model,
                              IntersectionInfo const& inters,
                              method_type /*method*/,
@@ -282,9 +282,9 @@ struct get_turn_info_for_endpoint
         }
 
         bool const is_p_first = retrieve_policy_p.is_first();
-        bool const is_p_last = retrieve_policy_p.is_last();
+        bool const is_p_last = ! retrieve_policy_p.has_k();
         bool const is_q_first = retrieve_policy_q.is_first();
-        bool const is_q_last = retrieve_policy_q.is_last();
+        bool const is_q_last = ! retrieve_policy_q.has_k();
 
         if (!is_p_first && !is_p_last && !is_q_first && !is_q_last)
         {
@@ -320,16 +320,16 @@ struct get_turn_info_for_endpoint
 
     template <typename Point1,
               typename Point2,
-              typename RetrievePolicy1,
-              typename RetrievePolicy2,
+              typename RetrieveAdditionalInfoPolicy1,
+              typename RetrieveAdditionalInfoPolicy2,
               typename TurnInfo,
               typename IntersectionInfo,
               typename OutputIterator>
     static inline
     bool analyse_segment_and_assign_ip(Point1 const& pi, Point1 const& pj,
                                        Point2 const& qi, Point2 const& qj,
-                                       RetrievePolicy1 const& retrieve_policy_p,
-                                       RetrievePolicy2 const& retrieve_policy_q,
+                                       RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
+                                       RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
                                        linear_intersections::ip_info const& ip_info,
                                        TurnInfo const& tp_model,
                                        IntersectionInfo const& inters,
@@ -348,9 +348,9 @@ struct get_turn_info_for_endpoint
 
         // TODO - calculate first/last only if needed
         bool const is_p_first = retrieve_policy_p.is_first();
-        bool const is_p_last = retrieve_policy_p.is_last();
+        bool const is_p_last = ! retrieve_policy_p.has_k();
         bool const is_q_first = retrieve_policy_q.is_first();
-        bool const is_q_last = retrieve_policy_q.is_last();
+        bool const is_q_last = ! retrieve_policy_q.has_k();
 
         bool is_p_first_ip = is_p_first && ip_info.is_pi;
         bool is_p_last_ip = is_p_last && ip_info.is_pj;

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
@@ -252,7 +252,7 @@ struct side_calculator_for_endpoint
 };
 
 
-template <typename AssignPolicy, bool EnableFirst, bool EnableLast>
+template <bool EnableFirst, bool EnableLast>
 struct get_turn_info_for_endpoint
 {
     BOOST_STATIC_ASSERT(EnableFirst || EnableLast);
@@ -376,11 +376,9 @@ struct get_turn_info_for_endpoint
                   && inters.i_info().count == 2
                   && inters.is_spike_p() )
                 {
-                    assign(range_q, range_q,
-                           inters.result(), ip_index, method, operation_blocked, q_operation,
+                    assign(inters.result(), ip_index, method, operation_blocked, q_operation,
                            p_pos, q_pos, is_p_first_ip, is_q_first_ip, true, false, tp_model, out);
-                    assign(range_q, range_q,
-                           inters.result(), ip_index, method, operation_intersection, q_operation,
+                    assign(inters.result(), ip_index, method, operation_intersection, q_operation,
                            p_pos, q_pos, is_p_first_ip, is_q_first_ip, true, false, tp_model, out);
                 }
                 // Q is spike and should be handled
@@ -388,18 +386,15 @@ struct get_turn_info_for_endpoint
                        && inters.i_info().count == 2
                        && inters.is_spike_q() )
                 {
-                    assign(range_q, range_q,
-                           inters.result(), ip_index, method, p_operation, operation_blocked,
+                    assign(inters.result(), ip_index, method, p_operation, operation_blocked,
                            p_pos, q_pos, is_p_first_ip, is_q_first_ip, false, true, tp_model, out);
-                    assign(range_q, range_q,
-                           inters.result(), ip_index, method, p_operation, operation_intersection,
+                    assign(inters.result(), ip_index, method, p_operation, operation_intersection,
                            p_pos, q_pos, is_p_first_ip, is_q_first_ip, false, true, tp_model, out);
                 }
                 // no spikes
                 else
                 {
-                    assign(range_q, range_q,
-                           inters.result(), ip_index, method, p_operation, q_operation,
+                    assign(inters.result(), ip_index, method, p_operation, q_operation,
                            p_pos, q_pos, is_p_first_ip, is_q_first_ip, false, false, tp_model, out);
                 }
             }
@@ -557,14 +552,10 @@ struct get_turn_info_for_endpoint
                ( is_ip_last_j ? position_back : position_middle );
     }
 
-    template <typename UniqueSubRange1,
-              typename UniqueSubRange2,
-              typename IntersectionResult,
+    template <typename IntersectionResult,
               typename TurnInfo,
               typename OutputIterator>
-    static inline void assign(UniqueSubRange1 const& range_p,
-                              UniqueSubRange2 const& range_q,
-                              IntersectionResult const& result,
+    static inline void assign(IntersectionResult const& result,
                               unsigned int ip_index,
                               method_type method,
                               operation_type op0, operation_type op1,
@@ -615,9 +606,6 @@ struct get_turn_info_for_endpoint
             }
         }
 
-        // TODO: this should get an intersection_info, which is unavailable here
-        // Because the assign_null policy accepts any structure, we pass the result instead for now
-        AssignPolicy::apply(tp, range_p.at(0), range_q.at(0), result);
         *out++ = tp;
     }
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
@@ -231,24 +231,33 @@ struct get_turn_info_for_endpoint
              typename Point2,
              typename TurnInfo,
              typename IntersectionInfo,
+             typename RetrievePolicy,
              typename OutputIterator
     >
     static inline bool apply(Point1 const& pi, Point1 const& pj, Point1 const& pk,
                              Point2 const& qi, Point2 const& qj, Point2 const& qk,
-                             bool is_p_first, bool is_p_last,
-                             bool is_q_first, bool is_q_last,
                              TurnInfo const& tp_model,
                              IntersectionInfo const& inters,
+                             RetrievePolicy const& retrieve_policy,
                              method_type /*method*/,
                              OutputIterator out)
     {
         std::size_t ip_count = inters.i_info().count;
         // no intersection points
-        if ( ip_count == 0 )
+        if (ip_count == 0)
+        {
             return false;
+        }
 
-        if ( !is_p_first && !is_p_last && !is_q_first && !is_q_last )
+        bool const is_p_first = retrieve_policy.is_first(0);
+        bool const is_p_last = retrieve_policy.is_last(0);
+        bool const is_q_first = retrieve_policy.is_first(1);
+        bool const is_q_last = retrieve_policy.is_last(1);
+
+        if (!is_p_first && !is_p_last && !is_q_first && !is_q_last)
+        {
             return false;
+        }
 
         linear_intersections intersections(pi, qi, inters.result(), is_p_last, is_q_last);
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
@@ -231,14 +231,16 @@ struct get_turn_info_for_endpoint
              typename Point2,
              typename TurnInfo,
              typename IntersectionInfo,
-             typename RetrievePolicy,
+             typename RetrievePolicy1,
+             typename RetrievePolicy2,
              typename OutputIterator
     >
     static inline bool apply(Point1 const& pi, Point1 const& pj, Point1 const& pk,
                              Point2 const& qi, Point2 const& qj, Point2 const& qk,
                              TurnInfo const& tp_model,
                              IntersectionInfo const& inters,
-                             RetrievePolicy const& retrieve_policy,
+                             RetrievePolicy1 const& retrieve_policy_p,
+                             RetrievePolicy2 const& retrieve_policy_q,
                              method_type /*method*/,
                              OutputIterator out)
     {
@@ -249,10 +251,10 @@ struct get_turn_info_for_endpoint
             return false;
         }
 
-        bool const is_p_first = retrieve_policy.is_first(0);
-        bool const is_p_last = retrieve_policy.is_last(0);
-        bool const is_q_first = retrieve_policy.is_first(1);
-        bool const is_q_last = retrieve_policy.is_last(1);
+        bool const is_p_first = retrieve_policy_p.is_first();
+        bool const is_p_last = retrieve_policy_p.is_last();
+        bool const is_q_first = retrieve_policy_q.is_first();
+        bool const is_q_last = retrieve_policy_q.is_last();
 
         if (!is_p_first && !is_p_last && !is_q_first && !is_q_last)
         {

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
@@ -278,17 +278,17 @@ struct get_turn_info_for_endpoint
         }
 
         bool const is_p_first = range_p.is_first();
-        bool const is_p_last = ! range_p.has_k();
+        bool const is_p_last = range_p.size() == 2u;
         bool const is_q_first = range_q.is_first();
-        bool const is_q_last = ! range_q.has_k();
+        bool const is_q_last = range_q.size() == 2u;
 
         if (!is_p_first && !is_p_last && !is_q_first && !is_q_last)
         {
             return false;
         }
 
-        linear_intersections intersections(range_p.get_point_i(),
-                                           range_q.get_point_i(),
+        linear_intersections intersections(range_p.at(0),
+                                           range_q.at(0),
                                            inters.result(), is_p_last, is_q_last);
 
         bool append0_last
@@ -332,9 +332,9 @@ struct get_turn_info_for_endpoint
     {
         // TODO - calculate first/last only if needed
         bool const is_p_first = range_p.is_first();
-        bool const is_p_last = ! range_p.has_k();
+        bool const is_p_last = range_p.size() == 2u;
         bool const is_q_first = range_q.is_first();
-        bool const is_q_last = ! range_q.has_k();
+        bool const is_q_last = range_q.size() == 2u;
 
         bool is_p_first_ip = is_p_first && ip_info.is_pi;
         bool is_p_last_ip = is_p_last && ip_info.is_pj;
@@ -623,7 +623,7 @@ struct get_turn_info_for_endpoint
 
         // TODO: this should get an intersection_info, which is unavailable here
         // Because the assign_null policy accepts any structure, we pass the result instead for now
-        AssignPolicy::apply(tp, range_p.get_point_i(), range_q.get_point_i(), result);
+        AssignPolicy::apply(tp, range_p.at(0), range_q.at(0), result);
         *out++ = tp;
     }
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
@@ -198,23 +198,23 @@ public:
 private:
 
     // only if collinear (same_dirs)
-    static inline operation_type union_or_blocked_same_dirs(int arrival, bool has_k)
+    static inline operation_type union_or_blocked_same_dirs(int arrival, bool is_last)
     {
         if ( arrival == 1 )
             return operation_blocked;
         else if ( arrival == -1 )
             return operation_union;
         else
-            return has_k ? operation_blocked : operation_union;
+            return is_last ? operation_blocked : operation_union;
             //return operation_blocked;
     }
 
     // only if not collinear (!same_dirs)
-    static inline operation_type union_or_blocked_different_dirs(int arrival, bool has_k)
+    static inline operation_type union_or_blocked_different_dirs(int arrival, bool is_last)
     {
         if ( arrival == 1 )
             //return operation_blocked;
-            return has_k ? operation_blocked : operation_union;
+            return is_last ? operation_blocked : operation_union;
         else
             return operation_union;
     }

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
@@ -413,12 +413,14 @@ struct get_turn_info_for_endpoint
                 }
                 else if ( ip_j2 )
                 {
-                    int const side_pk_q2 = sides.apply(range2.at(1), range2.at(2), range1.at(1));
-                    int const side_pk_p = sides.apply(range2.at(0), range1.at(0), range1.at(1));
-                    int const side_qk_p = sides.apply(range2.at(0), range1.at(0), range2.at(2));
+                    // TODO: find out why side is used with respect to non-segments
+                    // (that is: range2.at(0) to range1.at(0), denoted as x)
+                    int const side_pj_q2 = sides.apply(range2.at(1), range2.at(2), range1.at(1));
+                    int const side_pj_x = sides.apply(range2.at(0), range1.at(0), range1.at(1));
+                    int const side_qk_x = sides.apply(range2.at(0), range1.at(0), range2.at(2));
 
                     std::pair<operation_type, operation_type>
-                        operations = operations_of_equal(side_pk_q2, side_pk_p, side_qk_p);
+                        operations = operations_of_equal(side_pj_q2, side_pj_x, side_qk_x);
 
 // TODO: must the above be calculated?
 // wouldn't it be enough to check if segments are collinear?
@@ -465,12 +467,12 @@ struct get_turn_info_for_endpoint
                 }
                 else if ( ip_j2 )
                 {
-                    int const side_pk_q2 = sides.apply(range2.at(1), range2.at(2), range1.at(0));
-                    int const side_pk_p = sides.apply(range2.at(0), range1.at(1), range1.at(0));
-                    int const side_qk_p = sides.apply(range2.at(0), range1.at(1), range2.at(2));
+                    int const side_pi_q2 = sides.apply(range2.at(1), range2.at(2), range1.at(0));
+                    int const side_pi_x = sides.apply(range2.at(0), range1.at(1), range1.at(0));
+                    int const side_qk_x = sides.apply(range2.at(0), range1.at(1), range2.at(2));
 
                     std::pair<operation_type, operation_type>
-                        operations = operations_of_equal(side_pk_q2, side_pk_p, side_qk_p);
+                        operations = operations_of_equal(side_pi_q2, side_pi_x, side_qk_x);
 
 // TODO: must the above be calculated?
 // wouldn't it be enough to check if segments are collinear?

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
@@ -277,19 +277,20 @@ struct get_turn_info_for_endpoint
             return false;
         }
 
-        bool const is_p_first = range_p.is_first();
-        bool const is_p_last = range_p.size() == 2u;
-        bool const is_q_first = range_q.is_first();
-        bool const is_q_last = range_q.size() == 2u;
-
-        if (!is_p_first && !is_p_last && !is_q_first && !is_q_last)
+        if (! range_p.is_first()
+            && ! range_q.is_first()
+            && range_p.size() > 2u
+            && range_q.size() > 2u)
         {
+            // Not an end-point from segment p or q
             return false;
         }
 
         linear_intersections intersections(range_p.at(0),
                                            range_q.at(0),
-                                           inters.result(), is_p_last, is_q_last);
+                                           inters.result(),
+                                           range_p.size() == 2u,
+                                           range_q.size() == 2u);
 
         bool append0_last
             = analyse_segment_and_assign_ip(range_p, range_q,
@@ -331,15 +332,10 @@ struct get_turn_info_for_endpoint
                                        OutputIterator out)
     {
         // TODO - calculate first/last only if needed
-        bool const is_p_first = range_p.is_first();
-        bool const is_p_last = range_p.size() == 2u;
-        bool const is_q_first = range_q.is_first();
-        bool const is_q_last = range_q.size() == 2u;
-
-        bool is_p_first_ip = is_p_first && ip_info.is_pi;
-        bool is_p_last_ip = is_p_last && ip_info.is_pj;
-        bool is_q_first_ip = is_q_first && ip_info.is_qi;
-        bool is_q_last_ip = is_q_last && ip_info.is_qj;
+        bool is_p_first_ip = range_p.is_first() && ip_info.is_pi;
+        bool is_p_last_ip = range_p.size() == 2u && ip_info.is_pj;
+        bool is_q_first_ip = range_q.is_first() && ip_info.is_qi;
+        bool is_q_last_ip = range_q.size() == 2u && ip_info.is_qj;
         bool append_first = EnableFirst && (is_p_first_ip || is_q_first_ip);
         bool append_last = EnableLast && (is_p_last_ip || is_q_last_ip);
 
@@ -376,8 +372,7 @@ struct get_turn_info_for_endpoint
                 // handle spikes
 
                 // P is spike and should be handled
-                if ( !is_p_last
-                  && ip_info.is_pj // this check is redundant (also in is_spike_p) but faster
+                if (ip_info.is_pj // this check is redundant (also in is_spike_p) but faster
                   && inters.i_info().count == 2
                   && inters.is_spike_p() )
                 {
@@ -389,8 +384,7 @@ struct get_turn_info_for_endpoint
                            p_pos, q_pos, is_p_first_ip, is_q_first_ip, true, false, tp_model, out);
                 }
                 // Q is spike and should be handled
-                else if ( !is_q_last
-                       && ip_info.is_qj // this check is redundant (also in is_spike_q) but faster
+                else if (ip_info.is_qj // this check is redundant (also in is_spike_q) but faster
                        && inters.i_info().count == 2
                        && inters.is_spike_q() )
                 {

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
@@ -14,6 +14,7 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_TURN_INFO_HELPERS_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_TURN_INFO_HELPERS_HPP
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/policies/robustness/no_rescale_policy.hpp>
 #include <boost/geometry/algorithms/detail/direction_code.hpp>
 
@@ -103,6 +104,7 @@ struct robust_subrange_adapter
     //! Get precalculated point
     Point const& at(std::size_t index) const
     {
+        BOOST_GEOMETRY_ASSERT(index < size());
         switch (index)
         {
             case 0 : return m_robust_point_i;

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
@@ -428,8 +428,10 @@ public:
                 return false;
             }
 
-            int const qk_p1 = base::sides().qk_wrt_p1();
-            int const qk_p2 = base::sides().qk_wrt_p2();
+            // TODO: why is q used to determine spike property in p?
+            bool const has_qk = base::m_range_q.size() != 2u;
+            int const qk_p1 = has_qk ? base::sides().qk_wrt_p1() : 0;
+            int const qk_p2 = has_qk ? base::sides().qk_wrt_p2() : 0;
 
             if (qk_p1 == -qk_p2)
             {
@@ -464,8 +466,10 @@ public:
                 return false;
             }
 
-            int const pk_q1 = base::sides().pk_wrt_q1();
-            int const pk_q2 = base::sides().pk_wrt_q2();
+            // TODO: why is p used to determine spike property in q?
+            bool const has_pk = base::m_range_p.size() != 2u;
+            int const pk_q1 = has_pk ? base::sides().pk_wrt_q1() : 0;
+            int const pk_q2 = has_pk ? base::sides().pk_wrt_q2() : 0;
                 
             if (pk_q1 == -pk_q2)
             {

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
@@ -74,7 +74,7 @@ struct side_calculator
     inline point2_type const& get_qj() const { return m_range_q.at(1); }
     inline point2_type const& get_qk() const { return m_range_q.at(2); }
 
-    // Used side-strategy, owned by thie calculator,
+    // Used side-strategy, owned by the calculator,
     // created from .get_side_strategy()
     SideStrategy m_side_strategy;
 
@@ -414,7 +414,7 @@ public:
     // TODO: it's more like is_spike_ip_p
     inline bool is_spike_p() const
     {
-        if (base::m_range_p.size() == 2u)
+        if (base::m_range_p.is_last_segment())
         {
             return false;
         }
@@ -429,7 +429,7 @@ public:
             }
 
             // TODO: why is q used to determine spike property in p?
-            bool const has_qk = base::m_range_q.size() != 2u;
+            bool const has_qk = ! base::m_range_q.is_last_segment();
             int const qk_p1 = has_qk ? base::sides().qk_wrt_p1() : 0;
             int const qk_p2 = has_qk ? base::sides().qk_wrt_p2() : 0;
 
@@ -453,7 +453,7 @@ public:
 
     inline bool is_spike_q() const
     {
-        if (base::m_range_q.size() == 2u)
+        if (base::m_range_q.is_last_segment())
         {
             return false;
         }
@@ -467,7 +467,7 @@ public:
             }
 
             // TODO: why is p used to determine spike property in q?
-            bool const has_pk = base::m_range_p.size() != 2u;
+            bool const has_pk = ! base::m_range_p.is_last_segment();
             int const pk_q1 = has_pk ? base::sides().pk_wrt_q1() : 0;
             int const pk_q2 = has_pk ? base::sides().pk_wrt_q2() : 0;
                 

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
@@ -111,7 +111,6 @@ struct robust_points
             Point1, RobustPolicy
         >::type robust_point1_type;
 
-    // TODO: define robust_point2_type using Point2?
     typedef robust_point1_type robust_point2_type;
 
     inline robust_points(Point1 const& pi, Point1 const& pj, Point1 const& pk,
@@ -177,17 +176,11 @@ public:
                       base::m_rqi, base::m_rqj,
                       m_robust_retrieve_policy_p, m_robust_retrieve_policy_q,
                       intersection_strategy.get_side_strategy())
-        , m_pi(pi), m_pj(pj), m_pk(retrieve_policy_p.get())
-        , m_qi(qi), m_qj(qj), m_qk(retrieve_policy_q.get())
+        , m_pi(pi), m_qi(qi)
     {}
 
     inline Point1 const& pi() const { return m_pi; }
-    inline Point1 const& pj() const { return m_pj; }
-    inline Point1 const& pk() const { return m_pk; }
-
     inline Point2 const& qi() const { return m_qi; }
-    inline Point2 const& qj() const { return m_qj; }
-    inline Point2 const& qk() const { return m_qk; }
 
     inline robust_point1_type const& rpi() const { return base::m_rpi; }
     inline robust_point1_type const& rpj() const { return base::m_rpj; }
@@ -201,8 +194,7 @@ public:
     
     robust_swapped_side_calculator_type get_swapped_sides() const
     {
-        robust_swapped_side_calculator_type result(base::m_rqi, base::m_rqj,
-                            base::m_rpi, base::m_rpj,
+        robust_swapped_side_calculator_type result(rqi(), rqj(), rpi(), rpj(),
                             m_robust_retrieve_policy_q, m_robust_retrieve_policy_p,
                             m_side_calc.m_side_strategy);
         return result;
@@ -214,11 +206,7 @@ private:
     side_calculator_type m_side_calc;
 
     point1_type const& m_pi;
-    point1_type const& m_pj;
-    point1_type const& m_pk;
     point2_type const& m_qi;
-    point2_type const& m_qj;
-    point2_type const& m_qk;
 };
 
 template
@@ -264,20 +252,15 @@ public:
     {}
 
     inline Point1 const& pi() const { return m_side_calc.m_pi; }
-    inline Point1 const& pj() const { return m_side_calc.m_pj; }
-    inline Point1 const& pk() const { return m_side_calc.m_pk; }
-
     inline Point2 const& qi() const { return m_side_calc.m_qi; }
-    inline Point2 const& qj() const { return m_side_calc.m_qj; }
-    inline Point2 const& qk() const { return m_side_calc.m_qk; }
 
-    inline Point1 const& rpi() const { return pi(); }
-    inline Point1 const& rpj() const { return pj(); }
-    inline Point1 const& rpk() const { return pk(); }
+    inline Point1 const& rpi() const { return m_side_calc.m_pi; }
+    inline Point1 const& rpj() const { return m_side_calc.m_pj; }
+    inline Point1 const& rpk() const { return m_side_calc.m_pk; }
 
-    inline Point2 const& rqi() const { return qi(); }
-    inline Point2 const& rqj() const { return qj(); }
-    inline Point2 const& rqk() const { return qk(); }
+    inline Point2 const& rqi() const { return m_side_calc.m_qi; }
+    inline Point2 const& rqj() const { return m_side_calc.m_qj; }
+    inline Point2 const& rqk() const { return m_side_calc.m_qk; }
 
     inline side_calculator_type const& sides() const { return m_side_calc; }
 
@@ -394,7 +377,7 @@ public:
                 {
                     // qk is collinear with both p1 and p2,
                     // verify if pk goes backwards w.r.t. pi/pj
-                    return direction_code(base::pi(), base::pj(), base::pk()) == -1;
+                    return direction_code(base::rpi(), base::rpj(), base::rpk()) == -1;
                 }
 
                 // qk is at opposite side of p1/p2, therefore
@@ -423,7 +406,7 @@ public:
             {
                 if (pk_q1 == 0)
                 {
-                    return direction_code(base::qi(), base::qj(), base::qk()) == -1;
+                    return direction_code(base::rqi(), base::rqj(), base::rqk()) == -1;
                 }
                         
                 return true;

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
@@ -301,9 +301,6 @@ public:
                       intersection_strategy.get_side_strategy())
     {}
 
-    inline point1_type const& pi() const { return m_side_calc.get_pi(); }
-    inline point2_type const& qi() const { return m_side_calc.get_qi(); }
-
     inline point1_type const& rpi() const { return m_side_calc.get_pi(); }
     inline point1_type const& rpj() const { return m_side_calc.get_pj(); }
     inline point1_type const& rpk() const { return m_side_calc.get_pk(); }

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
@@ -113,7 +113,13 @@ public:
 
     typedef typename IntersectionStrategy::side_strategy_type side_strategy_type;
     typedef side_calculator<cs_tag, robust_point1_type, robust_point2_type, side_strategy_type> side_calculator_type;
-    
+
+    typedef side_calculator
+        <
+            cs_tag, robust_point2_type, robust_point1_type,
+            side_strategy_type
+        > robust_swapped_side_calculator_type;
+
     intersection_info_base(Point1 const& pi, Point1 const& pj, Point1 const& pk,
                            Point2 const& qi, Point2 const& qj, Point2 const& qk,
                            IntersectionStrategy const& intersection_strategy,
@@ -144,6 +150,13 @@ public:
 
     inline side_calculator_type const& sides() const { return m_side_calc; }
     
+    robust_swapped_side_calculator_type get_swapped_sides() const
+    {
+        robust_swapped_side_calculator_type result(base::m_rqi, base::m_rqj, base::m_rqk,
+                            base::m_rpi, base::m_rpj, base::m_rpk, m_side_calc.m_side_strategy);
+        return result;
+    }
+
 private:
     side_calculator_type m_side_calc;
 
@@ -169,6 +182,12 @@ public:
 
     typedef typename IntersectionStrategy::side_strategy_type side_strategy_type;
     typedef side_calculator<cs_tag, Point1, Point2, side_strategy_type> side_calculator_type;
+
+    typedef side_calculator
+        <
+            cs_tag, robust_point2_type, robust_point1_type,
+            side_strategy_type
+        > robust_swapped_side_calculator_type;
     
     intersection_info_base(Point1 const& pi, Point1 const& pj, Point1 const& pk,
                            Point2 const& qi, Point2 const& qj, Point2 const& qk,
@@ -195,7 +214,16 @@ public:
     inline Point2 const& rqk() const { return qk(); }
 
     inline side_calculator_type const& sides() const { return m_side_calc; }
-    
+
+    robust_swapped_side_calculator_type get_swapped_sides() const
+    {
+        robust_swapped_side_calculator_type result(m_side_calc.m_qi,
+            m_side_calc.m_qj, m_side_calc.m_qk,
+            m_side_calc.m_pi, m_side_calc.m_pj, m_side_calc.m_pk,
+            m_side_calc.m_side_strategy);
+        return result;
+    }
+
 private:
     side_calculator_type m_side_calc;
 };

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
@@ -37,10 +37,13 @@ struct turn_operation_linear
     bool is_collinear; // valid only for Linear geometry
 };
 
-template <typename TurnPointCSTag, typename PointP, typename PointQ,
-          typename SideStrategy,
-          typename Pi = PointP, typename Pj = PointP, typename Pk = PointP,
-          typename Qi = PointQ, typename Qj = PointQ, typename Qk = PointQ
+template
+<
+    typename TurnPointCSTag, typename PointP, typename PointQ,
+    typename RetrievePolicy1, typename RetrievePolicy2,
+    typename SideStrategy,
+    typename Pi = PointP, typename Pj = PointP, typename Pk = PointP,
+    typename Qi = PointQ, typename Qj = PointQ, typename Qk = PointQ
 >
 struct side_calculator
 {
@@ -70,7 +73,12 @@ struct side_calculator
     SideStrategy m_side_strategy;
 };
 
-template <typename Point1, typename Point2, typename RobustPolicy>
+template
+<
+    typename Point1, typename Point2,
+    typename RetrievePolicy1, typename RetrievePolicy2,
+    typename RobustPolicy
+>
 struct robust_points
 {
     typedef typename geometry::robust_point_type
@@ -97,11 +105,15 @@ struct robust_points
     robust_point2_type m_rqi, m_rqj, m_rqk;
 };
 
-template <typename Point1, typename Point2, typename TurnPoint, typename IntersectionStrategy, typename RobustPolicy>
+template
+<
+    typename Point1, typename Point2,
+    typename RetrievePolicy1, typename RetrievePolicy2,
+    typename TurnPoint, typename IntersectionStrategy, typename RobustPolicy>
 class intersection_info_base
-    : private robust_points<Point1, Point2, RobustPolicy>
+    : private robust_points<Point1, Point2, RetrievePolicy1, RetrievePolicy2, RobustPolicy>
 {
-    typedef robust_points<Point1, Point2, RobustPolicy> base;
+    typedef robust_points<Point1, Point2, RetrievePolicy1, RetrievePolicy2, RobustPolicy> base;
 
 public:
     typedef Point1 point1_type;
@@ -113,11 +125,13 @@ public:
     typedef typename cs_tag<TurnPoint>::type cs_tag;
 
     typedef typename IntersectionStrategy::side_strategy_type side_strategy_type;
-    typedef side_calculator<cs_tag, robust_point1_type, robust_point2_type, side_strategy_type> side_calculator_type;
+    typedef side_calculator<cs_tag, robust_point1_type, robust_point2_type,
+        RetrievePolicy1, RetrievePolicy2, side_strategy_type> side_calculator_type;
 
     typedef side_calculator
         <
             cs_tag, robust_point2_type, robust_point1_type,
+            RetrievePolicy2, RetrievePolicy1,
             side_strategy_type
         > robust_swapped_side_calculator_type;
 
@@ -169,8 +183,14 @@ private:
     point2_type const& m_qk;
 };
 
-template <typename Point1, typename Point2, typename TurnPoint, typename IntersectionStrategy>
-class intersection_info_base<Point1, Point2, TurnPoint, IntersectionStrategy, detail::no_rescale_policy>
+template
+<
+    typename Point1, typename Point2,
+    typename RetrievePolicy1, typename RetrievePolicy2,
+    typename TurnPoint, typename IntersectionStrategy
+>
+class intersection_info_base<Point1, Point2, RetrievePolicy1, RetrievePolicy2,
+        TurnPoint, IntersectionStrategy, detail::no_rescale_policy>
 {
 public:
     typedef Point1 point1_type;
@@ -182,11 +202,13 @@ public:
     typedef typename cs_tag<TurnPoint>::type cs_tag;
 
     typedef typename IntersectionStrategy::side_strategy_type side_strategy_type;
-    typedef side_calculator<cs_tag, Point1, Point2, side_strategy_type> side_calculator_type;
+    typedef side_calculator<cs_tag, Point1, Point2,
+        RetrievePolicy1, RetrievePolicy2, side_strategy_type> side_calculator_type;
 
     typedef side_calculator
         <
             cs_tag, robust_point2_type, robust_point1_type,
+            RetrievePolicy2, RetrievePolicy1,
             side_strategy_type
         > robust_swapped_side_calculator_type;
     
@@ -232,16 +254,18 @@ private:
 
 template
 <
-    typename Point1,
-    typename Point2,
+    typename Point1, typename Point2,
+    typename RetrievePolicy1, typename RetrievePolicy2,
     typename TurnPoint,
     typename IntersectionStrategy,
     typename RobustPolicy
 >
 class intersection_info
-    : public intersection_info_base<Point1, Point2, TurnPoint, IntersectionStrategy, RobustPolicy>
+    : public intersection_info_base<Point1, Point2, RetrievePolicy1, RetrievePolicy2,
+        TurnPoint, IntersectionStrategy, RobustPolicy>
 {
-    typedef intersection_info_base<Point1, Point2, TurnPoint, IntersectionStrategy, RobustPolicy> base;
+    typedef intersection_info_base<Point1, Point2, RetrievePolicy1, RetrievePolicy2,
+        TurnPoint, IntersectionStrategy, RobustPolicy> base;
 
 public:
     typedef segment_intersection_points

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
@@ -93,6 +93,8 @@ struct robust_subrange_adapter
         , m_k_retrieved(false)
     {}
 
+    std::size_t size() const { return m_unique_sub_range.size(); }
+
     //! Get precalculated point
     Point const& at(std::size_t index) const
     {
@@ -254,9 +256,9 @@ public:
         return result;
     }
 
-private:
     UniqueSubRange1 const& m_range_p;
     UniqueSubRange2 const& m_range_q;
+private :
     robust_subrange1 m_robust_range_p;
     robust_subrange2 m_robust_range_q;
     side_calculator_type m_side_calc;
@@ -319,9 +321,10 @@ public:
         return result;
     }
 
-private:
+protected :
     UniqueSubRange1 const& m_range_p;
     UniqueSubRange2 const& m_range_q;
+private :
     side_calculator_type m_side_calc;
 };
 
@@ -403,6 +406,10 @@ public:
     // TODO: it's more like is_spike_ip_p
     inline bool is_spike_p() const
     {
+        if (base::m_range_p.size() == 2u)
+        {
+            return false;
+        }
         if (base::sides().pk_wrt_p1() == 0)
         {
             // p:  pi--------pj--------pk
@@ -436,6 +443,11 @@ public:
 
     inline bool is_spike_q() const
     {
+        if (base::m_range_q.size() == 2u)
+        {
+            return false;
+        }
+
         // See comments at is_spike_p
         if (base::sides().qk_wrt_q1() == 0)
         {

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
@@ -73,7 +73,7 @@ struct side_calculator
     PointQ const& m_qi;
     PointQ const& m_qj;
 
-    SideStrategy const& m_side_strategy;
+    SideStrategy m_side_strategy; // NOTE: cannot be const&
     RetrievePolicy1 const& m_retrieve_policy_p;
     RetrievePolicy2 const& m_retrieve_policy_q;
 };

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
@@ -50,8 +50,8 @@ struct side_calculator
                            RetrievePolicy1 const& retrieve_policy_p,
                            RetrievePolicy2 const& retrieve_policy_q,
                            SideStrategy const& side_strategy)
-        : m_pi(pi), m_pj(pj), m_pk(retrieve_policy_p.get())
-        , m_qi(qi), m_qj(qj), m_qk(retrieve_policy_q.get())
+        : m_pi(pi), m_pj(pj)
+        , m_qi(qi), m_qj(qj)
         , m_side_strategy(side_strategy)
         , m_retrieve_policy_p(retrieve_policy_p)
         , m_retrieve_policy_q(retrieve_policy_q)
@@ -65,17 +65,15 @@ struct side_calculator
     inline int pk_wrt_q2() const { return m_side_strategy.apply(m_qj, get_qk(), get_pk()); }
     inline int qk_wrt_p2() const { return m_side_strategy.apply(m_pj, get_pk(), get_qk()); }
 
-    inline PointP get_pk() const { return m_retrieve_policy_p.get(); }
-    inline PointQ get_qk() const { return m_retrieve_policy_q.get(); }
+    inline PointP const& get_pk() const { return m_retrieve_policy_p.get(); }
+    inline PointQ const& get_qk() const { return m_retrieve_policy_q.get(); }
 
     PointP const& m_pi;
     PointP const& m_pj;
-    PointP m_pk;
     PointQ const& m_qi;
     PointQ const& m_qj;
-    PointQ m_qk;
 
-    SideStrategy m_side_strategy;
+    SideStrategy const& m_side_strategy;
     RetrievePolicy1 const& m_retrieve_policy_p;
     RetrievePolicy2 const& m_retrieve_policy_q;
 };
@@ -88,17 +86,23 @@ struct robust_retriever
 
         : m_retrieve_policy(retrieve_policy)
         , m_robust_policy(robust_policy)
+        , m_retrieved(false)
     {}
 
-    Point get() const
+    Point const& get() const
     {
-        Point result;
-        geometry::recalculate(result, m_retrieve_policy.get(), m_robust_policy);
-        return result;
+        if (! m_retrieved)
+        {
+            geometry::recalculate(m_result, m_retrieve_policy.get(), m_robust_policy);
+            m_retrieved = true;
+        }
+        return m_result;
     }
 
     RetrievePolicy const& m_retrieve_policy;
     RobustPolicy const& m_robust_policy;
+    mutable Point m_result;
+    mutable bool m_retrieved;
 };
 
 template
@@ -259,11 +263,11 @@ public:
 
     inline Point1 const& rpi() const { return m_side_calc.m_pi; }
     inline Point1 const& rpj() const { return m_side_calc.m_pj; }
-    inline Point1 rpk() const { return m_side_calc.get_pk(); }
+    inline Point1 const& rpk() const { return m_side_calc.get_pk(); }
 
     inline Point2 const& rqi() const { return m_side_calc.m_qi; }
     inline Point2 const& rqj() const { return m_side_calc.m_qj; }
-    inline Point2 rqk() const { return m_side_calc.get_qk(); }
+    inline Point2 const& rqk() const { return m_side_calc.get_qk(); }
 
     inline side_calculator_type const& sides() const { return m_side_calc; }
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
@@ -57,13 +57,16 @@ struct side_calculator
         , m_retrieve_policy_q(retrieve_policy_q)
     {}
 
-    inline int pk_wrt_p1() const { return m_side_strategy.apply(m_pi, m_pj, m_pk); }
-    inline int pk_wrt_q1() const { return m_side_strategy.apply(m_qi, m_qj, m_pk); }
-    inline int qk_wrt_p1() const { return m_side_strategy.apply(m_pi, m_pj, m_qk); }
-    inline int qk_wrt_q1() const { return m_side_strategy.apply(m_qi, m_qj, m_qk); }
+    inline int pk_wrt_p1() const { return m_side_strategy.apply(m_pi, m_pj, get_pk()); }
+    inline int pk_wrt_q1() const { return m_side_strategy.apply(m_qi, m_qj, get_pk()); }
+    inline int qk_wrt_p1() const { return m_side_strategy.apply(m_pi, m_pj, get_qk()); }
+    inline int qk_wrt_q1() const { return m_side_strategy.apply(m_qi, m_qj, get_qk()); }
 
-    inline int pk_wrt_q2() const { return m_side_strategy.apply(m_qj, m_qk, m_pk); }
-    inline int qk_wrt_p2() const { return m_side_strategy.apply(m_pj, m_pk, m_qk); }
+    inline int pk_wrt_q2() const { return m_side_strategy.apply(m_qj, get_qk(), get_pk()); }
+    inline int qk_wrt_p2() const { return m_side_strategy.apply(m_pj, get_pk(), get_qk()); }
+
+    inline PointP get_pk() const { return m_retrieve_policy_p.get(); }
+    inline PointQ get_qk() const { return m_retrieve_policy_q.get(); }
 
     PointP const& m_pi;
     PointP const& m_pj;
@@ -233,10 +236,10 @@ public:
 
     typedef side_calculator
         <
-            cs_tag, robust_point2_type, robust_point1_type,
+            cs_tag, point2_type, point1_type,
             RetrievePolicy2, RetrievePolicy1,
             side_strategy_type
-        > robust_swapped_side_calculator_type;
+        > swapped_side_calculator_type;
     
     intersection_info_base(Point1 const& pi, Point1 const& pj,
                            Point2 const& qi, Point2 const& qj,
@@ -256,17 +259,17 @@ public:
 
     inline Point1 const& rpi() const { return m_side_calc.m_pi; }
     inline Point1 const& rpj() const { return m_side_calc.m_pj; }
-    inline Point1 const& rpk() const { return m_side_calc.m_pk; }
+    inline Point1 rpk() const { return m_side_calc.get_pk(); }
 
     inline Point2 const& rqi() const { return m_side_calc.m_qi; }
     inline Point2 const& rqj() const { return m_side_calc.m_qj; }
-    inline Point2 const& rqk() const { return m_side_calc.m_qk; }
+    inline Point2 rqk() const { return m_side_calc.get_qk(); }
 
     inline side_calculator_type const& sides() const { return m_side_calc; }
 
-    robust_swapped_side_calculator_type get_swapped_sides() const
+    swapped_side_calculator_type get_swapped_sides() const
     {
-        robust_swapped_side_calculator_type result(m_side_calc.m_qi, m_side_calc.m_qj,
+        swapped_side_calculator_type result(m_side_calc.m_qi, m_side_calc.m_qj,
             m_side_calc.m_pi, m_side_calc.m_pj,
             m_retrieve_policy_q, m_retrieve_policy_p,
             m_side_calc.m_side_strategy);

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
@@ -40,13 +40,14 @@ struct turn_operation_linear
 template
 <
     typename TurnPointCSTag,
-    typename UniqueSubRange1, typename UniqueSubRange2,
+    typename UniqueSubRange1,
+    typename UniqueSubRange2,
     typename SideStrategy
 >
 struct side_calculator
 {
-    typedef typename UniqueSubRange1::point_type PointP;
-    typedef typename UniqueSubRange2::point_type PointQ;
+    typedef typename UniqueSubRange1::point_type point1_type;
+    typedef typename UniqueSubRange2::point_type point2_type;
 
     inline side_calculator(UniqueSubRange1 const& range_p,
                            UniqueSubRange2 const& range_q,
@@ -64,13 +65,13 @@ struct side_calculator
     inline int pk_wrt_q2() const { return m_side_strategy.apply(get_qj(), get_qk(), get_pk()); }
     inline int qk_wrt_p2() const { return m_side_strategy.apply(get_pj(), get_pk(), get_qk()); }
 
-    inline PointP const& get_pi() const { return m_range_p.at(0); }
-    inline PointP const& get_pj() const { return m_range_p.at(1); }
-    inline PointP const& get_pk() const { return m_range_p.at(2); }
+    inline point1_type const& get_pi() const { return m_range_p.at(0); }
+    inline point1_type const& get_pj() const { return m_range_p.at(1); }
+    inline point1_type const& get_pk() const { return m_range_p.at(2); }
 
-    inline PointQ const& get_qi() const { return m_range_q.at(0); }
-    inline PointQ const& get_qj() const { return m_range_q.at(1); }
-    inline PointQ const& get_qk() const { return m_range_q.at(2); }
+    inline point2_type const& get_qi() const { return m_range_q.at(0); }
+    inline point2_type const& get_qj() const { return m_range_q.at(1); }
+    inline point2_type const& get_qk() const { return m_range_q.at(2); }
 
     SideStrategy m_side_strategy; // NOTE: cannot be const&
     UniqueSubRange1 const& m_range_p;

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
@@ -73,7 +73,11 @@ struct side_calculator
     inline point2_type const& get_qj() const { return m_range_q.at(1); }
     inline point2_type const& get_qk() const { return m_range_q.at(2); }
 
-    SideStrategy m_side_strategy; // NOTE: cannot be const&
+    // Used side-strategy, owned by thie calculator,
+    // created from .get_side_strategy()
+    SideStrategy m_side_strategy;
+
+    // Used ranges - owned by get_turns or (for robust points) by intersection_info_base
     UniqueSubRange1 const& m_range_p;
     UniqueSubRange2 const& m_range_q;
 };
@@ -257,9 +261,11 @@ public:
         return result;
     }
 
+    // Owned by get_turns
     UniqueSubRange1 const& m_range_p;
     UniqueSubRange2 const& m_range_q;
 private :
+    // Owned by this class
     robust_subrange1 m_robust_range_p;
     robust_subrange2 m_robust_range_q;
     side_calculator_type m_side_calc;
@@ -320,9 +326,11 @@ public:
     }
 
 protected :
+    // Owned by get_turns
     UniqueSubRange1 const& m_range_p;
     UniqueSubRange2 const& m_range_q;
 private :
+    // Owned here, passed by .get_side_strategy()
     side_calculator_type m_side_calc;
 };
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -41,8 +41,6 @@ struct get_turn_info_linear_areal
 
     template
     <
-        typename Point1,
-        typename Point2,
         typename TurnInfo,
         typename IntersectionStrategy,
         typename RetrieveAdditionalInfoPolicy1,
@@ -51,8 +49,6 @@ struct get_turn_info_linear_areal
         typename OutputIterator
     >
     static inline OutputIterator apply(
-                Point1 const& pi, Point1 const& pj,
-                Point2 const& qi, Point2 const& qj,
                 TurnInfo const& tp_model,
                 IntersectionStrategy const& intersection_strategy,
                 RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
@@ -62,14 +58,20 @@ struct get_turn_info_linear_areal
     {
         typedef intersection_info
             <
-                Point1, Point2, RetrieveAdditionalInfoPolicy1, RetrieveAdditionalInfoPolicy2,
+                RetrieveAdditionalInfoPolicy1, RetrieveAdditionalInfoPolicy2,
                 typename TurnInfo::point_type,
                 IntersectionStrategy,
                 RobustPolicy
             > inters_info;
 
-        inters_info inters(pi, pj, qi, qj,
-                           retrieve_policy_p, retrieve_policy_q,
+        typedef typename RetrieveAdditionalInfoPolicy1::point_type Point1;
+        typedef typename RetrieveAdditionalInfoPolicy2::point_type Point2;
+        Point1 const& pi = retrieve_policy_p.get_point_i();
+        Point1 const& pj = retrieve_policy_p.get_point_j();
+        Point2 const& qi = retrieve_policy_q.get_point_i();
+        Point2 const& qj = retrieve_policy_q.get_point_j();
+
+        inters_info inters(retrieve_policy_p, retrieve_policy_q,
                            intersection_strategy, robust_policy);
 
         char const method = inters.d_info().how;

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -62,7 +62,7 @@ struct get_turn_info_linear_areal
     {
         typedef intersection_info
             <
-                Point1, Point2,
+                Point1, Point2, RetrievePolicy1, RetrievePolicy2,
                 typename TurnInfo::point_type,
                 IntersectionStrategy,
                 RobustPolicy

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -64,11 +64,8 @@ struct get_turn_info_linear_areal
                 RobustPolicy
             > inters_info;
 
-        typedef typename UniqueSubRange1::point_type Point1;
-        typedef typename UniqueSubRange2::point_type Point2;
-        Point1 const& pi = range_p.at(0);
-        Point1 const& pj = range_p.at(1);
-        Point2 const& qi = range_q.at(0);
+        typename UniqueSubRange1::point_type const& pi = range_p.at(0);
+        typename UniqueSubRange2::point_type const& qi = range_q.at(0);
 
         inters_info inters(range_p, range_q,
                            intersection_strategy, robust_policy);
@@ -374,7 +371,7 @@ struct get_turn_info_linear_areal
                         tp.operations[0].position = position_front;
                     }
                     else if ( range_p.size() == 2u
-                           && equals::equals_point_point(pj, tp.point) )
+                           && equals::equals_point_point(range_p.at(1), tp.point) )
                     {
                         tp.operations[0].position = position_back;
                     }

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -717,9 +717,6 @@ struct get_turn_info_linear_areal
             }
             else
             {
-                typedef typename IntersectionInfo::robust_point1_type rp1_type;
-                typedef typename IntersectionInfo::robust_point2_type rp2_type;
-
                 method_type replaced_method = method_touch_interior;
 
                 // The code below should avoid using a side_calculator.
@@ -732,20 +729,9 @@ struct get_turn_info_linear_areal
 
                 if ( ip0.is_qj )
                 {
-                    // TODO: wrong! q should never be substituted for p.
-                    // In the end point there is no point "k", that should be fixed in another way
-                    ov::side_calculator_for_endpoint
-                        <
-                            typename IntersectionInfo::cs_tag,
-                            rp1_type, rp2_type,
-                            typename IntersectionInfo::side_strategy_type,
-                            rp2_type
-                        > side_calc(inters.rqi(), inters.rpi(), inters.rpj(),
-                                    inters.rqi(), inters.rqj(), inters.rqk(),
-                                    inters.get_side_strategy());
-
-                    std::pair<operation_type, operation_type>
-                        operations = get_info_e::operations_of_equal(side_calc);
+                    std::pair<operation_type, operation_type> operations
+                        = get_info_e::template operations_of_equal<0, 1>(
+                            range_p, range_q, inters.get_side_strategy());
 
                     tp.operations[0].operation = operations.first;
                     tp.operations[1].operation = operations.second;
@@ -754,19 +740,9 @@ struct get_turn_info_linear_areal
                 }
                 else
                 {
-                    ov::side_calculator_for_endpoint
-                        <
-                            typename IntersectionInfo::cs_tag,
-                            rp1_type, rp2_type,
-                            typename IntersectionInfo::side_strategy_type,
-                            rp2_type, rp1_type, rp1_type,
-                            rp2_type, rp1_type, rp2_type
-                        > side_calc(inters.rqi(), inters.rpi(), inters.rpj(), // TODO: wrong! q should not be substituted for p
-                                    inters.rqi(), inters.rpi(), inters.rqj(), // TODO: wrong! p should not be substituted for q
-                                    inters.get_side_strategy());
-
-                    std::pair<operation_type, operation_type>
-                        operations = get_info_e::operations_of_equal(side_calc);
+                    std::pair<operation_type, operation_type> operations
+                        = get_info_e::template operations_of_equal<0, 1>(
+                            range_p, range_q, inters.get_side_strategy());
 
                     tp.operations[0].operation = operations.first;
                     tp.operations[1].operation = operations.second;
@@ -807,19 +783,9 @@ struct get_turn_info_linear_areal
             }
             else //if ( result.template get<0>().count == 1 )
             {
-                ov::side_calculator_for_endpoint
-                    <
-                        typename IntersectionInfo::cs_tag,
-                        typename IntersectionInfo::robust_point1_type,
-                        typename IntersectionInfo::robust_point2_type,
-                        typename IntersectionInfo::side_strategy_type,
-                        typename IntersectionInfo::robust_point2_type
-                    > side_calc(inters.rqi(), inters.rpj(), inters.rpi(), // TODO: wrong! q should not be substituted for p
-                                inters.rqi(), inters.rqj(), inters.rqk(),
-                                inters.get_side_strategy());
-
-                std::pair<operation_type, operation_type>
-                    operations = get_info_e::operations_of_equal(side_calc);
+                std::pair<operation_type, operation_type> operations
+                    = get_info_e::template operations_of_equal<1, 0>(
+                        range_p, range_q, inters.get_side_strategy());
 
                 tp.operations[0].operation = operations.first;
                 tp.operations[1].operation = operations.second;

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -45,8 +45,8 @@ struct get_turn_info_linear_areal
         typename Point2,
         typename TurnInfo,
         typename IntersectionStrategy,
-        typename RetrievePolicy1,
-        typename RetrievePolicy2,
+        typename RetrieveAdditionalInfoPolicy1,
+        typename RetrieveAdditionalInfoPolicy2,
         typename RobustPolicy,
         typename OutputIterator
     >
@@ -55,14 +55,14 @@ struct get_turn_info_linear_areal
                 Point2 const& qi, Point2 const& qj,
                 TurnInfo const& tp_model,
                 IntersectionStrategy const& intersection_strategy,
-                RetrievePolicy1 const& retrieve_policy_p,
-                RetrievePolicy2 const& retrieve_policy_q,
+                RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
+                RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
                 RobustPolicy const& robust_policy,
                 OutputIterator out)
     {
         typedef intersection_info
             <
-                Point1, Point2, RetrievePolicy1, RetrievePolicy2,
+                Point1, Point2, RetrieveAdditionalInfoPolicy1, RetrieveAdditionalInfoPolicy2,
                 typename TurnInfo::point_type,
                 IntersectionStrategy,
                 RobustPolicy
@@ -75,8 +75,8 @@ struct get_turn_info_linear_areal
         char const method = inters.d_info().how;
 
         bool const is_p_first = retrieve_policy_p.is_first();
-        bool const is_p_last = retrieve_policy_p.is_last();
-        bool const is_q_last = retrieve_policy_q.is_last();
+        bool const is_p_last = ! retrieve_policy_p.has_k();
+        bool const is_q_last = ! retrieve_policy_q.has_k();
 
         // Copy, to copy possibly extended fields
         TurnInfo tp = tp_model;
@@ -372,8 +372,7 @@ struct get_turn_info_linear_areal
                             >::apply(pi, pj, qi, qj,
                                 retrieve_policy_p, retrieve_policy_q,
                                 tp, out, inters,
-                                inters.sides(), transformer,
-                                !is_p_last, true); // qk is always valid
+                                inters.sides(), transformer);
                     }
                 }
             }
@@ -713,14 +712,14 @@ struct get_turn_info_linear_areal
               typename Point2,
               typename TurnInfo,
               typename IntersectionInfo,
-              typename RetrievePolicy1,
-              typename RetrievePolicy2,
+              typename RetrieveAdditionalInfoPolicy1,
+              typename RetrieveAdditionalInfoPolicy2,
               typename OutputIterator>
     static inline bool get_turn_info_for_endpoint(
                             Point1 const& pi, Point1 const& /*pj*/,
                             Point2 const& qi, Point2 const& /*qj*/,
-                            RetrievePolicy1 const& retrieve_policy_p,
-                            RetrievePolicy2 const& retrieve_policy_q,
+                            RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
+                            RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
                             TurnInfo const& tp_model,
                             IntersectionInfo const& inters,
                             method_type /*method*/,
@@ -730,7 +729,7 @@ struct get_turn_info_linear_areal
         typedef ov::get_turn_info_for_endpoint<AssignPolicy, EnableFirst, EnableLast> get_info_e;
 
         bool const is_p_first = retrieve_policy_p.is_first();
-        bool const is_p_last = retrieve_policy_p.is_last();
+        bool const is_p_last = ! retrieve_policy_p.has_k();
 
         const std::size_t ip_count = inters.i_info().count;
         // no intersection points
@@ -744,7 +743,7 @@ struct get_turn_info_linear_areal
             return false;
         }
 
-        bool const is_q_last = retrieve_policy_q.is_last();
+        bool const is_q_last = ! retrieve_policy_q.has_k();
 
         linear_intersections intersections(pi, qi, inters.result(), is_p_last, is_q_last);
         linear_intersections::ip_info const& ip0 = intersections.template get<0>();

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -114,7 +114,7 @@ struct get_turn_info_linear_areal
                     // If Q (1) arrives (1)
                     if ( inters.d_info().arrival[1] == 1 )
                     {
-                        policy::template apply<0>(pi, pj, pk, qi, qj, qk,
+                        policy::template apply<0>(pi, pj, qi, qj,
                                     tp, inters.i_info(), inters.d_info(),
                                     inters.sides());
                     }
@@ -130,7 +130,7 @@ struct get_turn_info_linear_areal
                             > swapped_side_calc(inters.rqi(), inters.rqj(), inters.rqk(),
                                                 inters.rpi(), inters.rpj(), inters.rpk(),
                                                 inters.get_side_strategy());
-                        policy::template apply<1>(qi, qj, qk, pi, pj, pk,
+                        policy::template apply<1>(qi, qj, pi, pj,
                                     tp, inters.i_info(), inters.d_info(),
                                     swapped_side_calc);
                     }
@@ -156,7 +156,7 @@ struct get_turn_info_linear_areal
             break;
             case 'i' :
             {
-                crosses<TurnInfo>::apply(pi, pj, pk, qi, qj, qk,
+                crosses<TurnInfo>::apply(pi, pj, qi, qj,
                                          tp, inters.i_info(), inters.d_info());
 
                 replace_operations_i(tp.operations[0].operation, tp.operations[1].operation);
@@ -176,7 +176,7 @@ struct get_turn_info_linear_areal
                 }
                 else 
                 {
-                    touch<TurnInfo>::apply(pi, pj, pk, qi, qj, qk,
+                    touch<TurnInfo>::apply(pi, pj, qi, qj,
                             tp, inters.i_info(), inters.d_info(), inters.sides());
 
                     if ( tp.operations[1].operation == operation_blocked )
@@ -273,7 +273,7 @@ struct get_turn_info_linear_areal
                     {
                         // Both equal
                         // or collinear-and-ending at intersection point
-                        equal<TurnInfo>::apply(pi, pj, pk, qi, qj, qk,
+                        equal<TurnInfo>::apply(pi, pj, qi, qj,
                             tp, inters.i_info(), inters.d_info(), inters.sides());
 
                         turn_transformer_ec<false> transformer(method_touch);
@@ -323,7 +323,7 @@ struct get_turn_info_linear_areal
                         if ( inters.d_info().arrival[0] == 0 )
                         {
                             // Collinear, but similar thus handled as equal
-                            equal<TurnInfo>::apply(pi, pj, pk, qi, qj, qk,
+                            equal<TurnInfo>::apply(pi, pj, qi, qj,
                                     tp, inters.i_info(), inters.d_info(), inters.sides());
 
                             method_replace = method_touch;
@@ -331,7 +331,8 @@ struct get_turn_info_linear_areal
                         }
                         else
                         {
-                            collinear<TurnInfo>::apply(pi, pj, pk, qi, qj, qk,
+                            collinear<TurnInfo>::apply(pi, pj, qi, qj,
+                                    retrieve_policy_p, retrieve_policy_q,
                                     tp, inters.i_info(), inters.d_info(), inters.sides());
 
                             //method_replace = method_touch_interior;
@@ -373,7 +374,8 @@ struct get_turn_info_linear_areal
                             <
                                 TurnInfo,
                                 AssignPolicy
-                            >::apply(pi, pj, pk, qi, qj, qk,
+                            >::apply(pi, pj, qi, qj,
+                                retrieve_policy_p, retrieve_policy_q,
                                 tp, out, inters,
                                 inters.sides(), transformer,
                                 !is_p_last, true); // qk is always valid

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -736,13 +736,15 @@ struct get_turn_info_linear_areal
 
                 if ( ip0.is_qj )
                 {
+                    // TODO: wrong! q should never be substituted for p.
+                    // In the end point there is no point "k", that should be fixed in another way
                     ov::side_calculator_for_endpoint
                         <
                             typename IntersectionInfo::cs_tag,
                             rp1_type, rp2_type,
                             typename IntersectionInfo::side_strategy_type,
                             rp2_type
-                        > side_calc(inters.rqi(), inters.rpi(), inters.rpj(), // TODO: wrong! q should not be substituted for p, and i/j should be j/k
+                        > side_calc(inters.rqi(), inters.rpi(), inters.rpj(),
                                     inters.rqi(), inters.rqj(), inters.rqk(),
                                     inters.get_side_strategy());
 
@@ -764,7 +766,7 @@ struct get_turn_info_linear_areal
                             rp2_type, rp1_type, rp1_type,
                             rp2_type, rp1_type, rp2_type
                         > side_calc(inters.rqi(), inters.rpi(), inters.rpj(), // TODO: wrong! q should not be substituted for p
-                                    inters.rqi(), inters.rpi(), inters.rqj(),
+                                    inters.rqi(), inters.rpi(), inters.rqj(), // TODO: wrong! p should not be substituted for q
                                     inters.get_side_strategy());
 
                     std::pair<operation_type, operation_type>
@@ -816,7 +818,7 @@ struct get_turn_info_linear_areal
                         typename IntersectionInfo::robust_point2_type,
                         typename IntersectionInfo::side_strategy_type,
                         typename IntersectionInfo::robust_point2_type
-                    > side_calc(inters.rqi(), inters.rpj(), inters.rpi(), // TODO: wrong! q should not be substituted for p; j/i should be j/k
+                    > side_calc(inters.rqi(), inters.rpj(), inters.rpi(), // TODO: wrong! q should not be substituted for p
                                 inters.rqi(), inters.rqj(), inters.rqk(),
                                 inters.get_side_strategy());
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -130,8 +130,6 @@ struct get_turn_info_linear_areal
                     calculate_spike_operation(tp.operations[0].operation,
                                               inters);
                     
-                    AssignPolicy::apply(tp, pi, qi, inters);
-
                     *out++ = tp;
                 }
             }
@@ -142,7 +140,6 @@ struct get_turn_info_linear_areal
 
                 replace_operations_i(tp.operations[0].operation, tp.operations[1].operation);
 
-                AssignPolicy::apply(tp, pi, qi, inters);
                 *out++ = tp;
             }
             break;
@@ -224,9 +221,6 @@ struct get_turn_info_linear_areal
                         = calculate_spike_operation(tp.operations[0].operation,
                                                     inters);
 
-// TODO: move this into the append_xxx and call for each turn?
-                    AssignPolicy::apply(tp, pi, qi, inters);
-
                     if ( ! BOOST_GEOMETRY_CONDITION(handle_spikes)
                       || ignore_spike
                       || ! append_opposite_spikes<append_touches>( // for 'i' or 'c' i???
@@ -257,10 +251,7 @@ struct get_turn_info_linear_areal
 
                         turn_transformer_ec<false> transformer(method_touch);
                         transformer(tp);
-                    
-// TODO: move this into the append_xxx and call for each turn?
-                        AssignPolicy::apply(tp, pi, qi, inters);
-                        
+
                         // conditionally handle spikes
                         if ( ! BOOST_GEOMETRY_CONDITION(handle_spikes)
                           || ! append_collinear_spikes(tp, inters,
@@ -319,9 +310,6 @@ struct get_turn_info_linear_areal
                         turn_transformer_ec<false> transformer(method_replace);
                         transformer(tp);
 
-// TODO: move this into the append_xxx and call for each turn?
-                        AssignPolicy::apply(tp, pi, qi, inters);
-                        
                         // conditionally handle spikes
                         if ( ! BOOST_GEOMETRY_CONDITION(handle_spikes)
                           || ! append_collinear_spikes(tp, inters,
@@ -377,7 +365,6 @@ struct get_turn_info_linear_areal
                     }
                     // tp.operations[1].position = position_middle;
 
-                    AssignPolicy::apply(tp, pi, qi, inters);
                     *out++ = tp;
                 }
             }
@@ -561,10 +548,6 @@ struct get_turn_info_linear_areal
 
                     BOOST_GEOMETRY_ASSERT(inters.i_info().count > 1);
                     base_turn_handler::assign_point(tp, method_touch_interior, inters.i_info(), 1);
-
-                    // The only place where pi() and qi() are accessed
-                    // Consider using the intersection point.
-                    AssignPolicy::apply(tp, inters.pi(), inters.qi(), inters);
                 }
 
                 tp.operations[0].operation = operation_blocked;
@@ -697,7 +680,7 @@ struct get_turn_info_linear_areal
                             OutputIterator out)
     {
         namespace ov = overlay;
-        typedef ov::get_turn_info_for_endpoint<AssignPolicy, EnableFirst, EnableLast> get_info_e;
+        typedef ov::get_turn_info_for_endpoint<EnableFirst, EnableLast> get_info_e;
 
         const std::size_t ip_count = inters.i_info().count;
         // no intersection points
@@ -807,7 +790,6 @@ struct get_turn_info_linear_areal
             // here is_p_first_ip == true
             tp.operations[0].is_collinear = false;
 
-            AssignPolicy::apply(tp, range_p.at(0), range_q.at(0), inters);
             *out++ = tp;
 
             was_first_point_handled = true;
@@ -863,7 +845,6 @@ struct get_turn_info_linear_areal
             unsigned int ip_index = ip_count > 1 ? 1 : 0;
             base_turn_handler::assign_point(tp, tp.method, inters.i_info(), ip_index);
 
-            AssignPolicy::apply(tp, range_p.at(0), range_q.at(0), inters);
             *out++ = tp;
 
             // don't ignore the first IP if the segment is opposite

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -776,6 +776,14 @@ struct get_turn_info_linear_areal
 
                 method_type replaced_method = method_touch_interior;
 
+                // The code below should avoid using a side_calculator.
+                // Mainly because it is constructed with the wrong points.
+                // It should never be constructed other than pi,pj,pk / qi,qj,qk
+                // That side calculator might not be necessary here.
+                // Relevant sides can be passed to the method operations_and_equal
+                // (and that method can assign the operations, no need to return
+                //  a pair, that is not done anywhere in all turns/operations)
+
                 if ( ip0.is_qj )
                 {
                     ov::side_calculator_for_endpoint
@@ -784,7 +792,7 @@ struct get_turn_info_linear_areal
                             rp1_type, rp2_type,
                             typename IntersectionInfo::side_strategy_type,
                             rp2_type
-                        > side_calc(inters.rqi(), inters.rpi(), inters.rpj(),
+                        > side_calc(inters.rqi(), inters.rpi(), inters.rpj(), // TODO: wrong! q should not be substituted for p, and i/j should be j/k
                                     inters.rqi(), inters.rqj(), inters.rqk(),
                                     inters.get_side_strategy());
 
@@ -805,7 +813,7 @@ struct get_turn_info_linear_areal
                             typename IntersectionInfo::side_strategy_type,
                             rp2_type, rp1_type, rp1_type,
                             rp2_type, rp1_type, rp2_type
-                        > side_calc(inters.rqi(), inters.rpi(), inters.rpj(),
+                        > side_calc(inters.rqi(), inters.rpi(), inters.rpj(), // TODO: wrong! q should not be substituted for p
                                     inters.rqi(), inters.rpi(), inters.rqj(),
                                     inters.get_side_strategy());
 
@@ -859,7 +867,7 @@ struct get_turn_info_linear_areal
                         typename IntersectionInfo::robust_point2_type,
                         typename IntersectionInfo::side_strategy_type,
                         typename IntersectionInfo::robust_point2_type
-                    > side_calc(inters.rqi(), inters.rpj(), inters.rpi(),
+                    > side_calc(inters.rqi(), inters.rpj(), inters.rpi(), // TODO: wrong! q should not be substituted for p; j/i should be j/k
                                 inters.rqi(), inters.rqj(), inters.rqk(),
                                 inters.get_side_strategy());
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -72,7 +72,6 @@ struct get_turn_info_linear_areal
 
         bool const is_p_first = retrieve_policy.is_first(0);
         bool const is_p_last = retrieve_policy.is_last(0);
-        bool const is_q_first = retrieve_policy.is_first(1);
         bool const is_q_last = retrieve_policy.is_last(1);
 
         // Copy, to copy possibly extended fields
@@ -86,8 +85,7 @@ struct get_turn_info_linear_areal
             case 's' : // starts from the middle
                 get_turn_info_for_endpoint<true, true>(
                     pi, pj, pk, qi, qj, qk,
-                    is_p_first, is_p_last, is_q_first, is_q_last,
-                    tp_model, inters, method_none, out);
+                    tp_model, inters, retrieve_policy, method_none, out);
                 break;
 
             case 'd' : // disjoint: never do anything
@@ -97,8 +95,7 @@ struct get_turn_info_linear_areal
             {
                 if ( get_turn_info_for_endpoint<false, true>(
                         pi, pj, pk, qi, qj, qk,
-                        is_p_first, is_p_last, is_q_first, is_q_last,
-                        tp_model, inters, method_touch_interior, out) )
+                        tp_model, inters, retrieve_policy, method_touch_interior, out) )
                 {
                     // do nothing
                 }
@@ -168,8 +165,7 @@ struct get_turn_info_linear_areal
                 // Both touch (both arrive there)
                 if ( get_turn_info_for_endpoint<false, true>(
                         pi, pj, pk, qi, qj, qk,
-                        is_p_first, is_p_last, is_q_first, is_q_last,
-                        tp_model, inters, method_touch, out) )
+                        tp_model, inters, retrieve_policy, method_touch, out) )
                 {
                     // do nothing
                 }
@@ -260,8 +256,7 @@ struct get_turn_info_linear_areal
             {
                 if ( get_turn_info_for_endpoint<true, true>(
                         pi, pj, pk, qi, qj, qk,
-                        is_p_first, is_p_last, is_q_first, is_q_last,
-                        tp_model, inters, method_equal, out) )
+                        tp_model, inters, retrieve_policy, method_equal, out) )
                 {
                     // do nothing
                 }
@@ -307,8 +302,7 @@ struct get_turn_info_linear_areal
                 // Collinear
                 if ( get_turn_info_for_endpoint<true, true>(
                         pi, pj, pk, qi, qj, qk,
-                        is_p_first, is_p_last, is_q_first, is_q_last,
-                        tp_model, inters, method_collinear, out) )
+                        tp_model, inters, retrieve_policy, method_collinear, out) )
                 {
                     // do nothing
                 }
@@ -715,29 +709,36 @@ struct get_turn_info_linear_areal
               typename Point2,
               typename TurnInfo,
               typename IntersectionInfo,
+              typename RetrievePolicy,
               typename OutputIterator>
     static inline bool get_turn_info_for_endpoint(
                             Point1 const& pi, Point1 const& /*pj*/, Point1 const& /*pk*/,
                             Point2 const& qi, Point2 const& /*qj*/, Point2 const& /*qk*/,
-                            bool is_p_first, bool is_p_last,
-                            bool /*is_q_first*/, bool is_q_last,
                             TurnInfo const& tp_model,
                             IntersectionInfo const& inters,
+                            RetrievePolicy const& retrieve_policy,
                             method_type /*method*/,
                             OutputIterator out)
     {
         namespace ov = overlay;
         typedef ov::get_turn_info_for_endpoint<AssignPolicy, EnableFirst, EnableLast> get_info_e;
 
+        bool const is_p_first = retrieve_policy.is_first(0);
+        bool const is_p_last = retrieve_policy.is_last(0);
+
         const std::size_t ip_count = inters.i_info().count;
         // no intersection points
-        if ( ip_count == 0 )
+        if (ip_count == 0)
+        {
             return false;
+        }
 
-        if ( !is_p_first && !is_p_last )
+        if (! is_p_first && ! is_p_last)
+        {
             return false;
+        }
 
-// TODO: is_q_last could probably be replaced by false and removed from parameters
+        bool const is_q_last = retrieve_policy.is_last(1);
 
         linear_intersections intersections(pi, qi, inters.result(), is_p_last, is_q_last);
         linear_intersections::ip_info const& ip0 = intersections.template get<0>();

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -51,8 +51,8 @@ struct get_turn_info_linear_areal
         typename OutputIterator
     >
     static inline OutputIterator apply(
-                Point1 const& pi, Point1 const& pj, Point1 const& pk,
-                Point2 const& qi, Point2 const& qj, Point2 const& qk,
+                Point1 const& pi, Point1 const& pj,
+                Point2 const& qi, Point2 const& qj,
                 TurnInfo const& tp_model,
                 IntersectionStrategy const& intersection_strategy,
                 RetrievePolicy1 const& retrieve_policy_p,
@@ -67,6 +67,9 @@ struct get_turn_info_linear_areal
                 IntersectionStrategy,
                 RobustPolicy
             > inters_info;
+
+        Point1 const& pk = retrieve_policy_p.get();
+        Point2 const& qk = retrieve_policy_q.get();
 
         inters_info inters(pi, pj, pk, qi, qj, qk, intersection_strategy, robust_policy);
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -90,7 +90,6 @@ struct get_turn_info_linear_areal
             case 'f' : // collinear, "from"
             case 's' : // starts from the middle
                 get_turn_info_for_endpoint<true, true>(
-                    pi, pj, qi, qj,
                     retrieve_policy_p, retrieve_policy_q,
                     tp_model, inters, method_none, out);
                 break;
@@ -101,7 +100,6 @@ struct get_turn_info_linear_areal
             case 'm' :
             {
                 if ( get_turn_info_for_endpoint<false, true>(
-                        pi, pj, qi, qj,
                         retrieve_policy_p, retrieve_policy_q,
                         tp_model, inters, method_touch_interior, out) )
                 {
@@ -162,7 +160,6 @@ struct get_turn_info_linear_areal
             {
                 // Both touch (both arrive there)
                 if ( get_turn_info_for_endpoint<false, true>(
-                        pi, pj, qi, qj,
                         retrieve_policy_p, retrieve_policy_q,
                         tp_model, inters, method_touch, out) )
                 {
@@ -254,7 +251,6 @@ struct get_turn_info_linear_areal
             case 'e':
             {
                 if ( get_turn_info_for_endpoint<true, true>(
-                        pi, pj, qi, qj,
                         retrieve_policy_p, retrieve_policy_q,
                         tp_model, inters, method_equal, out) )
                 {
@@ -301,7 +297,6 @@ struct get_turn_info_linear_areal
             {
                 // Collinear
                 if ( get_turn_info_for_endpoint<true, true>(
-                        pi, pj, qi, qj,
                         retrieve_policy_p, retrieve_policy_q,
                         tp_model, inters, method_collinear, out) )
                 {
@@ -709,16 +704,12 @@ struct get_turn_info_linear_areal
     
     template <bool EnableFirst,
               bool EnableLast,
-              typename Point1,
-              typename Point2,
               typename TurnInfo,
               typename IntersectionInfo,
               typename RetrieveAdditionalInfoPolicy1,
               typename RetrieveAdditionalInfoPolicy2,
               typename OutputIterator>
     static inline bool get_turn_info_for_endpoint(
-                            Point1 const& pi, Point1 const& /*pj*/,
-                            Point2 const& qi, Point2 const& /*qj*/,
                             RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
                             RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
                             TurnInfo const& tp_model,
@@ -746,7 +737,9 @@ struct get_turn_info_linear_areal
 
         bool const is_q_last = ! retrieve_policy_q.has_k();
 
-        linear_intersections intersections(pi, qi, inters.result(), is_p_last, is_q_last);
+        linear_intersections intersections(retrieve_policy_p.get_point_i(),
+                                           retrieve_policy_q.get_point_i(),
+                                           inters.result(), is_p_last, is_q_last);
         linear_intersections::ip_info const& ip0 = intersections.template get<0>();
         linear_intersections::ip_info const& ip1 = intersections.template get<1>();
 
@@ -837,7 +830,7 @@ struct get_turn_info_linear_areal
             // here is_p_first_ip == true
             tp.operations[0].is_collinear = false;
 
-            AssignPolicy::apply(tp, pi, qi, inters);
+            AssignPolicy::apply(tp, retrieve_policy_p.get_point_i(), retrieve_policy_q.get_point_i(), inters);
             *out++ = tp;
 
             was_first_point_handled = true;
@@ -893,7 +886,7 @@ struct get_turn_info_linear_areal
             unsigned int ip_index = ip_count > 1 ? 1 : 0;
             base_turn_handler::assign_point(tp, tp.method, inters.i_info(), ip_index);
 
-            AssignPolicy::apply(tp, pi, qi, inters);
+            AssignPolicy::apply(tp, retrieve_policy_p.get_point_i(), retrieve_policy_q.get_point_i(), inters);
             *out++ = tp;
 
             // don't ignore the first IP if the segment is opposite

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -688,6 +688,9 @@ struct get_turn_info_linear_areal
             return false;
         }
 
+        typename IntersectionInfo::side_strategy_type const& sides
+                = inters.get_side_strategy();
+
         linear_intersections intersections(range_p.at(0),
                                            range_q.at(0),
                                            inters.result(),
@@ -729,9 +732,12 @@ struct get_turn_info_linear_areal
 
                 if ( ip0.is_qj )
                 {
+                    int const side_pk_q2 = sides.apply(range_q.at(1), range_q.at(2), range_p.at(1));
+                    int const side_pk_p = sides.apply(range_q.at(0), range_p.at(0), range_p.at(1));
+                    int const side_qk_p = sides.apply(range_q.at(0), range_p.at(0), range_q.at(2));
+
                     std::pair<operation_type, operation_type> operations
-                        = get_info_e::template operations_of_equal<0, 1>(
-                            range_p, range_q, inters.get_side_strategy());
+                        = get_info_e::operations_of_equal(side_pk_q2, side_pk_p, side_qk_p);
 
                     tp.operations[0].operation = operations.first;
                     tp.operations[1].operation = operations.second;
@@ -740,9 +746,12 @@ struct get_turn_info_linear_areal
                 }
                 else
                 {
+                    int const side_pk_q2 = sides.apply(range_p.at(0), range_q.at(1), range_p.at(1));
+                    int const side_pk_p = sides.apply(range_q.at(0), range_p.at(0), range_p.at(1));
+                    int const side_qk_p = sides.apply(range_q.at(0), range_p.at(0), range_q.at(1));
+
                     std::pair<operation_type, operation_type> operations
-                        = get_info_e::template operations_of_equal<0, 1>(
-                            range_p, range_q, inters.get_side_strategy());
+                        = get_info_e::operations_of_equal(side_pk_q2, side_pk_p, side_qk_p);
 
                     tp.operations[0].operation = operations.first;
                     tp.operations[1].operation = operations.second;
@@ -783,9 +792,12 @@ struct get_turn_info_linear_areal
             }
             else //if ( result.template get<0>().count == 1 )
             {
+                int const side_pk_q2 = sides.apply(range_q.at(1), range_q.at(2), range_p.at(0));
+                int const side_pk_p = sides.apply(range_q.at(0), range_p.at(1), range_p.at(0));
+                int const side_qk_p = sides.apply(range_q.at(0), range_p.at(1), range_q.at(2));
+
                 std::pair<operation_type, operation_type> operations
-                    = get_info_e::template operations_of_equal<1, 0>(
-                        range_p, range_q, inters.get_side_strategy());
+                    = get_info_e::operations_of_equal(side_pk_q2, side_pk_p, side_qk_p);
 
                 tp.operations[0].operation = operations.first;
                 tp.operations[1].operation = operations.second;

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -45,7 +45,8 @@ struct get_turn_info_linear_areal
         typename Point2,
         typename TurnInfo,
         typename IntersectionStrategy,
-        typename RetrievePolicy,
+        typename RetrievePolicy1,
+        typename RetrievePolicy2,
         typename RobustPolicy,
         typename OutputIterator
     >
@@ -54,7 +55,8 @@ struct get_turn_info_linear_areal
                 Point2 const& qi, Point2 const& qj, Point2 const& qk,
                 TurnInfo const& tp_model,
                 IntersectionStrategy const& intersection_strategy,
-                RetrievePolicy const& retrieve_policy,
+                RetrievePolicy1 const& retrieve_policy_p,
+                RetrievePolicy2 const& retrieve_policy_q,
                 RobustPolicy const& robust_policy,
                 OutputIterator out)
     {
@@ -70,9 +72,9 @@ struct get_turn_info_linear_areal
 
         char const method = inters.d_info().how;
 
-        bool const is_p_first = retrieve_policy.is_first(0);
-        bool const is_p_last = retrieve_policy.is_last(0);
-        bool const is_q_last = retrieve_policy.is_last(1);
+        bool const is_p_first = retrieve_policy_p.is_first();
+        bool const is_p_last = retrieve_policy_p.is_last();
+        bool const is_q_last = retrieve_policy_q.is_last();
 
         // Copy, to copy possibly extended fields
         TurnInfo tp = tp_model;
@@ -85,7 +87,7 @@ struct get_turn_info_linear_areal
             case 's' : // starts from the middle
                 get_turn_info_for_endpoint<true, true>(
                     pi, pj, pk, qi, qj, qk,
-                    tp_model, inters, retrieve_policy, method_none, out);
+                    tp_model, inters, retrieve_policy_p, retrieve_policy_q, method_none, out);
                 break;
 
             case 'd' : // disjoint: never do anything
@@ -95,7 +97,7 @@ struct get_turn_info_linear_areal
             {
                 if ( get_turn_info_for_endpoint<false, true>(
                         pi, pj, pk, qi, qj, qk,
-                        tp_model, inters, retrieve_policy, method_touch_interior, out) )
+                        tp_model, inters, retrieve_policy_p, retrieve_policy_q, method_touch_interior, out) )
                 {
                     // do nothing
                 }
@@ -165,7 +167,7 @@ struct get_turn_info_linear_areal
                 // Both touch (both arrive there)
                 if ( get_turn_info_for_endpoint<false, true>(
                         pi, pj, pk, qi, qj, qk,
-                        tp_model, inters, retrieve_policy, method_touch, out) )
+                        tp_model, inters, retrieve_policy_p, retrieve_policy_q, method_touch, out) )
                 {
                     // do nothing
                 }
@@ -256,7 +258,7 @@ struct get_turn_info_linear_areal
             {
                 if ( get_turn_info_for_endpoint<true, true>(
                         pi, pj, pk, qi, qj, qk,
-                        tp_model, inters, retrieve_policy, method_equal, out) )
+                        tp_model, inters, retrieve_policy_p, retrieve_policy_q, method_equal, out) )
                 {
                     // do nothing
                 }
@@ -302,7 +304,7 @@ struct get_turn_info_linear_areal
                 // Collinear
                 if ( get_turn_info_for_endpoint<true, true>(
                         pi, pj, pk, qi, qj, qk,
-                        tp_model, inters, retrieve_policy, method_collinear, out) )
+                        tp_model, inters, retrieve_policy_p, retrieve_policy_q, method_collinear, out) )
                 {
                     // do nothing
                 }
@@ -709,22 +711,24 @@ struct get_turn_info_linear_areal
               typename Point2,
               typename TurnInfo,
               typename IntersectionInfo,
-              typename RetrievePolicy,
+              typename RetrievePolicy1,
+              typename RetrievePolicy2,
               typename OutputIterator>
     static inline bool get_turn_info_for_endpoint(
                             Point1 const& pi, Point1 const& /*pj*/, Point1 const& /*pk*/,
                             Point2 const& qi, Point2 const& /*qj*/, Point2 const& /*qk*/,
                             TurnInfo const& tp_model,
                             IntersectionInfo const& inters,
-                            RetrievePolicy const& retrieve_policy,
+                            RetrievePolicy1 const& retrieve_policy_p,
+                            RetrievePolicy2 const& retrieve_policy_q,
                             method_type /*method*/,
                             OutputIterator out)
     {
         namespace ov = overlay;
         typedef ov::get_turn_info_for_endpoint<AssignPolicy, EnableFirst, EnableLast> get_info_e;
 
-        bool const is_p_first = retrieve_policy.is_first(0);
-        bool const is_p_last = retrieve_policy.is_last(0);
+        bool const is_p_first = retrieve_policy_p.is_first();
+        bool const is_p_last = retrieve_policy_p.is_last();
 
         const std::size_t ip_count = inters.i_info().count;
         // no intersection points
@@ -738,7 +742,7 @@ struct get_turn_info_linear_areal
             return false;
         }
 
-        bool const is_q_last = retrieve_policy.is_last(1);
+        bool const is_q_last = retrieve_policy_q.is_last();
 
         linear_intersections intersections(pi, qi, inters.result(), is_p_last, is_q_last);
         linear_intersections::ip_info const& ip0 = intersections.template get<0>();

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -115,15 +115,13 @@ struct get_turn_info_linear_areal
                     // If Q (1) arrives (1)
                     if ( inters.d_info().arrival[1] == 1 )
                     {
-                        policy::template apply<0>(pi, pj, qi, qj,
-                                    tp, inters.i_info(), inters.d_info(),
+                        policy::template apply<0>(tp, inters.i_info(), inters.d_info(),
                                     inters.sides());
                     }
                     else
                     {
                         // Swap p/q
-                        policy::template apply<1>(qi, qj, pi, pj,
-                                    tp, inters.i_info(), inters.d_info(),
+                        policy::template apply<1>(tp, inters.i_info(), inters.d_info(),
                                     inters.get_swapped_sides());
                     }
 
@@ -167,8 +165,7 @@ struct get_turn_info_linear_areal
                 }
                 else 
                 {
-                    touch<TurnInfo>::apply(pi, pj, qi, qj,
-                            tp, inters.i_info(), inters.d_info(), inters.sides());
+                    touch<TurnInfo>::apply(tp, inters.i_info(), inters.d_info(), inters.sides());
 
                     if ( tp.operations[1].operation == operation_blocked )
                     {
@@ -264,8 +261,7 @@ struct get_turn_info_linear_areal
                     {
                         // Both equal
                         // or collinear-and-ending at intersection point
-                        equal<TurnInfo>::apply(pi, pj, qi, qj,
-                            tp, inters.i_info(), inters.d_info(), inters.sides());
+                        equal<TurnInfo>::apply(tp, inters.i_info(), inters.d_info(), inters.sides());
 
                         turn_transformer_ec<false> transformer(method_touch);
                         transformer(tp);
@@ -287,7 +283,7 @@ struct get_turn_info_linear_areal
                             <
                                 TurnInfo,
                                 AssignPolicy
-                            >::apply(pi, qi,
+                            >::apply(retrieve_policy_p, retrieve_policy_q,
                                      tp, out, inters);
                     }
                 }
@@ -314,16 +310,14 @@ struct get_turn_info_linear_areal
                         if ( inters.d_info().arrival[0] == 0 )
                         {
                             // Collinear, but similar thus handled as equal
-                            equal<TurnInfo>::apply(pi, pj, qi, qj,
-                                    tp, inters.i_info(), inters.d_info(), inters.sides());
+                            equal<TurnInfo>::apply(tp, inters.i_info(), inters.d_info(), inters.sides());
 
                             method_replace = method_touch;
                             version = append_equal;
                         }
                         else
                         {
-                            collinear<TurnInfo>::apply(pi, pj, qi, qj,
-                                    retrieve_policy_p, retrieve_policy_q,
+                            collinear<TurnInfo>::apply(retrieve_policy_p, retrieve_policy_q,
                                     tp, inters.i_info(), inters.d_info(), inters.sides());
 
                             //method_replace = method_touch_interior;
@@ -365,8 +359,7 @@ struct get_turn_info_linear_areal
                             <
                                 TurnInfo,
                                 AssignPolicy
-                            >::apply(pi, pj, qi, qj,
-                                retrieve_policy_p, retrieve_policy_q,
+                            >::apply(retrieve_policy_p, retrieve_policy_q,
                                 tp, out, inters,
                                 inters.sides(), transformer);
                     }

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -346,12 +346,12 @@ struct get_turn_info_linear_areal
                 {
                     only_convert::apply(tp, inters.i_info());
 
-                    if ( range_p.is_first()
+                    if ( range_p.is_first_segment()
                       && equals::equals_point_point(range_p.at(0), tp.point) )
                     {
                         tp.operations[0].position = position_front;
                     }
-                    else if ( range_p.size() == 2u
+                    else if ( range_p.is_last_segment()
                            && equals::equals_point_point(range_p.at(1), tp.point) )
                     {
                         tp.operations[0].position = position_back;
@@ -682,7 +682,7 @@ struct get_turn_info_linear_areal
             return false;
         }
 
-        if (! range_p.is_first() && range_p.size() > 2u)
+        if (! range_p.is_first_segment() && ! range_p.is_last_segment())
         {
             // P sub-range has no end-points
             return false;
@@ -694,8 +694,8 @@ struct get_turn_info_linear_areal
         linear_intersections intersections(range_p.at(0),
                                            range_q.at(0),
                                            inters.result(),
-                                           range_p.size() == 2u,
-                                           range_q.size() == 2u);
+                                           range_p.is_last_segment(),
+                                           range_q.is_last_segment());
         linear_intersections::ip_info const& ip0 = intersections.template get<0>();
         linear_intersections::ip_info const& ip1 = intersections.template get<1>();
 
@@ -706,7 +706,7 @@ struct get_turn_info_linear_areal
         // IP on the first point of Linear Geometry
         bool was_first_point_handled = false;
         if ( BOOST_GEOMETRY_CONDITION(EnableFirst)
-          && range_p.is_first() && ip0.is_pi && !ip0.is_qi ) // !q0i prevents duplication
+          && range_p.is_first_segment() && ip0.is_pi && !ip0.is_qi ) // !q0i prevents duplication
         {
             TurnInfo tp = tp_model;
             tp.operations[0].position = position_front;
@@ -779,7 +779,7 @@ struct get_turn_info_linear_areal
 
         // IP on the last point of Linear Geometry
         if ( BOOST_GEOMETRY_CONDITION(EnableLast)
-          && range_p.size() == 2u
+          && range_p.is_last_segment()
           && ( ip_count > 1 ? (ip1.is_pj && !ip1.is_qi) : (ip0.is_pj && !ip0.is_qi) ) ) // prevents duplication
         {
             TurnInfo tp = tp_model;

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -588,6 +588,8 @@ struct get_turn_info_linear_areal
                     BOOST_GEOMETRY_ASSERT(inters.i_info().count > 1);
                     base_turn_handler::assign_point(tp, method_touch_interior, inters.i_info(), 1);
 
+                    // The only place where pi() and qi() are accessed
+                    // Consider using the intersection point.
                     AssignPolicy::apply(tp, inters.pi(), inters.qi(), inters);
                 }
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -68,10 +68,9 @@ struct get_turn_info_linear_areal
                 RobustPolicy
             > inters_info;
 
-        Point1 const& pk = retrieve_policy_p.get();
-        Point2 const& qk = retrieve_policy_q.get();
-
-        inters_info inters(pi, pj, pk, qi, qj, qk, intersection_strategy, robust_policy);
+        inters_info inters(pi, pj, qi, qj,
+                           retrieve_policy_p, retrieve_policy_q,
+                           intersection_strategy, robust_policy);
 
         char const method = inters.d_info().how;
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -89,8 +89,9 @@ struct get_turn_info_linear_areal
             case 'f' : // collinear, "from"
             case 's' : // starts from the middle
                 get_turn_info_for_endpoint<true, true>(
-                    pi, pj, pk, qi, qj, qk,
-                    tp_model, inters, retrieve_policy_p, retrieve_policy_q, method_none, out);
+                    pi, pj, qi, qj,
+                    retrieve_policy_p, retrieve_policy_q,
+                    tp_model, inters, method_none, out);
                 break;
 
             case 'd' : // disjoint: never do anything
@@ -99,8 +100,9 @@ struct get_turn_info_linear_areal
             case 'm' :
             {
                 if ( get_turn_info_for_endpoint<false, true>(
-                        pi, pj, pk, qi, qj, qk,
-                        tp_model, inters, retrieve_policy_p, retrieve_policy_q, method_touch_interior, out) )
+                        pi, pj, qi, qj,
+                        retrieve_policy_p, retrieve_policy_q,
+                        tp_model, inters, method_touch_interior, out) )
                 {
                     // do nothing
                 }
@@ -169,8 +171,9 @@ struct get_turn_info_linear_areal
             {
                 // Both touch (both arrive there)
                 if ( get_turn_info_for_endpoint<false, true>(
-                        pi, pj, pk, qi, qj, qk,
-                        tp_model, inters, retrieve_policy_p, retrieve_policy_q, method_touch, out) )
+                        pi, pj, qi, qj,
+                        retrieve_policy_p, retrieve_policy_q,
+                        tp_model, inters, method_touch, out) )
                 {
                     // do nothing
                 }
@@ -260,8 +263,9 @@ struct get_turn_info_linear_areal
             case 'e':
             {
                 if ( get_turn_info_for_endpoint<true, true>(
-                        pi, pj, pk, qi, qj, qk,
-                        tp_model, inters, retrieve_policy_p, retrieve_policy_q, method_equal, out) )
+                        pi, pj, qi, qj,
+                        retrieve_policy_p, retrieve_policy_q,
+                        tp_model, inters, method_equal, out) )
                 {
                     // do nothing
                 }
@@ -306,8 +310,9 @@ struct get_turn_info_linear_areal
             {
                 // Collinear
                 if ( get_turn_info_for_endpoint<true, true>(
-                        pi, pj, pk, qi, qj, qk,
-                        tp_model, inters, retrieve_policy_p, retrieve_policy_q, method_collinear, out) )
+                        pi, pj, qi, qj,
+                        retrieve_policy_p, retrieve_policy_q,
+                        tp_model, inters, method_collinear, out) )
                 {
                     // do nothing
                 }
@@ -720,12 +725,12 @@ struct get_turn_info_linear_areal
               typename RetrievePolicy2,
               typename OutputIterator>
     static inline bool get_turn_info_for_endpoint(
-                            Point1 const& pi, Point1 const& /*pj*/, Point1 const& /*pk*/,
-                            Point2 const& qi, Point2 const& /*qj*/, Point2 const& /*qk*/,
-                            TurnInfo const& tp_model,
-                            IntersectionInfo const& inters,
+                            Point1 const& pi, Point1 const& /*pj*/,
+                            Point2 const& qi, Point2 const& /*qj*/,
                             RetrievePolicy1 const& retrieve_policy_p,
                             RetrievePolicy2 const& retrieve_policy_q,
+                            TurnInfo const& tp_model,
+                            IntersectionInfo const& inters,
                             method_type /*method*/,
                             OutputIterator out)
     {

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -732,12 +732,12 @@ struct get_turn_info_linear_areal
 
                 if ( ip0.is_qj )
                 {
-                    int const side_pk_q2 = sides.apply(range_q.at(1), range_q.at(2), range_p.at(1));
-                    int const side_pk_p = sides.apply(range_q.at(0), range_p.at(0), range_p.at(1));
-                    int const side_qk_p = sides.apply(range_q.at(0), range_p.at(0), range_q.at(2));
+                    int const side_pj_q2 = sides.apply(range_q.at(1), range_q.at(2), range_p.at(1));
+                    int const side_pj_x = sides.apply(range_q.at(0), range_p.at(0), range_p.at(1));
+                    int const side_qk_x = sides.apply(range_q.at(0), range_p.at(0), range_q.at(2));
 
                     std::pair<operation_type, operation_type> operations
-                        = get_info_e::operations_of_equal(side_pk_q2, side_pk_p, side_qk_p);
+                        = get_info_e::operations_of_equal(side_pj_q2, side_pj_x, side_qk_x);
 
                     tp.operations[0].operation = operations.first;
                     tp.operations[1].operation = operations.second;
@@ -746,12 +746,12 @@ struct get_turn_info_linear_areal
                 }
                 else
                 {
-                    int const side_pk_q2 = sides.apply(range_p.at(0), range_q.at(1), range_p.at(1));
-                    int const side_pk_p = sides.apply(range_q.at(0), range_p.at(0), range_p.at(1));
-                    int const side_qk_p = sides.apply(range_q.at(0), range_p.at(0), range_q.at(1));
+                    int const side_pj_y = sides.apply(range_p.at(0), range_q.at(1), range_p.at(1));
+                    int const side_pj_x = sides.apply(range_q.at(0), range_p.at(0), range_p.at(1));
+                    int const side_qj_x = sides.apply(range_q.at(0), range_p.at(0), range_q.at(1));
 
                     std::pair<operation_type, operation_type> operations
-                        = get_info_e::operations_of_equal(side_pk_q2, side_pk_p, side_qk_p);
+                        = get_info_e::operations_of_equal(side_pj_y, side_pj_x, side_qj_x);
 
                     tp.operations[0].operation = operations.first;
                     tp.operations[1].operation = operations.second;
@@ -792,12 +792,12 @@ struct get_turn_info_linear_areal
             }
             else //if ( result.template get<0>().count == 1 )
             {
-                int const side_pk_q2 = sides.apply(range_q.at(1), range_q.at(2), range_p.at(0));
-                int const side_pk_p = sides.apply(range_q.at(0), range_p.at(1), range_p.at(0));
-                int const side_qk_p = sides.apply(range_q.at(0), range_p.at(1), range_q.at(2));
+                int const side_pi_q2 = sides.apply(range_q.at(1), range_q.at(2), range_p.at(0));
+                int const side_pi_x = sides.apply(range_q.at(0), range_p.at(1), range_p.at(0));
+                int const side_qk_x = sides.apply(range_q.at(0), range_p.at(1), range_q.at(2));
 
                 std::pair<operation_type, operation_type> operations
-                    = get_info_e::operations_of_equal(side_pk_q2, side_pk_p, side_qk_p);
+                    = get_info_e::operations_of_equal(side_pi_q2, side_pi_x, side_qk_x);
 
                 tp.operations[0].operation = operations.first;
                 tp.operations[1].operation = operations.second;

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -64,9 +64,6 @@ struct get_turn_info_linear_areal
                 RobustPolicy
             > inters_info;
 
-        typename UniqueSubRange1::point_type const& pi = range_p.at(0);
-        typename UniqueSubRange2::point_type const& qi = range_q.at(0);
-
         inters_info inters(range_p, range_q,
                            intersection_strategy, robust_policy);
 
@@ -354,7 +351,7 @@ struct get_turn_info_linear_areal
                     only_convert::apply(tp, inters.i_info());
 
                     if ( range_p.is_first()
-                      && equals::equals_point_point(pi, tp.point) )
+                      && equals::equals_point_point(range_p.at(0), tp.point) )
                     {
                         tp.operations[0].position = position_front;
                     }

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -45,16 +45,16 @@ struct get_turn_info_linear_areal
         typename Point2,
         typename TurnInfo,
         typename IntersectionStrategy,
+        typename RetrievePolicy,
         typename RobustPolicy,
         typename OutputIterator
     >
     static inline OutputIterator apply(
                 Point1 const& pi, Point1 const& pj, Point1 const& pk,
                 Point2 const& qi, Point2 const& qj, Point2 const& qk,
-                bool is_p_first, bool is_p_last,
-                bool is_q_first, bool is_q_last,
                 TurnInfo const& tp_model,
                 IntersectionStrategy const& intersection_strategy,
+                RetrievePolicy const& retrieve_policy,
                 RobustPolicy const& robust_policy,
                 OutputIterator out)
     {
@@ -69,6 +69,11 @@ struct get_turn_info_linear_areal
         inters_info inters(pi, pj, pk, qi, qj, qk, intersection_strategy, robust_policy);
 
         char const method = inters.d_info().how;
+
+        bool const is_p_first = retrieve_policy.is_first(0);
+        bool const is_p_last = retrieve_policy.is_last(0);
+        bool const is_q_first = retrieve_policy.is_first(1);
+        bool const is_q_last = retrieve_policy.is_last(1);
 
         // Copy, to copy possibly extended fields
         TurnInfo tp = tp_model;

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -66,9 +66,9 @@ struct get_turn_info_linear_areal
 
         typedef typename UniqueSubRange1::point_type Point1;
         typedef typename UniqueSubRange2::point_type Point2;
-        Point1 const& pi = range_p.get_point_i();
-        Point1 const& pj = range_p.get_point_j();
-        Point2 const& qi = range_q.get_point_i();
+        Point1 const& pi = range_p.at(0);
+        Point1 const& pj = range_p.at(1);
+        Point2 const& qi = range_q.at(0);
 
         inters_info inters(range_p, range_q,
                            intersection_strategy, robust_policy);
@@ -76,8 +76,8 @@ struct get_turn_info_linear_areal
         char const method = inters.d_info().how;
 
         bool const is_p_first = range_p.is_first();
-        bool const is_p_last = ! range_p.has_k();
-        bool const is_q_last = ! range_q.has_k();
+        bool const is_p_last = range_p.size() == 2u;
+        bool const is_q_last = range_q.size() == 2u;
 
         // Copy, to copy possibly extended fields
         TurnInfo tp = tp_model;
@@ -713,7 +713,7 @@ struct get_turn_info_linear_areal
         typedef ov::get_turn_info_for_endpoint<AssignPolicy, EnableFirst, EnableLast> get_info_e;
 
         bool const is_p_first = range_p.is_first();
-        bool const is_p_last = ! range_p.has_k();
+        bool const is_p_last = range_p.size() == 2u;
 
         const std::size_t ip_count = inters.i_info().count;
         // no intersection points
@@ -727,10 +727,10 @@ struct get_turn_info_linear_areal
             return false;
         }
 
-        bool const is_q_last = ! range_q.has_k();
+        bool const is_q_last = range_q.size() == 2u;
 
-        linear_intersections intersections(range_p.get_point_i(),
-                                           range_q.get_point_i(),
+        linear_intersections intersections(range_p.at(0),
+                                           range_q.at(0),
                                            inters.result(), is_p_last, is_q_last);
         linear_intersections::ip_info const& ip0 = intersections.template get<0>();
         linear_intersections::ip_info const& ip1 = intersections.template get<1>();
@@ -822,7 +822,7 @@ struct get_turn_info_linear_areal
             // here is_p_first_ip == true
             tp.operations[0].is_collinear = false;
 
-            AssignPolicy::apply(tp, range_p.get_point_i(), range_q.get_point_i(), inters);
+            AssignPolicy::apply(tp, range_p.at(0), range_q.at(0), inters);
             *out++ = tp;
 
             was_first_point_handled = true;
@@ -878,7 +878,7 @@ struct get_turn_info_linear_areal
             unsigned int ip_index = ip_count > 1 ? 1 : 0;
             base_turn_handler::assign_point(tp, tp.method, inters.i_info(), ip_index);
 
-            AssignPolicy::apply(tp, range_p.get_point_i(), range_q.get_point_i(), inters);
+            AssignPolicy::apply(tp, range_p.at(0), range_q.at(0), inters);
             *out++ = tp;
 
             // don't ignore the first IP if the segment is opposite

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -102,13 +102,15 @@ struct get_turn_info_linear_areal
                     // If Q (1) arrives (1)
                     if ( inters.d_info().arrival[1] == 1 )
                     {
-                        policy::template apply<0>(tp, inters.i_info(), inters.d_info(),
+                        policy::template apply<0>(range_p, range_q, tp,
+                                    inters.i_info(), inters.d_info(),
                                     inters.sides());
                     }
                     else
                     {
                         // Swap p/q
-                        policy::template apply<1>(tp, inters.i_info(), inters.d_info(),
+                        policy::template apply<1>(range_q, range_p,
+                                    tp, inters.i_info(), inters.d_info(),
                                     inters.get_swapped_sides());
                     }
 
@@ -148,7 +150,8 @@ struct get_turn_info_linear_areal
                 }
                 else 
                 {
-                    touch<TurnInfo>::apply(tp, inters.i_info(), inters.d_info(), inters.sides());
+                    touch<TurnInfo>::apply(range_p, range_q, tp,
+                        inters.i_info(), inters.d_info(), inters.sides());
 
                     if ( tp.operations[1].operation == operation_blocked )
                     {
@@ -240,7 +243,8 @@ struct get_turn_info_linear_areal
                     {
                         // Both equal
                         // or collinear-and-ending at intersection point
-                        equal<TurnInfo>::apply(tp, inters.i_info(), inters.d_info(), inters.sides());
+                        equal<TurnInfo>::apply(range_p, range_q, tp,
+                            inters.i_info(), inters.d_info(), inters.sides());
 
                         turn_transformer_ec<false> transformer(method_touch);
                         transformer(tp);
@@ -286,15 +290,16 @@ struct get_turn_info_linear_areal
                         if ( inters.d_info().arrival[0] == 0 )
                         {
                             // Collinear, but similar thus handled as equal
-                            equal<TurnInfo>::apply(tp, inters.i_info(), inters.d_info(), inters.sides());
+                            equal<TurnInfo>::apply(range_p, range_q, tp,
+                                inters.i_info(), inters.d_info(), inters.sides());
 
                             method_replace = method_touch;
                             version = append_equal;
                         }
                         else
                         {
-                            collinear<TurnInfo>::apply(range_p, range_q,
-                                    tp, inters.i_info(), inters.d_info(), inters.sides());
+                            collinear<TurnInfo>::apply(range_p, range_q, tp,
+                                inters.i_info(), inters.d_info(), inters.sides());
 
                             //method_replace = method_touch_interior;
                             //version = append_collinear;

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -777,7 +777,7 @@ struct get_turn_info_linear_areal
 
                 if ( ip0.is_qj )
                 {
-                    side_calculator
+                    ov::side_calculator_for_endpoint
                         <
                             typename IntersectionInfo::cs_tag,
                             rp1_type, rp2_type,
@@ -797,7 +797,7 @@ struct get_turn_info_linear_areal
                 }
                 else
                 {
-                    side_calculator
+                    ov::side_calculator_for_endpoint
                         <
                             typename IntersectionInfo::cs_tag,
                             rp1_type, rp2_type,
@@ -851,7 +851,7 @@ struct get_turn_info_linear_areal
             }
             else //if ( result.template get<0>().count == 1 )
             {
-                side_calculator
+                ov::side_calculator_for_endpoint
                     <
                         typename IntersectionInfo::cs_tag,
                         typename IntersectionInfo::robust_point1_type,

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -41,18 +41,18 @@ struct get_turn_info_linear_areal
 
     template
     <
-        typename TurnInfo,
-        typename IntersectionStrategy,
         typename UniqueSubRange1,
         typename UniqueSubRange2,
+        typename TurnInfo,
+        typename IntersectionStrategy,
         typename RobustPolicy,
         typename OutputIterator
     >
     static inline OutputIterator apply(
-                TurnInfo const& tp_model,
-                IntersectionStrategy const& intersection_strategy,
                 UniqueSubRange1 const& range_p,
                 UniqueSubRange2 const& range_q,
+                TurnInfo const& tp_model,
+                IntersectionStrategy const& intersection_strategy,
                 RobustPolicy const& robust_policy,
                 OutputIterator out)
     {
@@ -78,8 +78,7 @@ struct get_turn_info_linear_areal
             case 'a' : // collinear, "at"
             case 'f' : // collinear, "from"
             case 's' : // starts from the middle
-                get_turn_info_for_endpoint<true, true>(
-                    range_p, range_q,
+                get_turn_info_for_endpoint<true, true>(range_p, range_q,
                     tp_model, inters, method_none, out);
                 break;
 
@@ -88,8 +87,7 @@ struct get_turn_info_linear_areal
 
             case 'm' :
             {
-                if ( get_turn_info_for_endpoint<false, true>(
-                        range_p, range_q,
+                if ( get_turn_info_for_endpoint<false, true>(range_p, range_q,
                         tp_model, inters, method_touch_interior, out) )
                 {
                     // do nothing
@@ -143,8 +141,7 @@ struct get_turn_info_linear_areal
             case 't' :
             {
                 // Both touch (both arrive there)
-                if ( get_turn_info_for_endpoint<false, true>(
-                        range_p, range_q,
+                if ( get_turn_info_for_endpoint<false, true>(range_p, range_q,
                         tp_model, inters, method_touch, out) )
                 {
                     // do nothing
@@ -230,8 +227,7 @@ struct get_turn_info_linear_areal
             break;
             case 'e':
             {
-                if ( get_turn_info_for_endpoint<true, true>(
-                        range_p, range_q,
+                if ( get_turn_info_for_endpoint<true, true>(range_p, range_q,
                         tp_model, inters, method_equal, out) )
                 {
                     // do nothing

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -123,18 +123,9 @@ struct get_turn_info_linear_areal
                     else
                     {
                         // Swap p/q
-                        side_calculator
-                            <
-                                typename inters_info::cs_tag,
-                                typename inters_info::robust_point2_type,
-                                typename inters_info::robust_point1_type,
-                                typename inters_info::side_strategy_type
-                            > swapped_side_calc(inters.rqi(), inters.rqj(), inters.rqk(),
-                                                inters.rpi(), inters.rpj(), inters.rpk(),
-                                                inters.get_side_strategy());
                         policy::template apply<1>(qi, qj, pi, pj,
                                     tp, inters.i_info(), inters.d_info(),
-                                    swapped_side_calc);
+                                    inters.get_swapped_sides());
                     }
 
                     if ( tp.operations[1].operation == operation_blocked )

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -43,42 +43,41 @@ struct get_turn_info_linear_areal
     <
         typename TurnInfo,
         typename IntersectionStrategy,
-        typename RetrieveAdditionalInfoPolicy1,
-        typename RetrieveAdditionalInfoPolicy2,
+        typename UniqueSubRange1,
+        typename UniqueSubRange2,
         typename RobustPolicy,
         typename OutputIterator
     >
     static inline OutputIterator apply(
                 TurnInfo const& tp_model,
                 IntersectionStrategy const& intersection_strategy,
-                RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
-                RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
+                UniqueSubRange1 const& range_p,
+                UniqueSubRange2 const& range_q,
                 RobustPolicy const& robust_policy,
                 OutputIterator out)
     {
         typedef intersection_info
             <
-                RetrieveAdditionalInfoPolicy1, RetrieveAdditionalInfoPolicy2,
+                UniqueSubRange1, UniqueSubRange2,
                 typename TurnInfo::point_type,
                 IntersectionStrategy,
                 RobustPolicy
             > inters_info;
 
-        typedef typename RetrieveAdditionalInfoPolicy1::point_type Point1;
-        typedef typename RetrieveAdditionalInfoPolicy2::point_type Point2;
-        Point1 const& pi = retrieve_policy_p.get_point_i();
-        Point1 const& pj = retrieve_policy_p.get_point_j();
-        Point2 const& qi = retrieve_policy_q.get_point_i();
-        Point2 const& qj = retrieve_policy_q.get_point_j();
+        typedef typename UniqueSubRange1::point_type Point1;
+        typedef typename UniqueSubRange2::point_type Point2;
+        Point1 const& pi = range_p.get_point_i();
+        Point1 const& pj = range_p.get_point_j();
+        Point2 const& qi = range_q.get_point_i();
 
-        inters_info inters(retrieve_policy_p, retrieve_policy_q,
+        inters_info inters(range_p, range_q,
                            intersection_strategy, robust_policy);
 
         char const method = inters.d_info().how;
 
-        bool const is_p_first = retrieve_policy_p.is_first();
-        bool const is_p_last = ! retrieve_policy_p.has_k();
-        bool const is_q_last = ! retrieve_policy_q.has_k();
+        bool const is_p_first = range_p.is_first();
+        bool const is_p_last = ! range_p.has_k();
+        bool const is_q_last = ! range_q.has_k();
 
         // Copy, to copy possibly extended fields
         TurnInfo tp = tp_model;
@@ -90,7 +89,7 @@ struct get_turn_info_linear_areal
             case 'f' : // collinear, "from"
             case 's' : // starts from the middle
                 get_turn_info_for_endpoint<true, true>(
-                    retrieve_policy_p, retrieve_policy_q,
+                    range_p, range_q,
                     tp_model, inters, method_none, out);
                 break;
 
@@ -100,7 +99,7 @@ struct get_turn_info_linear_areal
             case 'm' :
             {
                 if ( get_turn_info_for_endpoint<false, true>(
-                        retrieve_policy_p, retrieve_policy_q,
+                        range_p, range_q,
                         tp_model, inters, method_touch_interior, out) )
                 {
                     // do nothing
@@ -158,7 +157,7 @@ struct get_turn_info_linear_areal
             {
                 // Both touch (both arrive there)
                 if ( get_turn_info_for_endpoint<false, true>(
-                        retrieve_policy_p, retrieve_policy_q,
+                        range_p, range_q,
                         tp_model, inters, method_touch, out) )
                 {
                     // do nothing
@@ -248,7 +247,7 @@ struct get_turn_info_linear_areal
             case 'e':
             {
                 if ( get_turn_info_for_endpoint<true, true>(
-                        retrieve_policy_p, retrieve_policy_q,
+                        range_p, range_q,
                         tp_model, inters, method_equal, out) )
                 {
                     // do nothing
@@ -283,7 +282,7 @@ struct get_turn_info_linear_areal
                             <
                                 TurnInfo,
                                 AssignPolicy
-                            >::apply(retrieve_policy_p, retrieve_policy_q,
+                            >::apply(range_p, range_q,
                                      tp, out, inters);
                     }
                 }
@@ -293,7 +292,7 @@ struct get_turn_info_linear_areal
             {
                 // Collinear
                 if ( get_turn_info_for_endpoint<true, true>(
-                        retrieve_policy_p, retrieve_policy_q,
+                        range_p, range_q,
                         tp_model, inters, method_collinear, out) )
                 {
                     // do nothing
@@ -317,7 +316,7 @@ struct get_turn_info_linear_areal
                         }
                         else
                         {
-                            collinear<TurnInfo>::apply(retrieve_policy_p, retrieve_policy_q,
+                            collinear<TurnInfo>::apply(range_p, range_q,
                                     tp, inters.i_info(), inters.d_info(), inters.sides());
 
                             //method_replace = method_touch_interior;
@@ -359,7 +358,7 @@ struct get_turn_info_linear_areal
                             <
                                 TurnInfo,
                                 AssignPolicy
-                            >::apply(retrieve_policy_p, retrieve_policy_q,
+                            >::apply(range_p, range_q,
                                 tp, out, inters,
                                 inters.sides(), transformer);
                     }
@@ -699,12 +698,12 @@ struct get_turn_info_linear_areal
               bool EnableLast,
               typename TurnInfo,
               typename IntersectionInfo,
-              typename RetrieveAdditionalInfoPolicy1,
-              typename RetrieveAdditionalInfoPolicy2,
+              typename UniqueSubRange1,
+              typename UniqueSubRange2,
               typename OutputIterator>
     static inline bool get_turn_info_for_endpoint(
-                            RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
-                            RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
+                            UniqueSubRange1 const& range_p,
+                            UniqueSubRange2 const& range_q,
                             TurnInfo const& tp_model,
                             IntersectionInfo const& inters,
                             method_type /*method*/,
@@ -713,8 +712,8 @@ struct get_turn_info_linear_areal
         namespace ov = overlay;
         typedef ov::get_turn_info_for_endpoint<AssignPolicy, EnableFirst, EnableLast> get_info_e;
 
-        bool const is_p_first = retrieve_policy_p.is_first();
-        bool const is_p_last = ! retrieve_policy_p.has_k();
+        bool const is_p_first = range_p.is_first();
+        bool const is_p_last = ! range_p.has_k();
 
         const std::size_t ip_count = inters.i_info().count;
         // no intersection points
@@ -728,10 +727,10 @@ struct get_turn_info_linear_areal
             return false;
         }
 
-        bool const is_q_last = ! retrieve_policy_q.has_k();
+        bool const is_q_last = ! range_q.has_k();
 
-        linear_intersections intersections(retrieve_policy_p.get_point_i(),
-                                           retrieve_policy_q.get_point_i(),
+        linear_intersections intersections(range_p.get_point_i(),
+                                           range_q.get_point_i(),
                                            inters.result(), is_p_last, is_q_last);
         linear_intersections::ip_info const& ip0 = intersections.template get<0>();
         linear_intersections::ip_info const& ip1 = intersections.template get<1>();
@@ -823,7 +822,7 @@ struct get_turn_info_linear_areal
             // here is_p_first_ip == true
             tp.operations[0].is_collinear = false;
 
-            AssignPolicy::apply(tp, retrieve_policy_p.get_point_i(), retrieve_policy_q.get_point_i(), inters);
+            AssignPolicy::apply(tp, range_p.get_point_i(), range_q.get_point_i(), inters);
             *out++ = tp;
 
             was_first_point_handled = true;
@@ -879,7 +878,7 @@ struct get_turn_info_linear_areal
             unsigned int ip_index = ip_count > 1 ? 1 : 0;
             base_turn_handler::assign_point(tp, tp.method, inters.i_info(), ip_index);
 
-            AssignPolicy::apply(tp, retrieve_policy_p.get_point_i(), retrieve_policy_q.get_point_i(), inters);
+            AssignPolicy::apply(tp, range_p.get_point_i(), range_q.get_point_i(), inters);
             *out++ = tp;
 
             // don't ignore the first IP if the segment is opposite

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -150,8 +150,7 @@ struct get_turn_info_linear_areal
             break;
             case 'i' :
             {
-                crosses<TurnInfo>::apply(pi, pj, qi, qj,
-                                         tp, inters.i_info(), inters.d_info());
+                crosses<TurnInfo>::apply(tp, inters.i_info(), inters.d_info());
 
                 replace_operations_i(tp.operations[0].operation, tp.operations[1].operation);
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
@@ -57,7 +57,7 @@ struct get_turn_info_linear_linear
     {
         typedef intersection_info
             <
-                Point1, Point2,
+                Point1, Point2, RetrievePolicy1, RetrievePolicy2,
                 typename TurnInfo::point_type,
                 IntersectionStrategy,
                 RobustPolicy

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
@@ -403,22 +403,22 @@ struct get_turn_info_linear_linear
                     only_convert::apply(tp, inters.i_info());
 
                     // if any, only one of those should be true
-                    if ( range_p.is_first()
+                    if ( range_p.is_first_segment()
                       && equals::equals_point_point(range_p.at(0), tp.point) )
                     {
                         tp.operations[0].position = position_front;
                     }
-                    else if ( range_p.size() == 2u
+                    else if ( range_p.is_last_segment()
                            && equals::equals_point_point(range_p.at(1), tp.point) )
                     {
                         tp.operations[0].position = position_back;
                     }
-                    else if ( range_q.is_first()
+                    else if ( range_q.is_first_segment()
                            && equals::equals_point_point(range_q.at(0), tp.point) )
                     {
                         tp.operations[1].position = position_front;
                     }
-                    else if ( range_q.size() == 2u
+                    else if ( range_q.is_last_segment()
                            && equals::equals_point_point(range_q.at(1), tp.point) )
                     {
                         tp.operations[1].position = position_back;

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
@@ -36,18 +36,18 @@ struct get_turn_info_linear_linear
 
     template
     <
-        typename TurnInfo,
-        typename IntersectionStrategy,
         typename UniqueSubRange1,
         typename UniqueSubRange2,
+        typename TurnInfo,
+        typename IntersectionStrategy,
         typename RobustPolicy,
         typename OutputIterator
     >
     static inline OutputIterator apply(
-                TurnInfo const& tp_model,
-                IntersectionStrategy const& strategy,
                 UniqueSubRange1 const& range_p,
                 UniqueSubRange2 const& range_q,
+                TurnInfo const& tp_model,
+                IntersectionStrategy const& strategy,
                 RobustPolicy const& robust_policy,
                 OutputIterator out)
     {

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
@@ -71,11 +71,6 @@ struct get_turn_info_linear_linear
 
         char const method = inters.d_info().how;
 
-        bool const is_p_first = range_p.is_first();
-        bool const is_p_last = range_p.size() == 2u;
-        bool const is_q_first = range_q.is_first();
-        bool const is_q_last = range_q.size() == 2u;
-
         // Copy, to copy possibly extended fields
         TurnInfo tp = tp_model;
 
@@ -274,9 +269,7 @@ struct get_turn_info_linear_linear
                     AssignPolicy::apply(tp, pi, qi, inters);
 
                     if ( ! BOOST_GEOMETRY_CONDITION(handle_spikes)
-                      || ! append_opposite_spikes<append_touches>(tp, inters,
-                                                                  is_p_last, is_q_last,
-                                                                  out) )
+                      || ! append_opposite_spikes<append_touches>(tp, inters, out) )
                     {
                         *out++ = tp;
                     }
@@ -318,7 +311,6 @@ struct get_turn_info_linear_linear
                         // conditionally handle spikes
                         if ( ! BOOST_GEOMETRY_CONDITION(handle_spikes)
                           || ! append_collinear_spikes(tp, inters,
-                                                       is_p_last, is_q_last,
                                                        method_touch, spike_op,
                                                        out) )
                         {
@@ -389,7 +381,6 @@ struct get_turn_info_linear_linear
                         // conditionally handle spikes
                         if ( ! BOOST_GEOMETRY_CONDITION(handle_spikes)
                           || ! append_collinear_spikes(tp, inters,
-                                                       is_p_last, is_q_last,
                                                        method_replace, spike_op,
                                                        out) )
                         {
@@ -405,9 +396,7 @@ struct get_turn_info_linear_linear
                         // conditionally handle spikes
                         if ( BOOST_GEOMETRY_CONDITION(handle_spikes) )
                         {
-                            append_opposite_spikes<append_collinear_opposite>(tp, inters,
-                                                                              is_p_last, is_q_last,
-                                                                              out);
+                            append_opposite_spikes<append_collinear_opposite>(tp, inters, out);
                         }
 
                         // TODO: ignore for spikes?
@@ -433,22 +422,22 @@ struct get_turn_info_linear_linear
                     only_convert::apply(tp, inters.i_info());
 
                     // if any, only one of those should be true
-                    if ( is_p_first
+                    if ( range_p.is_first()
                       && equals::equals_point_point(pi, tp.point) )
                     {
                         tp.operations[0].position = position_front;
                     }
-                    else if ( is_p_last
+                    else if ( range_p.size() == 2u
                            && equals::equals_point_point(pj, tp.point) )
                     {
                         tp.operations[0].position = position_back;
                     }
-                    else if ( is_q_first
+                    else if ( range_q.is_first()
                            && equals::equals_point_point(qi, tp.point) )
                     {
                         tp.operations[1].position = position_front;
                     }
-                    else if ( is_q_last
+                    else if ( range_q.size() == 2u
                            && equals::equals_point_point(qj, tp.point) )
                     {
                         tp.operations[1].position = position_back;
@@ -479,7 +468,6 @@ struct get_turn_info_linear_linear
               typename OutIt>
     static inline bool append_collinear_spikes(TurnInfo & tp,
                                                IntersectionInfo const& inters_info,
-                                               bool is_p_last, bool is_q_last,
                                                method_type method, operation_type spike_op,
                                                OutIt out)
     {
@@ -487,10 +475,8 @@ struct get_turn_info_linear_linear
         // both position == middle
 
         bool is_p_spike = tp.operations[0].operation == spike_op
-                       && ! is_p_last
                        && inters_info.is_spike_p();
         bool is_q_spike = tp.operations[1].operation == spike_op
-                       && ! is_q_last
                        && inters_info.is_spike_q();
 
         if ( is_p_spike && is_q_spike )
@@ -549,7 +535,6 @@ struct get_turn_info_linear_linear
               typename OutIt>
     static inline bool append_opposite_spikes(TurnInfo & tp,
                                               IntersectionInfo const& inters,
-                                              bool is_p_last, bool is_q_last,
                                               OutIt out)
     {
         static const bool is_version_touches = (Version == append_touches);
@@ -558,13 +543,11 @@ struct get_turn_info_linear_linear
                             ( tp.operations[0].operation == operation_continue
                            || tp.operations[0].operation == operation_intersection ) :
                             true )
-                       && ! is_p_last
                        && inters.is_spike_p();
         bool is_q_spike = ( is_version_touches ?
                             ( tp.operations[1].operation == operation_continue
                            || tp.operations[1].operation == operation_intersection ) :
                             true )
-                       && ! is_q_last
                        && inters.is_spike_q();
 
         bool res = false;

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
@@ -85,8 +85,8 @@ struct get_turn_info_linear_linear
             case 'f' : // collinear, "from"
             case 's' : // starts from the middle
                 get_turn_info_for_endpoint<AssignPolicy, true, true>
-                    ::apply(pi, pj, pk, qi, qj, qk,
-                            tp_model, inters, retrieve_policy_p, retrieve_policy_q, method_none, out);
+                    ::apply(pi, pj, qi, qj, retrieve_policy_p, retrieve_policy_q,
+                            tp_model, inters, method_none, out);
                 break;
 
             case 'd' : // disjoint: never do anything
@@ -95,8 +95,8 @@ struct get_turn_info_linear_linear
             case 'm' :
             {
                 if ( get_turn_info_for_endpoint<AssignPolicy, false, true>
-                        ::apply(pi, pj, pk, qi, qj, qk,
-                                tp_model, inters, retrieve_policy_p, retrieve_policy_q, method_touch_interior, out) )
+                        ::apply(pi, pj, qi, qj, retrieve_policy_p, retrieve_policy_q,
+                                tp_model, inters, method_touch_interior, out) )
                 {
                     // do nothing
                 }
@@ -165,8 +165,8 @@ struct get_turn_info_linear_linear
             {
                 // Both touch (both arrive there)
                 if ( get_turn_info_for_endpoint<AssignPolicy, false, true>
-                        ::apply(pi, pj, pk, qi, qj, qk,
-                                tp_model, inters, retrieve_policy_p, retrieve_policy_q, method_touch, out) )
+                        ::apply(pi, pj, qi, qj, retrieve_policy_p, retrieve_policy_q,
+                                tp_model, inters, method_touch, out) )
                 {
                     // do nothing
                 }
@@ -299,8 +299,8 @@ struct get_turn_info_linear_linear
             case 'e':
             {
                 if ( get_turn_info_for_endpoint<AssignPolicy, true, true>
-                        ::apply(pi, pj, pk, qi, qj, qk,
-                                tp_model, inters, retrieve_policy_p, retrieve_policy_q, method_equal, out) )
+                        ::apply(pi, pj, qi, qj, retrieve_policy_p, retrieve_policy_q,
+                                tp_model, inters, method_equal, out) )
                 {
                     // do nothing
                 }
@@ -356,8 +356,8 @@ struct get_turn_info_linear_linear
             {
                 // Collinear
                 if ( get_turn_info_for_endpoint<AssignPolicy, true, true>
-                        ::apply(pi, pj, pk, qi, qj, qk,
-                                tp_model, inters, retrieve_policy_p, retrieve_policy_q, method_collinear, out) )
+                        ::apply(pi, pj, qi, qj, retrieve_policy_p, retrieve_policy_q,
+                                tp_model, inters,  method_collinear, out) )
                 {
                     // do nothing
                 }

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
@@ -86,7 +86,7 @@ struct get_turn_info_linear_linear
             case 'f' : // collinear, "from"
             case 's' : // starts from the middle
                 get_turn_info_for_endpoint<AssignPolicy, true, true>
-                    ::apply(pi, pj, qi, qj, retrieve_policy_p, retrieve_policy_q,
+                    ::apply(retrieve_policy_p, retrieve_policy_q,
                             tp_model, inters, method_none, out);
                 break;
 
@@ -96,7 +96,7 @@ struct get_turn_info_linear_linear
             case 'm' :
             {
                 if ( get_turn_info_for_endpoint<AssignPolicy, false, true>
-                        ::apply(pi, pj, qi, qj, retrieve_policy_p, retrieve_policy_q,
+                        ::apply(retrieve_policy_p, retrieve_policy_q,
                                 tp_model, inters, method_touch_interior, out) )
                 {
                     // do nothing
@@ -155,7 +155,7 @@ struct get_turn_info_linear_linear
             {
                 // Both touch (both arrive there)
                 if ( get_turn_info_for_endpoint<AssignPolicy, false, true>
-                        ::apply(pi, pj, qi, qj, retrieve_policy_p, retrieve_policy_q,
+                        ::apply(retrieve_policy_p, retrieve_policy_q,
                                 tp_model, inters, method_touch, out) )
                 {
                     // do nothing
@@ -289,7 +289,7 @@ struct get_turn_info_linear_linear
             case 'e':
             {
                 if ( get_turn_info_for_endpoint<AssignPolicy, true, true>
-                        ::apply(pi, pj, qi, qj, retrieve_policy_p, retrieve_policy_q,
+                        ::apply(retrieve_policy_p, retrieve_policy_q,
                                 tp_model, inters, method_equal, out) )
                 {
                     // do nothing
@@ -346,7 +346,7 @@ struct get_turn_info_linear_linear
             {
                 // Collinear
                 if ( get_turn_info_for_endpoint<AssignPolicy, true, true>
-                        ::apply(pi, pj, qi, qj, retrieve_policy_p, retrieve_policy_q,
+                        ::apply(retrieve_policy_p, retrieve_policy_q,
                                 tp_model, inters,  method_collinear, out) )
                 {
                     // do nothing

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
@@ -46,8 +46,8 @@ struct get_turn_info_linear_linear
         typename OutputIterator
     >
     static inline OutputIterator apply(
-                Point1 const& pi, Point1 const& pj, Point1 const& pk,
-                Point2 const& qi, Point2 const& qj, Point2 const& qk,
+                Point1 const& pi, Point1 const& pj,
+                Point2 const& qi, Point2 const& qj,
                 TurnInfo const& tp_model,
                 IntersectionStrategy const& strategy,
                 RetrievePolicy1 const& retrieve_policy_p,
@@ -62,6 +62,9 @@ struct get_turn_info_linear_linear
                 IntersectionStrategy,
                 RobustPolicy
             > inters_info;
+
+        Point1 const& pk = retrieve_policy_p.get();
+        Point2 const& qk = retrieve_policy_q.get();
 
         inters_info inters(pi, pj, pk, qi, qj, qk, strategy, robust_policy);
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
@@ -61,10 +61,10 @@ struct get_turn_info_linear_linear
 
         typedef typename UniqueSubRange1::point_type Point1;
         typedef typename UniqueSubRange2::point_type Point2;
-        Point1 const& pi = range_p.get_point_i();
-        Point1 const& pj = range_p.get_point_j();
-        Point2 const& qi = range_q.get_point_i();
-        Point2 const& qj = range_q.get_point_j();
+        Point1 const& pi = range_p.at(0);
+        Point1 const& pj = range_p.at(1);
+        Point2 const& qi = range_q.at(0);
+        Point2 const& qj = range_q.at(1);
 
         inters_info inters(range_p, range_q,
                            strategy, robust_policy);
@@ -72,9 +72,9 @@ struct get_turn_info_linear_linear
         char const method = inters.d_info().how;
 
         bool const is_p_first = range_p.is_first();
-        bool const is_p_last = ! range_p.has_k();
+        bool const is_p_last = range_p.size() == 2u;
         bool const is_q_first = range_q.is_first();
-        bool const is_q_last = ! range_q.has_k();
+        bool const is_q_last = range_q.size() == 2u;
 
         // Copy, to copy possibly extended fields
         TurnInfo tp = tp_model;

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
@@ -76,7 +76,7 @@ struct get_turn_info_linear_linear
             case 'a' : // collinear, "at"
             case 'f' : // collinear, "from"
             case 's' : // starts from the middle
-                get_turn_info_for_endpoint<AssignPolicy, true, true>
+                get_turn_info_for_endpoint<true, true>
                     ::apply(range_p, range_q,
                             tp_model, inters, method_none, out);
                 break;
@@ -86,7 +86,7 @@ struct get_turn_info_linear_linear
 
             case 'm' :
             {
-                if ( get_turn_info_for_endpoint<AssignPolicy, false, true>
+                if ( get_turn_info_for_endpoint<false, true>
                         ::apply(range_p, range_q,
                                 tp_model, inters, method_touch_interior, out) )
                 {
@@ -125,7 +125,6 @@ struct get_turn_info_linear_linear
                                                      tp.operations[0].operation,
                                                      tp.operations[1].operation);
                     
-                    AssignPolicy::apply(tp, pi, qi, inters);
                     *out++ = tp;
                 }
             }
@@ -136,14 +135,13 @@ struct get_turn_info_linear_linear
 
                 replace_operations_i(tp.operations[0].operation, tp.operations[1].operation);
 
-                AssignPolicy::apply(tp, pi, qi, inters);
                 *out++ = tp;
             }
             break;
             case 't' :
             {
                 // Both touch (both arrive there)
-                if ( get_turn_info_for_endpoint<AssignPolicy, false, true>
+                if ( get_turn_info_for_endpoint<false, true>
                         ::apply(range_p, range_q,
                                 tp_model, inters, method_touch, out) )
                 {
@@ -261,9 +259,6 @@ struct get_turn_info_linear_linear
                                                      tp.operations[0].operation,
                                                      tp.operations[1].operation);
 
-// TODO: move this into the append_xxx and call for each turn?
-                    AssignPolicy::apply(tp, pi, qi, inters);
-
                     if ( ! BOOST_GEOMETRY_CONDITION(handle_spikes)
                       || ! append_opposite_spikes<append_touches>(tp, inters, out) )
                     {
@@ -274,7 +269,7 @@ struct get_turn_info_linear_linear
             break;
             case 'e':
             {
-                if ( get_turn_info_for_endpoint<AssignPolicy, true, true>
+                if ( get_turn_info_for_endpoint<true, true>
                         ::apply(range_p, range_q,
                                 tp_model, inters, method_equal, out) )
                 {
@@ -301,9 +296,6 @@ struct get_turn_info_linear_linear
                         turn_transformer_ec transformer(method_touch);
                         transformer(tp);
 
-// TODO: move this into the append_xxx and call for each turn?
-                        AssignPolicy::apply(tp, pi, qi, inters);
-
                         // conditionally handle spikes
                         if ( ! BOOST_GEOMETRY_CONDITION(handle_spikes)
                           || ! append_collinear_spikes(tp, inters,
@@ -329,7 +321,7 @@ struct get_turn_info_linear_linear
             case 'c' :
             {
                 // Collinear
-                if ( get_turn_info_for_endpoint<AssignPolicy, true, true>
+                if ( get_turn_info_for_endpoint<true, true>
                         ::apply(range_p, range_q,
                                 tp_model, inters,  method_collinear, out) )
                 {
@@ -371,9 +363,6 @@ struct get_turn_info_linear_linear
                         turn_transformer_ec transformer(method_replace);
                         transformer(tp);
                         
-// TODO: move this into the append_xxx and call for each turn?
-                        AssignPolicy::apply(tp, pi, qi, inters);
-
                         // conditionally handle spikes
                         if ( ! BOOST_GEOMETRY_CONDITION(handle_spikes)
                           || ! append_collinear_spikes(tp, inters,
@@ -439,7 +428,6 @@ struct get_turn_info_linear_linear
                         tp.operations[1].position = position_back;
                     }
 
-                    AssignPolicy::apply(tp, pi, qi, inters);
                     *out++ = tp;
                 }
             }
@@ -567,8 +555,6 @@ struct get_turn_info_linear_linear
                 
                 base_turn_handler::assign_point(tp, method_touch_interior,
                                                 inters.i_info(), 1);
-
-                AssignPolicy::apply(tp, inters.pi(), inters.qi(), inters);
             }
 
             tp.operations[0].operation = operation_blocked;
@@ -599,8 +585,6 @@ struct get_turn_info_linear_linear
                 BOOST_GEOMETRY_ASSERT(inters.i_info().count > 0);
 
                 base_turn_handler::assign_point(tp, method_touch_interior, inters.i_info(), 0);
-
-                AssignPolicy::apply(tp, inters.pi(), inters.qi(), inters);
             }
 
             tp.operations[0].operation = operation_intersection;

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
@@ -111,15 +111,13 @@ struct get_turn_info_linear_linear
                     // If Q (1) arrives (1)
                     if ( inters.d_info().arrival[1] == 1)
                     {
-                        policy::template apply<0>(pi, pj, qi, qj,
-                                                  tp, inters.i_info(), inters.d_info(),
+                        policy::template apply<0>(tp, inters.i_info(), inters.d_info(),
                                                   inters.sides());
                     }
                     else
                     {
                         // Swap p/q
-                        policy::template apply<1>(qi, qj, pi, pj,
-                                                  tp, inters.i_info(), inters.d_info(),
+                        policy::template apply<1>(tp, inters.i_info(), inters.d_info(),
                                                   inters.get_swapped_sides());
                     }
                     
@@ -162,8 +160,7 @@ struct get_turn_info_linear_linear
                 }
                 else 
                 {
-                    touch<TurnInfo>::apply(pi, pj, qi, qj,
-                                           tp, inters.i_info(), inters.d_info(), inters.sides());
+                    touch<TurnInfo>::apply(tp, inters.i_info(), inters.d_info(), inters.sides());
 
                     // workarounds for touch<> not taking spikes into account starts here
                     // those was discovered empirically
@@ -303,8 +300,7 @@ struct get_turn_info_linear_linear
                     {
                         // Both equal
                         // or collinear-and-ending at intersection point
-                        equal<TurnInfo>::apply(pi, pj, qi, qj,
-                            tp, inters.i_info(), inters.d_info(), inters.sides());
+                        equal<TurnInfo>::apply(tp, inters.i_info(), inters.d_info(), inters.sides());
 
                         operation_type spike_op
                             = ( tp.operations[0].operation != operation_continue
@@ -337,7 +333,7 @@ struct get_turn_info_linear_linear
                             <
                                 TurnInfo,
                                 AssignPolicy
-                            >::apply(pi, qi, tp, out, inters);
+                            >::apply(retrieve_policy_p, retrieve_policy_q, tp, out, inters);
                     }
                 }
             }
@@ -365,8 +361,7 @@ struct get_turn_info_linear_linear
                         if ( inters.d_info().arrival[0] == 0 )
                         {
                             // Collinear, but similar thus handled as equal
-                            equal<TurnInfo>::apply(pi, pj, qi, qj,
-                                    tp, inters.i_info(), inters.d_info(), inters.sides());
+                            equal<TurnInfo>::apply(tp, inters.i_info(), inters.d_info(), inters.sides());
 
                             method_replace = method_touch;
                             if ( tp.operations[0].operation != operation_continue
@@ -377,8 +372,7 @@ struct get_turn_info_linear_linear
                         }
                         else
                         {
-                            collinear<TurnInfo>::apply(pi, pj, qi, qj,
-                                    retrieve_policy_p, retrieve_policy_q,
+                            collinear<TurnInfo>::apply(retrieve_policy_p, retrieve_policy_q,
                                     tp, inters.i_info(), inters.d_info(), inters.sides());
 
                             //method_replace = method_touch_interior;
@@ -424,8 +418,7 @@ struct get_turn_info_linear_linear
                             <
                                 TurnInfo,
                                 AssignPolicy
-                            >::apply(pi, pj, qi, qj,
-                                retrieve_policy_p, retrieve_policy_q,
+                            >::apply(retrieve_policy_p, retrieve_policy_q,
                                 tp, out, inters, inters.sides(),
                                 transformer);
                     }

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
@@ -117,19 +117,9 @@ struct get_turn_info_linear_linear
                     else
                     {
                         // Swap p/q
-                        side_calculator
-                            <
-                                typename inters_info::cs_tag,
-                                typename inters_info::robust_point2_type,
-                                typename inters_info::robust_point1_type,
-                                typename inters_info::side_strategy_type
-                            > swapped_side_calc(inters.rqi(), inters.rqj(), inters.rqk(),
-                                                inters.rpi(), inters.rpj(), inters.rpk(),
-                                                inters.get_side_strategy());
-
                         policy::template apply<1>(qi, qj, pi, pj,
                                                   tp, inters.i_info(), inters.d_info(),
-                                                  swapped_side_calc);
+                                                  inters.get_swapped_sides());
                     }
                     
                     if ( tp.operations[0].operation == operation_blocked )

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
@@ -40,7 +40,8 @@ struct get_turn_info_linear_linear
         typename Point2,
         typename TurnInfo,
         typename IntersectionStrategy,
-        typename RetrievePolicy,
+        typename RetrievePolicy1,
+        typename RetrievePolicy2,
         typename RobustPolicy,
         typename OutputIterator
     >
@@ -49,7 +50,8 @@ struct get_turn_info_linear_linear
                 Point2 const& qi, Point2 const& qj, Point2 const& qk,
                 TurnInfo const& tp_model,
                 IntersectionStrategy const& strategy,
-                RetrievePolicy const& retrieve_policy,
+                RetrievePolicy1 const& retrieve_policy_p,
+                RetrievePolicy2 const& retrieve_policy_q,
                 RobustPolicy const& robust_policy,
                 OutputIterator out)
     {
@@ -65,10 +67,10 @@ struct get_turn_info_linear_linear
 
         char const method = inters.d_info().how;
 
-        bool const is_p_first = retrieve_policy.is_first(0);
-        bool const is_p_last = retrieve_policy.is_last(0);
-        bool const is_q_first = retrieve_policy.is_first(1);
-        bool const is_q_last = retrieve_policy.is_last(1);
+        bool const is_p_first = retrieve_policy_p.is_first();
+        bool const is_p_last = retrieve_policy_p.is_last();
+        bool const is_q_first = retrieve_policy_q.is_first();
+        bool const is_q_last = retrieve_policy_q.is_last();
 
         // Copy, to copy possibly extended fields
         TurnInfo tp = tp_model;
@@ -81,7 +83,7 @@ struct get_turn_info_linear_linear
             case 's' : // starts from the middle
                 get_turn_info_for_endpoint<AssignPolicy, true, true>
                     ::apply(pi, pj, pk, qi, qj, qk,
-                            tp_model, inters, retrieve_policy, method_none, out);
+                            tp_model, inters, retrieve_policy_p, retrieve_policy_q, method_none, out);
                 break;
 
             case 'd' : // disjoint: never do anything
@@ -91,7 +93,7 @@ struct get_turn_info_linear_linear
             {
                 if ( get_turn_info_for_endpoint<AssignPolicy, false, true>
                         ::apply(pi, pj, pk, qi, qj, qk,
-                                tp_model, inters, retrieve_policy, method_touch_interior, out) )
+                                tp_model, inters, retrieve_policy_p, retrieve_policy_q, method_touch_interior, out) )
                 {
                     // do nothing
                 }
@@ -161,7 +163,7 @@ struct get_turn_info_linear_linear
                 // Both touch (both arrive there)
                 if ( get_turn_info_for_endpoint<AssignPolicy, false, true>
                         ::apply(pi, pj, pk, qi, qj, qk,
-                                tp_model, inters, retrieve_policy, method_touch, out) )
+                                tp_model, inters, retrieve_policy_p, retrieve_policy_q, method_touch, out) )
                 {
                     // do nothing
                 }
@@ -295,7 +297,7 @@ struct get_turn_info_linear_linear
             {
                 if ( get_turn_info_for_endpoint<AssignPolicy, true, true>
                         ::apply(pi, pj, pk, qi, qj, qk,
-                                tp_model, inters, retrieve_policy, method_equal, out) )
+                                tp_model, inters, retrieve_policy_p, retrieve_policy_q, method_equal, out) )
                 {
                     // do nothing
                 }
@@ -352,7 +354,7 @@ struct get_turn_info_linear_linear
                 // Collinear
                 if ( get_turn_info_for_endpoint<AssignPolicy, true, true>
                         ::apply(pi, pj, pk, qi, qj, qk,
-                                tp_model, inters, retrieve_policy, method_collinear, out) )
+                                tp_model, inters, retrieve_policy_p, retrieve_policy_q, method_collinear, out) )
                 {
                     // do nothing
                 }

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
@@ -110,7 +110,7 @@ struct get_turn_info_linear_linear
                     // If Q (1) arrives (1)
                     if ( inters.d_info().arrival[1] == 1)
                     {
-                        policy::template apply<0>(pi, pj, pk, qi, qj, qk,
+                        policy::template apply<0>(pi, pj, qi, qj,
                                                   tp, inters.i_info(), inters.d_info(),
                                                   inters.sides());
                     }
@@ -127,7 +127,7 @@ struct get_turn_info_linear_linear
                                                 inters.rpi(), inters.rpj(), inters.rpk(),
                                                 inters.get_side_strategy());
 
-                        policy::template apply<1>(qi, qj, qk, pi, pj, pk,
+                        policy::template apply<1>(qi, qj, pi, pj,
                                                   tp, inters.i_info(), inters.d_info(),
                                                   swapped_side_calc);
                     }
@@ -152,7 +152,7 @@ struct get_turn_info_linear_linear
             break;
             case 'i' :
             {
-                crosses<TurnInfo>::apply(pi, pj, pk, qi, qj, qk,
+                crosses<TurnInfo>::apply(pi, pj, qi, qj,
                                          tp, inters.i_info(), inters.d_info());
 
                 replace_operations_i(tp.operations[0].operation, tp.operations[1].operation);
@@ -172,7 +172,7 @@ struct get_turn_info_linear_linear
                 }
                 else 
                 {
-                    touch<TurnInfo>::apply(pi, pj, pk, qi, qj, qk,
+                    touch<TurnInfo>::apply(pi, pj, qi, qj,
                                            tp, inters.i_info(), inters.d_info(), inters.sides());
 
                     // workarounds for touch<> not taking spikes into account starts here
@@ -313,7 +313,7 @@ struct get_turn_info_linear_linear
                     {
                         // Both equal
                         // or collinear-and-ending at intersection point
-                        equal<TurnInfo>::apply(pi, pj, pk, qi, qj, qk,
+                        equal<TurnInfo>::apply(pi, pj, qi, qj,
                             tp, inters.i_info(), inters.d_info(), inters.sides());
 
                         operation_type spike_op
@@ -375,7 +375,7 @@ struct get_turn_info_linear_linear
                         if ( inters.d_info().arrival[0] == 0 )
                         {
                             // Collinear, but similar thus handled as equal
-                            equal<TurnInfo>::apply(pi, pj, pk, qi, qj, qk,
+                            equal<TurnInfo>::apply(pi, pj, qi, qj,
                                     tp, inters.i_info(), inters.d_info(), inters.sides());
 
                             method_replace = method_touch;
@@ -387,7 +387,8 @@ struct get_turn_info_linear_linear
                         }
                         else
                         {
-                            collinear<TurnInfo>::apply(pi, pj, pk, qi, qj, qk,
+                            collinear<TurnInfo>::apply(pi, pj, qi, qj,
+                                    retrieve_policy_p, retrieve_policy_q,
                                     tp, inters.i_info(), inters.d_info(), inters.sides());
 
                             //method_replace = method_touch_interior;
@@ -433,7 +434,8 @@ struct get_turn_info_linear_linear
                             <
                                 TurnInfo,
                                 AssignPolicy
-                            >::apply(pi, pj, pk, qi, qj, qk,
+                            >::apply(pi, pj, qi, qj,
+                                retrieve_policy_p, retrieve_policy_q,
                                 tp, out, inters, inters.sides(),
                                 transformer, !is_p_last, !is_q_last);
                     }

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
@@ -59,11 +59,7 @@ struct get_turn_info_linear_linear
                 RobustPolicy
             > inters_info;
 
-        typename UniqueSubRange1::point_type const& pi = range_p.at(0);
-        typename UniqueSubRange2::point_type const& qi = range_q.at(0);
-
-        inters_info inters(range_p, range_q,
-                           strategy, robust_policy);
+        inters_info inters(range_p, range_q, strategy, robust_policy);
 
         char const method = inters.d_info().how;
 
@@ -408,7 +404,7 @@ struct get_turn_info_linear_linear
 
                     // if any, only one of those should be true
                     if ( range_p.is_first()
-                      && equals::equals_point_point(pi, tp.point) )
+                      && equals::equals_point_point(range_p.at(0), tp.point) )
                     {
                         tp.operations[0].position = position_front;
                     }
@@ -418,7 +414,7 @@ struct get_turn_info_linear_linear
                         tp.operations[0].position = position_back;
                     }
                     else if ( range_q.is_first()
-                           && equals::equals_point_point(qi, tp.point) )
+                           && equals::equals_point_point(range_q.at(0), tp.point) )
                     {
                         tp.operations[1].position = position_front;
                     }

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
@@ -40,16 +40,16 @@ struct get_turn_info_linear_linear
         typename Point2,
         typename TurnInfo,
         typename IntersectionStrategy,
+        typename RetrievePolicy,
         typename RobustPolicy,
         typename OutputIterator
     >
     static inline OutputIterator apply(
                 Point1 const& pi, Point1 const& pj, Point1 const& pk,
                 Point2 const& qi, Point2 const& qj, Point2 const& qk,
-                bool is_p_first, bool is_p_last,
-                bool is_q_first, bool is_q_last,
                 TurnInfo const& tp_model,
                 IntersectionStrategy const& strategy,
+                RetrievePolicy const& retrieve_policy,
                 RobustPolicy const& robust_policy,
                 OutputIterator out)
     {
@@ -64,6 +64,11 @@ struct get_turn_info_linear_linear
         inters_info inters(pi, pj, pk, qi, qj, qk, strategy, robust_policy);
 
         char const method = inters.d_info().how;
+
+        bool const is_p_first = retrieve_policy.is_first(0);
+        bool const is_p_last = retrieve_policy.is_last(0);
+        bool const is_q_first = retrieve_policy.is_first(1);
+        bool const is_q_last = retrieve_policy.is_last(1);
 
         // Copy, to copy possibly extended fields
         TurnInfo tp = tp_model;

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
@@ -59,12 +59,8 @@ struct get_turn_info_linear_linear
                 RobustPolicy
             > inters_info;
 
-        typedef typename UniqueSubRange1::point_type Point1;
-        typedef typename UniqueSubRange2::point_type Point2;
-        Point1 const& pi = range_p.at(0);
-        Point1 const& pj = range_p.at(1);
-        Point2 const& qi = range_q.at(0);
-        Point2 const& qj = range_q.at(1);
+        typename UniqueSubRange1::point_type const& pi = range_p.at(0);
+        typename UniqueSubRange2::point_type const& qi = range_q.at(0);
 
         inters_info inters(range_p, range_q,
                            strategy, robust_policy);
@@ -428,7 +424,7 @@ struct get_turn_info_linear_linear
                         tp.operations[0].position = position_front;
                     }
                     else if ( range_p.size() == 2u
-                           && equals::equals_point_point(pj, tp.point) )
+                           && equals::equals_point_point(range_p.at(1), tp.point) )
                     {
                         tp.operations[0].position = position_back;
                     }
@@ -438,7 +434,7 @@ struct get_turn_info_linear_linear
                         tp.operations[1].position = position_front;
                     }
                     else if ( range_q.size() == 2u
-                           && equals::equals_point_point(qj, tp.point) )
+                           && equals::equals_point_point(range_q.at(1), tp.point) )
                     {
                         tp.operations[1].position = position_back;
                     }

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
@@ -143,8 +143,7 @@ struct get_turn_info_linear_linear
             break;
             case 'i' :
             {
-                crosses<TurnInfo>::apply(pi, pj, qi, qj,
-                                         tp, inters.i_info(), inters.d_info());
+                crosses<TurnInfo>::apply(tp, inters.i_info(), inters.d_info());
 
                 replace_operations_i(tp.operations[0].operation, tp.operations[1].operation);
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
@@ -36,8 +36,6 @@ struct get_turn_info_linear_linear
 
     template
     <
-        typename Point1,
-        typename Point2,
         typename TurnInfo,
         typename IntersectionStrategy,
         typename RetrieveAdditionalInfoPolicy1,
@@ -46,8 +44,6 @@ struct get_turn_info_linear_linear
         typename OutputIterator
     >
     static inline OutputIterator apply(
-                Point1 const& pi, Point1 const& pj,
-                Point2 const& qi, Point2 const& qj,
                 TurnInfo const& tp_model,
                 IntersectionStrategy const& strategy,
                 RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
@@ -57,14 +53,20 @@ struct get_turn_info_linear_linear
     {
         typedef intersection_info
             <
-                Point1, Point2, RetrieveAdditionalInfoPolicy1, RetrieveAdditionalInfoPolicy2,
+                RetrieveAdditionalInfoPolicy1, RetrieveAdditionalInfoPolicy2,
                 typename TurnInfo::point_type,
                 IntersectionStrategy,
                 RobustPolicy
             > inters_info;
 
-        inters_info inters(pi, pj, qi, qj,
-                           retrieve_policy_p, retrieve_policy_q,
+        typedef typename RetrieveAdditionalInfoPolicy1::point_type Point1;
+        typedef typename RetrieveAdditionalInfoPolicy2::point_type Point2;
+        Point1 const& pi = retrieve_policy_p.get_point_i();
+        Point1 const& pj = retrieve_policy_p.get_point_j();
+        Point2 const& qi = retrieve_policy_q.get_point_i();
+        Point2 const& qj = retrieve_policy_q.get_point_j();
+
+        inters_info inters(retrieve_policy_p, retrieve_policy_q,
                            strategy, robust_policy);
 
         char const method = inters.d_info().how;

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
@@ -38,43 +38,43 @@ struct get_turn_info_linear_linear
     <
         typename TurnInfo,
         typename IntersectionStrategy,
-        typename RetrieveAdditionalInfoPolicy1,
-        typename RetrieveAdditionalInfoPolicy2,
+        typename UniqueSubRange1,
+        typename UniqueSubRange2,
         typename RobustPolicy,
         typename OutputIterator
     >
     static inline OutputIterator apply(
                 TurnInfo const& tp_model,
                 IntersectionStrategy const& strategy,
-                RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
-                RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
+                UniqueSubRange1 const& range_p,
+                UniqueSubRange2 const& range_q,
                 RobustPolicy const& robust_policy,
                 OutputIterator out)
     {
         typedef intersection_info
             <
-                RetrieveAdditionalInfoPolicy1, RetrieveAdditionalInfoPolicy2,
+                UniqueSubRange1, UniqueSubRange2,
                 typename TurnInfo::point_type,
                 IntersectionStrategy,
                 RobustPolicy
             > inters_info;
 
-        typedef typename RetrieveAdditionalInfoPolicy1::point_type Point1;
-        typedef typename RetrieveAdditionalInfoPolicy2::point_type Point2;
-        Point1 const& pi = retrieve_policy_p.get_point_i();
-        Point1 const& pj = retrieve_policy_p.get_point_j();
-        Point2 const& qi = retrieve_policy_q.get_point_i();
-        Point2 const& qj = retrieve_policy_q.get_point_j();
+        typedef typename UniqueSubRange1::point_type Point1;
+        typedef typename UniqueSubRange2::point_type Point2;
+        Point1 const& pi = range_p.get_point_i();
+        Point1 const& pj = range_p.get_point_j();
+        Point2 const& qi = range_q.get_point_i();
+        Point2 const& qj = range_q.get_point_j();
 
-        inters_info inters(retrieve_policy_p, retrieve_policy_q,
+        inters_info inters(range_p, range_q,
                            strategy, robust_policy);
 
         char const method = inters.d_info().how;
 
-        bool const is_p_first = retrieve_policy_p.is_first();
-        bool const is_p_last = ! retrieve_policy_p.has_k();
-        bool const is_q_first = retrieve_policy_q.is_first();
-        bool const is_q_last = ! retrieve_policy_q.has_k();
+        bool const is_p_first = range_p.is_first();
+        bool const is_p_last = ! range_p.has_k();
+        bool const is_q_first = range_q.is_first();
+        bool const is_q_last = ! range_q.has_k();
 
         // Copy, to copy possibly extended fields
         TurnInfo tp = tp_model;
@@ -86,7 +86,7 @@ struct get_turn_info_linear_linear
             case 'f' : // collinear, "from"
             case 's' : // starts from the middle
                 get_turn_info_for_endpoint<AssignPolicy, true, true>
-                    ::apply(retrieve_policy_p, retrieve_policy_q,
+                    ::apply(range_p, range_q,
                             tp_model, inters, method_none, out);
                 break;
 
@@ -96,7 +96,7 @@ struct get_turn_info_linear_linear
             case 'm' :
             {
                 if ( get_turn_info_for_endpoint<AssignPolicy, false, true>
-                        ::apply(retrieve_policy_p, retrieve_policy_q,
+                        ::apply(range_p, range_q,
                                 tp_model, inters, method_touch_interior, out) )
                 {
                     // do nothing
@@ -153,7 +153,7 @@ struct get_turn_info_linear_linear
             {
                 // Both touch (both arrive there)
                 if ( get_turn_info_for_endpoint<AssignPolicy, false, true>
-                        ::apply(retrieve_policy_p, retrieve_policy_q,
+                        ::apply(range_p, range_q,
                                 tp_model, inters, method_touch, out) )
                 {
                     // do nothing
@@ -286,7 +286,7 @@ struct get_turn_info_linear_linear
             case 'e':
             {
                 if ( get_turn_info_for_endpoint<AssignPolicy, true, true>
-                        ::apply(retrieve_policy_p, retrieve_policy_q,
+                        ::apply(range_p, range_q,
                                 tp_model, inters, method_equal, out) )
                 {
                     // do nothing
@@ -333,7 +333,7 @@ struct get_turn_info_linear_linear
                             <
                                 TurnInfo,
                                 AssignPolicy
-                            >::apply(retrieve_policy_p, retrieve_policy_q, tp, out, inters);
+                            >::apply(range_p, range_q, tp, out, inters);
                     }
                 }
             }
@@ -342,7 +342,7 @@ struct get_turn_info_linear_linear
             {
                 // Collinear
                 if ( get_turn_info_for_endpoint<AssignPolicy, true, true>
-                        ::apply(retrieve_policy_p, retrieve_policy_q,
+                        ::apply(range_p, range_q,
                                 tp_model, inters,  method_collinear, out) )
                 {
                     // do nothing
@@ -372,7 +372,7 @@ struct get_turn_info_linear_linear
                         }
                         else
                         {
-                            collinear<TurnInfo>::apply(retrieve_policy_p, retrieve_policy_q,
+                            collinear<TurnInfo>::apply(range_p, range_q,
                                     tp, inters.i_info(), inters.d_info(), inters.sides());
 
                             //method_replace = method_touch_interior;
@@ -418,7 +418,7 @@ struct get_turn_info_linear_linear
                             <
                                 TurnInfo,
                                 AssignPolicy
-                            >::apply(retrieve_policy_p, retrieve_policy_q,
+                            >::apply(range_p, range_q,
                                 tp, out, inters, inters.sides(),
                                 transformer);
                     }

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
@@ -40,8 +40,8 @@ struct get_turn_info_linear_linear
         typename Point2,
         typename TurnInfo,
         typename IntersectionStrategy,
-        typename RetrievePolicy1,
-        typename RetrievePolicy2,
+        typename RetrieveAdditionalInfoPolicy1,
+        typename RetrieveAdditionalInfoPolicy2,
         typename RobustPolicy,
         typename OutputIterator
     >
@@ -50,14 +50,14 @@ struct get_turn_info_linear_linear
                 Point2 const& qi, Point2 const& qj,
                 TurnInfo const& tp_model,
                 IntersectionStrategy const& strategy,
-                RetrievePolicy1 const& retrieve_policy_p,
-                RetrievePolicy2 const& retrieve_policy_q,
+                RetrieveAdditionalInfoPolicy1 const& retrieve_policy_p,
+                RetrieveAdditionalInfoPolicy2 const& retrieve_policy_q,
                 RobustPolicy const& robust_policy,
                 OutputIterator out)
     {
         typedef intersection_info
             <
-                Point1, Point2, RetrievePolicy1, RetrievePolicy2,
+                Point1, Point2, RetrieveAdditionalInfoPolicy1, RetrieveAdditionalInfoPolicy2,
                 typename TurnInfo::point_type,
                 IntersectionStrategy,
                 RobustPolicy
@@ -70,9 +70,9 @@ struct get_turn_info_linear_linear
         char const method = inters.d_info().how;
 
         bool const is_p_first = retrieve_policy_p.is_first();
-        bool const is_p_last = retrieve_policy_p.is_last();
+        bool const is_p_last = ! retrieve_policy_p.has_k();
         bool const is_q_first = retrieve_policy_q.is_first();
-        bool const is_q_last = retrieve_policy_q.is_last();
+        bool const is_q_last = ! retrieve_policy_q.has_k();
 
         // Copy, to copy possibly extended fields
         TurnInfo tp = tp_model;
@@ -426,7 +426,7 @@ struct get_turn_info_linear_linear
                             >::apply(pi, pj, qi, qj,
                                 retrieve_policy_p, retrieve_policy_q,
                                 tp, out, inters, inters.sides(),
-                                transformer, !is_p_last, !is_q_last);
+                                transformer);
                     }
                 }
             }

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
@@ -98,13 +98,15 @@ struct get_turn_info_linear_linear
                     // If Q (1) arrives (1)
                     if ( inters.d_info().arrival[1] == 1)
                     {
-                        policy::template apply<0>(tp, inters.i_info(), inters.d_info(),
+                        policy::template apply<0>(range_p, range_q, tp,
+                                                  inters.i_info(), inters.d_info(),
                                                   inters.sides());
                     }
                     else
                     {
                         // Swap p/q
-                        policy::template apply<1>(tp, inters.i_info(), inters.d_info(),
+                        policy::template apply<1>(range_q, range_p, tp,
+                                                  inters.i_info(), inters.d_info(),
                                                   inters.get_swapped_sides());
                     }
                     
@@ -145,7 +147,8 @@ struct get_turn_info_linear_linear
                 }
                 else 
                 {
-                    touch<TurnInfo>::apply(tp, inters.i_info(), inters.d_info(), inters.sides());
+                    touch<TurnInfo>::apply(range_p, range_q, tp,
+                                           inters.i_info(), inters.d_info(), inters.sides());
 
                     // workarounds for touch<> not taking spikes into account starts here
                     // those was discovered empirically
@@ -280,7 +283,8 @@ struct get_turn_info_linear_linear
                     {
                         // Both equal
                         // or collinear-and-ending at intersection point
-                        equal<TurnInfo>::apply(tp, inters.i_info(), inters.d_info(), inters.sides());
+                        equal<TurnInfo>::apply(range_p, range_q, tp,
+                            inters.i_info(), inters.d_info(), inters.sides());
 
                         operation_type spike_op
                             = ( tp.operations[0].operation != operation_continue
@@ -337,7 +341,8 @@ struct get_turn_info_linear_linear
                         if ( inters.d_info().arrival[0] == 0 )
                         {
                             // Collinear, but similar thus handled as equal
-                            equal<TurnInfo>::apply(tp, inters.i_info(), inters.d_info(), inters.sides());
+                            equal<TurnInfo>::apply(range_p, range_q, tp,
+                                inters.i_info(), inters.d_info(), inters.sides());
 
                             method_replace = method_touch;
                             if ( tp.operations[0].operation != operation_continue

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
@@ -63,10 +63,9 @@ struct get_turn_info_linear_linear
                 RobustPolicy
             > inters_info;
 
-        Point1 const& pk = retrieve_policy_p.get();
-        Point2 const& qk = retrieve_policy_q.get();
-
-        inters_info inters(pi, pj, pk, qi, qj, qk, strategy, robust_policy);
+        inters_info inters(pi, pj, qi, qj,
+                           retrieve_policy_p, retrieve_policy_q,
+                           strategy, robust_policy);
 
         char const method = inters.d_info().how;
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
@@ -81,8 +81,7 @@ struct get_turn_info_linear_linear
             case 's' : // starts from the middle
                 get_turn_info_for_endpoint<AssignPolicy, true, true>
                     ::apply(pi, pj, pk, qi, qj, qk,
-                            is_p_first, is_p_last, is_q_first, is_q_last,
-                            tp_model, inters, method_none, out);
+                            tp_model, inters, retrieve_policy, method_none, out);
                 break;
 
             case 'd' : // disjoint: never do anything
@@ -92,8 +91,7 @@ struct get_turn_info_linear_linear
             {
                 if ( get_turn_info_for_endpoint<AssignPolicy, false, true>
                         ::apply(pi, pj, pk, qi, qj, qk,
-                                is_p_first, is_p_last, is_q_first, is_q_last,
-                                tp_model, inters, method_touch_interior, out) )
+                                tp_model, inters, retrieve_policy, method_touch_interior, out) )
                 {
                     // do nothing
                 }
@@ -163,8 +161,7 @@ struct get_turn_info_linear_linear
                 // Both touch (both arrive there)
                 if ( get_turn_info_for_endpoint<AssignPolicy, false, true>
                         ::apply(pi, pj, pk, qi, qj, qk,
-                                is_p_first, is_p_last, is_q_first, is_q_last,
-                                tp_model, inters, method_touch, out) )
+                                tp_model, inters, retrieve_policy, method_touch, out) )
                 {
                     // do nothing
                 }
@@ -298,8 +295,7 @@ struct get_turn_info_linear_linear
             {
                 if ( get_turn_info_for_endpoint<AssignPolicy, true, true>
                         ::apply(pi, pj, pk, qi, qj, qk,
-                                is_p_first, is_p_last, is_q_first, is_q_last,
-                                tp_model, inters, method_equal, out) )
+                                tp_model, inters, retrieve_policy, method_equal, out) )
                 {
                     // do nothing
                 }
@@ -356,8 +352,7 @@ struct get_turn_info_linear_linear
                 // Collinear
                 if ( get_turn_info_for_endpoint<AssignPolicy, true, true>
                         ::apply(pi, pj, pk, qi, qj, qk,
-                                is_p_first, is_p_last, is_q_first, is_q_last,
-                                tp_model, inters, method_collinear, out) )
+                                tp_model, inters, retrieve_policy, method_collinear, out) )
                 {
                     // do nothing
                 }

--- a/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
@@ -103,6 +103,7 @@ struct no_interrupt_policy
 
 template
 <
+    bool IsAreal,
     typename Section,
     typename Point,
     typename CircularIterator,
@@ -125,12 +126,12 @@ struct retrieve_additional_info_from_section
 
     inline bool is_first() const
     {
-        return m_section.is_non_duplicate_first && m_index == m_section.begin_index;
+        return !IsAreal && m_section.is_non_duplicate_first && m_index == m_section.begin_index;
     }
 
     inline bool has_k() const
     {
-        return m_section.is_non_duplicate_last && m_index + 1 >= m_section.end_index;
+        return IsAreal || ! (m_section.is_non_duplicate_last && m_index + 1 >= m_section.end_index);
     }
 
     inline Point const& get_point_k() const
@@ -271,6 +272,18 @@ public :
     {
         boost::ignore_unused(interrupt_policy);
 
+        static bool const areal1 = boost::is_same
+            <
+                typename tag_cast<typename tag<Geometry1>::type, areal_tag>::type,
+                areal_tag
+            >::type::value;
+        static bool const areal2 = boost::is_same
+            <
+                typename tag_cast<typename tag<Geometry2>::type, areal_tag>::type,
+                areal_tag
+            >::type::value;
+
+
         if ((sec1.duplicate && (sec1.count + 1) < sec1.range_count)
            || (sec2.duplicate && (sec2.count + 1) < sec2.range_count))
         {
@@ -314,7 +327,7 @@ public :
             it1 != end1 && ! detail::section::exceeding<0>(dir1, *prev1, sec1.bounding_box, sec2.bounding_box, robust_policy);
             ++prev1, ++it1, ++index1, ++next1, ++ndi1)
         {
-            retrieve_from_section<Section1, point1_type, circular1_iterator, RobustPolicy> retrieve_policy1(sec1, index1,
+            retrieve_additional_info_from_section<areal1, Section1, point1_type, circular1_iterator, RobustPolicy> retrieve_policy1(sec1, index1,
                 circular1_iterator(begin_range_1, end_range_1, next1, true), *it1, robust_policy);
 
             signed_size_type index2 = sec2.begin_index;
@@ -361,7 +374,7 @@ public :
 
                 if (! skip)
                 {
-                    retrieve_from_section<Section2, point2_type, circular2_iterator, RobustPolicy> retrieve_policy2(sec2, index2,
+                    retrieve_additional_info_from_section<areal2, Section2, point2_type, circular2_iterator, RobustPolicy> retrieve_policy2(sec2, index2,
                         circular2_iterator(begin_range_2, end_range_2, next2), *it2, robust_policy);
 
                     typedef typename boost::range_value<Turns>::type turn_info;

--- a/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
@@ -101,42 +101,26 @@ struct no_interrupt_policy
     }
 };
 
-template <typename Section0, typename Section1>
+template <typename Section>
 struct retrieve_from_sections
 {
-    retrieve_from_sections(Section0 const& section0, Section1 const& section1,
-                           signed_size_type index0, signed_size_type index1)
-      : m_section0(section0)
-      , m_section1(section1)
-      , m_index0(index0)
-      , m_index1(index1)
+    retrieve_from_sections(Section const& section, signed_size_type index)
+      : m_section(section)
+      , m_index(index)
     {}
 
-    inline bool is_first(int source_index) const
+    inline bool is_first() const
     {
-        return source_index == 0 ? is_first(m_section0, m_index0) : is_first(m_section1, m_index1);
-    }
-    inline bool is_last(int source_index) const
-    {
-        return source_index == 0 ? is_last(m_section0, m_index0) : is_last(m_section1, m_index1);
+        return m_section.is_non_duplicate_first && m_index == m_section.begin_index;
     }
 
-    template <typename Section>
-    inline bool is_first(Section const& section, signed_size_type index) const
+    inline bool is_last() const
     {
-        return section.is_non_duplicate_first && index == section.begin_index;
+        return m_section.is_non_duplicate_last && m_index + 1 >= m_section.end_index;
     }
 
-    template <typename Section>
-    inline bool is_last(Section const& section, signed_size_type index) const
-    {
-        return section.is_non_duplicate_last && index + 1 >= section.end_index;
-    }
-
-    Section0 const& m_section0;
-    Section1 const& m_section1;
-    signed_size_type m_index0;
-    signed_size_type m_index1;
+    Section const& m_section;
+    signed_size_type m_index;
 };
 
 
@@ -333,10 +317,11 @@ public :
 
                     std::size_t const size_before = boost::size(turns);
 
-                    retrieve_from_sections<Section1, Section2> retrieve_policy(sec1, sec2, index1, index2);
+                    retrieve_from_sections<Section1> retrieve_policy1(sec1, index1);
+                    retrieve_from_sections<Section1> retrieve_policy2(sec2, index2);
 
                     TurnPolicy::apply(*prev1, *it1, *nd_next1, *prev2, *it2, *nd_next2,
-                                      ti, intersection_strategy, retrieve_policy, robust_policy,
+                                      ti, intersection_strategy, retrieve_policy1, retrieve_policy2, robust_policy,
                                       std::back_inserter(turns));
 
                     if (InterruptPolicy::enabled)
@@ -705,22 +690,22 @@ private:
 
         ti.operations[1].seg_id = segment_identifier(source_id2, -1, -1, 0);
         TurnPolicy::apply(rp0, rp1, rp2, bp0, bp1, bp2,
-                          ti, intersection_strategy, retrieve_policy, robust_policy,
+                          ti, intersection_strategy, retrieve_policy, retrieve_policy, robust_policy,
                           std::back_inserter(turns));
 
         ti.operations[1].seg_id = segment_identifier(source_id2, -1, -1, 1);
         TurnPolicy::apply(rp0, rp1, rp2, bp1, bp2, bp3,
-                          ti, intersection_strategy, retrieve_policy, robust_policy,
+                          ti, intersection_strategy, retrieve_policy, retrieve_policy, robust_policy,
                           std::back_inserter(turns));
 
         ti.operations[1].seg_id = segment_identifier(source_id2, -1, -1, 2);
         TurnPolicy::apply(rp0, rp1, rp2, bp2, bp3, bp0,
-                          ti, intersection_strategy, retrieve_policy, robust_policy,
+                          ti, intersection_strategy, retrieve_policy, retrieve_policy, robust_policy,
                           std::back_inserter(turns));
 
         ti.operations[1].seg_id = segment_identifier(source_id2, -1, -1, 3);
         TurnPolicy::apply(rp0, rp1, rp2, bp3, bp0, bp1,
-                          ti, intersection_strategy, retrieve_policy, robust_policy,
+                          ti, intersection_strategy, retrieve_policy, retrieve_policy, robust_policy,
                           std::back_inserter(turns));
 
         if (InterruptPolicy::enabled)

--- a/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
@@ -405,7 +405,8 @@ public :
 
                     std::size_t const size_before = boost::size(turns);
 
-                    TurnPolicy::apply(ti, intersection_strategy, unique_sub_range1, unique_sub_range2, robust_policy,
+                    TurnPolicy::apply(unique_sub_range1, unique_sub_range2,
+                                      ti, intersection_strategy, robust_policy,
                                       std::back_inserter(turns));
 
                     if (InterruptPolicy::enabled)
@@ -800,22 +801,26 @@ private:
 
         unique_sub_range_from_box_policy box_unique_sub_range(box);
         ti.operations[1].seg_id = segment_identifier(source_id2, -1, -1, 0);
-        TurnPolicy::apply(ti, intersection_strategy, range_unique_sub_range, box_unique_sub_range, robust_policy,
+        TurnPolicy::apply(range_unique_sub_range, box_unique_sub_range,
+                          ti, intersection_strategy, robust_policy,
                           std::back_inserter(turns));
 
         ti.operations[1].seg_id = segment_identifier(source_id2, -1, -1, 1);
         box_unique_sub_range.next();
-        TurnPolicy::apply(ti, intersection_strategy, range_unique_sub_range, box_unique_sub_range, robust_policy,
+        TurnPolicy::apply(range_unique_sub_range, box_unique_sub_range,
+                          ti, intersection_strategy, robust_policy,
                           std::back_inserter(turns));
 
         ti.operations[1].seg_id = segment_identifier(source_id2, -1, -1, 2);
         box_unique_sub_range.next();
-        TurnPolicy::apply(ti, intersection_strategy, range_unique_sub_range, box_unique_sub_range, robust_policy,
+        TurnPolicy::apply(range_unique_sub_range, box_unique_sub_range,
+                          ti, intersection_strategy, robust_policy,
                           std::back_inserter(turns));
 
         ti.operations[1].seg_id = segment_identifier(source_id2, -1, -1, 3);
         box_unique_sub_range.next();
-        TurnPolicy::apply(ti, intersection_strategy, range_unique_sub_range, box_unique_sub_range, robust_policy,
+        TurnPolicy::apply(range_unique_sub_range, box_unique_sub_range,
+                          ti, intersection_strategy, robust_policy,
                           std::back_inserter(turns));
 
         if (InterruptPolicy::enabled)

--- a/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
@@ -109,11 +109,11 @@ template
     typename CircularIterator,
     typename RobustPolicy
 >
-struct retrieve_additional_info_from_section
+struct unique_sub_range_from_section
 {
     typedef Point point_type;
 
-    retrieve_additional_info_from_section(Section const& section, signed_size_type index,
+    unique_sub_range_from_section(Section const& section, signed_size_type index,
                           CircularIterator circular_iterator,
                           Point const& previous, Point const& current,
                           RobustPolicy const& robust_policy)
@@ -334,7 +334,7 @@ public :
             it1 != end1 && ! detail::section::exceeding<0>(dir1, *prev1, sec1.bounding_box, sec2.bounding_box, robust_policy);
             ++prev1, ++it1, ++index1, ++next1, ++ndi1)
         {
-            retrieve_additional_info_from_section<areal1, Section1, point1_type, circular1_iterator, RobustPolicy> retrieve_policy1(sec1, index1,
+            unique_sub_range_from_section<areal1, Section1, point1_type, circular1_iterator, RobustPolicy> unique_sub_range1(sec1, index1,
                 circular1_iterator(begin_range_1, end_range_1, next1, true), *prev1, *it1, robust_policy);
 
             signed_size_type index2 = sec2.begin_index;
@@ -381,7 +381,7 @@ public :
 
                 if (! skip)
                 {
-                    retrieve_additional_info_from_section<areal2, Section2, point2_type, circular2_iterator, RobustPolicy> retrieve_policy2(sec2, index2,
+                    unique_sub_range_from_section<areal2, Section2, point2_type, circular2_iterator, RobustPolicy> unique_sub_range2(sec2, index2,
                         circular2_iterator(begin_range_2, end_range_2, next2), *prev2, *it2, robust_policy);
 
                     typedef typename boost::range_value<Turns>::type turn_info;
@@ -396,7 +396,7 @@ public :
 
                     std::size_t const size_before = boost::size(turns);
 
-                    TurnPolicy::apply(ti, intersection_strategy, retrieve_policy1, retrieve_policy2, robust_policy,
+                    TurnPolicy::apply(ti, intersection_strategy, unique_sub_range1, unique_sub_range2, robust_policy,
                                       std::back_inserter(turns));
 
                     if (InterruptPolicy::enabled)
@@ -603,11 +603,11 @@ struct get_turns_cs
             view_type const
         >::type iterator_type;
 
-    struct retrieve_additional_info_from_box_policy
+    struct unique_sub_range_from_box_policy
     {
         typedef box_point_type point_type;
 
-        retrieve_additional_info_from_box_policy(box_array const& box, int index)
+        unique_sub_range_from_box_policy(box_array const& box, int index)
           : m_box(box)
           , m_index(index)
         {}
@@ -632,11 +632,11 @@ struct get_turns_cs
         int m_index;
     };
 
-    struct retrieve_additional_info_from_view_policy
+    struct unique_sub_range_from_view_policy
     {
         typedef range_point_type point_type;
 
-        retrieve_additional_info_from_view_policy(view_type const& view, point_type const& pi, point_type const& pj, iterator_type it)
+        unique_sub_range_from_view_policy(view_type const& view, point_type const& pi, point_type const& pj, iterator_type it)
           : m_view(view)
           , m_pi(pi)
           , m_pj(pj)
@@ -701,7 +701,7 @@ struct get_turns_cs
             segment_identifier seg_id(source_id1,
                         multi_index, ring_index, index);
 
-            retrieve_additional_info_from_view_policy view_retrieve_policy(view, *prev, *it, it);
+            unique_sub_range_from_view_policy view_unique_sub_range(view, *prev, *it, it);
 
             /*if (first)
             {
@@ -729,7 +729,7 @@ struct get_turns_cs
             if (true)
             {
                 get_turns_with_box(seg_id, source_id2,
-                        view_retrieve_policy,
+                        view_unique_sub_range,
                         box_points,
                         intersection_strategy,
                         robust_policy,
@@ -770,7 +770,7 @@ private:
         typename RobustPolicy
     >
     static inline void get_turns_with_box(segment_identifier const& seg_id, int source_id2,
-            retrieve_additional_info_from_view_policy const& range_retrieve_policy,
+            unique_sub_range_from_view_policy const& range_unique_sub_range,
             box_array const& box,
             IntersectionStrategy const& intersection_strategy,
             RobustPolicy const& robust_policy,
@@ -787,24 +787,24 @@ private:
         turn_info ti;
         ti.operations[0].seg_id = seg_id;
 
-        retrieve_additional_info_from_box_policy box_retrieve_policy(box, 0);
+        unique_sub_range_from_box_policy box_unique_sub_range(box, 0);
         ti.operations[1].seg_id = segment_identifier(source_id2, -1, -1, 0);
-        TurnPolicy::apply(ti, intersection_strategy, range_retrieve_policy, box_retrieve_policy, robust_policy,
+        TurnPolicy::apply(ti, intersection_strategy, range_unique_sub_range, box_unique_sub_range, robust_policy,
                           std::back_inserter(turns));
 
         ti.operations[1].seg_id = segment_identifier(source_id2, -1, -1, 1);
-        box_retrieve_policy.next();
-        TurnPolicy::apply(ti, intersection_strategy, range_retrieve_policy, box_retrieve_policy, robust_policy,
+        box_unique_sub_range.next();
+        TurnPolicy::apply(ti, intersection_strategy, range_unique_sub_range, box_unique_sub_range, robust_policy,
                           std::back_inserter(turns));
 
         ti.operations[1].seg_id = segment_identifier(source_id2, -1, -1, 2);
-        box_retrieve_policy.next();
-        TurnPolicy::apply(ti, intersection_strategy, range_retrieve_policy, box_retrieve_policy, robust_policy,
+        box_unique_sub_range.next();
+        TurnPolicy::apply(ti, intersection_strategy, range_unique_sub_range, box_unique_sub_range, robust_policy,
                           std::back_inserter(turns));
 
         ti.operations[1].seg_id = segment_identifier(source_id2, -1, -1, 3);
-        box_retrieve_policy.next();
-        TurnPolicy::apply(ti, intersection_strategy, range_retrieve_policy, box_retrieve_policy, robust_policy,
+        box_unique_sub_range.next();
+        TurnPolicy::apply(ti, intersection_strategy, range_unique_sub_range, box_unique_sub_range, robust_policy,
                           std::back_inserter(turns));
 
         if (InterruptPolicy::enabled)

--- a/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
@@ -128,9 +128,13 @@ struct unique_sub_range_from_section
     {
     }
 
-    inline bool is_first() const
+    inline bool is_first_segment() const
     {
         return !IsAreal && m_section.is_non_duplicate_first && m_index == m_section.begin_index;
+    }
+    inline bool is_last_segment() const
+    {
+        return size() == 2u;
     }
 
     inline std::size_t size() const
@@ -624,7 +628,8 @@ struct get_turns_cs
           , m_index(0)
         {}
 
-        static inline bool is_first() { return false; }
+        static inline bool is_first_segment() { return false; }
+        static inline bool is_last_segment() { return false; }
         static inline std::size_t size() { return 4; }
 
         inline box_point_type const& at(std::size_t index) const
@@ -656,7 +661,8 @@ struct get_turns_cs
             ++m_circular_iterator;
         }
 
-        static inline bool is_first() { return false; }
+        static inline bool is_first_segment() { return false; }
+        static inline bool is_last_segment() { return false; }
         static inline std::size_t size() { return 3; }
 
         inline point_type const& at(std::size_t index) const

--- a/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
@@ -655,7 +655,7 @@ struct get_turns_cs
         static inline bool is_first() { return false; }
         static inline std::size_t size() { return 3; }
 
-        inline box_point_type const& at(std::size_t index) const
+        inline point_type const& at(std::size_t index) const
         {
             switch (index)
             {

--- a/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
@@ -108,9 +108,9 @@ template
     typename CircularIterator,
     typename RobustPolicy
 >
-struct retrieve_from_section
+struct retrieve_additional_info_from_section
 {
-    retrieve_from_section(Section const& section, signed_size_type index,
+    retrieve_additional_info_from_section(Section const& section, signed_size_type index,
                           CircularIterator circular_iterator,
                           Point const& current,
                           RobustPolicy const& robust_policy)
@@ -128,12 +128,12 @@ struct retrieve_from_section
         return m_section.is_non_duplicate_first && m_index == m_section.begin_index;
     }
 
-    inline bool is_last() const
+    inline bool has_k() const
     {
         return m_section.is_non_duplicate_last && m_index + 1 >= m_section.end_index;
     }
 
-    inline Point const& get() const
+    inline Point const& get_point_k() const
     {
         if (! m_point_retrieved)
         {
@@ -584,17 +584,17 @@ struct get_turns_cs
             view_type const
         >::type iterator_type;
 
-    struct retrieve_from_box_policy
+    struct retrieve_additional_info_from_box_policy
     {
-        retrieve_from_box_policy(box_array const& box, int index)
+        retrieve_additional_info_from_box_policy(box_array const& box, int index)
           : m_box(box)
           , m_index(index)
         {}
 
         static inline bool is_first() { return false; }
-        static inline bool is_last() { return false; }
+        static inline bool has_k() { return true; }
 
-        inline box_point_type const& get() const
+        inline box_point_type const& get_point_k() const
         {
             return m_box[m_index];
         }
@@ -612,9 +612,9 @@ struct get_turns_cs
         int m_index;
     };
 
-    struct retrieve_from_view_policy
+    struct retrieve_additional_info_from_view_policy
     {
-        retrieve_from_view_policy(view_type const& view, iterator_type it)
+        retrieve_additional_info_from_view_policy(view_type const& view, iterator_type it)
           : m_view(view)
           , m_circular_iterator(boost::begin(view), boost::end(view), it, true)
         {
@@ -622,9 +622,9 @@ struct get_turns_cs
         }
 
         static inline bool is_first() { return false; }
-        static inline bool is_last() { return false; }
+        static inline bool has_k() { return true; }
 
-        inline point_type const& get() const
+        inline point_type const& get_point_k() const
         {
             return *m_circular_iterator;
         }
@@ -672,7 +672,7 @@ struct get_turns_cs
             segment_identifier seg_id(source_id1,
                         multi_index, ring_index, index);
 
-            retrieve_from_view_policy view_retrieve_policy(view, it);
+            retrieve_additional_info_from_view_policy view_retrieve_policy(view, it);
 
             /*if (first)
             {
@@ -743,7 +743,7 @@ private:
     static inline void get_turns_with_box(segment_identifier const& seg_id, int source_id2,
             point_type const& range_point_0,
             point_type const& range_point_1,
-            retrieve_from_view_policy const& range_retrieve_policy,
+            retrieve_additional_info_from_view_policy const& range_retrieve_policy,
             box_array const& box,
             IntersectionStrategy const& intersection_strategy,
             RobustPolicy const& robust_policy,
@@ -760,7 +760,7 @@ private:
         turn_info ti;
         ti.operations[0].seg_id = seg_id;
 
-        retrieve_from_box_policy box_retrieve_policy(box, 2);
+        retrieve_additional_info_from_box_policy box_retrieve_policy(box, 2);
         ti.operations[1].seg_id = segment_identifier(source_id2, -1, -1, 0);
         TurnPolicy::apply(range_point_0, range_point_1, box[0], box[1],
                           ti, intersection_strategy, range_retrieve_policy, box_retrieve_policy, robust_policy,

--- a/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
@@ -27,6 +27,7 @@
 #include <boost/range.hpp>
 
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/exterior_ring.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
@@ -140,6 +141,7 @@ struct unique_sub_range_from_section
 
     inline Point const& at(std::size_t index) const
     {
+        BOOST_GEOMETRY_ASSERT(index < size());
         switch (index)
         {
             case 0 : return m_previous_point;
@@ -627,6 +629,7 @@ struct get_turns_cs
 
         inline box_point_type const& at(std::size_t index) const
         {
+            BOOST_GEOMETRY_ASSERT(index < size());
             return m_box[(m_index + index) % 4];
         }
 
@@ -658,6 +661,7 @@ struct get_turns_cs
 
         inline point_type const& at(std::size_t index) const
         {
+            BOOST_GEOMETRY_ASSERT(index < size());
             switch (index)
             {
                 case 0 : return m_pi;

--- a/include/boost/geometry/algorithms/detail/overlay/linear_linear.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/linear_linear.hpp
@@ -139,18 +139,6 @@ protected:
         static bool const include_no_turn = false;
         static bool const include_degenerate = EnableDegenerateTurns;
         static bool const include_opposite = false;
-
-        template
-        <
-            typename Info,
-            typename Point1,
-            typename Point2,
-            typename IntersectionInfo
-        >
-        static inline void apply(Info& , Point1 const& , Point2 const& ,
-                                 IntersectionInfo const& )
-        {
-        }
     };
 
 

--- a/include/boost/geometry/algorithms/detail/relate/linear_areal.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/linear_areal.hpp
@@ -621,6 +621,37 @@ struct linear_areal
         static const std::size_t op_id = 0;
         static const std::size_t other_op_id = 1;
 
+        template <typename TurnPointCSTag, typename PointP, typename PointQ,
+                  typename SideStrategy,
+                  typename Pi = PointP, typename Pj = PointP, typename Pk = PointP,
+                  typename Qi = PointQ, typename Qj = PointQ, typename Qk = PointQ
+        >
+        struct la_side_calculator
+        {
+            inline la_side_calculator(Pi const& pi, Pj const& pj, Pk const& pk,
+                                   Qi const& qi, Qj const& qj, Qk const& qk,
+                                   SideStrategy const& side_strategy)
+                : m_pi(pi), m_pj(pj), m_pk(pk)
+                , m_qi(qi), m_qj(qj), m_qk(qk)
+                , m_side_strategy(side_strategy)
+            {}
+
+            inline int pk_wrt_p1() const { return m_side_strategy.apply(m_pi, m_pj, m_pk); }
+            inline int qk_wrt_p1() const { return m_side_strategy.apply(m_pi, m_pj, m_qk); }
+            inline int pk_wrt_q2() const { return m_side_strategy.apply(m_qj, m_qk, m_pk); }
+
+         private :
+            Pi const& m_pi;
+            Pj const& m_pj;
+            Pk const& m_pk;
+            Qi const& m_qi;
+            Qj const& m_qj;
+            Qk const& m_qk;
+
+            SideStrategy m_side_strategy;
+        };
+
+
     public:
         turns_analyser()
             : m_previous_turn_ptr(NULL)
@@ -1220,7 +1251,7 @@ struct linear_areal
                                                                  boost::end(range2));
 
                 // Will this sequence of points be always correct?
-                overlay::side_calculator<cs_tag, point1_type, point2_type, SideStrategy>
+                la_side_calculator<cs_tag, point1_type, point2_type, SideStrategy>
                     side_calc(qi_conv, new_pj, pi, qi, qj, *qk_it, side_strategy);
 
                 return calculate_from_inside_sides(side_calc);
@@ -1230,7 +1261,7 @@ struct linear_areal
                 point2_type new_qj;
                 geometry::convert(turn.point, new_qj);
 
-                overlay::side_calculator<cs_tag, point1_type, point2_type, SideStrategy>
+                la_side_calculator<cs_tag, point1_type, point2_type, SideStrategy>
                     side_calc(qi_conv, new_pj, pi, qi, new_qj, qj, side_strategy);
 
                 return calculate_from_inside_sides(side_calc);

--- a/test/algorithms/overlay/get_turn_info.cpp
+++ b/test/algorithms/overlay/get_turn_info.cpp
@@ -15,7 +15,7 @@
 
 #include <geometry_test_common.hpp>
 
-
+#include <boost/array.hpp>
 #include <boost/foreach.hpp>
 
 #include <boost/geometry/algorithms/intersection.hpp>
@@ -34,20 +34,24 @@
 template <typename Point>
 struct retrieve_from_point_policy
 {
-    retrieve_from_point_policy(Point const& point)
-      : m_point(point)
-    {}
-
-    static inline bool is_first() { return false; }
-    static inline bool has_k() { return true; }
-
-    inline Point const& get_point_k() const
+    retrieve_from_point_policy(Point const& i, Point const& j, Point const& k)
     {
-        return m_point;
+        m_points[0] = i;
+        m_points[1] = j;
+        m_points[2] = k;
+    }
+
+    static inline bool is_first() const { return false; }
+
+    static inline std::size_t size() const { return 3; }
+
+    inline Point const& at(std::size_t index) const
+    {
+        return m_points[index % 3];
     }
 
 private :
-    Point const& m_point;
+    boost::array<Point, 3> m_points;
 };
 
 template <typename P, typename T>
@@ -84,13 +88,12 @@ void test_with_point(std::string const& caseid,
     tp_vector info;
     strategy_type strategy;
     rescale_policy_type rescale_policy;
-    retrieve_from_point_policy<P> retrieve_policy_p(pk);
-    retrieve_from_point_policy<P> retrieve_policy_q(qk);
+    retrieve_from_point_policy<P> retrieve_policy_p(pi, pj, pk);
+    retrieve_from_point_policy<P> retrieve_policy_q(qi, qj, qk);
     bg::detail::overlay::get_turn_info
         <
             bg::detail::overlay::assign_null_policy
-        >::apply(pi, pj, qi, qj,
-        model, strategy, retrieve_policy_p, retrieve_policy_q, rescale_policy, std::back_inserter(info));
+        >::apply(model, strategy, retrieve_policy_p, retrieve_policy_q, rescale_policy, std::back_inserter(info));
 
     if (info.size() == 0)
     {

--- a/test/algorithms/overlay/get_turn_info.cpp
+++ b/test/algorithms/overlay/get_turn_info.cpp
@@ -65,12 +65,12 @@ void test_with_point(std::string const& caseid,
     tp_vector info;
     strategy_type strategy;
     rescale_policy_type rescale_policy;
+    bg::detail::overlay::retrieve_null_policy retrieve_policy;
     bg::detail::overlay::get_turn_info
         <
             bg::detail::overlay::assign_null_policy
         >::apply(pi, pj, pk, qi, qj, qk,
-                 false, false, false, false, // dummy parameters
-        model, strategy, rescale_policy, std::back_inserter(info));
+        model, strategy, retrieve_policy, retrieve_policy, rescale_policy, std::back_inserter(info));
 
 
     if (info.size() == 0)

--- a/test/algorithms/overlay/get_turn_info.cpp
+++ b/test/algorithms/overlay/get_turn_info.cpp
@@ -95,7 +95,7 @@ void test_with_point(std::string const& caseid,
     bg::detail::overlay::get_turn_info
         <
             bg::detail::overlay::assign_null_policy
-        >::apply(model, strategy, sub_range_p, sub_range_q, rescale_policy, std::back_inserter(info));
+        >::apply(sub_range_p, sub_range_q, model, strategy, rescale_policy, std::back_inserter(info));
 
     if (info.size() == 0)
     {

--- a/test/algorithms/overlay/get_turn_info.cpp
+++ b/test/algorithms/overlay/get_turn_info.cpp
@@ -30,6 +30,25 @@
 #endif
 
 
+// For test purposes, returns the point specified in the constructor
+template <typename Point>
+struct retrieve_from_point_policy
+{
+    retrieve_from_point_policy(Point const& point)
+      : m_point(point)
+    {}
+
+    static inline bool is_first() { return false; }
+    static inline bool is_last() { return false; }
+
+    inline Point const& get() const
+    {
+        return m_point;
+    }
+
+private :
+    Point const& m_point;
+};
 
 template <typename P, typename T>
 void test_with_point(std::string const& caseid,
@@ -65,13 +84,13 @@ void test_with_point(std::string const& caseid,
     tp_vector info;
     strategy_type strategy;
     rescale_policy_type rescale_policy;
-    bg::detail::overlay::retrieve_null_policy retrieve_policy;
+    retrieve_from_point_policy<P> retrieve_policy_p(pk);
+    retrieve_from_point_policy<P> retrieve_policy_q(qk);
     bg::detail::overlay::get_turn_info
         <
             bg::detail::overlay::assign_null_policy
-        >::apply(pi, pj, pk, qi, qj, qk,
-        model, strategy, retrieve_policy, retrieve_policy, rescale_policy, std::back_inserter(info));
-
+        >::apply(pi, pj, qi, qj,
+        model, strategy, retrieve_policy_p, retrieve_policy_q, rescale_policy, std::back_inserter(info));
 
     if (info.size() == 0)
     {

--- a/test/algorithms/overlay/get_turn_info.cpp
+++ b/test/algorithms/overlay/get_turn_info.cpp
@@ -43,7 +43,8 @@ struct sub_range_from_points
         m_points[2] = k;
     }
 
-    static inline bool is_first() { return false; }
+    static inline bool is_first_segment() { return false; }
+    static inline bool is_last_segment() { return false; }
 
     static inline std::size_t size() { return 3; }
 

--- a/test/algorithms/overlay/get_turn_info.cpp
+++ b/test/algorithms/overlay/get_turn_info.cpp
@@ -39,9 +39,9 @@ struct retrieve_from_point_policy
     {}
 
     static inline bool is_first() { return false; }
-    static inline bool is_last() { return false; }
+    static inline bool has_k() { return true; }
 
-    inline Point const& get() const
+    inline Point const& get_point_k() const
     {
         return m_point;
     }

--- a/test/algorithms/overlay/get_turn_info.cpp
+++ b/test/algorithms/overlay/get_turn_info.cpp
@@ -32,18 +32,20 @@
 
 // For test purposes, returns the point specified in the constructor
 template <typename Point>
-struct retrieve_from_point_policy
+struct sub_range_from_points
 {
-    retrieve_from_point_policy(Point const& i, Point const& j, Point const& k)
+    typedef Point point_type;
+
+    sub_range_from_points(Point const& i, Point const& j, Point const& k)
     {
         m_points[0] = i;
         m_points[1] = j;
         m_points[2] = k;
     }
 
-    static inline bool is_first() const { return false; }
+    static inline bool is_first() { return false; }
 
-    static inline std::size_t size() const { return 3; }
+    static inline std::size_t size() { return 3; }
 
     inline Point const& at(std::size_t index) const
     {
@@ -88,12 +90,12 @@ void test_with_point(std::string const& caseid,
     tp_vector info;
     strategy_type strategy;
     rescale_policy_type rescale_policy;
-    retrieve_from_point_policy<P> retrieve_policy_p(pi, pj, pk);
-    retrieve_from_point_policy<P> retrieve_policy_q(qi, qj, qk);
+    sub_range_from_points<P> sub_range_p(pi, pj, pk);
+    sub_range_from_points<P> sub_range_q(qi, qj, qk);
     bg::detail::overlay::get_turn_info
         <
             bg::detail::overlay::assign_null_policy
-        >::apply(model, strategy, retrieve_policy_p, retrieve_policy_q, rescale_policy, std::back_inserter(info));
+        >::apply(model, strategy, sub_range_p, sub_range_q, rescale_policy, std::back_inserter(info));
 
     if (info.size() == 0)
     {


### PR DESCRIPTION
This PR (actually my first) adds a retrieve policy, and passes it to get_turn_info.

This policy retrieves a point known as "k" (pk / qk), the first non-duplicate point coming consecutively after the points "i" and "j" (two points from two segments p and q, part of the intersection of two segments, so these points are pi,pj and qi,qj).

In the past points pk/qk were just passed. But now we need another point (pl/ql) and it is not convenient to add that. Therefore the policy is introduced.

An additional advantage is that point "k" is now retrieved lazily, on demand. Often that point is not necessary. It is actually only necessary if there are collinearies. And often that is not the case. So in all those cases, performance should increase just a little bit.

This PR adds the policy and retrieves point "k" using the method .get(). In another PR I will add an argument to get, to be able to retrieve also the subsequente point, as described above. But for now this PR is large enough.

It is also related to side calculation, the place where that point is used, to check whether it is located left/right or collinear to a segment.

To my surprise, also non-typical usage of side calculation were introduced in the implementations for linear intersections, and the typical order is changed there. Therefore I copied the originals there - they cannot use the policy because they don't use the "k" point. Actually there should be looked at, because it is looking suspicious, but we can do that afterwards.

I'm curious to your findings.