### PR TITLE
Add workaround for msvc-12 faulty array initialization.

### DIFF
--- a/include/boost/geometry/core/config.hpp
+++ b/include/boost/geometry/core/config.hpp
@@ -1,0 +1,20 @@
+// Boost.Geometry
+
+// Copyright (c) 2018 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_CORE_CONFIG_HPP
+#define BOOST_GEOMETRY_CORE_CONFIG_HPP
+
+#include <boost/config.hpp>
+
+// NOTE: workaround for VC++ 12 (aka 2013): cannot specify explicit initializer for arrays
+#if !defined(BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX) && (!defined(_MSC_VER) || (_MSC_VER >= 1900))
+#define BOOST_GEOMETRY_CXX11_ARRAY_UNIFIED_INITIALIZATION
+#endif
+
+#endif // BOOST_GEOMETRY_CORE_CONFIG_HPP

--- a/include/boost/geometry/srs/projections/impl/dms_parser.hpp
+++ b/include/boost/geometry/srs/projections/impl/dms_parser.hpp
@@ -42,9 +42,9 @@
 #include <string>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/config.hpp>
 #include <boost/static_assert.hpp>
 
+#include <boost/geometry/core/config.hpp>
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/srs/projections/str_cast.hpp>
 #include <boost/geometry/util/math.hpp>
@@ -123,7 +123,7 @@ struct dms_parser
         bool has_dms[3];
 
         dms_value()
-#if !defined(BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX) && (!defined(_MSC_VER) || (_MSC_VER >= 1900)) // workaround for VC++ 12 (aka 2013)
+#ifdef BOOST_GEOMETRY_CXX11_ARRAY_UNIFIED_INITIALIZATION
             : dms{0, 0, 0}
             , has_dms{false, false, false}
         {}

--- a/include/boost/geometry/srs/projections/par_data.hpp
+++ b/include/boost/geometry/srs/projections/par_data.hpp
@@ -10,9 +10,10 @@
 #ifndef BOOST_GEOMETRY_SRS_PROJECTIONS_PAR_DATA_HPP
 #define BOOST_GEOMETRY_SRS_PROJECTIONS_PAR_DATA_HPP
 
-#include <boost/config.hpp>
 #include <string>
 #include <vector>
+
+#include <boost/geometry/core/config.hpp>
 
 namespace boost { namespace geometry { namespace srs
 {
@@ -86,14 +87,14 @@ struct towgs84
 
     towgs84()
         : m_size(0)
-#ifndef BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX
+#ifdef BOOST_GEOMETRY_CXX11_ARRAY_UNIFIED_INITIALIZATION
         , m_data{0, 0, 0, 0, 0, 0, 0}
-#endif
+    {}
+#else
     {
-#ifdef BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX
         std::fill(m_data, m_data + 7, T(0));
-#endif
     }
+#endif
 
     template <typename It>
     towgs84(It first, It last)


### PR DESCRIPTION
This is a workaround for the following error:

    boost/geometry/srs/projections/par_data.hpp(92) : error C2536: 'boost::geometry::srs::detail::towgs84<T>::boost::geometry::srs::detail::towgs84<T>::m_data' : cannot specify explicit initializer for arrays

I added `core/config.hpp` file allowing us to add defines conveniently.