### PR TITLE
Add new algorithm detail::calculate_point_order() with strategies (and optimize remove_spikes()).

### DIFF
--- a/include/boost/geometry/algorithms/detail/calculate_point_order.hpp
+++ b/include/boost/geometry/algorithms/detail/calculate_point_order.hpp
@@ -1,0 +1,380 @@
+// Boost.Geometry
+
+// Copyright (c) 2019, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+#ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_CALCULATE_POINT_ORDER_HPP
+#define BOOST_GEOMETRY_ALGORITHMS_DETAIL_CALCULATE_POINT_ORDER_HPP
+
+
+#include <vector>
+
+#include <boost/mpl/assert.hpp>
+
+#include <boost/geometry/algorithms/area.hpp>
+#include <boost/geometry/core/point_order.hpp>
+#include <boost/geometry/core/radian_access.hpp>
+#include <boost/geometry/strategies/geographic/point_order.hpp>
+#include <boost/geometry/util/math.hpp>
+#include <boost/geometry/util/range.hpp>
+
+
+namespace boost { namespace geometry
+{
+
+namespace strategy { namespace order
+{
+
+
+
+}} // namespace strategy::order
+
+namespace detail
+{
+
+template <typename Iter, typename CalcT>
+struct clean_point
+{
+    explicit clean_point(Iter const& iter)
+        : m_iter(iter), m_azi(0), m_razi(0), m_azi_diff(0)
+        , m_is_azi_valid(false), m_is_azi_diff_valid(false)
+    {}
+
+    clean_point(Iter const& iter, CalcT const& azi, CalcT const& azi_diff)
+        : m_iter(iter), m_azi(azi), m_razi(0), m_azi_diff(azi_diff)
+        , m_is_azi_valid(true), m_is_azi_diff_valid(false)
+    {}
+
+    typename boost::iterators::iterator_reference<Iter>::type ref() const
+    {
+        return *m_iter;
+    }
+
+    CalcT const& azimuth() const
+    {
+        return m_azi;
+    }
+
+    CalcT const& reverse_azimuth() const
+    {
+        return m_razi;
+    }
+
+    CalcT const& azimuth_difference() const
+    {
+        return m_azi_diff;
+    }
+
+    void set_azimuths(CalcT const& azi, CalcT const& razi)
+    {
+        m_azi = azi;
+        m_razi = razi;
+        m_is_azi_valid = true;
+    }
+
+    void set_azimuth_invalid()
+    {
+        m_is_azi_valid = false;
+    }
+
+    bool is_azimuth_valid() const
+    {
+        return m_is_azi_valid;
+    }
+
+    void set_azimuth_difference(CalcT const& diff)
+    {
+        m_azi_diff = diff;
+        m_is_azi_diff_valid = true;
+    }
+
+    void set_azimuth_difference_invalid()
+    {
+        m_is_azi_diff_valid = false;
+    }
+
+    bool is_azimuth_difference_valid() const
+    {
+        return m_is_azi_diff_valid;
+    }
+
+private:
+    Iter m_iter;
+    CalcT m_azi;
+    CalcT m_razi;
+    CalcT m_azi_diff;
+    bool m_is_azi_valid;
+    bool m_is_azi_diff_valid;
+};
+
+struct calculate_point_order_by_azimuth
+{
+    template <typename Ring, typename Strategy>
+    static geometry::order_selector apply(Ring const& ring, Strategy const& strategy)
+    {
+        typedef typename boost::range_iterator<Ring const>::type iter_t;
+        typedef typename Strategy::template result_type<Ring>::type calc_t;
+        typedef clean_point<iter_t, calc_t> clean_point_t;
+        typedef std::vector<clean_point_t> cleaned_container_t;
+        typedef typename cleaned_container_t::iterator cleaned_iter_t;
+
+        calc_t const zero = 0;
+        calc_t const pi = math::pi<calc_t>();
+
+        std::size_t const count = boost::size(ring);
+        if (count < 3)
+        {
+            return geometry::order_undetermined;
+        }
+
+        // non-duplicated, non-spike points
+        cleaned_container_t cleaned;
+        cleaned.reserve(count);
+
+        for (iter_t it = boost::begin(ring); it != boost::end(ring); ++it)
+        {
+            // Add point
+            cleaned.push_back(clean_point_t(it));
+            
+            while (cleaned.size() >= 3)
+            {
+                cleaned_iter_t it0 = cleaned.end() - 3;
+                cleaned_iter_t it1 = cleaned.end() - 2;
+                cleaned_iter_t it2 = cleaned.end() - 1;
+
+                calc_t diff;                
+                if (get_or_calculate_azimuths_difference(*it0, *it1, *it2, diff, strategy)
+                    && ! math::equals(math::abs(diff), pi))
+                {
+                    // neither duplicate nor a spike - difference already stored
+                    break;
+                }
+                else
+                {
+                    // spike detected
+                    // TODO: angles have to be invalidated only if spike is detected
+                    // for duplicates it'd be ok to leave them
+                    it0->set_azimuth_invalid();
+                    it0->set_azimuth_difference_invalid();                    
+                    it2->set_azimuth_difference_invalid();
+                    cleaned.erase(it1);
+                }
+            }
+        }
+
+        // filter-out duplicates and spikes at the front and back of cleaned
+        cleaned_iter_t cleaned_b = cleaned.begin();
+        cleaned_iter_t cleaned_e = cleaned.end();
+        bool found = false;
+        do
+        {
+            found = false;
+            std::ptrdiff_t cleaned_count = std::distance(cleaned_b, cleaned_e);
+
+            while(cleaned_count >= 3)
+            {
+                cleaned_iter_t it0 = cleaned_e - 2;
+                cleaned_iter_t it1 = cleaned_e - 1;
+                cleaned_iter_t it2 = cleaned_b;
+                cleaned_iter_t it3 = cleaned_b + 1;
+
+                calc_t diff = 0;
+                if (! get_or_calculate_azimuths_difference(*it0, *it1, *it2, diff, strategy)
+                    || math::equals(math::abs(diff), pi))
+                {
+                    // spike at the back
+                    // TODO: angles have to be invalidated only if spike is detected
+                    // for duplicates it'd be ok to leave them
+                    it0->set_azimuth_invalid();
+                    it0->set_azimuth_difference_invalid();
+                    it2->set_azimuth_difference_invalid();
+                    --cleaned_e;
+                    found = true;
+                }
+                else if (! get_or_calculate_azimuths_difference(*it1, *it2, *it3, diff, strategy)
+                         || math::equals(math::abs(diff), pi))
+                {
+                    // spike at the front
+                    // TODO: angles have to be invalidated only if spike is detected
+                    // for duplicates it'd be ok to leave them
+                    it1->set_azimuth_invalid();
+                    it1->set_azimuth_difference_invalid();
+                    it3->set_azimuth_difference_invalid();
+                    ++cleaned_b;
+                    found = true;
+                }
+                else
+                {
+                    break;
+                }
+            }
+        }
+        while (found);
+
+        std::ptrdiff_t cleaned_count = std::distance(cleaned_b, cleaned_e);
+        if (cleaned_count < 3)
+        {
+            return geometry::order_undetermined;
+        }
+
+        // calculate the sum of external angles
+        calc_t angles_sum = zero;
+        for (cleaned_iter_t it = cleaned_b; it != cleaned_e; ++it)
+        {
+            cleaned_iter_t it0 = (it == cleaned_b ? cleaned_e - 1 : it - 1);
+            cleaned_iter_t it2 = (it == cleaned_e - 1 ? cleaned_b : it + 1);
+
+            calc_t diff = 0;
+            get_or_calculate_azimuths_difference(*it0, *it, *it2, diff, strategy);
+
+            angles_sum += diff;
+        }
+
+#ifdef BOOST_GEOMETRY_DEBUG_POINT_ORDER
+        std::cout << angles_sum  << " for " << geometry::wkt(ring) << std::endl;
+#endif
+
+        return angles_sum == zero ? geometry::order_undetermined
+             : angles_sum > zero  ? geometry::clockwise
+                                  : geometry::counterclockwise;
+    }
+
+private:
+    template <typename Iter, typename T, typename Strategy>
+    static bool get_or_calculate_azimuths_difference(clean_point<Iter, T> & p0,
+                                                     clean_point<Iter, T> & p1,
+                                                     clean_point<Iter, T> const& p2,
+                                                     T & diff,
+                                                     Strategy const& strategy)
+    {
+        if (p1.is_azimuth_difference_valid())
+        {
+            diff = p1.azimuth_difference();
+            return true;
+        }
+
+        T azi1, razi1, azi2, razi2;
+        if (get_or_calculate_azimuths(p0, p1, azi1, razi1, strategy)
+            && get_or_calculate_azimuths(p1, p2, azi2, razi2, strategy))
+        {
+            diff = strategy.apply(p0.ref(), p1.ref(), p2.ref(), razi1, azi2);
+            p1.set_azimuth_difference(diff);
+            return true;
+        }
+        return false;
+    }
+
+    template <typename Iter, typename T, typename Strategy>
+    static bool get_or_calculate_azimuths(clean_point<Iter, T> & p0,
+                                          clean_point<Iter, T> const& p1,
+                                          T & azi, T & razi,
+                                          Strategy const& strategy)
+    {
+        if (p0.is_azimuth_valid())
+        {
+            azi = p0.azimuth();
+            razi = p0.reverse_azimuth();
+            return true;
+        }
+        
+        if (strategy.apply(p0.ref(), p1.ref(), azi, razi))
+        {
+            p0.set_azimuths(azi, razi);
+            return true;
+        }
+
+        return false;
+    }
+};
+
+struct calculate_point_order_by_area
+{
+    template <typename Ring, typename Strategy>
+    static geometry::order_selector apply(Ring const& ring, Strategy const& strategy)
+    {
+        typedef detail::area::ring_area
+            <
+                geometry::order_as_direction<geometry::point_order<Ring>::value>::value,
+                geometry::closure<Ring>::value
+            > ring_area_type;
+
+        typedef typename area_result
+            <
+                Ring, Strategy
+            >::type result_type;
+
+        result_type const result = ring_area_type::apply(ring, strategy);
+
+        result_type const zero = 0;
+        return result == zero ? geometry::order_undetermined
+             : result > zero  ? geometry::clockwise
+                              : geometry::counterclockwise;
+    }
+};
+
+} // namespace detail
+
+namespace dispatch
+{
+
+template
+<
+    typename Strategy,
+    typename VersionTag = typename Strategy::version_tag
+>
+struct calculate_point_order
+{
+    BOOST_MPL_ASSERT_MSG
+    (
+        false, NOT_IMPLEMENTED_FOR_THIS_TAG, (types<VersionTag>)
+    );
+};
+
+template <typename Strategy>
+struct calculate_point_order<Strategy, strategy::point_order::area_tag>
+    : geometry::detail::calculate_point_order_by_area
+{};
+
+template <typename Strategy>
+struct calculate_point_order<Strategy, strategy::point_order::azimuth_tag>
+    : geometry::detail::calculate_point_order_by_azimuth
+{};
+
+
+} // namespace dispatch
+
+namespace detail
+{
+
+template <typename Ring, typename Strategy>
+inline geometry::order_selector calculate_point_order(Ring const& ring, Strategy const& strategy)
+{
+    concepts::check<Ring>();
+
+    return dispatch::calculate_point_order<Strategy>::apply(ring, strategy);
+}
+
+template <typename Ring>
+inline geometry::order_selector calculate_point_order(Ring const& ring)
+{
+    typedef typename strategy::point_order::services::default_strategy
+        <
+            typename geometry::cs_tag<Ring>::type
+        >::type strategy_type;
+
+    concepts::check<Ring>();
+
+    return dispatch::calculate_point_order<strategy_type>::apply(ring, strategy_type());
+}
+
+
+} // namespace detail
+
+}} // namespace boost::geometry
+
+
+#endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_CALCULATE_POINT_ORDER_HPP

