### PR TITLE
Fix disjoint Box/Poly and Box/Seg

### DIFF
--- a/include/boost/geometry/algorithms/detail/disjoint/segment_box.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/segment_box.hpp
@@ -5,8 +5,8 @@
 // Copyright (c) 2009-2014 Mateusz Loskot, London, UK.
 // Copyright (c) 2013-2014 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2013-2018.
-// Modifications copyright (c) 2013-2018, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013-2019.
+// Modifications copyright (c) 2013-2019, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
@@ -114,7 +114,6 @@ struct disjoint_segment_box_sphere_or_spheroid
         assert_dimension_equal<Segment, Box>();
 
         typedef typename point_type<Segment>::type segment_point_type;
-        typedef typename cs_tag<Segment>::type segment_cs_type;
 
         segment_point_type p0, p1;
         geometry::detail::assign_point_from_index<0>(segment, p0);
@@ -160,15 +159,17 @@ struct disjoint_segment_box_sphere_or_spheroid
 
         geometry::model::box<segment_point_type> box_seg;
 
-        // TODO: Shouldn't CSTag be taken from the caller, not from the segment?
+        // TODO: alp1 commented out due to the inconsistent handling of
+        //   coordinates and azimuth internally coordinates may be modified
+        //   before calculation but passed azimuth is not adapted to changes
         strategy::envelope::detail::envelope_segment_impl
             <
-                segment_cs_type
+                CS_Tag
             >::template apply<geometry::radian>(lon1, lat1,
                                                 lon2, lat2,
                                                 box_seg,
-                                                azimuth_strategy,
-                                                alp1);
+                                                azimuth_strategy/*,
+                                                alp1*/);
 
         if (disjoint_box_box(box, box_seg, disjoint_box_box_strategy))
         {

--- a/include/boost/geometry/strategies/cartesian/intersection.hpp
+++ b/include/boost/geometry/strategies/cartesian/intersection.hpp
@@ -3,8 +3,8 @@
 // Copyright (c) 2007-2014 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2013-2017 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2014, 2016, 2017, 2018.
-// Modifications copyright (c) 2014-2018, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014, 2016, 2017, 2018, 2019.
+// Modifications copyright (c) 2014-2019, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -35,6 +35,7 @@
 
 #include <boost/geometry/strategies/cartesian/area.hpp>
 #include <boost/geometry/strategies/cartesian/disjoint_box_box.hpp>
+#include <boost/geometry/strategies/cartesian/disjoint_segment_box.hpp>
 #include <boost/geometry/strategies/cartesian/distance_pythagoras.hpp>
 #include <boost/geometry/strategies/cartesian/envelope.hpp>
 #include <boost/geometry/strategies/cartesian/expand_box.hpp>
@@ -169,6 +170,13 @@ struct cartesian_segments
     static inline disjoint_box_box_strategy_type get_disjoint_box_box_strategy()
     {
         return disjoint_box_box_strategy_type();
+    }
+
+    typedef disjoint::segment_box disjoint_segment_box_strategy_type;
+
+    static inline disjoint_segment_box_strategy_type get_disjoint_segment_box_strategy()
+    {
+        return disjoint_segment_box_strategy_type();
     }
 
     typedef covered_by::cartesian_point_box disjoint_point_box_strategy_type;

--- a/include/boost/geometry/strategies/geographic/intersection.hpp
+++ b/include/boost/geometry/strategies/geographic/intersection.hpp
@@ -37,6 +37,7 @@
 #include <boost/geometry/srs/spheroid.hpp>
 
 #include <boost/geometry/strategies/geographic/area.hpp>
+#include <boost/geometry/strategies/geographic/disjoint_segment_box.hpp>
 #include <boost/geometry/strategies/geographic/distance.hpp>
 #include <boost/geometry/strategies/geographic/envelope.hpp>
 #include <boost/geometry/strategies/geographic/parameters.hpp>
@@ -179,6 +180,16 @@ struct geographic_segments
     static inline disjoint_box_box_strategy_type get_disjoint_box_box_strategy()
     {
         return disjoint_box_box_strategy_type();
+    }
+
+    typedef disjoint::segment_box_geographic
+        <
+            FormulaPolicy, Spheroid, CalculationType
+        > disjoint_segment_box_strategy_type;
+
+    inline disjoint_segment_box_strategy_type get_disjoint_segment_box_strategy() const
+    {
+        return disjoint_segment_box_strategy_type(m_spheroid);
     }
 
     typedef covered_by::spherical_point_box disjoint_point_box_strategy_type;

--- a/include/boost/geometry/strategies/spherical/intersection.hpp
+++ b/include/boost/geometry/strategies/spherical/intersection.hpp
@@ -2,7 +2,7 @@
 
 // Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
-// Copyright (c) 2016-2018, Oracle and/or its affiliates.
+// Copyright (c) 2016-2019, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -42,6 +42,7 @@
 #include <boost/geometry/strategies/side_info.hpp>
 #include <boost/geometry/strategies/spherical/area.hpp>
 #include <boost/geometry/strategies/spherical/disjoint_box_box.hpp>
+#include <boost/geometry/strategies/spherical/disjoint_segment_box.hpp>
 #include <boost/geometry/strategies/spherical/distance_haversine.hpp>
 #include <boost/geometry/strategies/spherical/envelope.hpp>
 #include <boost/geometry/strategies/spherical/expand_box.hpp>
@@ -187,6 +188,13 @@ struct ecef_segments
     static inline disjoint_box_box_strategy_type get_disjoint_box_box_strategy()
     {
         return disjoint_box_box_strategy_type();
+    }
+
+    typedef disjoint::segment_box_spherical disjoint_segment_box_strategy_type;
+
+    static inline disjoint_segment_box_strategy_type get_disjoint_segment_box_strategy()
+    {
+        return disjoint_segment_box_strategy_type();
     }
 
     typedef covered_by::spherical_point_box disjoint_point_box_strategy_type;

--- a/test/algorithms/disjoint/disjoint_seg_box.cpp
+++ b/test/algorithms/disjoint/disjoint_seg_box.cpp
@@ -1,6 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2016-2017 Oracle and/or its affiliates.
+// Copyright (c) 2016-2019 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -247,14 +247,12 @@ void disjoint_tests_sph_geo()
                                                              false);
 
     //https://github.com/boostorg/geometry/issues/579
