### PR TITLE
Fix azimuth validity in geographic_point_circle buffer strategy.

### DIFF
--- a/include/boost/geometry/formulas/differential_quantities.hpp
+++ b/include/boost/geometry/formulas/differential_quantities.hpp
@@ -11,6 +11,7 @@
 #ifndef BOOST_GEOMETRY_FORMULAS_INVERSE_DIFFERENTIAL_QUANTITIES_HPP
 #define BOOST_GEOMETRY_FORMULAS_INVERSE_DIFFERENTIAL_QUANTITIES_HPP
 
+#include <boost/geometry/core/assert.hpp>
 
 #include <boost/geometry/util/condition.hpp>
 #include <boost/geometry/util/math.hpp>
@@ -73,6 +74,9 @@ public:
             CT const sig_12 = dlon / one_minus_f;
             if (BOOST_GEOMETRY_CONDITION(EnableReducedLength))
             {
+                CT const pi = math::pi<CT>();
+                BOOST_GEOMETRY_ASSERT(-pi <= azimuth && azimuth <= pi);
+
                 int azi_sign = math::sign(azimuth) >= 0 ? 1 : -1; // for antipodal
                 CT m12 = azi_sign * sin(sig_12) * b;
                 reduced_length = m12;

--- a/include/boost/geometry/formulas/differential_quantities.hpp
+++ b/include/boost/geometry/formulas/differential_quantities.hpp
@@ -74,8 +74,7 @@ public:
             CT const sig_12 = dlon / one_minus_f;
             if (BOOST_GEOMETRY_CONDITION(EnableReducedLength))
             {
-                CT const pi = math::pi<CT>();
-                BOOST_GEOMETRY_ASSERT(-pi <= azimuth && azimuth <= pi);
+                BOOST_GEOMETRY_ASSERT((-math::pi<CT>() <= azimuth && azimuth <= math::pi<CT>()));
 
                 int azi_sign = math::sign(azimuth) >= 0 ? 1 : -1; // for antipodal
                 CT m12 = azi_sign * sin(sig_12) * b;

--- a/include/boost/geometry/formulas/thomas_direct.hpp
+++ b/include/boost/geometry/formulas/thomas_direct.hpp
@@ -15,6 +15,7 @@
 
 #include <boost/math/constants/constants.hpp>
 
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/radius.hpp>
 
 #include <boost/geometry/util/condition.hpp>
@@ -79,6 +80,8 @@ public:
 
         CT const pi = math::pi<CT>();
         CT const pi_half = pi / c2;
+
+        BOOST_GEOMETRY_ASSERT(-pi <= azimuth12 && azimuth12 <= pi);
 
         // keep azimuth small - experiments show low accuracy
         // if the azimuth is closer to (+-)180 deg.

--- a/include/boost/geometry/strategies/geographic/buffer_point_circle.hpp
+++ b/include/boost/geometry/strategies/geographic/buffer_point_circle.hpp
@@ -98,7 +98,9 @@ public :
         for (std::size_t i = 0; i < m_count; i++, angle += diff)
         {
             if (angle > pi)
+            {
                 angle -= two_pi;
+            }
 
             typename direct_t::result_type
                 dir_r = direct_t::apply(get_as_radian<0>(point), get_as_radian<1>(point),

--- a/include/boost/geometry/strategies/geographic/buffer_point_circle.hpp
+++ b/include/boost/geometry/strategies/geographic/buffer_point_circle.hpp
@@ -88,6 +88,7 @@ public :
             > direct_t;
 
         calculation_type const two_pi = geometry::math::two_pi<calculation_type>();
+        calculation_type const pi = geometry::math::pi<calculation_type>();
 
         calculation_type const diff = two_pi / calculation_type(m_count);
         // TODO: after calculation of some angles is corrected,
@@ -96,6 +97,9 @@ public :
 
         for (std::size_t i = 0; i < m_count; i++, angle += diff)
         {
+            if (angle > pi)
+                angle -= two_pi;
+
             typename direct_t::result_type
                 dir_r = direct_t::apply(get_as_radian<0>(point), get_as_radian<1>(point),
                                         buffer_distance, angle,


### PR DESCRIPTION
This PR also adds asserts in formulas.

It addresses the issue: https://github.com/boostorg/geometry/issues/542

It also fixed some failing cases for me from algorithms_buffer_point_geo test file (tested only with msvc-14.1).