### PR TITLE
Enhance/remove no self defines

### DIFF
--- a/test/algorithms/overlay/overlay.cpp
+++ b/test/algorithms/overlay/overlay.cpp
@@ -373,9 +373,6 @@ void test_overlay(std::string const& caseid,
         << "_" << string_from_type<typename bg::coordinate_type<Geometry>::type>::name()
         << (ccw ? "_ccw" : "")
         << (open ? "_open" : "")
-#if defined(BOOST_GEOMETRY_NO_SELF_TURNS)
-        << "_no_self"
-#endif
 #if defined(BOOST_GEOMETRY_NO_ROBUSTNESS)
         << "_no_rob"
 #endif

--- a/test/algorithms/set_operations/difference/difference.cpp
+++ b/test/algorithms/set_operations/difference/difference.cpp
@@ -41,14 +41,6 @@
     ( #caseid, caseid[0], caseid[1], clips1, -1, area1, clips2, -1, area2, \
                 clips3, -1, area1 + area2)
 
-#if defined(BOOST_GEOMETRY_NO_SELF_TURNS)
-#define TEST_DIFFERENCE_IGNORE(caseid, clips1, area1, clips2, area2, clips3) \
-    { ut_settings ignore_validity; ignore_validity.test_validity = false; \
-    (test_one<polygon, polygon, polygon>) \
-    ( #caseid, caseid[0], caseid[1], clips1, -1, area1, clips2, -1, area2, \
-                clips3, -1, area1 + area2, ignore_validity); }
-#endif
-
 template <typename P>
 void test_all()
 {
@@ -546,32 +538,14 @@ void test_all()
             5, 27, 1.6701714);
     ***/
 
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
-    TEST_DIFFERENCE(mysql_21977775,
-                           2, 160.856568913, 2, 92.3565689126, 4);
-#else
-    TEST_DIFFERENCE_IGNORE(mysql_21977775,
-                           1, 160.856568913, 2, 92.3565689126, 3);
-#endif
-
+    TEST_DIFFERENCE(mysql_21977775, 2, 160.856568913, 2, 92.3565689126, 4);
     TEST_DIFFERENCE(mysql_21965285, 1, 92.0, 1, 14.0, 1);
-
     TEST_DIFFERENCE(mysql_23023665_1, 1, 92.0, 1, 142.5, 2);
     TEST_DIFFERENCE(mysql_23023665_2, 1, 96.0, 1, 16.0, 2);
     TEST_DIFFERENCE(mysql_23023665_3, 1, 225.0, 1, 66.0, 2);
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_DIFFERENCE(mysql_23023665_5, 2, 165.23735, 2, 105.73735, 4);
-#else
-    TEST_DIFFERENCE_IGNORE(mysql_23023665_5, 1, 165.23735, 2, 105.73735, 3);
-#endif
-
     TEST_DIFFERENCE(mysql_23023665_6, 2, 105.68756, 3, 10.18756, 5);
-
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_DIFFERENCE(mysql_23023665_13, 3, 99.74526, 3, 37.74526, 6);
-#else
-    TEST_DIFFERENCE_IGNORE(mysql_23023665_13, 2, 99.74526, 3, 37.74526, 5);
-#endif
 }
 
 
@@ -598,11 +572,7 @@ void test_specific()
         1, 4, 6731652.0);
 
     // Generates spikes, both a-b and b-a
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_DIFFERENCE(ticket_11676, 2, 2537992.5, 2, 294963.5, 3);
-#else
-    TEST_DIFFERENCE_IGNORE(ticket_11676, 1, 2537992.5, 2, 294963.5, 2);
-#endif
 }
 
 