--- a/include/boost/geometry/algorithms/detail/calculate_point_order.hpp
+++ b/include/boost/geometry/algorithms/detail/calculate_point_order.hpp
@@ -26,13 +26,6 @@
 namespace boost { namespace geometry
 {
 
-namespace strategy { namespace order
-{
-
-
-
-}} // namespace strategy::order
-
 namespace detail
 {
 
@@ -42,11 +35,6 @@ struct clean_point
     explicit clean_point(Iter const& iter)
         : m_iter(iter), m_azi(0), m_razi(0), m_azi_diff(0)
         , m_is_azi_valid(false), m_is_azi_diff_valid(false)
-    {}
-
-    clean_point(Iter const& iter, CalcT const& azi, CalcT const& azi_diff)
-        : m_iter(iter), m_azi(azi), m_razi(0), m_azi_diff(azi_diff)
-        , m_is_azi_valid(true), m_is_azi_diff_valid(false)
     {}
 
     typename boost::iterators::iterator_reference<Iter>::type ref() const
@@ -107,6 +95,8 @@ private:
     CalcT m_azi;
     CalcT m_razi;
     CalcT m_azi_diff;
+    // NOTE: these flags could be removed and replaced with some magic number
+    //       assigned to the above variables, e.g. CalcT(1000).
     bool m_is_azi_valid;
     bool m_is_azi_diff_valid;
 };

--- a/include/boost/geometry/algorithms/detail/calculate_point_order.hpp
+++ b/include/boost/geometry/algorithms/detail/calculate_point_order.hpp
@@ -169,12 +169,11 @@ struct calculate_point_order_by_azimuth
         // filter-out duplicates and spikes at the front and back of cleaned
         cleaned_iter_t cleaned_b = cleaned.begin();
         cleaned_iter_t cleaned_e = cleaned.end();
+        std::size_t cleaned_count = cleaned.size();
         bool found = false;
         do
         {
             found = false;
-            std::ptrdiff_t cleaned_count = std::distance(cleaned_b, cleaned_e);
-
             while(cleaned_count >= 3)
             {
                 cleaned_iter_t it0 = cleaned_e - 2;
@@ -193,6 +192,7 @@ struct calculate_point_order_by_azimuth
                     it0->set_azimuth_difference_invalid();
                     it2->set_azimuth_difference_invalid();
                     --cleaned_e;
+                    --cleaned_count;
                     found = true;
                 }
                 else if (! get_or_calculate_azimuths_difference(*it1, *it2, *it3, diff, strategy)
@@ -205,6 +205,7 @@ struct calculate_point_order_by_azimuth
                     it1->set_azimuth_difference_invalid();
                     it3->set_azimuth_difference_invalid();
                     ++cleaned_b;
+                    --cleaned_count;
                     found = true;
                 }
                 else
@@ -215,7 +216,6 @@ struct calculate_point_order_by_azimuth
         }
         while (found);
 
-        std::ptrdiff_t cleaned_count = std::distance(cleaned_b, cleaned_e);
         if (cleaned_count < 3)
         {
             return geometry::order_undetermined;

--- a/include/boost/geometry/algorithms/remove_spikes.hpp
+++ b/include/boost/geometry/algorithms/remove_spikes.hpp
@@ -84,7 +84,9 @@ struct range_remove_spikes
             return;
         }
 
-        std::deque<point_type> cleaned;
+        std::vector<point_type> cleaned;
+        cleaned.reserve(n);
+
         for (typename boost::range_iterator<Range const>::type it = boost::begin(range);
             it != boost::end(range); ++it)
         {
@@ -102,10 +104,16 @@ struct range_remove_spikes
             }
         }
 
+        typedef typename std::vector<point_type>::iterator cleaned_iterator;
+        cleaned_iterator cleaned_b = cleaned.begin();
+        cleaned_iterator cleaned_e = cleaned.end();
+        std::size_t cleaned_count = cleaned.size();
+
         // For a closed-polygon, remove closing point, this makes checking first point(s) easier and consistent
         if ( BOOST_GEOMETRY_CONDITION(geometry::closure<Range>::value == geometry::closed) )
         {
-            cleaned.pop_back();
+            --cleaned_e;
+            --cleaned_count;
         }
 
         bool found = false;
@@ -113,45 +121,50 @@ struct range_remove_spikes
         {
             found = false;
             // Check for spike in first point
-            int const penultimate = 2;
-            while(cleaned.size() >= 3
-                  && detail::is_spike_or_equal(range::at(cleaned, cleaned.size() - penultimate),
-                                               range::back(cleaned),
-                                               range::front(cleaned),
+            while(cleaned_count >= 3
+                  && detail::is_spike_or_equal(*(cleaned_e - 2), // prev
+                                               *(cleaned_e - 1), // back
+                                               *(cleaned_b),     // front
                                                strategy))
             {
-                cleaned.pop_back();
+                --cleaned_e;
+                --cleaned_count;
                 found = true;
             }
             // Check for spike in second point
-            while(cleaned.size() >= 3
-                  && detail::is_spike_or_equal(range::back(cleaned),
-                                               range::front(cleaned),
-                                               range::at(cleaned, 1),
+            while(cleaned_count >= 3
+                  && detail::is_spike_or_equal(*(cleaned_e - 1), // back
+                                               *(cleaned_b),     // front
+                                               *(cleaned_b + 1), // next
                                                strategy))
             {
-                cleaned.pop_front();
+                ++cleaned_b;
+                --cleaned_count;
                 found = true;
             }
         }
         while (found);
 
-        if (cleaned.size() == 2)
+        if (cleaned_count == 2)
         {
             // Ticket #9871: open polygon with only two points.
             // the second point forms, by definition, a spike
-            cleaned.pop_back();
+            --cleaned_e;
+            //--cleaned_count;
         }
 
         // Close if necessary
         if ( BOOST_GEOMETRY_CONDITION(geometry::closure<Range>::value == geometry::closed) )
         {
-            cleaned.push_back(cleaned.front());
+            BOOST_GEOMETRY_ASSERT(cleaned_e != cleaned.end());
+            *cleaned_e = *cleaned_b;
+            ++cleaned_e;
+            //++cleaned_count;
         }
 
         // Copy output
         geometry::clear(range);
-        std::copy(cleaned.begin(), cleaned.end(), range::back_inserter(range));
+        std::copy(cleaned_b, cleaned_e, range::back_inserter(range));
     }
 };
 

--- a/include/boost/geometry/strategies/cartesian/point_order.hpp
+++ b/include/boost/geometry/strategies/cartesian/point_order.hpp
@@ -1,0 +1,48 @@
+// Boost.Geometry
+
+// Copyright (c) 2019, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+#ifndef BOOST_GEOMETRY_STRATEGIES_CARTESIAN_POINT_ORDER_HPP
+#define BOOST_GEOMETRY_STRATEGIES_CARTESIAN_POINT_ORDER_HPP
+
+
+#include <boost/geometry/core/tags.hpp>
+
+#include <boost/geometry/strategies/point_order.hpp>
+#include <boost/geometry/strategies/cartesian/area.hpp>
+
+
+namespace boost { namespace geometry
+{
+
+namespace strategy { namespace point_order
+{
+
+template <typename CalculationType = void>
+struct cartesian
+    : strategy::area::cartesian<CalculationType>
+{
+    typedef area_tag version_tag;
+};
+
+namespace services
+{
+
+template <>
+struct default_strategy<cartesian_tag>
+{
+    typedef cartesian<> type;
+};
+
+} // namespace services
+
+}} // namespace strategy::point_order
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_STRATEGIES_CARTESIAN_POINT_ORDER_HPP

--- a/include/boost/geometry/strategies/geographic/point_order.hpp
+++ b/include/boost/geometry/strategies/geographic/point_order.hpp
@@ -1,0 +1,120 @@
+// Boost.Geometry
+
+// Copyright (c) 2019, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+#ifndef BOOST_GEOMETRY_STRATEGIES_GEOGRAPHIC_POINT_ORDER_HPP
+#define BOOST_GEOMETRY_STRATEGIES_GEOGRAPHIC_POINT_ORDER_HPP
+
+
+#include <boost/geometry/core/tags.hpp>
+
+#include <boost/geometry/srs/spheroid.hpp>
+
+#include <boost/geometry/strategies/geographic/parameters.hpp>
+#include <boost/geometry/strategies/point_order.hpp>
+#include <boost/geometry/strategies/spherical/point_in_point.hpp>
+
+#include <boost/geometry/util/math.hpp>
+#include <boost/geometry/util/select_calculation_type.hpp>
+
+
+namespace boost { namespace geometry
+{
+
+namespace strategy { namespace point_order
+{
+
+template
+    <
+        typename FormulaPolicy = strategy::andoyer,
+        typename Spheroid = srs::spheroid<double>,
+        typename CalculationType = void
+    >
+struct geographic
+{
+    typedef azimuth_tag version_tag;
+
+    template <typename Geometry>
+    struct result_type
+    {
+        typedef typename geometry::select_calculation_type_alt
+            <
+                CalculationType, Geometry
+            >::type type;
+    };
+
+    geographic()
+    {}
+
+    explicit geographic(Spheroid const& spheroid)
+        : m_spheroid(spheroid)
+    {}
+
+    template <typename Point>
+    inline bool apply(Point const& p1, Point const& p2,
+                      typename result_type<Point>::type & azi,
+                      typename result_type<Point>::type & razi) const
+    {
+        typedef typename result_type<Point>::type calc_t;
+
+        if (equals_point_point(p1, p2))
+        {
+            return false;
+        }
+
+        formula::result_inverse<calc_t> res = FormulaPolicy::template inverse
+            <
+                calc_t, false, true, true, false, false
+            >::apply(geometry::get_as_radian<0>(p1),
+                     geometry::get_as_radian<1>(p1),
+                     geometry::get_as_radian<0>(p2),
+                     geometry::get_as_radian<1>(p2),
+                     m_spheroid);
+
+        azi = res.azimuth;
+        razi = res.reverse_azimuth;
+
+        return true;
+    }
+
+    template <typename Point>
+    inline typename result_type<Point>::type
+    apply(Point const& /*p0*/, Point const& /*p1*/, Point const& /*p2*/,
+          typename result_type<Point>::type const& azi1,
+          typename result_type<Point>::type const& azi2) const
+    {
+        // TODO: support poles
+        return math::longitude_distance_signed<radian>(azi1, azi2);
+    }
+
+private:
+    template <typename Point>
+    static bool equals_point_point(Point const& p0, Point const& p1)
+    {
+        return strategy::within::spherical_point_point::apply(p0, p1);
+    }
+
+    Spheroid m_spheroid;
+};
+
+namespace services
+{
+
+template <>
+struct default_strategy<geographic_tag>
+{
+    typedef geographic<> type;
+};
+
+} // namespace services
+
+}} // namespace strategy::point_order
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_STRATEGIES_GEOGRAPHIC_POINT_ORDER_HPP

--- a/include/boost/geometry/strategies/point_order.hpp
+++ b/include/boost/geometry/strategies/point_order.hpp
@@ -1,0 +1,45 @@
+// Boost.Geometry
+
+// Copyright (c) 2019, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+#ifndef BOOST_GEOMETRY_STRATEGIES_POINT_ORDER_HPP
+#define BOOST_GEOMETRY_STRATEGIES_POINT_ORDER_HPP
+
+
+#include <boost/mpl/assert.hpp>
+
+
+namespace boost { namespace geometry
+{
+
+namespace strategy { namespace point_order
+{
+
+struct area_tag {};
+struct azimuth_tag {};
+
+namespace services
+{
+
+template <typename CSTag>
+struct default_strategy
+{
+    BOOST_MPL_ASSERT_MSG
+        (
+            false, NOT_IMPLEMENTED_FOR_THIS_CS
+            , (types<CSTag>)
+        );
+};
+
+} // namespace services
+
+}} // namespace strategy::point_order
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_STRATEGIES_POINT_ORDER_HPP

--- a/include/boost/geometry/strategies/spherical/point_order.hpp
+++ b/include/boost/geometry/strategies/spherical/point_order.hpp
@@ -11,10 +11,19 @@
 #define BOOST_GEOMETRY_STRATEGIES_SPHERICAL_POINT_ORDER_HPP
 
 
+#include <boost/type_traits/is_same.hpp>
+
+
 #include <boost/geometry/core/tags.hpp>
 
-#include <boost/geometry/strategies/point_order.hpp>
+#include <boost/geometry/formulas/spherical.hpp>
+
 #include <boost/geometry/strategies/spherical/area.hpp>
+#include <boost/geometry/strategies/spherical/point_in_point.hpp>
+#include <boost/geometry/strategies/point_order.hpp>
+
+#include <boost/geometry/util/math.hpp>
+#include <boost/geometry/util/select_calculation_type.hpp>
 
 
 namespace boost { namespace geometry
@@ -22,6 +31,83 @@ namespace boost { namespace geometry
 
 namespace strategy { namespace point_order
 {
+
+//template <typename CalculationType = void>
+//struct spherical
+//{
+//    typedef azimuth_tag version_tag;
+//
+//    template <typename Geometry>
+//    struct result_type
+//    {
+//        typedef typename geometry::select_calculation_type_alt
+//            <
+//                CalculationType, Geometry
+//            >::type type;
+//    };
+//
+//    template <typename Point>
+//    inline bool apply(Point const& p1, Point const& p2,
+//                      typename result_type<Point>::type & azi,
+//                      typename result_type<Point>::type & razi) const
+//    {
+//        typedef typename result_type<Point>::type calc_t;
+//
+//        if (equals_point_point(p1, p2))
+//        {
+//            return false;
+//        }
+//
+//        calc_t lon1 = geometry::get_as_radian<0>(p1);
+//        calc_t lat1 = geometry::get_as_radian<1>(p1);
+//        calc_t lon2 = geometry::get_as_radian<0>(p2);
+//        calc_t lat2 = geometry::get_as_radian<1>(p2);
+//
+//        convert_latitudes<Point>(lat1, lat2);
+//
+//        formula::result_spherical<calc_t>
+//            res = formula::spherical_azimuth<calc_t, true>(lon1, lat1, lon2, lat2);
+//
+//        azi = res.azimuth;
+//        razi = res.reverse_azimuth;
+//
+//        return true;
+//    }
+//
+//    template <typename Point>
+//    inline typename result_type<Point>::type
+//    apply(Point const& /*p0*/, Point const& /*p1*/, Point const& /*p2*/,
+//          typename result_type<Point>::type const& azi1,
+//          typename result_type<Point>::type const& azi2) const
+//    {
+//        // TODO: support poles
+//        return math::longitude_distance_signed<radian>(azi1, azi2);
+//    }
+//
+//private:
+//    template <typename Point>
+//    static bool equals_point_point(Point const& p0, Point const& p1)
+//    {
+//        return strategy::within::spherical_point_point::apply(p0, p1);
+//    }
+//
+//    template <typename Point, typename CalcT>
+//    static void convert_latitudes(CalcT & lat1, CalcT & lat2)
+//    {
+//        static const bool is_polar = boost::is_same
+//            <
+//                typename geometry::cs_tag<Point>::type,
+//                spherical_polar_tag
+//            >::value;
+//
+//        if (BOOST_GEOMETRY_CONDITION(is_polar))
+//        {
+//            CalcT pi_half = math::half_pi<CalcT>();
+//            lat1 = pi_half - lat1;
+//            lat2 = pi_half - lat2;
+//        }
+//    }
+//};
 
 template <typename CalculationType = void>
 struct spherical
@@ -39,11 +125,11 @@ struct default_strategy<spherical_equatorial_tag>
     typedef spherical<> type;
 };
 
-template <>
+/*template <>
 struct default_strategy<spherical_polar_tag>
 {
     typedef spherical<> type;
-};
+};*/
 
 } // namespace services
 

--- a/include/boost/geometry/strategies/spherical/point_order.hpp
+++ b/include/boost/geometry/strategies/spherical/point_order.hpp
@@ -1,0 +1,54 @@
+// Boost.Geometry
+
+// Copyright (c) 2019, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+#ifndef BOOST_GEOMETRY_STRATEGIES_SPHERICAL_POINT_ORDER_HPP
+#define BOOST_GEOMETRY_STRATEGIES_SPHERICAL_POINT_ORDER_HPP
+
+
+#include <boost/geometry/core/tags.hpp>
+
+#include <boost/geometry/strategies/point_order.hpp>
+#include <boost/geometry/strategies/spherical/area.hpp>
+
+
+namespace boost { namespace geometry
+{
+
+namespace strategy { namespace point_order
+{
+
+template <typename CalculationType = void>
+struct spherical
+    : strategy::area::spherical<double, CalculationType>
+{
+    typedef area_tag version_tag;
+};
+
+namespace services
+{
+
+template <>
+struct default_strategy<spherical_equatorial_tag>
+{
+    typedef spherical<> type;
+};
+
+template <>
+struct default_strategy<spherical_polar_tag>
+{
+    typedef spherical<> type;
+};
+
+} // namespace services
+
+}} // namespace strategy::point_order
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_STRATEGIES_SPHERICAL_POINT_ORDER_HPP

--- a/test/algorithms/detail/Jamfile.v2
+++ b/test/algorithms/detail/Jamfile.v2
@@ -16,7 +16,7 @@
 test-suite boost-geometry-algorithms-detail
     :
     [ run as_range.cpp              : : : : algorithms_as_range ]
-	[ run calculate_point_order.cpp : : : : algorithms_calculate_point_order ]
+    [ run calculate_point_order.cpp : : : : algorithms_calculate_point_order ]
     [ run partition.cpp             : : : : algorithms_partition ]
     ;
 

--- a/test/algorithms/detail/Jamfile.v2
+++ b/test/algorithms/detail/Jamfile.v2
@@ -4,8 +4,8 @@
 # Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
 # Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 #
-# This file was modified by Oracle on 2015.
-# Modifications copyright (c) 2015 Oracle and/or its affiliates.
+# This file was modified by Oracle on 2015, 2019.
+# Modifications copyright (c) 2015, 2019 Oracle and/or its affiliates.
 #
 # Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 #
@@ -15,8 +15,9 @@
 
 test-suite boost-geometry-algorithms-detail
     :
-    [ run as_range.cpp  : : : : algorithms_as_range ]
-    [ run partition.cpp : : : : algorithms_partition ]
+    [ run as_range.cpp              : : : : algorithms_as_range ]
+	[ run calculate_point_order.cpp : : : : algorithms_calculate_point_order ]
+    [ run partition.cpp             : : : : algorithms_partition ]
     ;
 
 build-project sections ;

--- a/test/algorithms/detail/calculate_point_order.cpp
+++ b/test/algorithms/detail/calculate_point_order.cpp
@@ -1,0 +1,148 @@
+// Boost.Geometry
+// Unit Test
+
+// Copyright (c) 2019, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+
+#include <geometry_test_common.hpp>
+
+#include <boost/geometry/algorithms/detail/calculate_point_order.hpp>
+
+#include <boost/geometry/geometries/point.hpp>
+#include <boost/geometry/geometries/ring.hpp>
+
+#include <boost/geometry/io/wkt/wkt.hpp>
+
+#include <boost/geometry/strategies/cartesian/point_order.hpp>
+#include <boost/geometry/strategies/geographic/point_order.hpp>
+#include <boost/geometry/strategies/spherical/point_order.hpp>
+
+
+inline const char * order_str(bg::order_selector o)
+{
+    if (o == bg::clockwise)
+        return "clockwise";
+    else if (o == bg::counterclockwise)
+        return "counterclockwise";
+    else
+        return "order_undetermined";
+}
+
+inline const char * cs_str(bg::cartesian_tag)
+{
+    return "cartesian";
+}
+
+inline const char * cs_str(bg::spherical_equatorial_tag)
+{
+    return "spherical_equatorial";
+}
+
+inline const char * cs_str(bg::geographic_tag)
+{
+    return "geographic";
+}
+
+template <typename Ring>
+inline void test_one(Ring const& ring, bg::order_selector expected)
+{
+    typedef typename bg::cs_tag<Ring>::type cs_tag;
+
+    bg::order_selector result = bg::detail::calculate_point_order(ring);
+
+    BOOST_CHECK_MESSAGE(result == expected, "Expected: " << order_str(expected) << " for " << bg::wkt(ring) << " in " << cs_str(cs_tag()));
+
+    if (expected != bg::order_undetermined && result != bg::order_undetermined)
+    {
+        Ring ring_rev = ring;
+
+        std::reverse(boost::begin(ring_rev), boost::end(ring_rev));
+
+        bg::order_selector result_rev = bg::detail::calculate_point_order(ring_rev);
+
+        BOOST_CHECK_MESSAGE(result != result_rev, "Invalid order of reversed: " << bg::wkt(ring) << " in " << cs_str(cs_tag()));
+    }
+}
+
+template <typename P>
+inline void test_one(std::string const& ring_wkt, bg::order_selector expected)
+{
+    //typedef typename bg::cs_tag<P>::type cs_tag;
+
+    bg::model::ring<P> ring;
+    bg::read_wkt(ring_wkt, ring);
+
+    std::size_t n = boost::size(ring);
+    for (size_t i = 1; i < n; ++i)
+    {
+        test_one(ring, expected);
+        std::rotate(boost::begin(ring), boost::begin(ring) + 1, boost::end(ring));
+
+        // it seems that area method doesn't work for invalid "opened" polygons
+        //if (! boost::is_same<cs_tag, bg::geographic_tag>::value)
+        {
+            P p = bg::range::front(ring);
+            bg::range::push_back(ring, p);
+        }
+    }
+}
+
+template <typename P>
+void test_all()
+{
+    // From correct() test, rings rotated and reversed in test_one()
+    test_one<P>("POLYGON((0 0,0 1,1 1,1 0,0 0))", bg::clockwise);
+    test_one<P>("POLYGON((0 0,0 1,1 1,1 0))", bg::clockwise);
+    test_one<P>("POLYGON((0 0,0 4,4 4,4 0,0 0))", bg::clockwise);
+    test_one<P>("POLYGON((1 1,2 1,2 2,1 2,1 1))", bg::counterclockwise);
+
+   test_one<P>("POLYGON((0 5, 5 5, 5 0, 0 0, 0 5))", bg::clockwise);
+   test_one<P>("POLYGON((0 5, 0 5, 0 6, 0 6, 0 4, 0 5, 5 5, 5 0, 0 0, 0 6, 0 5))", bg::clockwise);
+   test_one<P>("POLYGON((2 0, 2 1, 2 -1, 2 0, 1 0, 1 -1, 0 -1, 0 1, 1 1, 1 0, 2 0))", bg::clockwise);
+   test_one<P>("POLYGON((2 0, 2 1, 2 -1, 2 0, 1 0, 1 -1, 0 -1, 0 1, 1 1, 1 0))", bg::clockwise);
+   test_one<P>("POLYGON((2 0, 2 1, 3 1, 3 -1, 2 -1, 2 0, 1 0, 1 -1, 0 -1, 0 1, 1 1, 1 0, 2 0))", bg::clockwise);
+   test_one<P>("POLYGON((0 85, 5 85, 5 84, 0 84, 0 85))", bg::clockwise);
+   test_one<P>("POLYGON((0 2, 170 2, 170 0, 0 0, 0 2))", bg::clockwise);
+   test_one<P>("POLYGON((0 2, 170 2, 170 1, 160 1, 10 1, 0 1, 0 2))", bg::clockwise);
+   test_one<P>("POLYGON((0 2, 170 2, 170 -2, 0 -2, 0 2))", bg::clockwise);
+   test_one<P>("POLYGON((5 5, 6 5, 6 6, 6 4, 6 5, 5 5, 5 4, 4 4, 4 6, 5 6, 5 5))", bg::clockwise);
+   test_one<P>("POLYGON((5 5, 6 5, 6 6, 6 4, 6 5, 5 5, 5 6, 4 6, 4 4, 5 4, 5 5))", bg::counterclockwise);
+   test_one<P>("POLYGON((5 5, 6 5, 6 5, 6 6, 6 5, 6 4, 6 5, 6 5, 5 5, 5 4, 4 4, 4 6, 5 6, 5 5))", bg::clockwise);
+
+   // https://github.com/boostorg/geometry/pull/554
+   test_one<P>("POLYGON((9.8591674311151110 54.602813224425063, 9.8591651519791412 54.602359676428932, 9.8584586199249316 54.602359676428932, 9.8591674311151110 54.602813224425063))",
+               bg::clockwise);
+}
+
+template <typename P>
+void test_cartesian()
+{
+    test_one<P>("POLYGON((0 5, 1 5, 1 6, 1 4, 2 4, 0 4, 0 3, 0 5))", bg::clockwise);
+}
+
+template <typename P>
+void test_spheroidal()
+{
+    test_one<P>("POLYGON((0 5, 1 5, 1 6, 1 4, 0 4, 0 3, 0 5))", bg::clockwise);
+
+    test_one<P>("POLYGON((0 45, 120 45, -120 45, 0 45))", bg::counterclockwise);
+}
+
+int test_main(int, char* [])
+{
+    test_all<bg::model::point<double, 2, bg::cs::cartesian> >();
+    test_all<bg::model::point<double, 2, bg::cs::spherical_equatorial<bg::degree> > >();
+    test_all<bg::model::point<double, 2, bg::cs::geographic<bg::degree> > >();
+
+    test_cartesian<bg::model::point<double, 2, bg::cs::cartesian> >();
+
+    test_spheroidal<bg::model::point<double, 2, bg::cs::spherical_equatorial<bg::degree> > >();
+    test_spheroidal<bg::model::point<double, 2, bg::cs::geographic<bg::degree> > >();
+    
+    return 0;
+}


### PR DESCRIPTION
This solves the issue caused by inaccurate area calculation for small polygons with andoyer formula.

For geographic CS instead of area the sum of external angles is calculated.

I tried something new with this algorithm. Instead of being dispatched by geometry tag I dispatched it by strategy's `version_tag`.

There are 2 versions of this algorithm:
- area-based which simply calculates the area and checks its value
- azimuth-based which filters out point duplicates and spikes (it's modified version of `remove_spikes`)

The version of an algorithm is defined by the strategy as a member type `version_tag`. The reason for this is that both algorithms are very different and the alternative would be to implement everything in strategies.

This algorithm works for Rings only (actually Ranges of points). It returns one of three values of type `bg::order_selector`.

As mentioned before geographic, azimuth-based version in modified `remove_spikes`. Instead of calling side strategy (2 azimuth calculated per point) it performs 1 azimuth/reverse-azimuth calculation per segment if needed and stores the result for future use. This means that 2x less azimuths are calculated compared to `remove_spike`. Spike detection is a side effect of the "normal" calculation of external angle for each segment. At a point reverse azimuth of previous segment is subtracted from azimuth of the next segment. Also because azimuths are the only thing that is calculated it's faster than `area` which does other things.

Benchmark results (of area, point_order and remove_spikes as a bonus, plus time taken to calculate azimuth for each segment of a ring):

Circle containing 2000001 points.

| formula | `area` | `remove_spikes` | `calculate_point_order` | azimuth for each segment |
| ----- | ----- | ----- | ----- | ----- |
| andoyer | 1.752 | 1.993 | **1.014** | 0.766 |
| thomas | 2.05 | 2.54 | **1.289** | 1.004 |
| vincenty | 2.723 | 2.858 | **1.646** | 1.184 |

Invalid polygon being one spike `(0 0, 45 45, 0 0, 45 45, ...)` containing 2000001 points.

| formula | `area` | `remove_spikes` | `calculate_point_order` | azimuth for each segment |
| ----- | ----- | ----- | ----- | ----- |
| andoyer | 1.572 | 1.192 | **0.948** | 0.725 |
| thomas | 1.871 | 1.439 | **1.205** | 0.956 |
| vincenty | 3.025 | 2.105 | **1.998** | 1.578 |

Note that `area` is faster than `remove_spikes` in the first case and slower in the second. My guess is that it has something to do with the fact that `remove_spikes` uses a vector of cleared points which is used to store points not being spikes nor duplicates and that in the second case all of the points are spike points so they are being cleared as they go and this temporary vector has at most 4 elements.

Note that in the second case the times of `remove_spikes` and `calculate_point_order` are similar. ~My guess is that it's because here the number of azimuths calculation is not 2x smaller as I stated before because if spike is detected in `calculate_point_order` the azimuths has to be recalculated for both neighboring segments which means that more azimuth calculations is performed here (Looks like 2x as many but I haven't checked)~.

Btw, I think `remove_spikes` could be slightly optimized:
- `cleared` container could contain only iterators to the original points
- the finalizing removal of spikes at the beginning and end of the container could be removed by range of iterators which means that `deque` could be replaced by `vector`.

I've done this in `calculate_point_order` and it seemed to be faster than the original. This is also probably the case why in the second benchmark `calculate_point_order` is still faster than `remove_spikes`.

But to be sure what's happening exactly more investigation would be needed.

EDIT:

I checked the numbers of azimuth calculations and the above remark about 2x as many calculations is not true. These are the numbers of inverse formula calls:

| benchmark # | `area` | `remove_spikes` | `calculate_point_order` |
| ----- | ----- | ----- | ----- |
| 1 | 2000000 | 4000002 | 2000001 |
| 2 | 2000000 | 4000002 | 2000000 |

So the small difference above is not due to the number of azimuths called but something else. Above I also added benchmark for pure azimuths calculation as a base-line. So I don't know right now why does `remove_spike` times fluctuate so much. It's very similar algorithm to `calculate_point_order`. Maybe I'll try to do the same modifications there (mainly replace deque with vector) and see what happens.