### PR TITLE
Fix and error in documentation building

### DIFF
--- a/doc/html/index.html
+++ b/doc/html/index.html
@@ -3,7 +3,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=US-ASCII">
 <title>Chapter&#160;1.&#160;Geometry</title>
 <link rel="stylesheet" href="../../../../doc/src/boostbook.css" type="text/css">
-<meta name="generator" content="DocBook XSL Stylesheets V1.77.1">
+<meta name="generator" content="DocBook XSL Stylesheets V1.78.1">
 <link rel="home" href="index.html" title="Chapter&#160;1.&#160;Geometry">
 <link rel="next" href="geometry/introduction.html" title="Introduction">
 </head>
@@ -40,8 +40,8 @@
 <div><div class="author"><h3 class="author">
 <span class="firstname">Vissarion</span> <span class="surname">Fisikopoulos</span>
 </h3></div></div>
-<div><p class="copyright">Copyright &#169; 2009-2018 Barend Gehrels, Bruno Lalande, Mateusz Loskot, Adam Wulkiewicz, Oracle
-      and/or its affiliates</p></div>
+<div><p class="copyright">Copyright &#169; 2009-2019 Barend Gehrels, Bruno Lalande, Mateusz Loskot, Adam
+      Wulkiewicz, Oracle and/or its affiliates</p></div>
 <div><div class="legalnotice">
 <a name="geometry.legal"></a><p>
         Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -51,7 +51,7 @@
 </div></div>
 <div class="toc">
 <p><b>Table of Contents</b></p>
-<dl>
+<dl class="toc">
 <dt><span class="section"><a href="geometry/introduction.html">Introduction</a></span></dt>
 <dt><span class="section"><a href="geometry/compilation.html">Compilation</a></span></dt>
 <dt><span class="section"><a href="geometry/design.html">Design Rationale</a></span></dt>
@@ -143,7 +143,7 @@
 </ul></div>
 </div>
 <table xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" width="100%"><tr>
-<td align="left"><p><small>Last revised: November 29, 2018 at 00:39:14 GMT</small></p></td>
+<td align="left"><p><small>Last revised: February 19, 2019 at 14:49:50 GMT</small></p></td>
 <td align="right"><div class="copyright-footer"></div></td>
 </tr></table>
 <hr>

--- a/doc/make_qbk.py
+++ b/doc/make_qbk.py
@@ -112,8 +112,7 @@ coordinate_systems = ["cartesian", "geographic", "polar", "spherical", "spherica
 
 core = ["closure", "coordinate_system", "coordinate_type", "cs_tag"
     , "dimension", "exception", "interior_type"
-    , "degree", "radian"
-    , "is_radian", "point_order"
+    , "degree", "radian", "point_order"
     , "point_type", "ring_type", "tag", "tag_cast" ]
 
 exceptions = ["exception", "centroid_exception"];

--- a/doc/quickref.xml
+++ b/doc/quickref.xml
@@ -195,7 +195,6 @@
      <member><link linkend="geometry.reference.core.coordinate_system">coordinate_system</link></member>
      <member><link linkend="geometry.reference.core.dimension">dimension</link></member>
      <member><link linkend="geometry.reference.core.interior_type">interior_type</link></member>
-     <member><link linkend="geometry.reference.core.is_radian">is_radian</link></member>
      <member><link linkend="geometry.reference.core.point_order">point_order</link></member>
      <member><link linkend="geometry.reference.core.point_type">point_type</link></member>
      <member><link linkend="geometry.reference.core.ring_type">ring_type</link></member>

--- a/doc/reference.qbk
+++ b/doc/reference.qbk
@@ -257,7 +257,6 @@
 [include generated/degree.qbk]
 [include generated/dimension.qbk]
 [include generated/interior_type.qbk]
-[include generated/is_radian.qbk]
 [include generated/point_order.qbk]
 [include generated/point_type.qbk]
 [include generated/radian.qbk]


### PR DESCRIPTION
Fix error `no ID for constraint linkend: geometry.reference.core.is_radian` in documentation building.