--- a/test/algorithms/set_operations/difference/difference_multi.cpp
+++ b/test/algorithms/set_operations/difference/difference_multi.cpp
@@ -104,11 +104,7 @@ void test_areal()
     TEST_DIFFERENCE(case_125_multi, 1, 0.25, 2, 0.400, 3);
 
     // A should have 3 clips, B should have 5 clips
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_DIFFERENCE(case_126_multi, 4, 16.0, 5, 27.0, 9);
-#else
-    TEST_DIFFERENCE_IGNORE(case_126_multi, 3, 16.0, 4, 27.0, 7);
-#endif
 
     {
         ut_settings settings;
@@ -155,16 +151,7 @@ void test_areal()
         ut_settings settings;
         settings.percentage = 0.001;
 
-        // This testcase is actually different for all combinations
-#if defined(BOOST_GEOMETRY_NO_SELF_TURNS) || defined(BOOST_GEOMETRY_NO_ROBUSTNESS)
-        settings.test_validity = false;
-#endif
-
-#if ! defined(BOOST_GEOMETRY_NO_SELF_TURNS) || defined(BOOST_GEOMETRY_NO_ROBUSTNESS)
         TEST_DIFFERENCE_WITH(0, 1, ggl_list_20120221_volker, 2, 7962.66, 2, 2775258.93, 4);
-#else
-        TEST_DIFFERENCE_WITH(0, 1, ggl_list_20120221_volker, 2, 7962.66, 1, 2775258.93, 3);
-#endif
     }
 
 #if defined(BOOST_GEOMETRY_NO_ROBUSTNESS)
