### PR TITLE
Add a constructor that takes matrix_type to matrix_transformer<CalculationType, 3, 3>

### DIFF
--- a/include/boost/geometry/strategies/transform/matrix_transformers.hpp
+++ b/include/boost/geometry/strategies/transform/matrix_transformers.hpp
@@ -129,6 +129,10 @@ public :
                     m_2_0, m_2_1, m_2_2)
     {}
 
+    inline matrix_transformer(matrix_type const& matrix)
+        : m_matrix(matrix)
+    {}
+
     inline matrix_transformer()
         : matrix_transformer<CalculationType, 2, 2>()
     {}

--- a/include/boost/geometry/strategies/transform/matrix_transformers.hpp
+++ b/include/boost/geometry/strategies/transform/matrix_transformers.hpp
@@ -157,6 +157,10 @@ public :
         qvm::A<3,0>(m_matrix) = m_3_0; qvm::A<3,1>(m_matrix) = m_3_1; qvm::A<3,2>(m_matrix) = m_3_2; qvm::A<3,3>(m_matrix) = m_3_3;
     }
 
+    inline matrix_transformer(matrix_type const& matrix)
+        : m_matrix(matrix)
+    {}
+
     inline matrix_transformer() {}
 
     template <typename P1, typename P2>

--- a/include/boost/geometry/strategies/transform/matrix_transformers.hpp
+++ b/include/boost/geometry/strategies/transform/matrix_transformers.hpp
@@ -117,6 +117,7 @@ template <typename CalculationType>
 class matrix_transformer<CalculationType, 3, 2> : public matrix_transformer<CalculationType, 2, 2>
 {
     typedef CalculationType ct;
+    typedef boost::qvm::mat<ct, 3, 3> matrix_type;
 
 public :
     inline matrix_transformer(
@@ -127,6 +128,10 @@ public :
                     m_0_0, m_0_1, m_0_2,
                     m_1_0, m_1_1, m_1_2,
                     m_2_0, m_2_1, m_2_2)
+    {}
+
+    inline matrix_transformer(matrix_type const& matrix)
+        : matrix_transformer<CalculationType, 2,2>(matrix)
     {}
 
     inline matrix_transformer()

--- a/include/boost/geometry/strategies/transform/matrix_transformers.hpp
+++ b/include/boost/geometry/strategies/transform/matrix_transformers.hpp
@@ -129,10 +129,6 @@ public :
                     m_2_0, m_2_1, m_2_2)
     {}
 
-    inline matrix_transformer(matrix_type const& matrix)
-        : m_matrix(matrix)
-    {}
-
     inline matrix_transformer()
         : matrix_transformer<CalculationType, 2, 2>()
     {}


### PR DESCRIPTION
The example file 06_b_transformation_example contains this useful example for composing matrix_transformers
`matrix_transformer<double, 2, 2> combined(rotate.matrix() * translate.matrix());`.

The analogue of this for matrix_transformer<CalculationType, 3, 3> causes a compiler error because the corresponding constructor is missing in the 3d case. This pull request is designed to fix this by adding the constructor 
`    inline matrix_transformer(matrix_type const& matrix)
        : m_matrix(matrix)
    {}`
to matrix_transformer<CalculationType, 3, 3>.