### PR TITLE
Add missing #includes

### DIFF
--- a/include/boost/geometry/algorithms/densify.hpp
+++ b/include/boost/geometry/algorithms/densify.hpp
@@ -15,6 +15,7 @@
 #include <boost/geometry/algorithms/detail/convert_point_to_point.hpp>
 #include <boost/geometry/algorithms/not_implemented.hpp>
 #include <boost/geometry/core/closure.hpp>
+#include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/exception.hpp>
 #include <boost/geometry/core/point_type.hpp>
 #include <boost/geometry/core/tag.hpp>

--- a/include/boost/geometry/algorithms/detail/buffer/buffer_policies.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/buffer_policies.hpp
@@ -2,8 +2,8 @@
 
 // Copyright (c) 2012-2014 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -26,6 +26,7 @@
 
 #include <boost/geometry/algorithms/covered_by.hpp>
 #include <boost/geometry/algorithms/detail/overlay/backtrack_check_si.hpp>
+#include <boost/geometry/algorithms/detail/overlay/traversal_info.hpp>
 #include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>
 
 #include <boost/geometry/strategies/buffer.hpp>

--- a/include/boost/geometry/algorithms/detail/buffer/turn_in_original_visitor.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/turn_in_original_visitor.hpp
@@ -16,6 +16,7 @@
 
 #include <boost/core/ignore_unused.hpp>
 
+#include <boost/geometry/algorithms/detail/buffer/buffer_policies.hpp>
 #include <boost/geometry/algorithms/expand.hpp>
 #include <boost/geometry/strategies/agnostic/point_in_poly_winding.hpp>
 #include <boost/geometry/strategies/buffer.hpp>

--- a/include/boost/geometry/algorithms/detail/covered_by/implementation.hpp
+++ b/include/boost/geometry/algorithms/detail/covered_by/implementation.hpp
@@ -4,8 +4,8 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2013, 2014, 2017.
-// Modifications copyright (c) 2013-2017 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013, 2014, 2017, 2019.
+// Modifications copyright (c) 2013-2019 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -36,7 +36,7 @@ struct use_point_in_geometry
     template <typename Geometry1, typename Geometry2, typename Strategy>
     static inline bool apply(Geometry1 const& geometry1, Geometry2 const& geometry2, Strategy const& strategy)
     {
-        return detail::within::point_in_geometry(geometry1, geometry2, strategy) >= 0;
+        return detail::within::covered_by_point_geometry(geometry1, geometry2, strategy);
     }
 };
 

--- a/include/boost/geometry/algorithms/detail/disjoint/linear_areal.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/linear_areal.hpp
@@ -5,8 +5,8 @@
 // Copyright (c) 2009-2014 Mateusz Loskot, London, UK.
 // Copyright (c) 2013-2014 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2013-2017.
-// Modifications copyright (c) 2013-2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013-2018.
+// Modifications copyright (c) 2013-2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
@@ -41,8 +41,9 @@
 #include <boost/geometry/algorithms/detail/check_iterator_range.hpp>
 #include <boost/geometry/algorithms/detail/point_on_border.hpp>
 
-#include <boost/geometry/algorithms/detail/disjoint/multirange_geometry.hpp>
+#include <boost/geometry/algorithms/detail/disjoint/linear_linear.hpp>
 #include <boost/geometry/algorithms/detail/disjoint/linear_segment_or_box.hpp>
+#include <boost/geometry/algorithms/detail/disjoint/multirange_geometry.hpp>
 #include <boost/geometry/algorithms/detail/disjoint/point_box.hpp>
 #include <boost/geometry/algorithms/detail/disjoint/segment_box.hpp>
 

--- a/include/boost/geometry/algorithms/detail/distance/point_to_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/distance/point_to_geometry.hpp
@@ -5,10 +5,11 @@
 // Copyright (c) 2009-2014 Mateusz Loskot, London, UK.
 // Copyright (c) 2013-2014 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2014.
-// Modifications copyright (c) 2014, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014, 2019.
+// Modifications copyright (c) 2014-2019, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
@@ -39,13 +40,12 @@
 #include <boost/geometry/strategies/tags.hpp>
 
 #include <boost/geometry/algorithms/assign.hpp>
-#include <boost/geometry/algorithms/covered_by.hpp>
-#include <boost/geometry/algorithms/within.hpp>
 
 #include <boost/geometry/algorithms/detail/closest_feature/geometry_to_range.hpp>
 #include <boost/geometry/algorithms/detail/closest_feature/point_to_range.hpp>
 #include <boost/geometry/algorithms/detail/distance/is_comparable.hpp>
 #include <boost/geometry/algorithms/detail/distance/iterator_selector.hpp>
+#include <boost/geometry/algorithms/detail/within/point_in_geometry.hpp>
 
 #include <boost/geometry/algorithms/dispatch/distance.hpp>
 
