### PR TITLE
Deactivate old tests that fail or not compile in extensions

### DIFF
--- a/extensions/test/algorithms/Jamfile.v2
+++ b/extensions/test/algorithms/Jamfile.v2
@@ -10,11 +10,11 @@
 
 test-suite boost-geometry-extensions-algorithms
     :
-    [ run dissolve.cpp ]
+#    [ run dissolve.cpp ]
     [ run distance_info.cpp ]
     [ run connect.cpp ]
-    [ run offset.cpp ]
+#    [ run offset.cpp ]
     [ run midpoints.cpp ]
-    [ run selected.cpp ]
+#    [ run selected.cpp ]
     ;
 

--- a/extensions/test/gis/latlong/Jamfile.v2
+++ b/extensions/test/gis/latlong/Jamfile.v2
@@ -10,8 +10,8 @@
 
 test-suite boost-geometry-extensions-gis-latong
     :
-    [ run area_ll.cpp ]
-    [ run cross_track.cpp ]
-    [ run distance_mixed.cpp ]
+#    [ run area_ll.cpp ]
+#    [ run cross_track.cpp ]
+#    [ run distance_mixed.cpp ]
     [ run point_ll.cpp ]
     ;


### PR DESCRIPTION
There are tests in extensions that use old code and does not compile or fail. I propose to deactivate for now and in the future fix them (if  they are relevant) or remove them.