### PR TITLE
Documentation fixes.

### DIFF
--- a/doc/doxy/Doxyfile
+++ b/doc/doxy/Doxyfile
@@ -203,6 +203,7 @@ INPUT                  = . .. ../../../../boost/geometry/core \
                          ../../../../boost/geometry/geometries/adapted \
                          ../../../../boost/geometry/geometries/register \
                          ../../../../boost/geometry/iterators \
+                         ../../../../boost/geometry/io/dsv \
                          ../../../../boost/geometry/io/wkt \
                          ../../../../boost/geometry/io/svg \
                          ../../../../boost/geometry/policies \

--- a/doc/doxy/doxygen_input/groups/groups.hpp
+++ b/doc/doxy/doxygen_input/groups/groups.hpp
@@ -37,6 +37,7 @@
 \defgroup discrete_hausdorff_distance discrete_hausdorff_distance : calculate discrete hausdorff distance between two geometries
 \defgroup disjoint disjoint: detect if geometries are not spatially related
 \defgroup distance distance: calculate distance between two geometries
+\defgroup dsv: stream DSV (Delimiter-Separated Values)
 \defgroup enum enum: enumerations
 \defgroup envelope envelope: calculate envelope (minimum bounding rectangle) of a geometry
 \defgroup equals equals: detect if two geometries are spatially equal

--- a/doc/html/index.html
+++ b/doc/html/index.html
@@ -40,9 +40,8 @@
 <div><div class="author"><h3 class="author">
 <span class="firstname">Vissarion</span> <span class="surname">Fisikopoulos</span>
 </h3></div></div>
-<div><p class="copyright">Copyright &#169; 2009-2017 Barend
-      Gehrels, Bruno Lalande, Mateusz Loskot, Adam Wulkiewicz, Oracle and/or its
-      affiliates</p></div>
+<div><p class="copyright">Copyright &#169; 2009-2018 Barend Gehrels, Bruno Lalande, Mateusz Loskot, Adam Wulkiewicz, Oracle
+      and/or its affiliates</p></div>
 <div><div class="legalnotice">
 <a name="geometry.legal"></a><p>
         Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -135,10 +134,16 @@
         Samuel Debionne (variant support for distance, assign, crosses, intersection,
         ...)
       </li>