@@ -160,7 +160,8 @@ struct point_to_ring
                                     Ring const& ring,
                                     Strategy const& strategy)
     {
-        if (geometry::within(point, ring))
+        // TODO: pass strategy
+        if (within::within_point_geometry(point, ring))
         {
             return return_type(0);
         }
@@ -204,7 +205,8 @@ private:
         {
             for (InteriorRingIterator it = first; it != last; ++it)
             {
-                if (geometry::within(point, *it))
+                // TODO: pass strategy
+                if (within::within_point_geometry(point, *it))
                 {
                     // the point is inside a polygon hole, so its distance
                     // to the polygon its distance to the polygon's
@@ -233,7 +235,8 @@ public:
                                     Polygon const& polygon,
                                     Strategy const& strategy)
     {
-        if (!geometry::covered_by(point, exterior_ring(polygon)))
+        // TODO: pass strategy
+        if (! within::covered_by_point_geometry(point, exterior_ring(polygon)))
         {
             // the point is outside the exterior ring, so its distance
             // to the polygon is its distance to the polygon's exterior ring
@@ -330,7 +333,8 @@ struct point_to_multigeometry<Point, MultiPolygon, Strategy, true>
                                     MultiPolygon const& multipolygon,
                                     Strategy const& strategy)
     {
-        if (geometry::covered_by(point, multipolygon))
+        // TODO: pass strategy
+        if (within::covered_by_point_geometry(point, multipolygon))
         {
             return 0;
         }

--- a/include/boost/geometry/algorithms/detail/distance/segment_to_box.hpp
+++ b/include/boost/geometry/algorithms/detail/distance/segment_to_box.hpp
@@ -4,12 +4,14 @@
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Licensed under the Boost Software License version 1.0.
 // http://www.boost.org/users/license.html
 
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_DISTANCE_SEGMENT_TO_BOX_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_DISTANCE_SEGMENT_TO_BOX_HPP
+
 #include <cstddef>
 
 #include <functional>
@@ -27,25 +29,24 @@
 #include <boost/geometry/core/point_type.hpp>
 #include <boost/geometry/core/tags.hpp>
 
+#include <boost/geometry/algorithms/detail/assign_box_corners.hpp>
+#include <boost/geometry/algorithms/detail/assign_indexed_point.hpp>
+#include <boost/geometry/algorithms/detail/closest_feature/point_to_range.hpp>
+#include <boost/geometry/algorithms/detail/distance/default_strategies.hpp>
+#include <boost/geometry/algorithms/detail/distance/is_comparable.hpp>
+#include <boost/geometry/algorithms/dispatch/distance.hpp>
+#include <boost/geometry/algorithms/equals.hpp>
+#include <boost/geometry/algorithms/intersects.hpp>
+#include <boost/geometry/algorithms/not_implemented.hpp>
+
+#include <boost/geometry/policies/compare.hpp>
+
 #include <boost/geometry/util/calculation_type.hpp>
 #include <boost/geometry/util/condition.hpp>
 #include <boost/geometry/util/math.hpp>
 
 #include <boost/geometry/strategies/distance.hpp>
 #include <boost/geometry/strategies/tags.hpp>
-
-#include <boost/geometry/policies/compare.hpp>
-
-#include <boost/geometry/algorithms/equals.hpp>
-#include <boost/geometry/algorithms/intersects.hpp>
-#include <boost/geometry/algorithms/not_implemented.hpp>
-
-#include <boost/geometry/algorithms/detail/assign_box_corners.hpp>
-#include <boost/geometry/algorithms/detail/assign_indexed_point.hpp>
-#include <boost/geometry/algorithms/detail/distance/default_strategies.hpp>
-#include <boost/geometry/algorithms/detail/distance/is_comparable.hpp>
-
-#include <boost/geometry/algorithms/dispatch/distance.hpp>
 
 
 namespace boost { namespace geometry

--- a/include/boost/geometry/algorithms/detail/distance/segment_to_box.hpp
+++ b/include/boost/geometry/algorithms/detail/distance/segment_to_box.hpp
@@ -43,6 +43,7 @@
 
 #include <boost/geometry/util/calculation_type.hpp>
 #include <boost/geometry/util/condition.hpp>
+#include <boost/geometry/util/has_nan_coordinate.hpp>
 #include <boost/geometry/util/math.hpp>
 
 #include <boost/geometry/strategies/disjoint.hpp>

--- a/include/boost/geometry/algorithms/detail/distance/segment_to_box.hpp
+++ b/include/boost/geometry/algorithms/detail/distance/segment_to_box.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014-2018 Oracle and/or its affiliates.
+// Copyright (c) 2014-2019 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
@@ -32,11 +32,11 @@
 #include <boost/geometry/algorithms/detail/assign_box_corners.hpp>
 #include <boost/geometry/algorithms/detail/assign_indexed_point.hpp>
 #include <boost/geometry/algorithms/detail/closest_feature/point_to_range.hpp>
+#include <boost/geometry/algorithms/detail/disjoint/segment_box.hpp>
 #include <boost/geometry/algorithms/detail/distance/default_strategies.hpp>
 #include <boost/geometry/algorithms/detail/distance/is_comparable.hpp>
+#include <boost/geometry/algorithms/detail/equals/point_point.hpp>
 #include <boost/geometry/algorithms/dispatch/distance.hpp>
-#include <boost/geometry/algorithms/equals.hpp>
-#include <boost/geometry/algorithms/intersects.hpp>
 #include <boost/geometry/algorithms/not_implemented.hpp>
 
 #include <boost/geometry/policies/compare.hpp>
@@ -45,6 +45,7 @@
 #include <boost/geometry/util/condition.hpp>
 #include <boost/geometry/util/math.hpp>
 
+#include <boost/geometry/strategies/disjoint.hpp>
 #include <boost/geometry/strategies/distance.hpp>
 #include <boost/geometry/strategies/tags.hpp>
 
@@ -56,6 +57,20 @@ namespace boost { namespace geometry
 #ifndef DOXYGEN_NO_DETAIL
 namespace detail { namespace distance
 {
+
+
+// TODO: Take strategy
+template <typename Segment, typename Box>
+inline bool intersects_segment_box(Segment const& segment, Box const& box)
+{
+    typedef typename strategy::disjoint::services::default_strategy
+        <
+            Segment, Box
+        >::type strategy_type;
+
+    return ! detail::disjoint::disjoint_segment_box::apply(segment, box,
+                                                           strategy_type());
+}
 
 
 template
@@ -100,7 +115,7 @@ public:
                                     Strategy const& strategy,
                                     bool check_intersection = true)
     {
-        if (check_intersection && geometry::intersects(segment, box))
+        if (check_intersection && intersects_segment_box(segment, box))
         {
             return 0;
         }
@@ -215,7 +230,7 @@ public:
                                     Strategy const& strategy,
                                     bool check_intersection = true)
     {
-        if (check_intersection && geometry::intersects(segment, box))
+        if (check_intersection && intersects_segment_box(segment, box))
         {
             return 0;
         }
@@ -754,7 +769,8 @@ public:
         detail::assign_point_from_index<0>(segment, p[0]);
         detail::assign_point_from_index<1>(segment, p[1]);
 
-        if (geometry::equals(p[0], p[1]))
+        if (detail::equals::equals_point_point(p[0], p[1],
+                sb_strategy.get_equals_point_point_strategy()))
         {
             typedef typename boost::mpl::if_
                 <

--- a/include/boost/geometry/algorithms/detail/envelope/range_of_boxes.hpp
+++ b/include/boost/geometry/algorithms/detail/envelope/range_of_boxes.hpp
@@ -20,17 +20,20 @@
 
 #include <boost/range.hpp>
 
+#include <boost/geometry/algorithms/detail/convert_point_to_point.hpp>
+#include <boost/geometry/algorithms/detail/max_interval_gap.hpp>
+#include <boost/geometry/algorithms/detail/expand/indexed.hpp>
+
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/coordinate_system.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
 
 #include <boost/geometry/util/math.hpp>
+#include <boost/geometry/util/normalize_spheroidal_coordinates.hpp>
 #include <boost/geometry/util/range.hpp>
 
-#include <boost/geometry/algorithms/detail/convert_point_to_point.hpp>
-#include <boost/geometry/algorithms/detail/max_interval_gap.hpp>
-#include <boost/geometry/algorithms/detail/expand/indexed.hpp>
+#include <boost/geometry/views/detail/indexed_point_view.hpp>
 
 
 namespace boost { namespace geometry

--- a/include/boost/geometry/algorithms/detail/extreme_points.hpp
+++ b/include/boost/geometry/algorithms/detail/extreme_points.hpp
@@ -5,8 +5,8 @@
 // Copyright (c) 2009-2013 Mateusz Loskot, London, UK.
 // Copyright (c) 2013-2017 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -25,6 +25,7 @@
 #include <boost/geometry/algorithms/detail/interior_iterator.hpp>
 
 #include <boost/geometry/core/cs.hpp>
+#include <boost/geometry/core/point_order.hpp>
 #include <boost/geometry/core/point_type.hpp>
 #include <boost/geometry/core/ring_type.hpp>
 #include <boost/geometry/core/tags.hpp>

--- a/include/boost/geometry/algorithms/detail/get_left_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/get_left_turns.hpp
@@ -2,8 +2,8 @@
 
 // Copyright (c) 2012-2014 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -14,11 +14,14 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_GET_LEFT_TURNS_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_GET_LEFT_TURNS_HPP
 
+#include <set>
+#include <vector>
+
 #include <boost/geometry/core/assert.hpp>
 
-#include <boost/geometry/arithmetic/arithmetic.hpp>
 #include <boost/geometry/algorithms/detail/overlay/segment_identifier.hpp>
 #include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>
+#include <boost/geometry/arithmetic/arithmetic.hpp>
 #include <boost/geometry/iterators/closing_iterator.hpp>
 #include <boost/geometry/iterators/ever_circling_iterator.hpp>
 #include <boost/geometry/strategies/side.hpp>

--- a/include/boost/geometry/algorithms/detail/get_max_size.hpp
+++ b/include/boost/geometry/algorithms/detail/get_max_size.hpp
@@ -5,6 +5,11 @@
 // Copyright (c) 2014 Mateusz Loskot, London, UK.
 // Copyright (c) 2014 Adam Wulkiewicz, Lodz, Poland.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -12,10 +17,10 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_GET_MAX_SIZE_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_GET_MAX_SIZE_HPP
 
-
 #include <cstddef>
 
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/util/math.hpp>
 
 namespace boost { namespace geometry

--- a/include/boost/geometry/algorithms/detail/is_valid/complement_graph.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/complement_graph.hpp
@@ -1,8 +1,9 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014, Oracle and/or its affiliates.
+// Copyright (c) 2014, 2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Licensed under the Boost Software License version 1.0.
 // http://www.boost.org/users/license.html
@@ -19,6 +20,7 @@
 
 #include <boost/core/addressof.hpp>
 
+#include <boost/geometry/algorithms/detail/signed_size_type.hpp>
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/policies/compare.hpp>
 
@@ -221,9 +223,11 @@ public:
         return false;
     }
 
+#ifdef BOOST_GEOMETRY_TEST_DEBUG
     template <typename OStream, typename TP>
     friend inline
     void debug_print_complement_graph(OStream&, complement_graph<TP> const&);
+#endif // BOOST_GEOMETRY_TEST_DEBUG
 
 private:
     std::size_t m_num_rings, m_num_turns;

--- a/include/boost/geometry/algorithms/detail/is_valid/debug_complement_graph.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/debug_complement_graph.hpp
@@ -1,8 +1,9 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014, Oracle and/or its affiliates.
+// Copyright (c) 2014, 2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Licensed under the Boost Software License version 1.0.
 // http://www.boost.org/users/license.html
@@ -13,6 +14,8 @@
 #ifdef BOOST_GEOMETRY_TEST_DEBUG
 #include <iostream>
 #endif
+
+#include <boost/geometry/algorithms/detail/is_valid/complement_graph.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/algorithms/detail/is_valid/debug_validity_phase.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/debug_validity_phase.hpp
@@ -1,8 +1,9 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014, Oracle and/or its affiliates.
+// Copyright (c) 2014, 2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Licensed under the Boost Software License version 1.0.
 // http://www.boost.org/users/license.html
@@ -12,11 +13,10 @@
 
 #ifdef GEOMETRY_TEST_DEBUG
 #include <iostream>
+#endif
 
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tags.hpp>
-#endif
-
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/algorithms/detail/is_valid/has_invalid_coordinate.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/has_invalid_coordinate.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014-2015, Oracle and/or its affiliates.
+// Copyright (c) 2014-2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -15,15 +15,17 @@
 
 #include <boost/type_traits/is_floating_point.hpp>
 
+#include <boost/geometry/algorithms/detail/check_iterator_range.hpp>
+#include <boost/geometry/algorithms/validity_failure_type.hpp>
+
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/point_type.hpp>
 
-#include <boost/geometry/util/has_non_finite_coordinate.hpp>
-
 #include <boost/geometry/iterators/point_iterator.hpp>
-#include <boost/geometry/views/detail/indexed_point_view.hpp>
-#include <boost/geometry/algorithms/detail/check_iterator_range.hpp>
 
+#include <boost/geometry/views/detail/indexed_point_view.hpp>
+
+#include <boost/geometry/util/has_non_finite_coordinate.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/algorithms/detail/is_valid/has_valid_self_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/has_valid_self_turns.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014-2017, Oracle and/or its affiliates.
+// Copyright (c) 2014-2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -16,18 +16,18 @@
 #include <boost/core/ignore_unused.hpp>
 #include <boost/range.hpp>
 
+#include <boost/geometry/algorithms/detail/is_valid/is_acceptable_turn.hpp>
+#include <boost/geometry/algorithms/detail/overlay/get_turn_info.hpp>
+#include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>
+#include <boost/geometry/algorithms/detail/overlay/self_turn_points.hpp>
+#include <boost/geometry/algorithms/validity_failure_type.hpp>
+
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/point_type.hpp>
 
 #include <boost/geometry/policies/predicate_based_interrupt_policy.hpp>
 #include <boost/geometry/policies/robustness/segment_ratio_type.hpp>
 #include <boost/geometry/policies/robustness/get_rescale_policy.hpp>
-
-#include <boost/geometry/algorithms/detail/overlay/get_turn_info.hpp>
-#include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>
-#include <boost/geometry/algorithms/detail/overlay/self_turn_points.hpp>
-
-#include <boost/geometry/algorithms/detail/is_valid/is_acceptable_turn.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/algorithms/detail/is_valid/ring.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/ring.hpp
@@ -2,7 +2,7 @@
 
 // Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
-// Copyright (c) 2014-2017, Oracle and/or its affiliates.
+// Copyright (c) 2014-2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -20,6 +20,7 @@
 #include <boost/geometry/core/closure.hpp>
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/point_order.hpp>
+#include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/util/order_as_direction.hpp>
 #include <boost/geometry/util/range.hpp>
@@ -36,6 +37,7 @@
 #include <boost/geometry/algorithms/detail/is_valid/has_invalid_coordinate.hpp>
 #include <boost/geometry/algorithms/detail/is_valid/has_spikes.hpp>
 #include <boost/geometry/algorithms/detail/is_valid/has_valid_self_turns.hpp>
+#include <boost/geometry/algorithms/dispatch/is_valid.hpp>
 
 #include <boost/geometry/strategies/area.hpp>
 

--- a/include/boost/geometry/algorithms/detail/overlay/append_no_dups_or_spikes.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/append_no_dups_or_spikes.hpp
@@ -21,6 +21,8 @@
 #include <boost/geometry/algorithms/detail/point_is_spike_or_equal.hpp>
 #include <boost/geometry/algorithms/detail/equals/point_point.hpp>
 
+#include <boost/geometry/core/closure.hpp>
+
 #include <boost/geometry/util/condition.hpp>
 #include <boost/geometry/util/range.hpp>
 

--- a/include/boost/geometry/algorithms/detail/overlay/check_enrich.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/check_enrich.hpp
@@ -2,6 +2,11 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018 Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -9,11 +14,18 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_CHECK_ENRICH_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_CHECK_ENRICH_HPP
 
+#ifdef BOOST_GEOMETRY_DEBUG_ENRICH
+#include <iostream>
+#endif // BOOST_GEOMETRY_DEBUG_ENRICH
 
 #include <cstddef>
+#include <vector>
 
-#include <boost/range.hpp>
+#include <boost/range/begin.hpp>
+#include <boost/range/end.hpp>
+#include <boost/range/value_type.hpp>
 
+#include <boost/geometry/algorithms/detail/overlay/overlay_type.hpp>
 #include <boost/geometry/algorithms/detail/ring_identifier.hpp>
 
 
@@ -42,7 +54,7 @@ struct meta_turn
 
 
 template <typename MetaTurn>
-inline void display(MetaTurn const& meta_turn, std::string const& reason = "")
+inline void display(MetaTurn const& meta_turn, const char* reason = "")
 {
 #ifdef BOOST_GEOMETRY_DEBUG_ENRICH
     std::cout << meta_turn.index

--- a/include/boost/geometry/algorithms/detail/overlay/convert_ring.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/convert_ring.hpp
@@ -2,6 +2,11 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -9,18 +14,16 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_CONVERT_RING_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_CONVERT_RING_HPP
 
-
 #include <boost/mpl/assert.hpp>
-#include <boost/range.hpp>
 #include <boost/range/algorithm/reverse.hpp>
+
+#include <boost/geometry/algorithms/convert.hpp>
+#include <boost/geometry/algorithms/detail/ring_identifier.hpp>
+#include <boost/geometry/algorithms/num_points.hpp>
 
 #include <boost/geometry/core/tags.hpp>
 #include <boost/geometry/core/exterior_ring.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
-#include <boost/geometry/algorithms/detail/ring_identifier.hpp>
-
-#include <boost/geometry/algorithms/convert.hpp>
-
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/algorithms/detail/overlay/copy_segments.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/copy_segments.hpp
@@ -23,22 +23,26 @@
 #include <boost/range.hpp>
 #include <boost/type_traits/integral_constant.hpp>
 
+#include <boost/geometry/algorithms/detail/assign_box_corners.hpp>
+#include <boost/geometry/algorithms/detail/signed_size_type.hpp>
+#include <boost/geometry/algorithms/detail/overlay/append_no_duplicates.hpp>
+#include <boost/geometry/algorithms/detail/overlay/append_no_dups_or_spikes.hpp>
+#include <boost/geometry/algorithms/not_implemented.hpp>
+
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/exterior_ring.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
 #include <boost/geometry/core/ring_type.hpp>
 #include <boost/geometry/core/tags.hpp>
-#include <boost/geometry/algorithms/not_implemented.hpp>
-#include <boost/geometry/geometries/concepts/check.hpp>
-#include <boost/geometry/iterators/ever_circling_iterator.hpp>
-#include <boost/geometry/views/closeable_view.hpp>
-#include <boost/geometry/views/reversible_view.hpp>
 
-#include <boost/geometry/algorithms/detail/overlay/append_no_duplicates.hpp>
-#include <boost/geometry/algorithms/detail/overlay/append_no_dups_or_spikes.hpp>
-#include <boost/geometry/algorithms/detail/signed_size_type.hpp>
+#include <boost/geometry/geometries/concepts/check.hpp>
+
+#include <boost/geometry/iterators/ever_circling_iterator.hpp>
 
 #include <boost/geometry/util/range.hpp>
+
+#include <boost/geometry/views/closeable_view.hpp>
+#include <boost/geometry/views/reversible_view.hpp>
 
 
 namespace boost { namespace geometry

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -3,8 +3,8 @@
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2015, 2017.
-// Modifications copyright (c) 2015-2017 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2015, 2017, 2018.
+// Modifications copyright (c) 2015-2018 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -21,6 +21,7 @@
 
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/assert.hpp>
+#include <boost/geometry/core/exception.hpp>
 
 #include <boost/geometry/algorithms/convert.hpp>
 #include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
@@ -15,8 +15,10 @@
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_TURN_INFO_FOR_ENDPOINT_HPP
 
 #include <boost/core/ignore_unused.hpp>
-#include <boost/geometry/core/assert.hpp>
+
+#include <boost/geometry/algorithms/detail/equals/point_point.hpp>
 #include <boost/geometry/algorithms/detail/overlay/get_turn_info.hpp>
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/policies/robustness/no_rescale_policy.hpp>
 
 namespace boost { namespace geometry {

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
@@ -2,8 +2,8 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2013, 2014, 2015, 2017.
-// Modifications copyright (c) 2013-2017 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013, 2014, 2015, 2017, 2018.
+// Modifications copyright (c) 2013-2018 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -14,9 +14,15 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_TURN_INFO_HELPERS_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_TURN_INFO_HELPERS_HPP
 
-#include <boost/geometry/core/assert.hpp>
-#include <boost/geometry/policies/robustness/no_rescale_policy.hpp>
 #include <boost/geometry/algorithms/detail/direction_code.hpp>
+#include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>
+#include <boost/geometry/core/assert.hpp>
+#include <boost/geometry/geometries/segment.hpp> // referring_segment
+#include <boost/geometry/policies/relate/direction.hpp>
+#include <boost/geometry/policies/relate/intersection_points.hpp>
+#include <boost/geometry/policies/relate/tupled.hpp>
+#include <boost/geometry/policies/robustness/no_rescale_policy.hpp>
+#include <boost/geometry/strategies/intersection_result.hpp>
 
 namespace boost { namespace geometry {
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
@@ -16,6 +16,7 @@
 
 #include <boost/geometry/algorithms/detail/direction_code.hpp>
 #include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>
+#include <boost/geometry/algorithms/detail/recalculate.hpp>
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/geometries/segment.hpp> // referring_segment
 #include <boost/geometry/policies/relate/direction.hpp>

--- a/include/boost/geometry/algorithms/detail/overlay/stream_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/stream_info.hpp
@@ -51,10 +51,10 @@ namespace detail { namespace overlay
                 << (info.opposite ? " o" : "")
                 << "]"
             << " sd "
-                << dir(info.sides.get<0,0>())
-                << dir(info.sides.get<0,1>())
-                << dir(info.sides.get<1,0>())
-                << dir(info.sides.get<1,1>())
+                << dir(info.sides.template get<0,0>())
+                << dir(info.sides.template get<0,1>())
+                << dir(info.sides.template get<1,0>())
+                << dir(info.sides.template get<1,1>())
             << " nxt seg " << info.travels_to_vertex_index
             << " , ip " << info.travels_to_ip_index
             << " , or " << info.next_ip_index

--- a/include/boost/geometry/algorithms/detail/overlay/stream_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/stream_info.hpp
@@ -2,6 +2,11 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018 Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -12,7 +17,7 @@
 
 #include <string>
 
-#include <boost/array.hpp>
+#include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>
 
 
 namespace boost { namespace geometry
@@ -32,8 +37,8 @@ namespace detail { namespace overlay
         return h == 0 ? "-" : (h == 1 ? "A" : "D");
     }
 
-    template <typename P>
-    std::ostream& operator<<(std::ostream &os, turn_info<P> const& info)
+    template <typename P, typename SR, typename O, typename C>
+    std::ostream& operator<<(std::ostream &os, turn_info<P, SR, O, C> const& info)
     {
         os  << "\t"
             << " src " << info.seg_id.source_index

--- a/include/boost/geometry/algorithms/detail/overlay/traversal.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/traversal.hpp
@@ -2,8 +2,8 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -15,9 +15,11 @@
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_TRAVERSAL_HPP
 
 #include <cstddef>
+#include <set>
 
 #include <boost/range.hpp>
 
+#include <boost/geometry/algorithms/detail/overlay/cluster_info.hpp>
 #include <boost/geometry/algorithms/detail/overlay/is_self_turn.hpp>
 #include <boost/geometry/algorithms/detail/overlay/sort_by_side.hpp>
 #include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>

--- a/include/boost/geometry/algorithms/detail/overlay/traversal_ring_creator.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/traversal_ring_creator.hpp
@@ -2,8 +2,8 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -17,6 +17,7 @@
 
 #include <boost/range.hpp>
 
+#include <boost/geometry/algorithms/detail/overlay/backtrack_check_si.hpp>
 #include <boost/geometry/algorithms/detail/overlay/copy_segments.hpp>
 #include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>
 #include <boost/geometry/algorithms/detail/overlay/traversal.hpp>

--- a/include/boost/geometry/algorithms/detail/overlay/traversal_switch_detector.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/traversal_switch_detector.hpp
@@ -2,6 +2,11 @@
 
 // Copyright (c) 2015-2016 Barend Gehrels, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018 Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -10,6 +15,7 @@
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_TRAVERSAL_SWITCH_DETECTOR_HPP
 
 #include <cstddef>
+#include <map>
 
 #include <boost/range.hpp>
 

--- a/include/boost/geometry/algorithms/detail/relate/boundary_checker.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/boundary_checker.hpp
@@ -13,13 +13,14 @@
 
 #include <boost/core/ignore_unused.hpp>
 
-#include <boost/geometry/util/range.hpp>
-#include <boost/geometry/algorithms/num_points.hpp>
-#include <boost/geometry/algorithms/detail/sub_range.hpp>
-
 #include <boost/geometry/algorithms/detail/equals/point_point.hpp>
+#include <boost/geometry/algorithms/detail/sub_range.hpp>
+#include <boost/geometry/algorithms/num_points.hpp>
+
+#include <boost/geometry/policies/compare.hpp>
 
 #include <boost/geometry/util/has_nan_coordinate.hpp>
+#include <boost/geometry/util/range.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/algorithms/detail/relate/follow_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/follow_helpers.hpp
@@ -5,22 +5,29 @@
 // This file was modified by Oracle on 2013, 2014, 2018.
 // Modifications copyright (c) 2013-2018 Oracle and/or its affiliates.
 
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_RELATE_FOLLOW_HELPERS_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_RELATE_FOLLOW_HELPERS_HPP
 
+#include <vector>
+
 #include <boost/core/ignore_unused.hpp>
+
+#include <boost/geometry/algorithms/detail/overlay/overlay_type.hpp>
+#include <boost/geometry/algorithms/detail/overlay/segment_identifier.hpp>
+#include <boost/geometry/algorithms/detail/relate/boundary_checker.hpp>
+#include <boost/geometry/algorithms/not_implemented.hpp>
 
 #include <boost/geometry/core/assert.hpp>
 
 #include <boost/geometry/util/condition.hpp>
 #include <boost/geometry/util/range.hpp>
-//#include <boost/geometry/algorithms/detail/sub_range.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/algorithms/detail/relate/follow_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/follow_helpers.hpp
@@ -19,6 +19,7 @@
 
 #include <boost/core/ignore_unused.hpp>
 
+#include <boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp>
 #include <boost/geometry/algorithms/detail/overlay/overlay_type.hpp>
 #include <boost/geometry/algorithms/detail/overlay/segment_identifier.hpp>
 #include <boost/geometry/algorithms/detail/relate/boundary_checker.hpp>

--- a/include/boost/geometry/algorithms/detail/relate/multi_point_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/multi_point_geometry.hpp
@@ -17,6 +17,7 @@
 #include <boost/geometry/algorithms/detail/disjoint/box_box.hpp>
 #include <boost/geometry/algorithms/detail/disjoint/point_box.hpp>
 #include <boost/geometry/algorithms/detail/expand_by_epsilon.hpp>
+#include <boost/geometry/algorithms/detail/partition.hpp>
 #include <boost/geometry/algorithms/detail/relate/result.hpp>
 #include <boost/geometry/algorithms/detail/relate/topology_check.hpp>
 #include <boost/geometry/algorithms/detail/within/point_in_geometry.hpp>

--- a/include/boost/geometry/algorithms/detail/relate/result.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/result.hpp
@@ -3,8 +3,8 @@
 // Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2013-2016.
-// Modifications copyright (c) 2013-2016 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013-2018.
+// Modifications copyright (c) 2013-2018 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -25,6 +25,7 @@
 #include <boost/mpl/end.hpp>
 #include <boost/mpl/is_sequence.hpp>
 #include <boost/mpl/next.hpp>
+#include <boost/mpl/size.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/throw_exception.hpp>
 #include <boost/tuple/tuple.hpp>

--- a/include/boost/geometry/algorithms/detail/relate/topology_check.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/topology_check.hpp
@@ -13,6 +13,7 @@
 
 
 #include <boost/geometry/algorithms/detail/equals/point_point.hpp>
+#include <boost/geometry/algorithms/not_implemented.hpp>
 
 #include <boost/geometry/policies/compare.hpp>
 

--- a/include/boost/geometry/algorithms/detail/sections/section_functions.hpp
+++ b/include/boost/geometry/algorithms/detail/sections/section_functions.hpp
@@ -22,6 +22,8 @@
 // For spherical/geographic longitudes covered_by point/box
 #include <boost/geometry/strategies/cartesian/point_in_box.hpp>
 
+#include <boost/geometry/util/select_coordinate_type.hpp>
+
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/algorithms/detail/sub_range.hpp
+++ b/include/boost/geometry/algorithms/detail/sub_range.hpp
@@ -2,21 +2,29 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2013, 2014.
-// Modifications copyright (c) 2013-2014, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013, 2014, 2018.
+// Modifications copyright (c) 2013-2018, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
-
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_SUB_RANGE_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_SUB_RANGE_HPP
 
 #include <boost/mpl/if.hpp>
+#include <boost/type_traits/is_base_of.hpp>
+
+#include <boost/geometry/algorithms/not_implemented.hpp>
 
 #include <boost/geometry/core/assert.hpp>
+#include <boost/geometry/core/exterior_ring.hpp>
+#include <boost/geometry/core/interior_rings.hpp>
+#include <boost/geometry/core/tag.hpp>
+#include <boost/geometry/core/tags.hpp>
+
 #include <boost/geometry/util/range.hpp>
 
 namespace boost { namespace geometry {

--- a/include/boost/geometry/algorithms/detail/within/implementation.hpp
+++ b/include/boost/geometry/algorithms/detail/within/implementation.hpp
@@ -4,8 +4,8 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2013, 2014, 2017.
-// Modifications copyright (c) 2013-2017 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013, 2014, 2017, 2019.
+// Modifications copyright (c) 2013-2019 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -61,7 +61,7 @@ struct use_point_in_geometry
     template <typename Geometry1, typename Geometry2, typename Strategy>
     static inline bool apply(Geometry1 const& geometry1, Geometry2 const& geometry2, Strategy const& strategy)
     {
-        return detail::within::point_in_geometry(geometry1, geometry2, strategy) == 1;
+        return detail::within::within_point_geometry(geometry1, geometry2, strategy);
     }
 };
 

--- a/include/boost/geometry/algorithms/detail/within/point_in_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/within/point_in_geometry.hpp
@@ -5,8 +5,8 @@
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 // Copyright (c) 2014 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2013, 2014, 2015, 2017, 2018.
-// Modifications copyright (c) 2013-2018, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013, 2014, 2015, 2017, 2018, 2019.
+// Modifications copyright (c) 2013-2019, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -380,6 +380,30 @@ inline int point_in_geometry(Point const& point, Geometry const& geometry)
         >::type strategy_type;
 
     return point_in_geometry(point, geometry, strategy_type());
+}
+
+template <typename Point, typename Geometry, typename Strategy>
+inline bool within_point_geometry(Point const& point, Geometry const& geometry, Strategy const& strategy)
+{
+    return point_in_geometry(point, geometry, strategy) > 0;
+}
+
+template <typename Point, typename Geometry>
+inline bool within_point_geometry(Point const& point, Geometry const& geometry)
+{
+    return point_in_geometry(point, geometry) > 0;
+}
+
+template <typename Point, typename Geometry, typename Strategy>
+inline bool covered_by_point_geometry(Point const& point, Geometry const& geometry, Strategy const& strategy)
+{
+    return point_in_geometry(point, geometry, strategy) >= 0;
+}
+
+template <typename Point, typename Geometry>
+inline bool covered_by_point_geometry(Point const& point, Geometry const& geometry)
+{
+    return point_in_geometry(point, geometry) >= 0;
 }
 
 }} // namespace detail::within

--- a/include/boost/geometry/algorithms/dispatch/disjoint.hpp
+++ b/include/boost/geometry/algorithms/dispatch/disjoint.hpp
@@ -5,8 +5,8 @@
 // Copyright (c) 2009-2014 Mateusz Loskot, London, UK.
 // Copyright (c) 2013-2014 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2013-2017.
-// Modifications copyright (c) 2013-2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013-2018.
+// Modifications copyright (c) 2013-2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
@@ -23,6 +23,7 @@
 
 #include <cstddef>
 
+#include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tag_cast.hpp>
 #include <boost/geometry/core/tags.hpp>

--- a/include/boost/geometry/algorithms/dispatch/distance.hpp
+++ b/include/boost/geometry/algorithms/dispatch/distance.hpp
@@ -5,10 +5,11 @@
 // Copyright (c) 2009-2014 Mateusz Loskot, London, UK.
 // Copyright (c) 2013-2014 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2014.
-// Modifications copyright (c) 2014, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014, 2018.
+// Modifications copyright (c) 2014-2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
@@ -25,8 +26,9 @@
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tag_cast.hpp>
 #include <boost/geometry/core/tags.hpp>
-#include <boost/geometry/strategies/distance.hpp>
+#include <boost/geometry/algorithms/detail/distance/default_strategies.hpp>
 #include <boost/geometry/algorithms/not_implemented.hpp>
+#include <boost/geometry/strategies/distance.hpp>
 
 
 namespace boost { namespace geometry

--- a/include/boost/geometry/algorithms/simplify.hpp
+++ b/include/boost/geometry/algorithms/simplify.hpp
@@ -20,6 +20,7 @@
 #define BOOST_GEOMETRY_ALGORITHMS_SIMPLIFY_HPP
 
 #include <cstddef>
+#include <set>
 
 #include <boost/core/ignore_unused.hpp>
 #include <boost/range.hpp>

--- a/include/boost/geometry/extensions/algebra/algorithms/detail.hpp
+++ b/include/boost/geometry/extensions/algebra/algorithms/detail.hpp
@@ -2,6 +2,10 @@
 
 // Copyright (c) 2013 Adam Wulkiewicz, Lodz, Poland.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -12,7 +16,14 @@
 // TODO - for multiplication of coordinates
 // if coordinate_type is_integral - use double as the result type
 
+#include <boost/geometry/extensions/algebra/core/access.hpp>
+#include <boost/geometry/extensions/algebra/core/coordinate_type.hpp>
+#include <boost/geometry/extensions/algebra/core/coordinate_dimension.hpp>
+
 #include <boost/geometry/util/math.hpp>
+#include <boost/geometry/util/select_most_precise.hpp>
+
+#include <boost/static_assert.hpp>
 
 namespace boost { namespace geometry
 {
@@ -37,8 +48,8 @@ struct dot_impl
     BOOST_STATIC_ASSERT(0 < N);
 
     typedef typename geometry::select_most_precise<
-        typename traits::coordinate_type<S1>::type,
-        typename traits::coordinate_type<S2>::type
+        typename geometry::coordinate_type<S1>::type,
+        typename geometry::coordinate_type<S2>::type
     >::type coordinate_type;
 
     static inline coordinate_type apply(S1 const& s1, S2 const& s2)
@@ -51,8 +62,8 @@ template <typename S1, typename S2, std::size_t IS1, std::size_t IS2>
 struct dot_impl<S1, S2, IS1, IS2, 1>
 {
     typedef typename geometry::select_most_precise<
-        typename traits::coordinate_type<S1>::type,
-        typename traits::coordinate_type<S2>::type
+        typename geometry::coordinate_type<S1>::type,
+        typename geometry::coordinate_type<S2>::type
     >::type coordinate_type;
 
     static inline coordinate_type apply(S1 const& s1, S2 const& s2)
@@ -64,8 +75,8 @@ struct dot_impl<S1, S2, IS1, IS2, 1>
 template <std::size_t IS1, std::size_t IS2, std::size_t N, typename S1, typename S2>
 inline static
 typename geometry::select_most_precise<
-    typename traits::coordinate_type<S1>::type,
-    typename traits::coordinate_type<S2>::type
+    typename geometry::coordinate_type<S1>::type,
+    typename geometry::coordinate_type<S2>::type
 >::type
 dot(S1 const& s1, S2 const& s2)
 {
@@ -143,7 +154,7 @@ struct matrix_mul_row_impl
 {
     BOOST_STATIC_ASSERT(0 < N);
 
-    static const std::size_t dimension = traits::dimension<M>::value;
+    static const std::size_t dimension = geometry::dimension<M>::value;
 
     static inline
     typename traits::coordinate_type<VD>::type
@@ -156,7 +167,7 @@ struct matrix_mul_row_impl
 template <typename M, typename V, typename VD, std::size_t I>
 struct matrix_mul_row_impl<M, V, VD, I, 1>
 {
-    static const std::size_t dimension = traits::dimension<M>::value;
+    static const std::size_t dimension = geometry::dimension<M>::value;
 
     static inline
     typename traits::coordinate_type<VD>::type
@@ -187,7 +198,7 @@ struct matrix_mul_impl<M, V, VD, N, N>
 template <typename M, typename V, typename VD>
 inline static void matrix_rotate(M const& m, V const& v, VD & vd)
 {
-    static const std::size_t dimension = traits::dimension<M>::value;
+    static const std::size_t dimension = geometry::dimension<M>::value;
 
     matrix_mul_impl<M, V, VD, 0, dimension>::apply(m, v, vd);
 }
@@ -200,8 +211,8 @@ inline static void quaternion_rotate(V & v, Q const& r)
     // TODO - choose more precise type?
 
     typedef typename geometry::select_most_precise<
-        typename traits::coordinate_type<V>::type,
-        typename traits::coordinate_type<Q>::type
+        typename geometry::coordinate_type<V>::type,
+        typename geometry::coordinate_type<Q>::type
     >::type T;
 
     // Hamilton product T=Q*V

--- a/include/boost/geometry/extensions/algebra/algorithms/rotation.hpp
+++ b/include/boost/geometry/extensions/algebra/algorithms/rotation.hpp
@@ -2,6 +2,10 @@
 
 // Copyright (c) 2013 Adam Wulkiewicz, Lodz, Poland.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -14,6 +18,7 @@
 #include <boost/geometry/extensions/algebra/algorithms/detail.hpp>
 
 #include <boost/geometry/extensions/algebra/geometries/concepts/rotation_quaternion_concept.hpp>
+#include <boost/geometry/extensions/algebra/geometries/vector.hpp>
 
 // TODO - for multiplication of coordinates
 // if coordinate_type is_integral - use double as the result type

--- a/include/boost/geometry/extensions/algebra/algorithms/transform_geometrically.hpp
+++ b/include/boost/geometry/extensions/algebra/algorithms/transform_geometrically.hpp
@@ -2,6 +2,10 @@
 
 // Copyright (c) 2013 Adam Wulkiewicz, Lodz, Poland.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -9,10 +13,13 @@
 #ifndef BOOST_GEOMETRY_EXTENSIONS_ALGEBRA_ALGORITHMS_TRANSFORM_HPP
 #define BOOST_GEOMETRY_EXTENSIONS_ALGEBRA_ALGORITHMS_TRANSFORM_HPP
 
+#include <boost/geometry/algorithms/convert.hpp>
+#include <boost/geometry/arithmetic/arithmetic.hpp>
+#include <boost/geometry/extensions/algebra/algorithms/detail.hpp>
 #include <boost/geometry/extensions/algebra/geometries/concepts/vector_concept.hpp>
 #include <boost/geometry/extensions/algebra/geometries/concepts/rotation_quaternion_concept.hpp>
 #include <boost/geometry/extensions/algebra/geometries/concepts/rotation_matrix_concept.hpp>
-#include <boost/geometry/arithmetic/arithmetic.hpp>
+#include <boost/geometry/geometries/concepts/check.hpp>
 
 namespace boost { namespace geometry {
 

--- a/include/boost/geometry/extensions/algebra/algorithms/translation.hpp
+++ b/include/boost/geometry/extensions/algebra/algorithms/translation.hpp
@@ -2,6 +2,10 @@
 
 // Copyright (c) 2013 Adam Wulkiewicz, Lodz, Poland.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -9,11 +13,11 @@
 #ifndef BOOST_GEOMETRY_EXTENSIONS_ALGEBRA_ALGORITHMS_TRANSLATION_HPP
 #define BOOST_GEOMETRY_EXTENSIONS_ALGEBRA_ALGORITHMS_TRANSLATION_HPP
 
+#include <boost/geometry/arithmetic/arithmetic.hpp>
 #include <boost/geometry/extensions/algebra/geometries/concepts/vector_concept.hpp>
-
+#include <boost/geometry/geometries/concepts/check.hpp>
 //#include <boost/geometry/geometries/concepts/point_concept.hpp>
 //#include <boost/geometry/util/for_each_coordinate.hpp>
-#include <boost/geometry/arithmetic/arithmetic.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/extensions/algebra/core/coordinate_dimension.hpp
+++ b/include/boost/geometry/extensions/algebra/core/coordinate_dimension.hpp
@@ -5,6 +5,10 @@
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 // Copyright (c) 2013 Adam Wulkiewicz, Lodz, Poland.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -15,11 +19,27 @@
 #ifndef BOOST_GEOMETRY_EXTENSIONS_ALGEBRA_CORE_COORDINATE_DIMENSION_HPP
 #define BOOST_GEOMETRY_EXTENSIONS_ALGEBRA_CORE_COORDINATE_DIMENSION_HPP
 
-#include <boost/geometry/core/coordinate_system.hpp>
+#include <boost/geometry/core/coordinate_dimension.hpp>
 
 #include <boost/geometry/extensions/algebra/core/tags.hpp>
 
+#include <boost/geometry/util/bare_type.hpp>
+
+#include <boost/mpl/assert.hpp>
+
 namespace boost { namespace geometry {
+
+namespace traits {
+
+template <typename Geometry, std::size_t Index>
+struct indexed_dimension
+{
+     BOOST_MPL_ASSERT_MSG(false,
+                          NOT_IMPLEMENTED_FOR_THIS_GEOMETRY_OR_INDEX,
+                          (Geometry, boost::integral_constant<std::size_t, Index>));
+};
+
+} // namespace traits
 
 #ifndef DOXYGEN_NO_DISPATCH
 namespace core_dispatch {
@@ -33,6 +53,14 @@ template <typename G>
 struct dimension<quaternion_tag, G>
     : traits::dimension<typename geometry::util::bare_type<G>::type>
 {};
+
+template <typename T, typename G, std::size_t Index>
+struct indexed_dimension
+{
+    BOOST_MPL_ASSERT_MSG(false,
+                         NOT_IMPLEMENTED_FOR_THIS_GEOMETRY_OR_INDEX,
+                         (G, boost::integral_constant<std::size_t, Index>));
+};
 
 template <typename G, std::size_t Index>
 struct indexed_dimension<matrix_tag, G, Index>

--- a/include/boost/geometry/extensions/algebra/geometries/concepts/check.hpp
+++ b/include/boost/geometry/extensions/algebra/geometries/concepts/check.hpp
@@ -5,6 +5,10 @@
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 // Copyright (c) 2013 Adam Wulkiewicz, Lodz, Poland.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -16,6 +20,13 @@
 #ifndef BOOST_GEOMETRY_EXTENSIONS_ALGEBRA_GEOMETRIES_CONCEPTS_CHECK_HPP
 #define BOOST_GEOMETRY_EXTENSIONS_ALGEBRA_GEOMETRIES_CONCEPTS_CHECK_HPP
 
+
+#include <boost/geometry/extensions/algebra/core/tags.hpp>
+#include <boost/geometry/extensions/algebra/geometries/concepts/matrix_concept.hpp>
+#include <boost/geometry/extensions/algebra/geometries/concepts/quaternion_concept.hpp>
+#include <boost/geometry/extensions/algebra/geometries/concepts/rotation_matrix_concept.hpp>
+#include <boost/geometry/extensions/algebra/geometries/concepts/rotation_quaternion_concept.hpp>
+#include <boost/geometry/extensions/algebra/geometries/concepts/vector_concept.hpp>
 
 #include <boost/geometry/geometries/concepts/check.hpp>
 

--- a/include/boost/geometry/extensions/algebra/geometries/concepts/matrix_concept.hpp
+++ b/include/boost/geometry/extensions/algebra/geometries/concepts/matrix_concept.hpp
@@ -5,6 +5,10 @@
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 // Copyright (c) 2013 Adam Wulkiewicz, Lodz, Poland.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -17,8 +21,12 @@
 
 #include <boost/concept_check.hpp>
 #include <boost/core/ignore_unused.hpp>
-#include <boost/geometry/core/coordinate_dimension.hpp>
-#include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/cs.hpp>
+#include <boost/geometry/extensions/algebra/core/access.hpp>
+#include <boost/geometry/extensions/algebra/core/coordinate_dimension.hpp>
+#include <boost/geometry/extensions/algebra/core/coordinate_system.hpp>
+#include <boost/geometry/extensions/algebra/core/coordinate_type.hpp>
+#include <boost/mpl/assert.hpp>
 
 namespace boost { namespace geometry { namespace concepts {
 
@@ -54,7 +62,7 @@ class Matrix
     {
         static void apply()
         {
-            dimension_checker_row<G, I, 0, N>;
+            dimension_checker_row<G, I, 0, N>::apply();
             dimension_checker<G, I+1, N>::apply();
         }
     };
@@ -95,7 +103,7 @@ class ConstMatrix
         static void apply()
         {
             const G* g = 0;
-            ctype coord(geometry::get<I, J>(*g));
+            typename coordinate_type<G>::type coord(geometry::get<I, J>(*g));
             boost::ignore_unused(coord);
             dimension_checker_row<G, I, J+1, N>::apply();
         }
@@ -112,7 +120,7 @@ class ConstMatrix
     {
         static void apply()
         {
-            dimension_checker_row<G, I, 0, N>;
+            dimension_checker_row<G, I, 0, N>::apply();
             dimension_checker<G, I+1, N>::apply();
         }
     };

--- a/include/boost/geometry/extensions/algebra/geometries/concepts/quaternion_concept.hpp
+++ b/include/boost/geometry/extensions/algebra/geometries/concepts/quaternion_concept.hpp
@@ -5,6 +5,10 @@
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 // Copyright (c) 2013 Adam Wulkiewicz, Lodz, Poland.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -78,7 +82,7 @@ class ConstQuaternion
         static void apply()
         {
             const G* g = 0;
-            ctype coord(geometry::get<I>(*g));
+            typename coordinate_type<Geometry>::type coord(geometry::get<I>(*g));
             boost::ignore_unused(coord);
             dimension_checker<G, I+1, N>::apply();
         }

--- a/include/boost/geometry/extensions/algebra/geometries/concepts/rotation_matrix_concept.hpp
+++ b/include/boost/geometry/extensions/algebra/geometries/concepts/rotation_matrix_concept.hpp
@@ -5,6 +5,10 @@
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 // Copyright (c) 2013 Adam Wulkiewicz, Lodz, Poland.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -17,8 +21,12 @@
 
 #include <boost/concept_check.hpp>
 #include <boost/core/ignore_unused.hpp>
-#include <boost/geometry/core/coordinate_dimension.hpp>
-#include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/cs.hpp>
+#include <boost/geometry/extensions/algebra/core/access.hpp>
+#include <boost/geometry/extensions/algebra/core/coordinate_dimension.hpp>
+#include <boost/geometry/extensions/algebra/core/coordinate_system.hpp>
+#include <boost/geometry/extensions/algebra/core/coordinate_type.hpp>
+#include <boost/mpl/assert.hpp>
 
 namespace boost { namespace geometry { namespace concepts {
 
@@ -54,7 +62,7 @@ class RotationMatrix
     {
         static void apply()
         {
-            dimension_checker_row<G, I, 0, N>;
+            dimension_checker_row<G, I, 0, N>::apply();
             dimension_checker<G, I+1, N>::apply();
         }
     };
@@ -112,7 +120,7 @@ class ConstRotationMatrix
     {
         static void apply()
         {
-            dimension_checker_row<G, I, 0, N>;
+            dimension_checker_row<G, I, 0, N>::apply();
             dimension_checker<G, I+1, N>::apply();
         }
     };

--- a/include/boost/geometry/extensions/algebra/geometries/concepts/rotation_quaternion_concept.hpp
+++ b/include/boost/geometry/extensions/algebra/geometries/concepts/rotation_quaternion_concept.hpp
@@ -5,6 +5,10 @@
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 // Copyright (c) 2013 Adam Wulkiewicz, Lodz, Poland.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -17,8 +21,12 @@
 
 #include <boost/concept_check.hpp>
 #include <boost/core/ignore_unused.hpp>
-#include <boost/geometry/core/coordinate_dimension.hpp>
-#include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/cs.hpp>
+#include <boost/geometry/extensions/algebra/core/access.hpp>
+#include <boost/geometry/extensions/algebra/core/coordinate_dimension.hpp>
+#include <boost/geometry/extensions/algebra/core/coordinate_system.hpp>
+#include <boost/geometry/extensions/algebra/core/coordinate_type.hpp>
+#include <boost/mpl/assert.hpp>
 
 namespace boost { namespace geometry { namespace concepts {
 

--- a/include/boost/geometry/extensions/algebra/geometries/concepts/vector_concept.hpp
+++ b/include/boost/geometry/extensions/algebra/geometries/concepts/vector_concept.hpp
@@ -5,6 +5,10 @@
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 // Copyright (c) 2013 Adam Wulkiewicz, Lodz, Poland.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -17,8 +21,11 @@
 
 #include <boost/concept_check.hpp>
 #include <boost/core/ignore_unused.hpp>
-#include <boost/geometry/core/coordinate_dimension.hpp>
-#include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/cs.hpp>
+#include <boost/geometry/extensions/algebra/core/access.hpp>
+#include <boost/geometry/extensions/algebra/core/coordinate_dimension.hpp>
+#include <boost/geometry/extensions/algebra/core/coordinate_type.hpp>
+#include <boost/geometry/extensions/algebra/core/coordinate_system.hpp>
 
 namespace boost { namespace geometry { namespace concepts {
 

--- a/include/boost/geometry/extensions/algebra/geometries/matrix.hpp
+++ b/include/boost/geometry/extensions/algebra/geometries/matrix.hpp
@@ -5,6 +5,10 @@
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 // Copyright (c) 2013 Adam Wulkiewicz, Lodz, Poland.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -17,6 +21,8 @@
 
 #include <cstddef>
 
+#include <boost/geometry/extensions/algebra/core/access.hpp>
+#include <boost/geometry/extensions/algebra/core/coordinate_dimension.hpp>
 #include <boost/geometry/extensions/algebra/core/tags.hpp>
 #include <boost/geometry/extensions/algebra/geometries/concepts/matrix_concept.hpp>
 
@@ -88,15 +94,6 @@ struct coordinate_type<model::matrix<CoordinateType, Rows, Cols> >
 //    typedef cs::cartesian type;
 //};
 
-// TODO - move this class to traits.hpp
-template <typename Geometry, std::size_t Index>
-struct indexed_dimension
-{
-     BOOST_MPL_ASSERT_MSG(false,
-                          NOT_IMPLEMENTED_FOR_THIS_GEOMETRY_OR_INDEX,
-                          (Geometry, boost::integral_constant<std::size_t, Index>));
-};
-
 template <typename CoordinateType, std::size_t Rows, std::size_t Cols>
 struct indexed_dimension<model::matrix<CoordinateType, Rows, Cols>, 0>
     : boost::integral_constant<std::size_t, Rows>
@@ -108,7 +105,7 @@ struct indexed_dimension<model::matrix<CoordinateType, Rows, Cols>, 1>
 {};
 
 template <typename CoordinateType, std::size_t Rows, std::size_t Cols, std::size_t I, std::size_t J>
-struct indexed_access<model::matrix<CoordinateType, Dimension>, I, J>
+struct indexed_access<model::matrix<CoordinateType, Rows, Cols>, I, J>
 {
     typedef CoordinateType coordinate_type;
 

--- a/include/boost/geometry/extensions/algebra/geometries/rotation_matrix.hpp
+++ b/include/boost/geometry/extensions/algebra/geometries/rotation_matrix.hpp
@@ -5,6 +5,10 @@
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 // Copyright (c) 2013 Adam Wulkiewicz, Lodz, Poland.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -17,6 +21,9 @@
 
 #include <cstddef>
 
+#include <boost/geometry/core/cs.hpp>
+
+#include <boost/geometry/extensions/algebra/core/coordinate_system.hpp>
 #include <boost/geometry/extensions/algebra/core/tags.hpp>
 #include <boost/geometry/extensions/algebra/geometries/concepts/rotation_matrix_concept.hpp>
 

--- a/include/boost/geometry/extensions/algebra/geometries/rotation_quaternion.hpp
+++ b/include/boost/geometry/extensions/algebra/geometries/rotation_quaternion.hpp
@@ -5,6 +5,10 @@
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 // Copyright (c) 2013 Adam Wulkiewicz, Lodz, Poland.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -17,6 +21,9 @@
 
 #include <cstddef>
 
+#include <boost/geometry/core/cs.hpp>
+
+#include <boost/geometry/extensions/algebra/core/coordinate_system.hpp>
 #include <boost/geometry/extensions/algebra/core/tags.hpp>
 #include <boost/geometry/extensions/algebra/geometries/concepts/rotation_quaternion_concept.hpp>
 

--- a/include/boost/geometry/extensions/algorithms/connect.hpp
+++ b/include/boost/geometry/extensions/algorithms/connect.hpp
@@ -2,6 +2,10 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -11,6 +15,9 @@
 
 #include <map>
 
+#ifdef BOOST_GEOMETRY_DEBUG_CONNECT
+#include <iostream>
+#endif
 
 #include <boost/range.hpp>
 
@@ -144,7 +151,9 @@ struct map_policy
         // Alternatively, we might look for the closest points
         if (boost::size(range) == 0)
         {
+#ifdef BOOST_GEOMETRY_DEBUG_CONNECT
             std::cout << "nothing found" << std::endl;
+#endif
             return closest;
         }
 
@@ -318,7 +327,9 @@ struct fuzzy_policy
         // Alternatively, we might look for the closest points
         if (boost::size(range) == 0)
         {
+#ifdef BOOST_GEOMETRY_DEBUG_CONNECT
             std::cout << "nothing found" << std::endl;
+#endif
             return closest;
         }
 
@@ -339,7 +350,9 @@ struct fuzzy_policy
                     closest = *it;
                     min_dist = d;
 
+#ifdef BOOST_GEOMETRY_DEBUG_CONNECT
                     //std::cout << "TO " << geometry::wkt(p2) << std::endl;
+#endif
                 }
             }
         }
@@ -347,9 +360,12 @@ struct fuzzy_policy
     }
 };
 
+
 template <typename Policy>
 inline void debug(Policy const& policy)
 {
+#ifdef BOOST_GEOMETRY_DEBUG_CONNECT
+
     std::cout << "MAP" << std::endl;
     typedef typename Policy::map_type::const_iterator iterator;
     typedef typename Policy::point_type point_type;
@@ -369,8 +385,9 @@ inline void debug(Policy const& policy)
         }
         std::cout << std::endl;
     }
-}
 
+#endif // BOOST_GEOMETRY_DEBUG_CONNECT
+}
 
 
 

--- a/include/boost/geometry/extensions/algorithms/parse.hpp
+++ b/include/boost/geometry/extensions/algorithms/parse.hpp
@@ -4,6 +4,10 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -16,13 +20,13 @@
 
 #include <string>
 
-
+#include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/geometries/concepts/check.hpp>
 
-#include <boost/geometry/extensions/gis/geographic/strategies/dms_parser.hpp>
-#include <boost/geometry/extensions/strategies/parse.hpp>
+#include <boost/geometry/srs/projections/impl/dms_parser.hpp>
+//#include <boost/geometry/extensions/strategies/parse.hpp>
 
 
 namespace boost { namespace geometry
@@ -51,30 +55,39 @@ struct parsing<point_tag, Point>
     static inline void parse(Point& point, std::string const& c1, std::string const& c2, S const& strategy)
     {
         assert_dimension<Point, 2>();
-        dms_result r1 = strategy(c1.c_str());
-        dms_result r2 = strategy(c2.c_str());
+
+        typedef typename coordinate_type<Point>::type coord_t;
+        typedef boost::geometry::projections::detail::dms_result<coord_t> dms_result_t;
+        dms_result_t r1 = strategy(c1.c_str());
+        dms_result_t r2 = strategy(c2.c_str());
 
         if (0 == r1.axis())
-            set<0>(point, r1);
+            set<0>(point, r1.angle());
         else
-            set<1>(point, r1);
+            set<1>(point, r1.angle());
 
         if (0 == r2.axis())
-            set<0>(point, r2);
+            set<0>(point, r2.angle());
         else
-            set<1>(point, r2);
+            set<1>(point, r2.angle());
     }
 
     static inline void parse(Point& point, std::string const& c1, std::string const& c2)
     {
+        typedef typename coordinate_type<Point>::type coord_t;
         // strategy-parser corresponding to degree/radian
-        typename strategy_parse
-            <
-            typename cs_tag<Point>::type,
-            typename coordinate_system<Point>::type
-            >::type strategy;
+        //typename strategy_parse
+        //    <
+        //        typename cs_tag<Point>::type,
+        //        typename coordinate_system<Point>::type
+        //    >::type strategy;
+        typedef boost::geometry::projections::detail::dms_parser
+                    <
+                        coord_t/*,
+                        as_radian*/
+                    > dms_parser_t;
 
-        parse(point, c1, c2, strategy);
+        parse(point, c1, c2, dms_parser_t());
     }
 };
 

--- a/include/boost/geometry/extensions/algorithms/remove_marked.hpp
+++ b/include/boost/geometry/extensions/algorithms/remove_marked.hpp
@@ -2,6 +2,10 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -16,6 +20,7 @@
 // as mark_spikes is now replaced by remove_spikes
 
 #include <boost/range.hpp>
+#include <boost/typeof/typeof.hpp>
 
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/cs.hpp>

--- a/include/boost/geometry/extensions/strategies/cartesian/distance_info.hpp
+++ b/include/boost/geometry/extensions/strategies/cartesian/distance_info.hpp
@@ -5,6 +5,10 @@
 // Copyright (c) 2009-2013 Mateusz Loskot, London, UK.
 // Copyright (c) 2013 Adam Wulkiewicz, Lodz, Poland.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -21,6 +25,8 @@
 #include <boost/geometry/algorithms/convert.hpp>
 #include <boost/geometry/arithmetic/arithmetic.hpp>
 #include <boost/geometry/arithmetic/dot_product.hpp>
+
+#include <boost/geometry/geometries/point.hpp>
 
 #include <boost/geometry/strategies/tags.hpp>
 #include <boost/geometry/strategies/distance.hpp>

--- a/include/boost/geometry/formulas/area_formulas.hpp
+++ b/include/boost/geometry/formulas/area_formulas.hpp
@@ -12,6 +12,7 @@
 #ifndef BOOST_GEOMETRY_FORMULAS_AREA_FORMULAS_HPP
 #define BOOST_GEOMETRY_FORMULAS_AREA_FORMULAS_HPP
 
+#include <boost/geometry/core/radian_access.hpp>
 #include <boost/geometry/formulas/flattening.hpp>
 #include <boost/geometry/util/math.hpp>
 #include <boost/math/special_functions/hypot.hpp>

--- a/include/boost/geometry/formulas/eccentricity_sqr.hpp
+++ b/include/boost/geometry/formulas/eccentricity_sqr.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2016 Oracle and/or its affiliates.
+// Copyright (c) 2016, 2018 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -11,11 +11,13 @@
 #ifndef BOOST_GEOMETRY_FORMULAS_ECCENCRICITY_SQR_HPP
 #define BOOST_GEOMETRY_FORMULAS_ECCENCRICITY_SQR_HPP
 
+#include <boost/geometry/algorithms/not_implemented.hpp>
+
 #include <boost/geometry/core/radius.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tags.hpp>
 
-#include <boost/geometry/algorithms/not_implemented.hpp>
+#include <boost/geometry/util/math.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/formulas/karney_direct.hpp
+++ b/include/boost/geometry/formulas/karney_direct.hpp
@@ -2,7 +2,12 @@
 
 // Copyright (c) 2018 Adeel Ahmad, Islamabad, Pakistan.
 
-// Contributed and/or modified by Adeel Ahmad, as part of Google Summer of Code 2018 program.
+// Contributed and/or modified by Adeel Ahmad,
+//   as part of Google Summer of Code 2018 program.
+
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -30,12 +35,13 @@
 #include <boost/math/constants/constants.hpp>
 #include <boost/math/special_functions/hypot.hpp>
 
-#include <boost/geometry/util/math.hpp>
-#include <boost/geometry/util/series_expansion.hpp>
-#include <boost/geometry/util/normalize_spheroidal_coordinates.hpp>
-
 #include <boost/geometry/formulas/flattening.hpp>
 #include <boost/geometry/formulas/result_direct.hpp>
+
+#include <boost/geometry/util/condition.hpp>
+#include <boost/geometry/util/math.hpp>
+#include <boost/geometry/util/normalize_spheroidal_coordinates.hpp>
+#include <boost/geometry/util/series_expansion.hpp>
 
 
 namespace boost { namespace geometry { namespace formula

--- a/include/boost/geometry/formulas/meridian_direct.hpp
+++ b/include/boost/geometry/formulas/meridian_direct.hpp
@@ -3,6 +3,7 @@
 // Copyright (c) 2018 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -15,13 +16,14 @@
 
 #include <boost/geometry/core/radius.hpp>
 
-#include <boost/geometry/util/condition.hpp>
-#include <boost/geometry/util/math.hpp>
-
-#include <boost/geometry/formulas/meridian_inverse.hpp>
+#include <boost/geometry/formulas/differential_quantities.hpp>
 #include <boost/geometry/formulas/flattening.hpp>
+#include <boost/geometry/formulas/meridian_inverse.hpp>
 #include <boost/geometry/formulas/quarter_meridian.hpp>
 #include <boost/geometry/formulas/result_direct.hpp>
+
+#include <boost/geometry/util/condition.hpp>
+#include <boost/geometry/util/math.hpp>
 
 namespace boost { namespace geometry { namespace formula
 {

--- a/include/boost/geometry/formulas/meridian_segment.hpp
+++ b/include/boost/geometry/formulas/meridian_segment.hpp
@@ -1,8 +1,9 @@
 // Boost.Geometry
 
-// Copyright (c) 2017 Oracle and/or its affiliates.
+// Copyright (c) 2017-2018 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -14,7 +15,6 @@
 #include <boost/math/constants/constants.hpp>
 
 #include <boost/geometry/core/radius.hpp>
-#include <boost/geometry/srs/srs.hpp>
 
 #include <boost/geometry/util/condition.hpp>
 #include <boost/geometry/util/math.hpp>

--- a/include/boost/geometry/formulas/quarter_meridian.hpp
+++ b/include/boost/geometry/formulas/quarter_meridian.hpp
@@ -3,6 +3,7 @@
 // Copyright (c) 2018 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -11,11 +12,15 @@
 #ifndef BOOST_GEOMETRY_FORMULAS_QUARTER_MERIDIAN_HPP
 #define BOOST_GEOMETRY_FORMULAS_QUARTER_MERIDIAN_HPP
 
+#include <boost/geometry/algorithms/not_implemented.hpp>
+
 #include <boost/geometry/core/radius.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tags.hpp>
 
-#include <boost/geometry/algorithms/not_implemented.hpp>
+#include <boost/geometry/formulas/flattening.hpp>
+
+#include <boost/geometry/util/math.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/geometries/adapted/boost_polygon/ring_proxy.hpp
+++ b/include/boost/geometry/geometries/adapted/boost_polygon/ring_proxy.hpp
@@ -2,6 +2,11 @@
 
 // Copyright (c) 2010-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -14,9 +19,11 @@
 //   pair{begin_points, end_points} -> ring_proxy
 
 #include <boost/polygon/polygon.hpp>
-#include <boost/range.hpp>
+#include <boost/range/const_iterator.hpp>
+#include <boost/range/mutable_iterator.hpp>
 
-
+#include <boost/geometry/core/mutable_range.hpp>
+#include <boost/geometry/core/tag.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/geometries/adapted/boost_tuple.hpp
+++ b/include/boost/geometry/geometries/adapted/boost_tuple.hpp
@@ -4,6 +4,11 @@
 // Copyright (c) 2008-2012 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -19,6 +24,7 @@
 
 #include <boost/tuple/tuple.hpp>
 
+#include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/point_type.hpp>

--- a/include/boost/geometry/geometries/adapted/std_array.hpp
+++ b/include/boost/geometry/geometries/adapted/std_array.hpp
@@ -12,6 +12,12 @@
 #define BOOST_GEOMETRY_GEOMETRIES_ADAPTED_STD_ARRAY_HPP
 
 
+#include <boost/config.hpp>
+
+
+#ifndef BOOST_NO_CXX11_HDR_ARRAY
+
+
 #define BOOST_GEOMETRY_ADAPTED_STD_ARRAY_TAG_DEFINED
 
 
@@ -109,6 +115,15 @@ struct access<std::array<CoordinateType, DimensionCount>, Dimension>
         typedef CoordinateSystem type; \
     }; \
     }}}
+
+
+#else
+
+
+#warning "This file requires compiler and library support for the ISO C++ 2011 standard."
+
+
+#endif // BOOST_NO_CXX11_HDR_ARRAY
 
 
 #endif // BOOST_GEOMETRY_GEOMETRIES_ADAPTED_STD_ARRAY_HPP

--- a/include/boost/geometry/geometries/concepts/multi_point_concept.hpp
+++ b/include/boost/geometry/geometries/concepts/multi_point_concept.hpp
@@ -20,6 +20,7 @@
 #include <boost/range/concepts.hpp>
 #include <boost/range/metafunctions.hpp>
 
+#include <boost/geometry/core/mutable_range.hpp>
 
 #include <boost/geometry/geometries/concepts/point_concept.hpp>
 

--- a/include/boost/geometry/geometries/variant.hpp
+++ b/include/boost/geometry/geometries/variant.hpp
@@ -4,6 +4,11 @@
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -15,8 +20,10 @@
 #define BOOST_GEOMETRY_GEOMETRIES_VARIANT_GEOMETRY_HPP
 
 
-#include <boost/variant/variant_fwd.hpp>
 #include <boost/mpl/front.hpp>
+#include <boost/variant/variant_fwd.hpp>
+
+#include <boost/geometry/core/point_type.hpp>
 
 
 namespace boost { namespace geometry {

--- a/include/boost/geometry/iterators/detail/point_iterator/iterator_type.hpp
+++ b/include/boost/geometry/iterators/detail/point_iterator/iterator_type.hpp
@@ -1,8 +1,9 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014, Oracle and/or its affiliates.
+// Copyright (c) 2014, 2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Licensed under the Boost Software License version 1.0.
 // http://www.boost.org/users/license.html
@@ -12,6 +13,7 @@
 
 #include <boost/range.hpp>
 
+#include <boost/geometry/core/interior_type.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tags.hpp>
 

--- a/include/boost/geometry/policies/robustness/rescale_policy.hpp
+++ b/include/boost/geometry/policies/robustness/rescale_policy.hpp
@@ -5,7 +5,8 @@
 // Copyright (c) 2014-2015 Mateusz Loskot, London, UK.
 // Copyright (c) 2014-2015 Adam Wulkiewicz, Lodz, Poland.
 
-// Copyright (c) 2015, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2015, 2018.
+// Modifications copyright (c) 2015-2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -17,6 +18,8 @@
 #define BOOST_GEOMETRY_POLICIES_ROBUSTNESS_RESCALE_POLICY_HPP
 
 #include <cstddef>
+
+#include <boost/geometry/core/coordinate_type.hpp>
 
 #include <boost/geometry/policies/robustness/segment_ratio.hpp>
 #include <boost/geometry/policies/robustness/segment_ratio_type.hpp>

--- a/include/boost/geometry/srs/projections/dpar.hpp
+++ b/include/boost/geometry/srs/projections/dpar.hpp
@@ -22,11 +22,16 @@
 
 #include <boost/mpl/assert.hpp>
 #include <boost/mpl/if.hpp>
+#include <boost/range/begin.hpp>
+#include <boost/range/end.hpp>
+#include <boost/range/size.hpp>
+#include <boost/range/value_type.hpp>
 #include <boost/tuple/tuple.hpp>
-#include <boost/variant/variant.hpp>
 #include <boost/type_traits/integral_constant.hpp>
+#include <boost/type_traits/is_convertible.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/is_void.hpp>
+#include <boost/variant/variant.hpp>
 
 #include <string>
 #include <vector>

--- a/include/boost/geometry/srs/projections/impl/aasincos.hpp
+++ b/include/boost/geometry/srs/projections/impl/aasincos.hpp
@@ -42,6 +42,8 @@
 
 #include <cmath>
 
+#include <boost/geometry/srs/projections/exception.hpp>
+#include <boost/geometry/srs/projections/impl/pj_strerrno.hpp>
 #include <boost/geometry/util/math.hpp>
 
 

--- a/include/boost/geometry/srs/projections/impl/pj_apply_gridshift.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_apply_gridshift.hpp
@@ -44,7 +44,10 @@
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/radian_access.hpp>
 
+#include <boost/geometry/srs/projections/impl/adjlon.hpp>
 #include <boost/geometry/srs/projections/impl/pj_gridlist.hpp>
+
+#include <boost/geometry/util/range.hpp>
 
 
 namespace boost { namespace geometry { namespace projections

--- a/include/boost/geometry/srs/projections/impl/pj_ellps.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_ellps.hpp
@@ -39,8 +39,6 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_IMPL_PJ_ELLPS_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_IMPL_PJ_ELLPS_HPP
 
-#include <boost/geometry/srs/projections/impl/projects.hpp>
-
 #include <string>
 
 namespace boost { namespace geometry { namespace projections {

--- a/include/boost/geometry/srs/projections/impl/pj_gauss.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_gauss.hpp
@@ -40,7 +40,8 @@
 #define BOOST_GEOMETRY_PROJECTIONS_IMPL_PJ_GAUSS_HPP
 
 
-#include <boost/geometry/util/math.hpp>
+#include <boost/geometry/srs/projections/constants.hpp>
+#include <boost/geometry/srs/projections/exception.hpp>
 
 
 namespace boost { namespace geometry { namespace projections {

--- a/include/boost/geometry/srs/projections/impl/pj_gridinfo.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_gridinfo.hpp
@@ -44,6 +44,7 @@
 #include <boost/algorithm/string.hpp>
 
 #include <boost/geometry/core/assert.hpp>
+#include <boost/geometry/util/math.hpp>
 
 #include <boost/cstdint.hpp>
 

--- a/include/boost/geometry/srs/projections/impl/pj_gridlist.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_gridlist.hpp
@@ -41,8 +41,10 @@
 #define BOOST_GEOMETRY_SRS_PROJECTIONS_IMPL_PJ_GRIDLIST_HPP
 
 
+#include <boost/geometry/srs/projections/exception.hpp>
 #include <boost/geometry/srs/projections/grids.hpp>
 #include <boost/geometry/srs/projections/impl/pj_gridinfo.hpp>
+#include <boost/geometry/srs/projections/impl/pj_strerrno.hpp>
 #include <boost/geometry/srs/projections/par_data.hpp>
 
 

--- a/include/boost/geometry/srs/projections/impl/pj_gridlist.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_gridlist.hpp
@@ -43,6 +43,7 @@
 
 #include <boost/geometry/srs/projections/grids.hpp>
 #include <boost/geometry/srs/projections/impl/pj_gridinfo.hpp>
+#include <boost/geometry/srs/projections/par_data.hpp>
 
 
 namespace boost { namespace geometry { namespace projections

--- a/include/boost/geometry/srs/projections/impl/pj_gridlist_shared.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_gridlist_shared.hpp
@@ -43,6 +43,7 @@
 
 #include <boost/geometry/srs/projections/shared_grids.hpp>
 #include <boost/geometry/srs/projections/impl/pj_gridinfo.hpp>
+#include <boost/geometry/srs/projections/impl/pj_gridlist.hpp>
 
 
 namespace boost { namespace geometry { namespace projections

--- a/include/boost/geometry/srs/projections/impl/pj_mlfn.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_mlfn.hpp
@@ -48,6 +48,8 @@
 
 #include <cstdlib>
 
+#include <boost/geometry/srs/projections/exception.hpp>
+#include <boost/geometry/srs/projections/impl/pj_strerrno.hpp>
 #include <boost/geometry/util/math.hpp>
 
 

--- a/include/boost/geometry/srs/projections/impl/pj_phi2.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_phi2.hpp
@@ -39,6 +39,8 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_PHI2_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_PHI2_HPP
 
+#include <boost/geometry/srs/projections/exception.hpp>
+#include <boost/geometry/srs/projections/impl/pj_strerrno.hpp>
 #include <boost/geometry/util/math.hpp>
 
 namespace boost { namespace geometry { namespace projections {

--- a/include/boost/geometry/srs/projections/impl/pj_transform.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_transform.hpp
@@ -41,6 +41,7 @@
 
 
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/radian_access.hpp>
 
 #include <boost/geometry/srs/projections/impl/geocent.hpp>

--- a/include/boost/geometry/srs/projections/impl/proj_mdist.hpp
+++ b/include/boost/geometry/srs/projections/impl/proj_mdist.hpp
@@ -40,6 +40,8 @@
 #define BOOST_GEOMETRY_PROJECTIONS_PROJ_MDIST_HPP
 
 
+#include <boost/geometry/srs/projections/exception.hpp>
+#include <boost/geometry/srs/projections/impl/pj_strerrno.hpp>
 #include <boost/geometry/util/math.hpp>
 
 

--- a/include/boost/geometry/srs/projections/par_data.hpp
+++ b/include/boost/geometry/srs/projections/par_data.hpp
@@ -13,6 +13,7 @@
 #include <string>
 #include <vector>
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/config.hpp>
 
 namespace boost { namespace geometry { namespace srs

--- a/include/boost/geometry/srs/projections/proj/aeqd.hpp
+++ b/include/boost/geometry/srs/projections/proj/aeqd.hpp
@@ -45,17 +45,21 @@
 #define BOOST_GEOMETRY_PROJECTIONS_AEQD_HPP
 
 #include <boost/config.hpp>
+
 #include <boost/geometry/formulas/vincenty_direct.hpp>
 #include <boost/geometry/formulas/vincenty_inverse.hpp>
-#include <boost/geometry/util/math.hpp>
-#include <boost/math/special_functions/hypot.hpp>
 
+#include <boost/geometry/srs/projections/impl/aasincos.hpp>
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
-#include <boost/geometry/srs/projections/impl/aasincos.hpp>
 #include <boost/geometry/srs/projections/impl/pj_mlfn.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
+
+#include <boost/geometry/util/math.hpp>
+
+#include <boost/math/special_functions/hypot.hpp>
 
 #include <boost/type_traits/is_same.hpp>
 

--- a/include/boost/geometry/srs/projections/proj/airy.hpp
+++ b/include/boost/geometry/srs/projections/proj/airy.hpp
@@ -45,12 +45,13 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_AIRY_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_AIRY_HPP
 
-#include <boost/geometry/util/math.hpp>
-
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
+
+#include <boost/geometry/util/math.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/aitoff.hpp
+++ b/include/boost/geometry/srs/projections/proj/aitoff.hpp
@@ -47,14 +47,15 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_AITOFF_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_AITOFF_HPP
 
-
 #include <boost/core/ignore_unused.hpp>
-#include <boost/geometry/util/math.hpp>
 
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
+
+#include <boost/geometry/util/math.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/bipc.hpp
+++ b/include/boost/geometry/srs/projections/proj/bipc.hpp
@@ -40,13 +40,15 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_BIPC_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_BIPC_HPP
 
-#include <boost/geometry/util/math.hpp>
-#include <boost/math/special_functions/hypot.hpp>
-
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
+
+#include <boost/geometry/util/math.hpp>
+
+#include <boost/math/special_functions/hypot.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/bonne.hpp
+++ b/include/boost/geometry/srs/projections/proj/bonne.hpp
@@ -40,14 +40,16 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_BONNE_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_BONNE_HPP
 
-#include <boost/geometry/util/math.hpp>
-#include <boost/math/special_functions/hypot.hpp>
-
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
 #include <boost/geometry/srs/projections/impl/pj_mlfn.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
+
+#include <boost/geometry/util/math.hpp>
+
+#include <boost/math/special_functions/hypot.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/cea.hpp
+++ b/include/boost/geometry/srs/projections/proj/cea.hpp
@@ -40,14 +40,15 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_CEA_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_CEA_HPP
 
-#include <boost/geometry/util/math.hpp>
-
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
 #include <boost/geometry/srs/projections/impl/pj_auth.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
 #include <boost/geometry/srs/projections/impl/pj_qsfn.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
+
+#include <boost/geometry/util/math.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/chamb.hpp
+++ b/include/boost/geometry/srs/projections/proj/chamb.hpp
@@ -40,14 +40,16 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_CHAMB_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_CHAMB_HPP
 
-#include <boost/geometry/util/math.hpp>
 #include <cstdio>
 
+#include <boost/geometry/srs/projections/impl/aasincos.hpp>
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
-#include <boost/geometry/srs/projections/impl/aasincos.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
+
+#include <boost/geometry/util/math.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/eqc.hpp
+++ b/include/boost/geometry/srs/projections/proj/eqc.hpp
@@ -42,8 +42,9 @@
 
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/eqdc.hpp
+++ b/include/boost/geometry/srs/projections/proj/eqdc.hpp
@@ -40,15 +40,17 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_EQDC_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_EQDC_HPP
 
-#include <boost/geometry/util/math.hpp>
-#include <boost/math/special_functions/hypot.hpp>
-
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
 #include <boost/geometry/srs/projections/impl/pj_mlfn.hpp>
 #include <boost/geometry/srs/projections/impl/pj_msfn.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
+
+#include <boost/geometry/util/math.hpp>
+
+#include <boost/math/special_functions/hypot.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/etmerc.hpp
+++ b/include/boost/geometry/srs/projections/proj/etmerc.hpp
@@ -54,13 +54,14 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_ETMERC_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_ETMERC_HPP
 
-#include <boost/math/special_functions/hypot.hpp>
-
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
 #include <boost/geometry/srs/projections/impl/function_overloads.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
+
+#include <boost/math/special_functions/hypot.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/fouc_s.hpp
+++ b/include/boost/geometry/srs/projections/proj/fouc_s.hpp
@@ -40,13 +40,14 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_FOUC_S_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_FOUC_S_HPP
 
-#include <boost/geometry/util/math.hpp>
-
+#include <boost/geometry/srs/projections/impl/aasincos.hpp>
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
-#include <boost/geometry/srs/projections/impl/aasincos.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
+
+#include <boost/geometry/util/math.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/gn_sinu.hpp
+++ b/include/boost/geometry/srs/projections/proj/gn_sinu.hpp
@@ -40,14 +40,15 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_GN_SINU_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_GN_SINU_HPP
 
-#include <boost/geometry/util/math.hpp>
-
+#include <boost/geometry/srs/projections/impl/aasincos.hpp>
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
-#include <boost/geometry/srs/projections/impl/aasincos.hpp>
 #include <boost/geometry/srs/projections/impl/pj_mlfn.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
+
+#include <boost/geometry/util/math.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/hammer.hpp
+++ b/include/boost/geometry/srs/projections/proj/hammer.hpp
@@ -42,8 +42,9 @@
 
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/healpix.hpp
+++ b/include/boost/geometry/srs/projections/proj/healpix.hpp
@@ -49,14 +49,15 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_HEALPIX_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_HEALPIX_HPP
 
-#include <boost/geometry/util/math.hpp>
-
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
 #include <boost/geometry/srs/projections/impl/pj_auth.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
 #include <boost/geometry/srs/projections/impl/pj_qsfn.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
+
+#include <boost/geometry/util/math.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/imw_p.hpp
+++ b/include/boost/geometry/srs/projections/proj/imw_p.hpp
@@ -40,13 +40,14 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_IMW_P_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_IMW_P_HPP
 
-#include <boost/geometry/util/math.hpp>
-
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
 #include <boost/geometry/srs/projections/impl/pj_mlfn.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
+
+#include <boost/geometry/util/math.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/isea.hpp
+++ b/include/boost/geometry/srs/projections/proj/isea.hpp
@@ -48,12 +48,14 @@
 #include <boost/core/ignore_unused.hpp>
 
 #include <boost/geometry/core/assert.hpp>
-#include <boost/geometry/util/math.hpp>
 
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
+
+#include <boost/geometry/util/math.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/krovak.hpp
+++ b/include/boost/geometry/srs/projections/proj/krovak.hpp
@@ -47,8 +47,9 @@
 
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/labrd.hpp
+++ b/include/boost/geometry/srs/projections/proj/labrd.hpp
@@ -42,8 +42,9 @@
 
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/lagrng.hpp
+++ b/include/boost/geometry/srs/projections/proj/lagrng.hpp
@@ -40,12 +40,13 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_LAGRNG_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_LAGRNG_HPP
 
-#include <boost/geometry/util/math.hpp>
-
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
+
+#include <boost/geometry/util/math.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/lcc.hpp
+++ b/include/boost/geometry/srs/projections/proj/lcc.hpp
@@ -40,17 +40,18 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_LCC_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_LCC_HPP
 
-#include <boost/geometry/util/math.hpp>
-#include <boost/math/special_functions/hypot.hpp>
-
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
 #include <boost/geometry/srs/projections/impl/pj_msfn.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
 #include <boost/geometry/srs/projections/impl/pj_phi2.hpp>
 #include <boost/geometry/srs/projections/impl/pj_tsfn.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
 
+#include <boost/geometry/util/math.hpp>
+
+#include <boost/math/special_functions/hypot.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/loxim.hpp
+++ b/include/boost/geometry/srs/projections/proj/loxim.hpp
@@ -40,12 +40,13 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_LOXIM_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_LOXIM_HPP
 
-#include <boost/geometry/util/math.hpp>
-
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
+
+#include <boost/geometry/util/math.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/lsat.hpp
+++ b/include/boost/geometry/srs/projections/proj/lsat.hpp
@@ -40,13 +40,14 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_LSAT_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_LSAT_HPP
 
-#include <boost/geometry/util/math.hpp>
-
+#include <boost/geometry/srs/projections/impl/aasincos.hpp>
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
-#include <boost/geometry/srs/projections/impl/aasincos.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
+
+#include <boost/geometry/util/math.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/merc.hpp
+++ b/include/boost/geometry/srs/projections/proj/merc.hpp
@@ -40,15 +40,16 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_MERC_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_MERC_HPP
 
-#include <boost/geometry/util/math.hpp>
-
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
 #include <boost/geometry/srs/projections/impl/pj_msfn.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
 #include <boost/geometry/srs/projections/impl/pj_phi2.hpp>
 #include <boost/geometry/srs/projections/impl/pj_tsfn.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
+
+#include <boost/geometry/util/math.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/nsper.hpp
+++ b/include/boost/geometry/srs/projections/proj/nsper.hpp
@@ -41,13 +41,16 @@
 #define BOOST_GEOMETRY_PROJECTIONS_NSPER_HPP
 
 #include <boost/config.hpp>
-#include <boost/geometry/util/math.hpp>
-#include <boost/math/special_functions/hypot.hpp>
 
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
+
+#include <boost/geometry/util/math.hpp>
+
+#include <boost/math/special_functions/hypot.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/ocea.hpp
+++ b/include/boost/geometry/srs/projections/proj/ocea.hpp
@@ -44,8 +44,9 @@
 
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/oea.hpp
+++ b/include/boost/geometry/srs/projections/proj/oea.hpp
@@ -42,11 +42,12 @@
 
 #include <boost/math/special_functions/hypot.hpp>
 
+#include <boost/geometry/srs/projections/impl/aasincos.hpp>
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
-#include <boost/geometry/srs/projections/impl/aasincos.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/omerc.hpp
+++ b/include/boost/geometry/srs/projections/proj/omerc.hpp
@@ -46,10 +46,11 @@
 
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
 #include <boost/geometry/srs/projections/impl/pj_phi2.hpp>
 #include <boost/geometry/srs/projections/impl/pj_tsfn.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/rpoly.hpp
+++ b/include/boost/geometry/srs/projections/proj/rpoly.hpp
@@ -42,8 +42,9 @@
 
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/sconics.hpp
+++ b/include/boost/geometry/srs/projections/proj/sconics.hpp
@@ -46,8 +46,9 @@
 
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/stere.hpp
+++ b/include/boost/geometry/srs/projections/proj/stere.hpp
@@ -46,9 +46,10 @@
 
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
 #include <boost/geometry/srs/projections/impl/pj_tsfn.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/tpeqd.hpp
+++ b/include/boost/geometry/srs/projections/proj/tpeqd.hpp
@@ -43,11 +43,12 @@
 #include <boost/geometry/util/math.hpp>
 #include <boost/math/special_functions/hypot.hpp>
 
+#include <boost/geometry/srs/projections/impl/aasincos.hpp>
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
-#include <boost/geometry/srs/projections/impl/aasincos.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/urm5.hpp
+++ b/include/boost/geometry/srs/projections/proj/urm5.hpp
@@ -40,11 +40,12 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_URM5_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_URM5_HPP
 
+#include <boost/geometry/srs/projections/impl/aasincos.hpp>
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
-#include <boost/geometry/srs/projections/impl/aasincos.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/urmfps.hpp
+++ b/include/boost/geometry/srs/projections/proj/urmfps.hpp
@@ -40,11 +40,12 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_URMFPS_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_URMFPS_HPP
 
+#include <boost/geometry/srs/projections/impl/aasincos.hpp>
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
-#include <boost/geometry/srs/projections/impl/aasincos.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/wag3.hpp
+++ b/include/boost/geometry/srs/projections/proj/wag3.hpp
@@ -42,8 +42,9 @@
 
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/wink1.hpp
+++ b/include/boost/geometry/srs/projections/proj/wink1.hpp
@@ -42,8 +42,9 @@
 
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/wink2.hpp
+++ b/include/boost/geometry/srs/projections/proj/wink2.hpp
@@ -44,8 +44,9 @@
 
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
-#include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
+#include <boost/geometry/srs/projections/impl/projects.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/strategies/agnostic/hull_graham_andrew.hpp
+++ b/include/boost/geometry/strategies/agnostic/hull_graham_andrew.hpp
@@ -2,8 +2,8 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2014.
-// Modifications copyright (c) 2014 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014, 2018.
+// Modifications copyright (c) 2014, 2018 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -22,18 +22,17 @@
 #include <algorithm>
 #include <vector>
 
-#include <boost/range.hpp>
+#include <boost/range/begin.hpp>
+#include <boost/range/end.hpp>
 
+#include <boost/geometry/algorithms/detail/for_each_range.hpp>
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/point_type.hpp>
-#include <boost/geometry/strategies/convex_hull.hpp>
-
-#include <boost/geometry/views/detail/range_type.hpp>
-
 #include <boost/geometry/policies/compare.hpp>
-
-#include <boost/geometry/algorithms/detail/for_each_range.hpp>
+#include <boost/geometry/strategies/convex_hull.hpp>
+#include <boost/geometry/strategies/side.hpp>
+#include <boost/geometry/views/detail/range_type.hpp>
 #include <boost/geometry/views/reversible_view.hpp>
 
 

--- a/include/boost/geometry/strategies/agnostic/point_in_box_by_side.hpp
+++ b/include/boost/geometry/strategies/agnostic/point_in_box_by_side.hpp
@@ -24,6 +24,7 @@
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/algorithms/assign.hpp>
 #include <boost/geometry/strategies/covered_by.hpp>
+#include <boost/geometry/strategies/side.hpp>
 #include <boost/geometry/strategies/within.hpp>
 
 

--- a/include/boost/geometry/strategies/cartesian/area.hpp
+++ b/include/boost/geometry/strategies/cartesian/area.hpp
@@ -5,8 +5,8 @@
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 // Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2016, 2017.
-// Modifications copyright (c) 2016-2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2016, 2017, 2018.
+// Modifications copyright (c) 2016-2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -24,6 +24,7 @@
 #include <boost/mpl/if.hpp>
 
 //#include <boost/geometry/arithmetic/determinant.hpp>
+#include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/strategies/area.hpp>

--- a/include/boost/geometry/strategies/cartesian/azimuth.hpp
+++ b/include/boost/geometry/strategies/cartesian/azimuth.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2016-2017 Oracle and/or its affiliates.
+// Copyright (c) 2016-2018 Oracle and/or its affiliates.
 // Contributed and/or modified by Vissarion Fisikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -12,6 +12,8 @@
 #define BOOST_GEOMETRY_STRATEGIES_CARTESIAN_AZIMUTH_HPP
 
 #include <boost/geometry/core/tags.hpp>
+
+#include <boost/geometry/strategies/azimuth.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/strategies/cartesian/buffer_end_flat.hpp
+++ b/include/boost/geometry/strategies/cartesian/buffer_end_flat.hpp
@@ -2,6 +2,11 @@
 
 // Copyright (c) 2012-2014 Barend Gehrels, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -9,15 +14,12 @@
 #ifndef BOOST_GEOMETRY_STRATEGIES_CARTESIAN_BUFFER_END_FLAT_HPP
 #define BOOST_GEOMETRY_STRATEGIES_CARTESIAN_BUFFER_END_FLAT_HPP
 
-#include <boost/geometry/core/cs.hpp>
+#include <boost/geometry/core/coordinate_type.hpp>
+#include <boost/geometry/strategies/buffer.hpp>
 #include <boost/geometry/strategies/tags.hpp>
 #include <boost/geometry/strategies/side.hpp>
 #include <boost/geometry/util/math.hpp>
 #include <boost/geometry/util/select_most_precise.hpp>
-
-#include <boost/geometry/strategies/buffer.hpp>
-
-
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/strategies/cartesian/buffer_point_circle.hpp
+++ b/include/boost/geometry/strategies/cartesian/buffer_point_circle.hpp
@@ -2,10 +2,11 @@
 
 // Copyright (c) 2012-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2015.
-// Modifications copyright (c) 2015, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2015, 2018.
+// Modifications copyright (c) 2015, 2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -16,12 +17,15 @@
 
 #include <cstddef>
 
-#include <boost/range.hpp>
+#include <boost/range/value_type.hpp>
 
-#include <boost/geometry/util/math.hpp>
+#include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/coordinate_type.hpp>
 
 #include <boost/geometry/strategies/buffer.hpp>
 
+#include <boost/geometry/util/math.hpp>
+#include <boost/geometry/util/select_most_precise.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/strategies/cartesian/buffer_point_square.hpp
+++ b/include/boost/geometry/strategies/cartesian/buffer_point_square.hpp
@@ -1,5 +1,12 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
+
 // Copyright (c) 2012-2014 Barend Gehrels, Amsterdam, the Netherlands.
+
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -9,12 +16,11 @@
 
 #include <cstddef>
 
-#include <boost/range.hpp>
+#include <boost/range/value_type.hpp>
 
-#include <boost/geometry/util/math.hpp>
-
+#include <boost/geometry/core/access.hpp>
 #include <boost/geometry/strategies/buffer.hpp>
-
+#include <boost/geometry/util/math.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/strategies/cartesian/centroid_bashein_detmer.hpp
+++ b/include/boost/geometry/strategies/cartesian/centroid_bashein_detmer.hpp
@@ -4,8 +4,8 @@
 // Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2015.
-// Modifications copyright (c) 2015 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2015, 2018.
+// Modifications copyright (c) 2015, 2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -31,6 +31,7 @@
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/point_type.hpp>
 #include <boost/geometry/strategies/centroid.hpp>
+#include <boost/geometry/util/math.hpp>
 #include <boost/geometry/util/select_coordinate_type.hpp>
 
 

--- a/include/boost/geometry/strategies/cartesian/densify.hpp
+++ b/include/boost/geometry/strategies/cartesian/densify.hpp
@@ -18,6 +18,7 @@
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
+#include <boost/geometry/geometries/point.hpp>
 #include <boost/geometry/strategies/densify.hpp>
 #include <boost/geometry/util/math.hpp>
 #include <boost/geometry/util/select_most_precise.hpp>

--- a/include/boost/geometry/strategies/cartesian/disjoint_box_box.hpp
+++ b/include/boost/geometry/strategies/cartesian/disjoint_box_box.hpp
@@ -24,6 +24,7 @@
 #include <cstddef>
 
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/strategies/disjoint.hpp>

--- a/include/boost/geometry/strategies/cartesian/distance_pythagoras.hpp
+++ b/include/boost/geometry/strategies/cartesian/distance_pythagoras.hpp
@@ -4,6 +4,11 @@
 // Copyright (c) 2008-2012 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -16,6 +21,8 @@
 
 
 #include <boost/geometry/core/access.hpp>
+
+#include <boost/geometry/geometries/concepts/point_concept.hpp>
 
 #include <boost/geometry/strategies/distance.hpp>
 

--- a/include/boost/geometry/strategies/cartesian/distance_pythagoras_box_box.hpp
+++ b/include/boost/geometry/strategies/cartesian/distance_pythagoras_box_box.hpp
@@ -4,10 +4,11 @@
 // Copyright (c) 2008-2014 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2009-2014 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2014.
-// Modifications copyright (c) 2014, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014, 2018.
+// Modifications copyright (c) 2014, 2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
@@ -21,12 +22,14 @@
 
 
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/point_type.hpp>
+
+#include <boost/geometry/geometries/concepts/point_concept.hpp>
 
 #include <boost/geometry/strategies/distance.hpp>
 
 #include <boost/geometry/util/math.hpp>
 #include <boost/geometry/util/calculation_type.hpp>
-
 
 
 

--- a/include/boost/geometry/strategies/cartesian/distance_pythagoras_point_box.hpp
+++ b/include/boost/geometry/strategies/cartesian/distance_pythagoras_point_box.hpp
@@ -4,10 +4,11 @@
 // Copyright (c) 2008-2014 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2009-2014 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2014.
-// Modifications copyright (c) 2014, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014, 2018.
+// Modifications copyright (c) 2014, 2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
@@ -21,6 +22,9 @@
 
 
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/point_type.hpp>
+
+#include <boost/geometry/geometries/concepts/point_concept.hpp>
 
 #include <boost/geometry/strategies/distance.hpp>
 

--- a/include/boost/geometry/strategies/cartesian/distance_segment_box.hpp
+++ b/include/boost/geometry/strategies/cartesian/distance_segment_box.hpp
@@ -2,6 +2,7 @@
 
 // Copyright (c) 2018 Oracle and/or its affiliates.
 // Contributed and/or modified by Vissarion Fisikopoulos, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -11,6 +12,8 @@
 #define BOOST_GEOMETRY_STRATEGIES_CARTESIAN_DISTANCE_SEGMENT_BOX_HPP
 
 #include <boost/geometry/algorithms/detail/distance/segment_to_box.hpp>
+
+#include <boost/geometry/strategies/cartesian/distance_projected_point.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/strategies/cartesian/distance_segment_box.hpp
+++ b/include/boost/geometry/strategies/cartesian/distance_segment_box.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2018 Oracle and/or its affiliates.
+// Copyright (c) 2018-2019 Oracle and/or its affiliates.
 // Contributed and/or modified by Vissarion Fisikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -14,6 +14,7 @@
 #include <boost/geometry/algorithms/detail/distance/segment_to_box.hpp>
 
 #include <boost/geometry/strategies/cartesian/distance_projected_point.hpp>
+#include <boost/geometry/strategies/cartesian/point_in_point.hpp>
 
 namespace boost { namespace geometry
 {
@@ -61,6 +62,13 @@ struct cartesian_segment_box
     inline typename distance_ps_strategy::type get_distance_ps_strategy() const
     {
         return typename distance_ps_strategy::type();
+    }
+
+    typedef within::cartesian_point_point equals_point_point_strategy_type;
+
+    static inline equals_point_point_strategy_type get_equals_point_point_strategy()
+    {
+        return equals_point_point_strategy_type();
     }
 
     template <typename LessEqual, typename ReturnType,

--- a/include/boost/geometry/strategies/cartesian/point_in_poly_crossings_multiply.hpp
+++ b/include/boost/geometry/strategies/cartesian/point_in_poly_crossings_multiply.hpp
@@ -4,6 +4,11 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -15,6 +20,7 @@
 #define BOOST_GEOMETRY_STRATEGIES_CARTESIAN_POINT_IN_POLY_CROSSINGS_MULTIPLY_HPP
 
 
+#include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/util/select_calculation_type.hpp>
 

--- a/include/boost/geometry/strategies/cartesian/point_in_poly_franklin.hpp
+++ b/include/boost/geometry/strategies/cartesian/point_in_poly_franklin.hpp
@@ -4,6 +4,11 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -15,6 +20,7 @@
 #define BOOST_GEOMETRY_STRATEGIES_CARTESIAN_POINT_IN_POLY_FRANKLIN_HPP
 
 
+#include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/util/select_calculation_type.hpp>
 

--- a/include/boost/geometry/strategies/concepts/area_concept.hpp
+++ b/include/boost/geometry/strategies/concepts/area_concept.hpp
@@ -5,6 +5,10 @@
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 // Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -18,6 +22,9 @@
 
 #include <boost/concept_check.hpp>
 #include <boost/core/ignore_unused.hpp>
+
+#include <boost/geometry/geometries/point.hpp>
+
 
 namespace boost { namespace geometry { namespace concepts
 {

--- a/include/boost/geometry/strategies/concepts/distance_concept.hpp
+++ b/include/boost/geometry/strategies/concepts/distance_concept.hpp
@@ -4,10 +4,11 @@
 // Copyright (c) 2008-2014 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2014 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2014.
-// Modifications copyright (c) 2014, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014, 2018.
+// Modifications copyright (c) 2014, 2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
@@ -33,6 +34,7 @@
 #include <boost/geometry/geometries/segment.hpp>
 #include <boost/geometry/geometries/point.hpp>
 
+#include <boost/geometry/strategies/distance.hpp>
 #include <boost/geometry/strategies/tags.hpp>
 
 

--- a/include/boost/geometry/strategies/concepts/within_concept.hpp
+++ b/include/boost/geometry/strategies/concepts/within_concept.hpp
@@ -28,6 +28,9 @@
 #include <boost/geometry/core/tag_cast.hpp>
 #include <boost/geometry/core/tags.hpp>
 
+#include <boost/geometry/geometries/concepts/box_concept.hpp>
+#include <boost/geometry/geometries/concepts/point_concept.hpp>
+
 #include <boost/geometry/util/parameter_type_of.hpp>
 
 

--- a/include/boost/geometry/strategies/convex_hull.hpp
+++ b/include/boost/geometry/strategies/convex_hull.hpp
@@ -4,6 +4,11 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -14,6 +19,7 @@
 #ifndef BOOST_GEOMETRY_STRATEGIES_CONVEX_HULL_HPP
 #define BOOST_GEOMETRY_STRATEGIES_CONVEX_HULL_HPP
 
+#include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/strategies/tags.hpp>
 
 

--- a/include/boost/geometry/strategies/geographic/area.hpp
+++ b/include/boost/geometry/strategies/geographic/area.hpp
@@ -20,6 +20,7 @@
 #include <boost/geometry/formulas/authalic_radius_sqr.hpp>
 #include <boost/geometry/formulas/eccentricity_sqr.hpp>
 
+#include <boost/geometry/strategies/area.hpp>
 #include <boost/geometry/strategies/geographic/parameters.hpp>
 
 

--- a/include/boost/geometry/strategies/geographic/distance_cross_track.hpp
+++ b/include/boost/geometry/strategies/geographic/distance_cross_track.hpp
@@ -1,8 +1,9 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2016-2017, Oracle and/or its affiliates.
+// Copyright (c) 2016-2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -27,6 +28,7 @@
 
 #include <boost/geometry/strategies/distance.hpp>
 #include <boost/geometry/strategies/concepts/distance_concept.hpp>
+#include <boost/geometry/strategies/spherical/distance_cross_track.hpp>
 #include <boost/geometry/strategies/spherical/distance_haversine.hpp>
 #include <boost/geometry/strategies/spherical/point_in_point.hpp>
 #include <boost/geometry/strategies/geographic/azimuth.hpp>

--- a/include/boost/geometry/strategies/geographic/distance_cross_track_box_box.hpp
+++ b/include/boost/geometry/strategies/geographic/distance_cross_track_box_box.hpp
@@ -25,6 +25,8 @@
 
 #include <boost/geometry/strategies/distance.hpp>
 #include <boost/geometry/strategies/concepts/distance_concept.hpp>
+#include <boost/geometry/strategies/geographic/distance.hpp>
+#include <boost/geometry/strategies/geographic/distance_cross_track.hpp>
 #include <boost/geometry/strategies/spherical/distance_cross_track.hpp>
 #include <boost/geometry/strategies/spherical/distance_cross_track_box_box.hpp>
 

--- a/include/boost/geometry/strategies/geographic/distance_segment_box.hpp
+++ b/include/boost/geometry/strategies/geographic/distance_segment_box.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2018 Oracle and/or its affiliates.
+// Copyright (c) 2018-2019 Oracle and/or its affiliates.
 // Contributed and/or modified by Vissarion Fisikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -22,6 +22,7 @@
 #include <boost/geometry/strategies/normalize.hpp>
 #include <boost/geometry/strategies/spherical/disjoint_box_box.hpp>
 #include <boost/geometry/strategies/spherical/distance_segment_box.hpp>
+#include <boost/geometry/strategies/spherical/point_in_point.hpp>
 
 #include <boost/geometry/util/promote_floating_point.hpp>
 #include <boost/geometry/util/select_calculation_type.hpp>
@@ -80,6 +81,13 @@ struct geographic_segment_box
     {
         typedef typename distance_ps_strategy::type distance_type;
         return distance_type(m_spheroid);
+    }
+
+    typedef within::spherical_point_point equals_point_point_strategy_type;
+
+    static inline equals_point_point_strategy_type get_equals_point_point_strategy()
+    {
+        return equals_point_point_strategy_type();
     }
 
     //constructor

--- a/include/boost/geometry/strategies/side.hpp
+++ b/include/boost/geometry/strategies/side.hpp
@@ -4,6 +4,11 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -14,6 +19,8 @@
 #ifndef BOOST_GEOMETRY_STRATEGIES_SIDE_HPP
 #define BOOST_GEOMETRY_STRATEGIES_SIDE_HPP
 
+
+#include <boost/mpl/assert.hpp>
 
 #include <boost/geometry/strategies/tags.hpp>
 

--- a/include/boost/geometry/strategies/spherical/compare.hpp
+++ b/include/boost/geometry/strategies/spherical/compare.hpp
@@ -2,8 +2,8 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2018.
+// Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -25,6 +25,7 @@
 #include <boost/geometry/core/coordinate_system.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/cs.hpp>
+#include <boost/geometry/core/radian_access.hpp>
 #include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/strategies/compare.hpp>

--- a/include/boost/geometry/strategies/spherical/densify.hpp
+++ b/include/boost/geometry/strategies/spherical/densify.hpp
@@ -22,6 +22,7 @@
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/radian_access.hpp>
 #include <boost/geometry/formulas/spherical.hpp>
+#include <boost/geometry/geometries/point.hpp>
 #include <boost/geometry/srs/sphere.hpp>
 #include <boost/geometry/strategies/densify.hpp>
 #include <boost/geometry/strategies/spherical/get_radius.hpp>

--- a/include/boost/geometry/strategies/spherical/distance_cross_track.hpp
+++ b/include/boost/geometry/strategies/spherical/distance_cross_track.hpp
@@ -28,6 +28,8 @@
 #include <boost/geometry/core/radian_access.hpp>
 #include <boost/geometry/core/tags.hpp>
 
+#include <boost/geometry/formulas/spherical.hpp>
+
 #include <boost/geometry/strategies/distance.hpp>
 #include <boost/geometry/strategies/concepts/distance_concept.hpp>
 #include <boost/geometry/strategies/spherical/distance_haversine.hpp>

--- a/include/boost/geometry/strategies/spherical/distance_segment_box.hpp
+++ b/include/boost/geometry/strategies/spherical/distance_segment_box.hpp
@@ -16,6 +16,7 @@
 #include <boost/geometry/strategies/distance.hpp>
 #include <boost/geometry/strategies/normalize.hpp>
 #include <boost/geometry/strategies/spherical/disjoint_box_box.hpp>
+#include <boost/geometry/strategies/spherical/distance_cross_track.hpp>
 #include <boost/geometry/strategies/cartesian/point_in_box.hpp> // spherical
 
 namespace boost { namespace geometry

--- a/include/boost/geometry/strategies/spherical/distance_segment_box.hpp
+++ b/include/boost/geometry/strategies/spherical/distance_segment_box.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2018 Oracle and/or its affiliates.
+// Copyright (c) 2018-2019 Oracle and/or its affiliates.
 // Contributed and/or modified by Vissarion Fisikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -17,6 +17,7 @@
 #include <boost/geometry/strategies/normalize.hpp>
 #include <boost/geometry/strategies/spherical/disjoint_box_box.hpp>
 #include <boost/geometry/strategies/spherical/distance_cross_track.hpp>
+#include <boost/geometry/strategies/spherical/point_in_point.hpp>
 #include <boost/geometry/strategies/cartesian/point_in_box.hpp> // spherical
 
 namespace boost { namespace geometry
@@ -210,6 +211,13 @@ struct spherical_segment_box
     inline typename distance_ps_strategy::type get_distance_ps_strategy() const
     {
         return typename distance_ps_strategy::type();
+    }
+
+    typedef within::spherical_point_point equals_point_point_strategy_type;
+
+    static inline equals_point_point_strategy_type get_equals_point_point_strategy()
+    {
+        return equals_point_point_strategy_type();
     }
 
     // methods

--- a/include/boost/geometry/util/calculation_type.hpp
+++ b/include/boost/geometry/util/calculation_type.hpp
@@ -4,6 +4,11 @@
 // Copyright (c) 2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2012 Mateusz Loskot, London, UK.
 
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -13,6 +18,7 @@
 
 #include <boost/config.hpp>
 #include <boost/mpl/if.hpp>
+#include <boost/static_assert.hpp>
 #include <boost/type_traits/is_floating_point.hpp>
 #include <boost/type_traits/is_fundamental.hpp>
 #include <boost/type_traits/is_void.hpp>

--- a/include/boost/geometry/util/combine_if.hpp
+++ b/include/boost/geometry/util/combine_if.hpp
@@ -2,10 +2,11 @@
 
 // Copyright (c) 2014-2015 Samuel Debionne, Grenoble, France.
 
-// This file was modified by Oracle on 2015.
-// Modifications copyright (c) 2015, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2015, 2018.
+// Modifications copyright (c) 2015-2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
@@ -17,13 +18,13 @@
 #ifndef BOOST_GEOMETRY_UTIL_COMBINE_IF_HPP
 #define BOOST_GEOMETRY_UTIL_COMBINE_IF_HPP
 
+#include <boost/mpl/bind.hpp>
 #include <boost/mpl/fold.hpp>
 #include <boost/mpl/if.hpp>
-#include <boost/mpl/bind.hpp>
-#include <boost/mpl/set.hpp>
 #include <boost/mpl/insert.hpp>
+#include <boost/mpl/pair.hpp>
 #include <boost/mpl/placeholders.hpp>
-
+#include <boost/mpl/set.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/util/is_inverse_spheroidal_coordinates.hpp
+++ b/include/boost/geometry/util/is_inverse_spheroidal_coordinates.hpp
@@ -3,6 +3,7 @@
 // Copyright (c) 2018 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -10,6 +11,10 @@
 
 #ifndef BOOST_GEOMETRY_UTIL_IS_INVERSE_SPHEROIDAL_COORDINATES_HPP
 #define BOOST_GEOMETRY_UTIL_IS_INVERSE_SPHEROIDAL_COORDINATES_HPP
+
+#include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/coordinate_type.hpp>
+#include <boost/geometry/core/point_type.hpp>
 
 #include <boost/geometry/util/math.hpp>
 

--- a/include/boost/geometry/views/detail/boundary_view/implementation.hpp
+++ b/include/boost/geometry/views/detail/boundary_view/implementation.hpp
@@ -1,8 +1,9 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2015, Oracle and/or its affiliates.
+// Copyright (c) 2015, 2018, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Licensed under the Boost Software License version 1.0.
 // http://www.boost.org/users/license.html
@@ -23,7 +24,6 @@
 #include <boost/iterator/iterator_categories.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/mpl/if.hpp>
-#include <boost/range.hpp>
 #include <boost/type_traits/is_const.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 #include <boost/type_traits/remove_reference.hpp>
@@ -40,6 +40,7 @@
 #include <boost/geometry/util/range.hpp>
 
 #include <boost/geometry/views/closeable_view.hpp>
+#include <boost/geometry/views/detail/boundary_view/interface.hpp>
 
 #include <boost/geometry/algorithms/num_interior_rings.hpp>
 

--- a/test/algorithms/similarity/discrete_hausdorff_distance.cpp
+++ b/test/algorithms/similarity/discrete_hausdorff_distance.cpp
@@ -2,7 +2,12 @@
 
 // Copyright (c) 2018 Yaghyavardhan Singh Khangarot, Hyderabad, India.
 
-// Contributed and/or modified by Yaghyavardhan Singh Khangarot, as part of Google Summer of Code 2018 program.
+// Contributed and/or modified by Yaghyavardhan Singh Khangarot,
+//   as part of Google Summer of Code 2018 program.
+
+// This file was modified by Oracle on 2018.
+// Modifications copyright (c) 2018 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -13,6 +18,8 @@
 #include <boost/geometry/geometries/linestring.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/polygon.hpp>
+#include <boost/geometry/geometries/multi_linestring.hpp>
+#include <boost/geometry/geometries/multi_point.hpp>
 
 #include "test_hausdorff_distance.hpp"
 

--- a/test/algorithms/within/test_within.hpp
+++ b/test/algorithms/within/test_within.hpp
@@ -4,8 +4,8 @@
 // Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2013-2015 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2014, 2015, 2017.
-// Modifications copyright (c) 2014-2017 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014, 2015, 2017, 2019.
+// Modifications copyright (c) 2014-2019 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -21,6 +21,7 @@
 
 #include <geometry_test_common.hpp>
 
+#include <boost/geometry/algorithms/covered_by.hpp>
 #include <boost/geometry/algorithms/within.hpp>
 #include <boost/geometry/core/ring_type.hpp>
 #include <boost/geometry/geometries/ring.hpp>


### PR DESCRIPTION
This PR adds missing includes in order to make headers in line with Boost one header policy.
A part of fixes needed by https://github.com/boostorg/geometry/issues/523
Not all headers are fixed by this PR.

This PR also decrease inter-dependencies:
- projections are no longer included by `meridian_segment` formula,
- the whole `within`, `covered_by`, `relate` and `rtree` code is no longer included by distance strategies