@@ -194,11 +181,7 @@ void test_areal()
     TEST_DIFFERENCE_IGNORE(bug_21155501, 1, 3.758937, 0, 0.0, 1);
 #endif
 
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_DIFFERENCE(ticket_12503, 46, 920.625, 4, 7.625, 50);
-#else
-    TEST_DIFFERENCE_IGNORE(ticket_12503, 45, 920.625, 3, 7.625, 48);
-#endif
 
     // Areas and #clips correspond with POSTGIS (except sym case)
     test_one<Polygon, MultiPolygon, MultiPolygon>("case_101_multi",
@@ -233,11 +216,7 @@ void test_areal()
 
     // Areas correspond with POSTGIS,
     // #clips in PostGIS is 11,11,5 but should most probably be be 12,12,6
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_DIFFERENCE(case_recursive_boxes_1, 12, 26.0, 12, 24.0, 6);
-#else
-    TEST_DIFFERENCE_IGNORE(case_recursive_boxes_1, 11, 26.0, 12, 24.0, 5);
-#endif
 
     // Areas and #clips correspond with POSTGIS
     test_one<Polygon, MultiPolygon, MultiPolygon>("case_recursive_boxes_2",
@@ -255,17 +234,8 @@ void test_areal()
 
     // 4, input is not valid
 
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_DIFFERENCE(case_recursive_boxes_5, 16, 22.0, 12, 27.0, 10);
-#else
-    TEST_DIFFERENCE_IGNORE(case_recursive_boxes_5, 15, 22.0, 11, 27.0, 8);
-#endif
-
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_DIFFERENCE(case_recursive_boxes_6, 7, 3.5, 3, 1.5, 9);
-#else
-    TEST_DIFFERENCE_IGNORE(case_recursive_boxes_6, 6, 3.5, 3, 1.5, 8);
-#endif
 
     test_one<Polygon, MultiPolygon, MultiPolygon>("case_recursive_boxes_7",
         case_recursive_boxes_7[0], case_recursive_boxes_7[1],
@@ -301,13 +271,8 @@ void test_areal()
     TEST_DIFFERENCE(case_recursive_boxes_13, 4, 4.75, 3, 5.5, 3);
     TEST_DIFFERENCE(case_recursive_boxes_14, 3, 2.0, 4, 2.5, 5);
     TEST_DIFFERENCE(case_recursive_boxes_15, 3, 3.0, 2, 2.5, 3);
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_DIFFERENCE(case_recursive_boxes_16, 8, 6.5, 3, 5.5, 9);
     TEST_DIFFERENCE(case_recursive_boxes_17, 10, 7.75, 7, 5.5, 13);
-#else
-    TEST_DIFFERENCE_IGNORE(case_recursive_boxes_16, 7, 6.5, 3, 5.5, 8);
-    TEST_DIFFERENCE_IGNORE(case_recursive_boxes_17, 9, 7.75, 6, 5.5, 11);
-#endif
     TEST_DIFFERENCE(case_recursive_boxes_18, 2, 1.0, 1, 1.5, 3);
     TEST_DIFFERENCE(case_recursive_boxes_19, 2, 1.0, 2, 1.5, 3);
     TEST_DIFFERENCE(case_recursive_boxes_20, 2, 1.0, 0, 0.0, 2);
@@ -326,11 +291,7 @@ void test_areal()
     TEST_DIFFERENCE(case_recursive_boxes_31, 2, 2.0, 1, 0.5, 2);
     TEST_DIFFERENCE(case_recursive_boxes_32, 2, 2.75, 2, 1.25, 2);
     TEST_DIFFERENCE(case_recursive_boxes_33, 4, 3.0, 3, 6.0, 4);
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_DIFFERENCE(case_recursive_boxes_34, 7, 7.25, 1, 0.5, 8);
-#else
-    TEST_DIFFERENCE_IGNORE(case_recursive_boxes_34, 5, 7.25, 1, 0.5, 6);
-#endif
     TEST_DIFFERENCE(case_recursive_boxes_35, 5, 1.75, 5, 2.75, 10);
     TEST_DIFFERENCE(case_recursive_boxes_36, 2, 1.0, 2, 1.5, 3);
     TEST_DIFFERENCE(case_recursive_boxes_37, 3, 2.5, 2, 4.25, 2);
@@ -339,104 +300,48 @@ void test_areal()
     TEST_DIFFERENCE(case_recursive_boxes_40, 11, 14.0, 9, 13.0, 11);
 
     TEST_DIFFERENCE(case_recursive_boxes_41, 1, 0.5, 1, 0.5, 2);
-#ifdef BOOST_GEOMETRY_NO_SELF_TURNS
-    // 42.a Fails with self-turns
     TEST_DIFFERENCE(case_recursive_boxes_42, 1, 1.0, 4, 4.0, 5);
-#endif
     TEST_DIFFERENCE(case_recursive_boxes_43, 1, 0.5, 3, 2.0, 4);
     TEST_DIFFERENCE(case_recursive_boxes_44, 3, 5.0, 0, 0.0, 3);
     TEST_DIFFERENCE(case_recursive_boxes_45, 6, 20.0, 7, 20.0, 3);
     TEST_DIFFERENCE(case_recursive_boxes_46, 4, 14.0, 5, 12.0, 5);
     TEST_DIFFERENCE(case_recursive_boxes_47, 4, 10.0, 7, 11.0, 1);
     TEST_DIFFERENCE(case_recursive_boxes_48, 0, 0.0, 1, 9.0, 1);
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_DIFFERENCE(case_recursive_boxes_49, 10, 22.0, 10, 17.0, 11);
-#else
-    TEST_DIFFERENCE_IGNORE(case_recursive_boxes_49, 9, 22.0, 10, 17.0, 10);
-#endif
     TEST_DIFFERENCE(case_recursive_boxes_50, 14, 21.0, 16, 21.0, 14);
     TEST_DIFFERENCE(case_recursive_boxes_51, 14, 25.0, 12, 31.0, 7);
-
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_DIFFERENCE(case_recursive_boxes_52, 13, 30.0, 15, 25.0, 8);
-#else
-    TEST_DIFFERENCE_IGNORE(case_recursive_boxes_52, 13, 30.0, 15, 25.0, 8);
-#endif
     TEST_DIFFERENCE(case_recursive_boxes_53, 6, 3.5, 4, 1.5, 9);
     TEST_DIFFERENCE(case_recursive_boxes_54, 6, 6.5, 8, 6.0, 7);
     TEST_DIFFERENCE(case_recursive_boxes_55, 4, 5.5, 6, 7.75, 4);
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_DIFFERENCE(case_recursive_boxes_56, 4, 4.5, 5, 2.75, 6);
-#else
-    TEST_DIFFERENCE_IGNORE(case_recursive_boxes_56, 4, 4.5, 5, 2.75, 6);
-#endif
     TEST_DIFFERENCE(case_recursive_boxes_57, 5, 3.75, 9, 6.5, 10);
     TEST_DIFFERENCE(case_recursive_boxes_58, 4, 2.25, 6, 3.75, 7);
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_DIFFERENCE(case_recursive_boxes_59, 8, 6.5, 7, 7.0, 12);
-#else
-    TEST_DIFFERENCE_IGNORE(case_recursive_boxes_59, 8, 6.5, 6, 7.0, 11);
-#endif
-
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_DIFFERENCE(case_recursive_boxes_60, 6, 5.25, 7, 5.25, 11);
-#else
-    TEST_DIFFERENCE_IGNORE(case_recursive_boxes_60, 5, 5.25, 5, 5.25, 8);
-#endif
     TEST_DIFFERENCE(case_recursive_boxes_61, 2, 1.5, 6, 2.0, 7);
 #if defined(BOOST_GEOMETRY_TEST_INCLUDE_FAILING_TESTS)
     // Misses one triangle
     TEST_DIFFERENCE(case_recursive_boxes_62, 5, 5.0, 11, 5.75, 12);
 #endif
 
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_DIFFERENCE(case_recursive_boxes_63, 9, 10.5, 5, 27.75, 4);
-#else
-    TEST_DIFFERENCE_IGNORE(case_recursive_boxes_63, 6, 10.5, 5, 27.75, 2);
-#endif
-
     TEST_DIFFERENCE(case_recursive_boxes_64, 6, 2.75, 7, 4.5, 11);
-
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_DIFFERENCE(case_recursive_boxes_65, 6, 4.25, 7, 3.0, 13);
-#else
-    TEST_DIFFERENCE_IGNORE(case_recursive_boxes_65, 4, 4.25, 7, 3.0, 11);
-#endif
-
     TEST_DIFFERENCE(case_recursive_boxes_66, 5, 4.75, 7, 4.0, 9);
     TEST_DIFFERENCE(case_recursive_boxes_67, 7, 6.25, 9, 6.0, 10);
     TEST_DIFFERENCE(case_recursive_boxes_68, 10, 6.5, 9, 6.5, 7);
     TEST_DIFFERENCE(case_recursive_boxes_69, 5, 6.25, 5, 6.75, 8);
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_DIFFERENCE(case_recursive_boxes_70, 5, 2.0, 8, 4.5, 11);
-#else
-    TEST_DIFFERENCE_IGNORE(case_recursive_boxes_70, 5, 2.0, 6, 4.5, 9);
-#endif
-
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_DIFFERENCE(case_recursive_boxes_71, 7, 8.25, 7, 5.75, 8);
-#else
-    TEST_DIFFERENCE_IGNORE(case_recursive_boxes_71, 6, 8.25, 7, 5.75, 7);
-#endif
-
     TEST_DIFFERENCE(case_recursive_boxes_72, 6, 6.5, 7, 4.0, 10);
     TEST_DIFFERENCE(case_recursive_boxes_73, 4, 1.75, 5, 4.0, 8);
-
     TEST_DIFFERENCE(case_recursive_boxes_74, 3, 3.00, 3, 1.5, 5);
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_DIFFERENCE(case_recursive_boxes_75, 7, 4.5, 4, 2.0, 11);
-#else
-    TEST_DIFFERENCE_IGNORE(case_recursive_boxes_75, 5, 4.5, 4, 2.0, 9);
-#endif
-
     TEST_DIFFERENCE(case_recursive_boxes_76, 7, 3.75, 4, 2.5, 9);
     TEST_DIFFERENCE(case_recursive_boxes_77, 4, 3.75, 7, 6.25, 8);
     TEST_DIFFERENCE(case_recursive_boxes_78, 11, 5.5, 8, 4.5, 14);
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_DIFFERENCE(case_recursive_boxes_79, 2, 1.25, 6, 4.5, 8);
-#else
-    TEST_DIFFERENCE_IGNORE(case_recursive_boxes_79, 2, 1.25, 5, 4.5, 7);
-#endif
 
 #if defined(BOOST_GEOMETRY_NO_ROBUSTNESS)
     TEST_DIFFERENCE(case_recursive_boxes_80, 1, 0.5, 2, 0.75, 2);
@@ -447,12 +352,7 @@ void test_areal()
 #endif
 
     TEST_DIFFERENCE(case_recursive_boxes_81, 3, 5.0, 6, 6.75, 6);
-
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_DIFFERENCE(case_recursive_boxes_82, 5, 7.25, 7, 4.5, 8);
-#else
-    TEST_DIFFERENCE_IGNORE(case_recursive_boxes_82, 5, 7.25, 6, 4.5, 7);
-#endif
     TEST_DIFFERENCE(case_recursive_boxes_83, 9, 5.25, 8, 5.25, 12);
     TEST_DIFFERENCE(case_recursive_boxes_84, 4, 8.0, 7, 9.0, 4);
 #ifdef BOOST_GEOMETRY_NO_ROBUSTNESS
@@ -521,25 +421,9 @@ void test_specific_areal()
 
         ut_settings settings;
         settings.remove_spikes = true;
-#if defined(BOOST_GEOMETRY_NO_SELF_TURNS)
-        settings.sym_difference = false;
-        settings.test_validity = false;
-#endif
 
-        std::string a_min_b =
-            TEST_DIFFERENCE_WITH(0, 1, ticket_12751, 1, 2781965.0, 1, 597.0, 2);
-
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
+        TEST_DIFFERENCE_WITH(0, 1, ticket_12751, 1, 2781965.0, 1, 597.0, 2);
         TEST_DIFFERENCE_WITH(2, 3, ticket_12751, 2, 2537992.5, 2, 294963.5, 3);
-#else
-
-        // Testing consistency of testcase itself
-        boost::ignore_unused(a_min_b);
-        // BOOST_CHECK_EQUAL(a_min_b, ticket_12751[2]);
-
-        TEST_DIFFERENCE_WITH(2, 3, ticket_12751, 1, 2537992.5, 2, 294963.5, 3);
-#endif
-
     }
 
     {
@@ -548,13 +432,7 @@ void test_specific_areal()
         ut_settings settings;
         settings.remove_spikes = true;
         settings.sym_difference = false;
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
         TEST_DIFFERENCE_WITH(0, 1, ticket_12752, 3, 2776692.0, 3, 7893.0, 2);
-#else
-        // If self-intersections are not tested, result is not valid
-        settings.test_validity = false;
-        TEST_DIFFERENCE_WITH(0, 1, ticket_12752, 3, 2776692.0, 3, 7893.0, 6);
-#endif
     }
 
     {
@@ -571,12 +449,7 @@ void test_specific_areal()
     {
         ut_settings settings;
         settings.sym_difference = false;
-#ifdef BOOST_GEOMETRY_NO_SELF_TURNS
-        settings.test_validity = false;
-        TEST_DIFFERENCE_WITH(0, 1, ticket_9942, 3, 7427491.5, 4, 131506, 4);
-#else
         TEST_DIFFERENCE_WITH(0, 1, ticket_9942, 4, 7427727.5, 4, 131506, 4);
-#endif
         TEST_DIFFERENCE_WITH(0, 1, ticket_9942a, 2, 412676.5, 2, 76779.5, 4);
     }
 }

--- a/test/algorithms/set_operations/difference/test_difference.hpp
+++ b/test/algorithms/set_operations/difference/test_difference.hpp
@@ -105,9 +105,6 @@ void difference_output(std::string const& caseid, G1 const& g1, G2 const& g2, Ou
             << string_from_type<coordinate_type>::name()
             << (ccw ? "_ccw" : "")
             << (open ? "_open" : "")
-#if defined(BOOST_GEOMETRY_NO_SELF_TURNS)
-           << "_no_self"
-#endif
 #if defined(BOOST_GEOMETRY_NO_ROBUSTNESS)
             << "_no_rob"
 #endif

--- a/test/algorithms/set_operations/intersection/intersection.cpp
+++ b/test/algorithms/set_operations/intersection/intersection.cpp
@@ -56,13 +56,6 @@ BOOST_GEOMETRY_REGISTER_LINESTRING_TEMPLATED(std::vector)
     ( #caseid #index1 "_" #index2, caseid[index1], caseid[index2], \
      clips, points, area, settings)
 
-#if defined(BOOST_GEOMETRY_NO_SELF_TURNS)
-    #define TEST_INTERSECTION_IGNORE(caseid, clips, points, area) \
-        { ut_settings ignore_validity; ignore_validity.test_validity = false; \
-        (test_one<Polygon, Polygon, Polygon>) \
-        ( #caseid, caseid[0], caseid[1], clips, points, area, ignore_validity); }
-#endif
-
 template <typename Polygon>
 void test_areal()
 {
@@ -395,14 +388,8 @@ void test_areal()
         TEST_INTERSECTION_WITH(case_precision_13, 1, 0, 1, -1, 2.0, settings);
     }
 
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_INTERSECTION(case_106, 2, -1, 3.5);
     TEST_INTERSECTION(case_107, 3, -1, 3.0);
-#else
-    TEST_INTERSECTION_IGNORE(case_106, 0, -1, 3.5);
-    TEST_INTERSECTION_IGNORE(case_107, 0, -1, 3.0);
-#endif
-
 
     test_one<Polygon, Polygon, Polygon>("mysql_21964049",
         mysql_21964049[0], mysql_21964049[1],
@@ -417,12 +404,7 @@ void test_areal()
         mysql_21965285_b_inv[1],
         2, -1, 183.71376870369406);
 
-    // Needs self-intersections to solve validity
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_INTERSECTION(mysql_23023665_6, 2, 0, 11.812440191387557);
-#else
-    TEST_INTERSECTION_IGNORE(mysql_23023665_6, 1, -1, 11.812440191387557);
-#endif
 
     test_one<Polygon, Polygon, Polygon>("mysql_23023665_10",
         mysql_23023665_10[0], mysql_23023665_10[1],

--- a/test/algorithms/set_operations/intersection/intersection_multi.cpp
+++ b/test/algorithms/set_operations/intersection/intersection_multi.cpp
@@ -150,11 +150,7 @@ void test_areal()
     TEST_INTERSECTION(case_123_multi, 3, 13, 1.875);
     TEST_INTERSECTION(case_124_multi, 2, 13, 2.0625);
     TEST_INTERSECTION(case_125_multi, 3, 17, 2.1);
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_INTERSECTION(case_126_multi, 5, 27, 9.0);
-#else
-    TEST_INTERSECTION_IGNORE(case_126_multi, 3, 23, 9.0);
-#endif
     TEST_INTERSECTION(case_127_multi, 3, 19, 24.0);
     TEST_INTERSECTION(case_128_multi, 2, 26, 75.5);
     TEST_INTERSECTION(case_129_multi, 1, 20, 20.5);
@@ -171,11 +167,7 @@ void test_areal()
     TEST_INTERSECTION(case_140_multi, 2, 23, 40.546875);
     TEST_INTERSECTION(case_141_multi, 3, -1, 74.5);
 
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_INTERSECTION(case_recursive_boxes_1, 10, 89, 47.0);
-#else
-    TEST_INTERSECTION_IGNORE(case_recursive_boxes_1, 8, 97, 47.0);
-#endif
 
     test_one<Polygon, MultiPolygon, MultiPolygon>("case_recursive_boxes_2",
         case_recursive_boxes_2[0], case_recursive_boxes_2[1],
@@ -184,11 +176,7 @@ void test_areal()
         case_recursive_boxes_3[0], case_recursive_boxes_3[1],
         19, 84, 12.5); // Area from SQL Server
 
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_INTERSECTION_IGNORE(case_recursive_boxes_4, 13, 158, 67.0);
-#else
-    TEST_INTERSECTION_IGNORE(case_recursive_boxes_4, 8, 178, 67.0);
-#endif
 
     // Fixed by replacing handle_tangencies in less_by_segment_ratio sort order
     // Should contain 6 output polygons
@@ -316,40 +304,18 @@ void test_areal()
     TEST_INTERSECTION(case_recursive_boxes_60, 8, -1, 10.0);
     TEST_INTERSECTION(case_recursive_boxes_61, 2, -1, 20.0);
     TEST_INTERSECTION(case_recursive_boxes_62, 9, -1, 10.5);
-
     TEST_INTERSECTION(case_recursive_boxes_63, 11, -1, 5.75);
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_INTERSECTION(case_recursive_boxes_64, 5, -1, 17.25);
-#else
-    TEST_INTERSECTION_IGNORE(case_recursive_boxes_64, 4, -1, 17.25);
-#endif
     TEST_INTERSECTION(case_recursive_boxes_65, 3, -1, 17.25);
-
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_INTERSECTION(case_recursive_boxes_66, 4, -1, 16.0);
-#else
-    TEST_INTERSECTION_IGNORE(case_recursive_boxes_66, 2, -1, 16.0);
-#endif
-
     TEST_INTERSECTION(case_recursive_boxes_67, 5, -1, 2.5);
     TEST_INTERSECTION(case_recursive_boxes_68, 8, -1, 9.5);
     TEST_INTERSECTION(case_recursive_boxes_69, 6, -1, 3.25);
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_INTERSECTION(case_recursive_boxes_70, 6, -1, 18.5);
-#else
-    // Misses a necessary self-turn and therefore a ring
-    TEST_INTERSECTION_IGNORE(case_recursive_boxes_70, 3, -1, 18.0);
-#endif
-
     TEST_INTERSECTION(case_recursive_boxes_71, 3, -1, 1.75);
     TEST_INTERSECTION(case_recursive_boxes_72, 8, -1, 4.5);
     TEST_INTERSECTION(case_recursive_boxes_73, 3, -1, 18.5);
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_INTERSECTION(case_recursive_boxes_74, 3, -1, 20.25);
-#else
-    TEST_INTERSECTION_IGNORE(case_recursive_boxes_74, 2, -1, 20.25);
-#endif
-
     TEST_INTERSECTION(case_recursive_boxes_75, 5, -1, 16.75);
     TEST_INTERSECTION(case_recursive_boxes_76, 2, -1, 18.25);
     TEST_INTERSECTION(case_recursive_boxes_77, 5, -1, 3.5);
@@ -357,12 +323,7 @@ void test_areal()
     TEST_INTERSECTION(case_recursive_boxes_79, 5, -1, 9.0);
     TEST_INTERSECTION(case_recursive_boxes_80, 1, -1, 0.25);
     TEST_INTERSECTION(case_recursive_boxes_81, 5, -1, 3.75);
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_INTERSECTION(case_recursive_boxes_82, 5, -1, 8.5);
-#else
-    TEST_INTERSECTION_IGNORE(case_recursive_boxes_82, 3, -1, 8.5);
-#endif
-
     TEST_INTERSECTION(case_recursive_boxes_83, 5, -1, 10.25);
     TEST_INTERSECTION(case_recursive_boxes_84, 1, -1, 0.5);
 #ifdef BOOST_GEOMETRY_NO_ROBUSTNESS
@@ -417,12 +378,7 @@ void test_areal()
         mysql_23023665_7[0], mysql_23023665_7[1],
         2, 11, 9.80505786783);
 
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_INTERSECTION(mysql_23023665_12, 2, 0, 11.812440191387557);
-#else
-    TEST_INTERSECTION_IGNORE(mysql_23023665_12, 1, -1, 11.812440191387557);
-#endif
-
     TEST_INTERSECTION(mysql_regression_1_65_2017_08_31, 2, -1, 29.9022122);
 }
 

--- a/test/algorithms/set_operations/intersection/test_intersection.hpp
+++ b/test/algorithms/set_operations/intersection/test_intersection.hpp
@@ -256,9 +256,6 @@ typename bg::default_area_result<G1>::type test_intersection(std::string const& 
             << string_from_type<CalculationType>::name()
             << (ccw ? "_ccw" : "")
             << (open ? "_open" : "")
-#if defined(BOOST_GEOMETRY_NO_SELF_TURNS)
-           << "_no_self"
-#endif
 #if defined(BOOST_GEOMETRY_NO_ROBUSTNESS)
             << "_no_rob"
 #endif

--- a/test/algorithms/set_operations/union/test_union.hpp
+++ b/test/algorithms/set_operations/union/test_union.hpp
@@ -223,9 +223,6 @@ void test_union(std::string const& caseid, G1 const& g1, G2 const& g2,
             << string_from_type<coordinate_type>::name()
             << (ccw ? "_ccw" : "")
             << (open ? "_open" : "")
-#if defined(BOOST_GEOMETRY_NO_SELF_TURNS)
-           << "_no_self"
-#endif
 #if defined(BOOST_GEOMETRY_NO_ROBUSTNESS)
             << "_no_rob"
 #endif

--- a/test/algorithms/set_operations/union/union_multi.cpp
+++ b/test/algorithms/set_operations/union/union_multi.cpp
@@ -130,11 +130,7 @@ void test_areal()
         case_108_multi[0], case_108_multi[1],
         1, 1, 20, 22.75);
 
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_UNION(case_109_multi, 1, 2, 14, 1400);
-#else
-    TEST_UNION_IGNORE(case_109_multi, 1, 1, 14, 1400);
-#endif
 
     // Should have 9 holes, they are all separate and touching
     test_one<Polygon, MultiPolygon, MultiPolygon>("case_110_multi",
@@ -183,11 +179,7 @@ void test_areal()
     TEST_UNION(case_125_multi, 1, 0, 9, 2.75);
     TEST_UNION(case_126_multi, 1, 2, 27, 52.0);
 
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_UNION(case_131_multi, 1, 2, 15, 14.0);
-#else
-    TEST_UNION_IGNORE(case_131_multi, 1, 1, 15, 14.0);
-#endif
 
     // SQL Server returns: MULTIPOLYGON (((4 4, 5.5 4.5, 6 6, 4.5 5.5, 4 4)), ((2 2, 3.5 2.5, 4 4, 2.5 3.5, 2 2)), ((0 0, 8 0, 8 8, 0 8, 0 0), (2 2, 2 4, 4 4, 4 6, 6 6, 6 4, 4 4, 4 2, 2 2)))
     // Which is one self-connected hole with two island polygons in both parts, basically identical to what Boost.Geometry delivers
@@ -221,11 +213,7 @@ void test_areal()
         case_recursive_boxes_4[0], case_recursive_boxes_4[1],
         1, 2, 26, 96.75);
 
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_UNION(case_recursive_boxes_5, 3, 10, 98, 70.0);
-#else
-    TEST_UNION_IGNORE(case_recursive_boxes_5, 3, 9, 115, 70.0);
-#endif
 
     test_one<Polygon, MultiPolygon, MultiPolygon>("case_recursive_boxes_6",
         case_recursive_boxes_6[0], case_recursive_boxes_6[1],
@@ -264,10 +252,7 @@ void test_areal()
     // to break regions at self-intersection points (postponed)
 
     TEST_UNION_IGNORE(case_recursive_boxes_12_invalid, 5, 0, -1, 6.0);
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
-    // Only apply it with self-turns. Without them a whole part is missed
     TEST_UNION_IGNORE(case_recursive_boxes_13_invalid, 2, 0, -1, 10.25);
-#endif
     TEST_UNION_IGNORE(case_recursive_boxes_14_invalid, 4, 0, -1, 4.5);
 
     test_one<Polygon, MultiPolygon, MultiPolygon>("case_recursive_boxes_15",
@@ -346,42 +331,17 @@ void test_areal()
     TEST_UNION(case_recursive_boxes_46, 1, 4, 51, 33.0);
     TEST_UNION(case_recursive_boxes_47, 1, 0, -1, 22.0);
     TEST_UNION(case_recursive_boxes_48, 1, 1, -1, 10.0);
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_UNION(case_recursive_boxes_49, 1, 3, -1, 59.0);
-#else
-    TEST_UNION_IGNORE(case_recursive_boxes_49, 1, 2, -1, 59.0);
-#endif
-
     TEST_UNION(case_recursive_boxes_50, 7, 4, -1, 68.0);
-
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_UNION(case_recursive_boxes_51, 2, 6, -1, 75.0);
-#else
-    TEST_UNION_IGNORE(case_recursive_boxes_51, 2, 5, -1, 75.0);
-#endif
-
     TEST_UNION(case_recursive_boxes_52, 2, 6, -1, 77.0);
     TEST_UNION(case_recursive_boxes_53, 1, 1, -1, 24.75);
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_UNION(case_recursive_boxes_54, 1, 2, -1, 22.5);
-#else
-    TEST_UNION_IGNORE(case_recursive_boxes_54, 1, 1, -1, 22.5);
-#endif
-
     TEST_UNION(case_recursive_boxes_55, 3, 1, -1, 15.5);
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_UNION(case_recursive_boxes_56, 5, 1, -1, 7.75);
-#else
-    TEST_UNION_IGNORE(case_recursive_boxes_56, 5, 0, -1, 7.75);
-#endif
     TEST_UNION(case_recursive_boxes_57, 3, 4, -1, 19.75);
     TEST_UNION(case_recursive_boxes_58, 6, 1, -1, 6.25);
-
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
-    // If there are no self-turns, an interior ring is missed
     TEST_UNION(case_recursive_boxes_59, 1, 3, -1, 21.75);
-#endif
-
     TEST_UNION(case_recursive_boxes_60, 3, 0, -1, 20.5);
     TEST_UNION(case_recursive_boxes_61, 1, 1, -1, 23.5);
     TEST_UNION(case_recursive_boxes_62, 2, 3, -1, 21.25);
@@ -471,17 +431,8 @@ void test_areal()
     // Generates two polygons, which should (without rescaling) be merged into one
     TEST_UNION(mail_2019_01_21_johan, 2, 0, -1, 0.00058896);
 
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_UNION(mysql_23023665_7, 1, 1, -1, 99.19494);
-#else
-    TEST_UNION_IGNORE(mysql_23023665_7, 1, 0, -1, 99.19494);
-#endif
-
-#ifndef BOOST_GEOMETRY_NO_SELF_TURNS
     TEST_UNION(mysql_23023665_8, 1, 2, -1, 1400.0);
-#else
-    TEST_UNION_IGNORE(mysql_23023665_8, 1, 1, -1, 1400.0);
-#endif
 
     test_one<Polygon, MultiPolygon, MultiPolygon>("mysql_23023665_9",
         mysql_23023665_9[0], mysql_23023665_9[1],


### PR DESCRIPTION
Please review, I would like to merge this.
It removes the BOOST_GEOMETRY_NO_SELF_TURN conditions from the unit tests.
Because self turns are stable, necessary, and unit testing without them is not tested anymore and can be omitted now.,