-#ifdef BOOST_GEOMETRY_ENABLE_FAILING_TESTS
     test_disjoint<bg::model::box<P>, bg::model::segment<P> >("BOX(10 10,20 20)",
                                                              "SEGMENT(12 2,12 1)",
                                                              true);
     test_disjoint<bg::model::box<P>, bg::model::segment<P> >("BOX(10 10,20 20)",
                                                              "SEGMENT(12 1,12 2)",
                                                              true);
-#endif
 }
 
 template <typename CT>

--- a/test/algorithms/disjoint/disjoint_sph.cpp
+++ b/test/algorithms/disjoint/disjoint_sph.cpp
@@ -1,6 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2016 Oracle and/or its affiliates.
+// Copyright (c) 2016, 2019 Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -253,6 +253,41 @@ void test_point_polygon()
                            false);
 }
 
+template <typename P>
+void test_box_polygon()
+{
+    typedef bg::model::box<P> box;
+    typedef bg::model::polygon<P> poly;
+
+    // https://github.com/boostorg/geometry/issues/466
+    test_geometry<box, poly>("BOX(2.2 48.88, 2.5 48.9021)",
+                             "POLYGON((2.4 48.90205, 2.4 48.89, 2.3 48.89, 2.3 48.90205, 2.4 48.90205))",
+                             false);
+    test_geometry<box, poly>("BOX(2.2 48.88, 2.5 48.9021)",
+                             "POLYGON((2.4 48.9021, 2.4 48.89, 2.3 48.89, 2.3 48.9021, 2.4 48.9021))",
+                             false);
+    test_geometry<box, poly>("BOX(2.2 48.88, 2.5 48.9021)",
+                             "POLYGON((2.4 48.90215, 2.4 48.89, 2.3 48.89, 2.3 48.90215, 2.4 48.90215))",
+                             false);
+    // extended
+    test_geometry<box, poly>("BOX(2.2 48.88, 2.5 48.9021)",
+                             "POLYGON((2.4 48.9022, 2.4 48.89, 2.3 48.89, 2.3 48.9022, 2.4 48.9022))",
+                             false);
+    // box within poly
+    test_geometry<box, poly>("BOX(2.2 48.88, 2.5 48.9021)",
+                             "POLYGON((2.6 48.9021, 2.6 48.8, 2.1 48.8, 2.1 48.9021, 2.6 48.9021))",
+                             false);
+    test_geometry<box, poly>("BOX(2.2 48.88, 2.5 48.9021)",
+                             "POLYGON((2.6 48.9022, 2.6 48.8, 2.1 48.8, 2.1 48.9022, 2.6 48.9022))",
+                             false);
+
+    // related to https://github.com/boostorg/geometry/issues/579
+    test_geometry<box, poly>("BOX(10 10,20 20)",
+                             "POLYGON((11 0,10 1,11 2,12 3,13 1,11 0),"
+                                     "(12 1,11 1,12 2,12 1))",
+                             true);
+}
+
 
 template <typename P>
 void test_all()
@@ -270,16 +305,19 @@ void test_all()
     test_linestring_multi_linestring<P>();
     test_multi_linestring_multi_linestring<P>();
 
-    test_linestring_linestring_radians<bg::model::point<double, 2,
-                                     bg::cs::spherical_equatorial<bg::radian> > >();
-
     test_point_polygon<P>();
+    test_box_polygon<P>();
 }
 
 
 int test_main( int , char* [] )
 {
-    test_all<bg::model::point<double, 2, bg::cs::spherical_equatorial<bg::degree> > >();
+    typedef bg::model::point<double, 2, bg::cs::spherical_equatorial<bg::degree> > point_deg;
+    typedef bg::model::point<double, 2, bg::cs::spherical_equatorial<bg::radian> > point_rad;
+
+    test_all<point_deg>();
+
+    test_linestring_linestring_radians<point_rad>();
 
 #if defined(HAVE_TTMATH)
     test_cs<bg::model::point<ttmath_big, 2, bg::cs::spherical_equatorial<bg::degree> > >();


### PR DESCRIPTION
This fixes issues https://github.com/boostorg/geometry/issues/466 and https://github.com/boostorg/geometry/issues/579. The latter is fixed by commenting out the `alp1` parameter so it's similar to the proposed fix https://github.com/boostorg/geometry/pull/580 but here the code is not removed in case we decided to keep the parameter. I'm fine with removing it entirely so merging both PRs.