+<li class="listitem">
+        Adeel Ahmad (Karney's solution of direct and inverse geodesic problems)
+      </li>
+<li class="listitem">
+        Yaghyavardhan Singh Khangarot (discrete frechet and hausdorff distance)
+      </li>
 </ul></div>
 </div>
 <table xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" width="100%"><tr>
-<td align="left"><p><small>Last revised: March 02, 2018 at 22:11:06 GMT</small></p></td>
+<td align="left"><p><small>Last revised: November 29, 2018 at 00:39:14 GMT</small></p></td>
 <td align="right"><div class="copyright-footer"></div></td>
 </tr></table>
 <hr>

--- a/doc/make_qbk.py
+++ b/doc/make_qbk.py
@@ -188,6 +188,7 @@ for i in views:
 model_to_quickbook2("d2_1_1point__xy", "point_xy")
 
 group_to_quickbook("arithmetic")
+group_to_quickbook("dsv")
 group_to_quickbook("enum")
 group_to_quickbook("register")
 group_to_quickbook("svg")

--- a/doc/reference.qbk
+++ b/doc/reference.qbk
@@ -283,6 +283,9 @@
 
 
 [section:io IO (input/output)]
+[section:dsv DSV (Delimiter-Separated Values)]
+[include generated/dsv.qbk]
+[endsect]
 [section:wkt WKT (Well-Known Text)]
 [include reference/io/wkt_format.qbk]
 [include generated/wkt.qbk]

--- a/doc/release_notes.qbk
+++ b/doc/release_notes.qbk
@@ -27,10 +27,12 @@
 
 * [@https://github.com/boostorg/geometry/pull/486 486] Karney's solution of direct geodesic problem for internal use (thanks to Adeel Ahmad).
 * [@https://github.com/boostorg/geometry/pull/490 490] Discrete Frechet and Hausdorff distance algorithms (thanks to Yaghyavardhan Singh Khangarot).
-* [@https://github.com/boostorg/geometry/pull/496 496] New run-time and upgraded compile-time SRS transformation interfaces.
+* [@https://github.com/boostorg/geometry/pull/496 496] New run-time and upgraded compile-time SRS transformation interfaces (undocumented for now due to potential interface changes).
 
 [*Solved issues]
 
+* [@https://github.com/boostorg/geometry/issues/520 520] Missing documentation for dsv().
+* [@https://github.com/boostorg/geometry/issues/521 521] Wrong documentation description for distance().
 * [@https://github.com/boostorg/geometry/issues/524 524] Fixed 'enumeration values not handled in switch' warnings.
 * [@https://github.com/boostorg/geometry/issues/527 527] Workaround for VS 2017 (msvc-15).
 

--- a/include/boost/geometry/algorithms/detail/distance/interface.hpp
+++ b/include/boost/geometry/algorithms/detail/distance/interface.hpp
@@ -6,10 +6,11 @@
 // Copyright (c) 2013-2014 Adam Wulkiewicz, Lodz, Poland.
 // Copyright (c) 2014 Samuel Debionne, Grenoble, France.
 
-// This file was modified by Oracle on 2014.
-// Modifications copyright (c) 2014, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014, 2018.
+// Modifications copyright (c) 2014-2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
@@ -320,10 +321,10 @@ struct distance
 
 
 /*!
-\brief \brief_calc2{distance} \brief_strategy
+\brief Calculate the distance between two geometries \brief_strategy
 \ingroup distance
 \details
-\details \details_calc{area}. \brief_strategy. \details_strategy_reasons
+\details The free function distance calculates the distance between two geometries \brief_strategy. \details_strategy_reasons
 
 \tparam Geometry1 \tparam_geometry
 \tparam Geometry2 \tparam_geometry
@@ -376,9 +377,10 @@ distance(Geometry1 const& geometry1,
 
 
 /*!
-\brief \brief_calc2{distance}
+\brief Calculate the distance between two geometries.
 \ingroup distance
-\details The default strategy is used, corresponding to the coordinate system of the geometries
+\details The free function distance calculates the distance between two geometries. \details_default_strategy
+
 \tparam Geometry1 \tparam_geometry
 \tparam Geometry2 \tparam_geometry
 \param geometry1 \param_geometry

--- a/include/boost/geometry/algorithms/discrete_frechet_distance.hpp
+++ b/include/boost/geometry/algorithms/discrete_frechet_distance.hpp
@@ -150,7 +150,8 @@ struct discrete_frechet_distance<Linestring1,Linestring2,linestring_tag,linestri
 
 
 /*!
-\brief calculate discrete frechet distance between two geometries ( currently work for LineString-LineString) using specified strategy
+\brief Calculate discrete Frechet distance between two geometries (currently
+    works for LineString-LineString) using specified strategy.
 \ingroup discrete_frechet_distance
 \tparam Geometry1 \tparam_geometry
 \tparam Geometry2 \tparam_geometry
@@ -188,7 +189,8 @@ discrete_frechet_distance(Geometry1 const& geometry1, Geometry2 const& geometry2
 // Algorithm overload using default Pt-Pt distance strategy
 
 /*!
-\brief calculate discrete frechet distance between two geometries ( currently work for LineString-LineString)
+\brief Calculate discrete Frechet distance between two geometries (currently
+    work for LineString-LineString).
 \ingroup discrete_frechet_distance
 \tparam Geometry1 \tparam_geometry
 \tparam Geometry2 \tparam_geometry

--- a/include/boost/geometry/algorithms/discrete_hausdorff_distance.hpp
+++ b/include/boost/geometry/algorithms/discrete_hausdorff_distance.hpp
@@ -264,7 +264,9 @@ struct discrete_hausdorff_distance<multi_linestring1, multi_linestring2, multi_l
 // Algorithm overload using explicitly passed Pt-Pt distance strategy
 
 /*!
-\brief calculate discrete hausdorff distance between two geometries ( currently works for LineString-LineString, MultiPoint-MultiPoint, Point-MultiPoint, MultiLineString-MultiLineString ) using specified strategy
+\brief Calculate discrete hausdorff distance between two geometries (currently
+    works for LineString-LineString, MultiPoint-MultiPoint, Point-MultiPoint,
+    MultiLineString-MultiLineString) using specified strategy.
 \ingroup discrete_hausdorff_distance
 \tparam Geometry1 \tparam_geometry
 \tparam Geometry2 \tparam_geometry
@@ -295,13 +297,20 @@ typename distance_result
         typename point_type<Geometry2>::type,
         Strategy
     >::type
-discrete_hausdorff_distance(Geometry1 const& g1, Geometry2 const& g2, Strategy const& strategy)
+discrete_hausdorff_distance(Geometry1 const& geometry1,
+                            Geometry2 const& geometry2,
+                            Strategy const& strategy)
 {
-    return dispatch::discrete_hausdorff_distance<Geometry1, Geometry2>::apply(g1, g2, strategy);
+    return dispatch::discrete_hausdorff_distance
+        <
+            Geometry1, Geometry2
+        >::apply(geometry1, geometry2, strategy);
 }
 
 /*!
-\brief calculate discrete hausdorff distance between two geometries ( currently works for LineString-LineString, MultiPoint-MultiPoint, Point-MultiPoint, MultiLineString-MultiLineString )
+\brief Calculate discrete hausdorff distance between two geometries (currently
+    works for LineString-LineString, MultiPoint-MultiPoint, Point-MultiPoint,
+    MultiLineString-MultiLineString).
 \ingroup discrete_hausdorff_distance
 \tparam Geometry1 \tparam_geometry
 \tparam Geometry2 \tparam_geometry
@@ -323,7 +332,8 @@ typename distance_result
         typename point_type<Geometry1>::type,
         typename point_type<Geometry2>::type
     >::type
-discrete_hausdorff_distance(Geometry1 const& g1, Geometry2 const& g2)
+discrete_hausdorff_distance(Geometry1 const& geometry1,
+                            Geometry2 const& geometry2)
 {
     typedef typename strategy::distance::services::default_strategy
         <
@@ -332,7 +342,7 @@ discrete_hausdorff_distance(Geometry1 const& g1, Geometry2 const& g2)
             typename point_type<Geometry2>::type
         >::type strategy_type;
 
-    return discrete_hausdorff_distance(g1, g2, strategy_type());
+    return discrete_hausdorff_distance(geometry1, geometry2, strategy_type());
 }
 
 }} // namespace boost::geometry

--- a/include/boost/geometry/algorithms/discrete_hausdorff_distance.hpp
+++ b/include/boost/geometry/algorithms/discrete_hausdorff_distance.hpp
@@ -264,7 +264,7 @@ struct discrete_hausdorff_distance<multi_linestring1, multi_linestring2, multi_l
 // Algorithm overload using explicitly passed Pt-Pt distance strategy
 
 /*!
-\brief Calculate discrete hausdorff distance between two geometries (currently
+\brief Calculate discrete Hausdorff distance between two geometries (currently
     works for LineString-LineString, MultiPoint-MultiPoint, Point-MultiPoint,
     MultiLineString-MultiLineString) using specified strategy.
 \ingroup discrete_hausdorff_distance
@@ -308,7 +308,7 @@ discrete_hausdorff_distance(Geometry1 const& geometry1,
 }
 
 /*!
-\brief Calculate discrete hausdorff distance between two geometries (currently
+\brief Calculate discrete Hausdorff distance between two geometries (currently
     works for LineString-LineString, MultiPoint-MultiPoint, Point-MultiPoint,
     MultiLineString-MultiLineString).
 \ingroup discrete_hausdorff_distance

--- a/include/boost/geometry/io/dsv/write.hpp
+++ b/include/boost/geometry/io/dsv/write.hpp
@@ -5,6 +5,11 @@
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 // Copyright (c) 2014 Adam Wulkiewicz, Lodz, Poland.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -405,7 +410,7 @@ struct dsv<multi_tag, Geometry>
 \note Useful for examples and testing purposes
 \note With this function GeoJSON objects can be created, using the right
     delimiters
-\ingroup utility
+\ingroup dsv
 */
 template <typename Geometry>
 inline detail::dsv::dsv_manipulator<Geometry> dsv(Geometry const& geometry


### PR DESCRIPTION
1. Wrong arguments' names of `discrete_hausdorff_distance()`
2. Wrong description of `distance()`
https://github.com/boostorg/geometry/issues/521
3. Missing documentation of `dsv()`
https://github.com/boostorg/geometry/issues/520