### PR TITLE
Feature/add start turn

### DIFF
--- a/include/boost/geometry/algorithms/detail/overlay/enrich_intersection_points.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/enrich_intersection_points.hpp
@@ -53,9 +53,9 @@ namespace detail { namespace overlay
 {
 
 template <typename Turns>
-struct discarded_turn
+struct discarded_indexed_turn
 {
-    discarded_turn(Turns const& turns)
+    discarded_indexed_turn(Turns const& turns)
         : m_turns(turns)
     {}
 
@@ -272,7 +272,7 @@ inline void enrich_adapt(Operations& operations, Turns& turns)
     }
 
     // Remove discarded turns from operations to avoid having them as next turn
-    discarded_turn<Turns> const predicate(turns);
+    discarded_indexed_turn<Turns> const predicate(turns);
     operations.erase(std::remove_if(boost::begin(operations),
         boost::end(operations), predicate), boost::end(operations));
 }
@@ -425,6 +425,13 @@ inline void enrich_intersection_points(Turns& turns,
             ring_identifier,
             std::vector<indexed_turn_operation>
         > mapped_vector_type;
+
+    // As long as turn indexes are not used yet, turns might be erased from
+    // the vector
+    detail::overlay::erase_colocated_start_turns(turns, geometry1, geometry2);
+
+    // From here on, turn indexes are used (in clusters, next_index, etc)
+    // and may only be flagged as discarded
 
     bool has_cc = false;
     bool const has_colocations

--- a/include/boost/geometry/algorithms/detail/overlay/get_distance_measure.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_distance_measure.hpp
@@ -14,6 +14,8 @@
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/util/select_coordinate_type.hpp>
 
+#include <cmath>
+
 namespace boost { namespace geometry
 {
 
@@ -24,10 +26,10 @@ namespace detail
 template <typename T>
 struct distance_measure
 {
-    T value;
+    T measure;
 
     distance_measure()
-        : value(T())
+        : measure(T())
     {}
 
     bool is_small() const { return true; }
@@ -48,7 +50,7 @@ struct distance_measure_floating
     // This is an arbitrary boundary, to enable some behaviour
     // (for example include or exclude turns), which are checked later
     // with other conditions.
-    bool is_small() const { return std::fabs(measure) < 1.0e-3; }
+    bool is_small() const { return std::abs(measure) < 1.0e-3; }
 
     // Returns true if the distance measure is absolutely zero
     bool is_zero() const { return measure == 0.0; }
@@ -76,9 +78,12 @@ struct distance_measure<float>
 namespace detail_dispatch
 {
 
-template <typename CalculationType, typename Tag>
+// TODO: this is effectively a strategy, but for internal usage.
+// It might be moved to the strategies folder.
+
+template <typename CalculationType, typename CsTag>
 struct get_distance_measure
-        : not_implemented<Tag>
+        : not_implemented<CsTag>
 {};
 
 template <typename CalculationType>
@@ -168,6 +173,7 @@ namespace detail
 // 0 (absolutely 0, not even an epsilon) means collinear. Like side,
 // a negative means that p is to the right of p1-p2. And a positive value
 // means that p is to the left of p1-p2.
+
 template <typename cs_tag, typename SegmentPoint, typename Point>
 static distance_measure<typename select_coordinate_type<SegmentPoint, Point>::type>
 get_distance_measure(SegmentPoint const& p1, SegmentPoint const& p2, Point const& p)

--- a/include/boost/geometry/algorithms/detail/overlay/get_distance_measure.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_distance_measure.hpp
@@ -135,33 +135,8 @@ struct get_distance_measure<CalculationType, spherical_tag>
 };
 
 template <typename CalculationType>
-struct get_distance_measure<CalculationType, spherical_equatorial_tag>
-{
-    typedef detail::distance_measure<CalculationType> result_type;
-
-    template <typename SegmentPoint, typename Point>
-    static result_type apply(SegmentPoint const& , SegmentPoint const& ,
-                             Point const& )
-    {
-        // TODO, optional
-        result_type result;
-        return result;
-    }
-};
-template <typename CalculationType>
 struct get_distance_measure<CalculationType, geographic_tag>
-{
-    typedef detail::distance_measure<CalculationType> result_type;
-
-    template <typename SegmentPoint, typename Point>
-    static result_type apply(SegmentPoint const& , SegmentPoint const& ,
-                             Point const& )
-    {
-        // TODO, optional
-        result_type result;
-        return result;
-    }
-};
+        : get_distance_measure<CalculationType, spherical_tag> {};
 
 
 } // namespace detail_dispatch

--- a/include/boost/geometry/algorithms/detail/overlay/get_distance_measure.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_distance_measure.hpp
@@ -168,14 +168,14 @@ namespace detail
 // 0 (absolutely 0, not even an epsilon) means collinear. Like side,
 // a negative means that p is to the right of p1-p2. And a positive value
 // means that p is to the left of p1-p2.
-template <typename SegmentPoint, typename Point>
+template <typename cs_tag, typename SegmentPoint, typename Point>
 static distance_measure<typename select_coordinate_type<SegmentPoint, Point>::type>
 get_distance_measure(SegmentPoint const& p1, SegmentPoint const& p2, Point const& p)
 {
     return detail_dispatch::get_distance_measure
             <
                 typename select_coordinate_type<SegmentPoint, Point>::type,
-                typename geometry::cs_tag<SegmentPoint>::type
+                cs_tag
             >::apply(p1, p2, p);
 
 }

--- a/include/boost/geometry/algorithms/detail/overlay/get_distance_measure.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_distance_measure.hpp
@@ -1,0 +1,188 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2019 Barend Gehrels, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_DISTANCE_MEASURE_HPP
+#define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_DISTANCE_MEASURE_HPP
+
+#include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/coordinate_system.hpp>
+#include <boost/geometry/core/coordinate_type.hpp>
+#include <boost/geometry/util/select_coordinate_type.hpp>
+
+namespace boost { namespace geometry
+{
+
+#ifndef DOXYGEN_NO_DETAIL
+namespace detail
+{
+
+template <typename T>
+struct distance_measure
+{
+    T value;
+
+    distance_measure()
+        : value(T())
+    {}
+
+    bool is_small() const { return true; }
+    bool is_zero() const { return true; }
+    bool is_positive() const { return false; }
+};
+
+template <typename T>
+struct distance_measure_floating
+{
+    T measure;
+
+    distance_measure_floating()
+        : measure(T())
+    {}
+
+    // Returns true if the distance measure is small.
+    // This is an arbitrary boundary, to enable some behaviour
+    // (for example include or exclude turns), which are checked later
+    // with other conditions.
+    bool is_small() const { return std::fabs(measure) < 1.0e-3; }
+
+    // Returns true if the distance measure is absolutely zero
+    bool is_zero() const { return measure == 0.0; }
+
+    // Returns true if the distance measure is positive. Distance measure
+    // algorithm should return positive value if it is located on the left side.
+    bool is_positive() const { return measure > 0.0; }
+};
+
+template <>
+struct distance_measure<long double>
+    : public distance_measure_floating<long double> {};
+
+template <>
+struct distance_measure<double>
+    : public distance_measure_floating<double> {};
+
+template <>
+struct distance_measure<float>
+    : public distance_measure_floating<float> {};
+
+} // detail
+
+
+namespace detail_dispatch
+{
+
+template <typename CalculationType, typename Tag>
+struct get_distance_measure
+        : not_implemented<Tag>
+{};
+
+template <typename CalculationType>
+struct get_distance_measure<CalculationType, cartesian_tag>
+{
+    typedef detail::distance_measure<CalculationType> result_type;
+
+    template <typename SegmentPoint, typename Point>
+    static result_type apply(SegmentPoint const& p1, SegmentPoint const& p2,
+                             Point const& p)
+    {
+        typedef CalculationType ct;
+
+        // Construct a line in general form (ax + by + c = 0),
+        // (will be replaced by a general_form structure in next PR)
+        ct const x1 = geometry::get<0>(p1);
+        ct const y1 = geometry::get<1>(p1);
+        ct const x2 = geometry::get<0>(p2);
+        ct const y2 = geometry::get<1>(p2);
+        ct const a = y1 - y2;
+        ct const b = x2 - x1;
+        ct const c = -a * x1 - b * y1;
+
+        // Returns a distance measure
+        // https://en.wikipedia.org/wiki/Distance_from_a_point_to_a_line#Line_defined_by_an_equation
+        // dividing by sqrt(a*a+b*b) is not necessary for this distance measure,
+        // it is not a real distance and purpose is to detect small differences
+        // in collinearity
+        result_type result;
+        result.measure = a * geometry::get<0>(p) + b * geometry::get<1>(p) + c;
+
+        return result;
+    }
+};
+
+template <typename CalculationType>
+struct get_distance_measure<CalculationType, spherical_tag>
+{
+    typedef detail::distance_measure<CalculationType> result_type;
+
+    template <typename SegmentPoint, typename Point>
+    static result_type apply(SegmentPoint const& , SegmentPoint const& ,
+                             Point const& )
+    {
+        // TODO, optional
+        result_type result;
+        return result;
+    }
+};
+
+template <typename CalculationType>
+struct get_distance_measure<CalculationType, spherical_equatorial_tag>
+{
+    typedef detail::distance_measure<CalculationType> result_type;
+
+    template <typename SegmentPoint, typename Point>
+    static result_type apply(SegmentPoint const& , SegmentPoint const& ,
+                             Point const& )
+    {
+        // TODO, optional
+        result_type result;
+        return result;
+    }
+};
+template <typename CalculationType>
+struct get_distance_measure<CalculationType, geographic_tag>
+{
+    typedef detail::distance_measure<CalculationType> result_type;
+
+    template <typename SegmentPoint, typename Point>
+    static result_type apply(SegmentPoint const& , SegmentPoint const& ,
+                             Point const& )
+    {
+        // TODO, optional
+        result_type result;
+        return result;
+    }
+};
+
+
+} // namespace detail_dispatch
+
+namespace detail
+{
+
+// Returns a (often very tiny) value to indicate its side, and distance,
+// 0 (absolutely 0, not even an epsilon) means collinear. Like side,
+// a negative means that p is to the right of p1-p2. And a positive value
+// means that p is to the left of p1-p2.
+template <typename SegmentPoint, typename Point>
+static distance_measure<typename select_coordinate_type<SegmentPoint, Point>::type>
+get_distance_measure(SegmentPoint const& p1, SegmentPoint const& p2, Point const& p)
+{
+    return detail_dispatch::get_distance_measure
+            <
+                typename select_coordinate_type<SegmentPoint, Point>::type,
+                typename geometry::cs_tag<SegmentPoint>::type
+            >::apply(p1, p2, p);
+
+}
+
+} // namespace detail
+#endif // DOXYGEN_NO_DETAIL
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_DISTANCE_MEASURE_HPP

--- a/include/boost/geometry/algorithms/detail/overlay/get_ring.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_ring.hpp
@@ -18,6 +18,8 @@
 #include <boost/geometry/core/ring_type.hpp>
 #include <boost/geometry/core/tags.hpp>
 #include <boost/geometry/algorithms/detail/ring_identifier.hpp>
+#include <boost/geometry/algorithms/detail/overlay/segment_identifier.hpp>
+#include <boost/geometry/algorithms/num_points.hpp>
 #include <boost/geometry/geometries/concepts/check.hpp>
 #include <boost/geometry/util/range.hpp>
 
@@ -47,8 +49,6 @@ struct get_ring<void>
         return range::at(container, id.multi_index);
     }
 };
-
-
 
 
 template<>
@@ -112,6 +112,17 @@ struct get_ring<multi_polygon_tag>
     }
 };
 
+
+template <typename Geometry>
+inline std::size_t segment_count_on_ring(Geometry const& geometry,
+                                         segment_identifier const& seg_id)
+{
+    typedef typename geometry::tag<Geometry>::type tag;
+    ring_identifier const rid(0, seg_id.multi_index, seg_id.ring_index);
+    // A closed polygon, a triangle of 4 points, including starting point,
+    // contains 3 segments. So handle as if closed and subtract one.
+    return geometry::num_points(detail::overlay::get_ring<tag>::apply(rid, geometry), true) - 1;
+}
 
 }} // namespace detail::overlay
 #endif // DOXYGEN_NO_DETAIL

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -21,11 +21,12 @@
 
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/assert.hpp>
+#include <boost/geometry/core/config.hpp>
 #include <boost/geometry/core/exception.hpp>
 
 #include <boost/geometry/algorithms/convert.hpp>
+#include <boost/geometry/algorithms/detail/overlay/get_distance_measure.hpp>
 #include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>
-#include <boost/geometry/algorithms/detail/recalculate.hpp>
 
 #include <boost/geometry/geometries/segment.hpp>
 
@@ -142,6 +143,51 @@ struct base_turn_handler
         ctype const dy = get<1>(a) - get<1>(b);
         return dx * dx + dy * dy;
     }
+
+    template
+    <
+            std::size_t IndexP,
+            std::size_t IndexQ,
+            typename UniqueSubRange1,
+            typename UniqueSubRange2,
+            typename TurnInfo
+    >
+    static inline void both_collinear(UniqueSubRange1 const& range_p,
+            UniqueSubRange2 const& range_q,
+            std::size_t index_p, std::size_t index_q,
+            TurnInfo& ti)
+    {
+#if ! defined(BOOST_GEOMETRY_USE_RESCALING)
+        ti.operations[IndexP].remaining_distance = distance_measure(ti.point, range_p.at(index_p));
+        ti.operations[IndexQ].remaining_distance = distance_measure(ti.point, range_q.at(index_q));
+
+        // pk/q2 is considered as collinear, but there might be
+        // a tiny measurable difference. If so, use that.
+        // Calculate pk // qj-qk
+        typedef detail::distance_measure
+            <
+                typename select_coordinate_type
+                    <
+                        typename UniqueSubRange1::point_type,
+                        typename UniqueSubRange2::point_type
+                    >::type
+            > dm_type;
+
+        dm_type const dm = get_distance_measure(range_q.at(index_q - 1),
+            range_q.at(index_q), range_p.at(index_p));
+
+        if (! dm.is_zero())
+        {
+            // Not truely collinear, distinguish for union/intersection
+            // If p goes left (positive), take that for a union
+            ui_else_iu(dm.is_positive(), ti);
+            return;
+        }
+#endif
+
+        both(ti, operation_continue);
+    }
+
 };
 
 
@@ -266,19 +312,8 @@ struct touch_interior : public base_turn_handler
             // Q intersects on interior of P and continues collinearly
             if (side_qk_q == side_qi_p)
             {
-                // Collinearly in the same direction
-                // (Q comes from left of P and turns left,
-                //  OR Q comes from right of P and turns right)
-                // Omit second intersection point.
-                // Union: just continue
-                // Intersection: just continue
-                both(ti, operation_continue);
-
-                // Calculate remaining distance.
-                // Q arrives at p, at point qj, so use qk for q
-                // and use pj for p
-                ti.operations[index_p].remaining_distance = distance_measure(ti.point, range_p.at(1));
-                ti.operations[index_q].remaining_distance = distance_measure(ti.point, range_q.at(2));
+                both_collinear<index_p, index_q>(range_p, range_q, 1, 2, ti);
+                return;
             }
             else
             {
@@ -369,12 +404,11 @@ struct touch : public base_turn_handler
                 // (#BRL2)
                 if (side_pk_q2 == 0 && ! block_q)
                 {
-                    both(ti, operation_continue);
+                    both_collinear<0, 1>(range_p, range_q, 2, 2, ti);
                     return;
                 }
 
                 int const side_pk_q1 = has_pk && has_qk ? side.pk_wrt_q1() : 0;
-
 
                 // Collinear opposite case -> block P
                 // (#BRL4, #BLR8)
@@ -538,7 +572,7 @@ struct equal : public base_turn_handler
         // oppositely
         if (side_pk_q2 == 0 && side_pk_p == side_qk_p)
         {
-            both(ti, operation_continue);
+            both_collinear<0, 1>(range_p, range_q, 2, 2, ti);
 
             return;
         }
@@ -557,6 +591,130 @@ struct equal : public base_turn_handler
             ui_else_iu(side_pk_p != -1, ti);
         }
     }
+};
+
+
+template
+<
+    typename TurnInfo
+>
+struct start : public base_turn_handler
+{
+    template
+    <
+        typename UniqueSubRange1,
+        typename UniqueSubRange2,
+        typename IntersectionInfo,
+        typename DirInfo,
+        typename SidePolicy
+    >
+    static inline bool apply(UniqueSubRange1 const& range_p,
+                UniqueSubRange2 const& range_q,
+                TurnInfo& ti,
+                IntersectionInfo const& info,
+                DirInfo const& dir_info,
+                SidePolicy const& side)
+    {
+#if defined(BOOST_GEOMETRY_USE_RESCALING)
+        // If rescaled, it is not necessary to handle start turns
+        return false;
+#endif
+
+        if (dir_info.opposite)
+        {
+            // They should not be collinear
+            return false;
+        }
+
+        int const side_pj_q1 = side.pj_wrt_q1();
+        int const side_qj_p1 = side.qj_wrt_p1();
+
+        // Get side values at starting point
+        typedef detail::distance_measure
+            <
+                typename select_coordinate_type
+                    <
+                        typename UniqueSubRange1::point_type,
+                        typename UniqueSubRange2::point_type
+                    >::type
+            > dm_type;
+
+        dm_type const dm_pi_q1 = get_distance_measure(range_q.at(0), range_q.at(1), range_p.at(0));
+        dm_type const dm_qi_p1 = get_distance_measure(range_p.at(0), range_p.at(1), range_q.at(0));
+
+        if (dir_info.how_a == -1 && dir_info.how_b == -1)
+        {
+            // Both p and q leave
+            if (dm_pi_q1.is_zero() && dm_qi_p1.is_zero())
+            {
+                // Exactly collinear, not necessary to handle it
+                return false;
+            }
+
+            if (! (dm_pi_q1.is_small() && dm_qi_p1.is_small()))
+            {
+                // Not nearly collinear
+                return false;
+            }
+
+           if (side_qj_p1 == 0)
+            {
+                // Collinear is not handled
+                return false;
+            }
+
+            ui_else_iu(side_qj_p1 == -1, ti);
+        }
+        else if (dir_info.how_b == -1)
+        {
+            // p --------------->
+            //             |
+            //             | q         q leaves
+            //             v
+            //
+
+            if (dm_qi_p1.is_zero() || ! dm_qi_p1.is_small())
+            {
+                // Exactly collinear
+                return false;
+            }
+
+            if (side_qj_p1 == 0)
+            {
+                // Collinear is not handled
+                return false;
+            }
+
+            ui_else_iu(side_qj_p1 == -1, ti);
+        }
+        else if (dir_info.how_a == -1)
+        {
+            if (dm_pi_q1.is_zero() || ! dm_pi_q1.is_small())
+            {
+                // It starts exactly, not necessary to handle it
+                return false;
+            }
+
+            // p leaves
+            if (side_pj_q1 == 0)
+            {
+                // Collinear is not handled
+                return false;
+            }
+
+            ui_else_iu(side_pj_q1 == 1, ti);
+        }
+        else
+        {
+            // Not supported
+            return false;
+        }
+
+        // Copy intersection point
+        assign_point(ti, method_start, info, 0);
+        return true;
+    }
+
 };
 
 
@@ -978,18 +1136,13 @@ struct get_turn_info
         // Copy, to copy possibly extended fields
         TurnInfo tp = tp_model;
 
+        bool do_only_convert = false;
+
         // Select method and apply
         switch(method)
         {
-            case 'a' : // collinear, "at"
-            case 'f' : // collinear, "from"
-            case 's' : // starts from the middle
-                if (AssignPolicy::include_no_turn
-                    && inters.i_info().count > 0)
-                {
-                    only_convert::apply(tp, inters.i_info());
-                    *out++ = tp;
-                }
+            case 'a' : // "angle"
+                do_only_convert = true;
                 break;
 
             case 'd' : // disjoint: never do anything
@@ -1028,6 +1181,20 @@ struct get_turn_info
                 // Both touch (both arrive there)
                 touch<TurnInfo>::apply(range_p, range_q, tp, inters.i_info(), inters.d_info(), inters.sides());
                 *out++ = tp;
+            }
+            break;
+            case 'f' :
+            case 's' :
+            {
+                // "from" or "start" without rescaling, it is in some cases necessary to handle
+                if (start<TurnInfo>::apply(range_p, range_q, tp, inters.i_info(), inters.d_info(), inters.sides()))
+                {
+                    *out++ = tp;
+                }
+                else
+                {
+                    do_only_convert = true;
+                }
             }
             break;
             case 'e':
@@ -1103,6 +1270,14 @@ struct get_turn_info
 #endif
             }
             break;
+        }
+
+        if (do_only_convert
+            && AssignPolicy::include_no_turn
+            && inters.i_info().count > 0)
+        {
+            only_convert::apply(tp, inters.i_info());
+            *out++ = tp;
         }
 
         return out;

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
@@ -217,7 +217,7 @@ private :
 template
 <
     typename UniqueSubRange1, typename UniqueSubRange2,
-    typename TurnPoint, typename IntersectionStrategy, typename RobustPolicy>
+    typename TurnPoint, typename UmbrellaStrategy, typename RobustPolicy>
 class intersection_info_base
     : private robust_points<UniqueSubRange1, UniqueSubRange2, RobustPolicy>
 {
@@ -232,7 +232,7 @@ public:
 
     typedef typename cs_tag<TurnPoint>::type cs_tag;
 
-    typedef typename IntersectionStrategy::side_strategy_type side_strategy_type;
+    typedef typename UmbrellaStrategy::side_strategy_type side_strategy_type;
     typedef side_calculator<cs_tag, robust_subrange1, robust_subrange2,
              side_strategy_type> side_calculator_type;
 
@@ -244,7 +244,7 @@ public:
 
     intersection_info_base(UniqueSubRange1 const& range_p,
                            UniqueSubRange2 const& range_q,
-                           IntersectionStrategy const& intersection_strategy,
+                           UmbrellaStrategy const& umbrella_strategy,
                            RobustPolicy const& robust_policy)
         : base(range_p, range_q, robust_policy)
         , m_range_p(range_p)
@@ -252,7 +252,7 @@ public:
         , m_robust_range_p(range_p, base::m_rpi, base::m_rpj, robust_policy)
         , m_robust_range_q(range_q, base::m_rqi, base::m_rqj, robust_policy)
         , m_side_calc(m_robust_range_p, m_robust_range_q,
-                      intersection_strategy.get_side_strategy())
+                      umbrella_strategy.get_side_strategy())
     {}
 
     inline typename UniqueSubRange1::point_type const& pi() const { return m_range_p.at(0); }
@@ -289,10 +289,10 @@ private :
 template
 <
     typename UniqueSubRange1, typename UniqueSubRange2,
-    typename TurnPoint, typename IntersectionStrategy
+    typename TurnPoint, typename UmbrellaStrategy
 >
 class intersection_info_base<UniqueSubRange1, UniqueSubRange2,
-        TurnPoint, IntersectionStrategy, detail::no_rescale_policy>
+        TurnPoint, UmbrellaStrategy, detail::no_rescale_policy>
 {
 public:
     typedef typename UniqueSubRange1::point_type point1_type;
@@ -301,9 +301,9 @@ public:
     typedef typename UniqueSubRange1::point_type robust_point1_type;
     typedef typename UniqueSubRange2::point_type robust_point2_type;
 
-    typedef typename cs_tag<TurnPoint>::type cs_tag;
+    typedef typename UmbrellaStrategy::cs_tag cs_tag;
 
-    typedef typename IntersectionStrategy::side_strategy_type side_strategy_type;
+    typedef typename UmbrellaStrategy::side_strategy_type side_strategy_type;
     typedef side_calculator<cs_tag, UniqueSubRange1, UniqueSubRange2, side_strategy_type> side_calculator_type;
 
     typedef side_calculator
@@ -314,12 +314,12 @@ public:
     
     intersection_info_base(UniqueSubRange1 const& range_p,
                            UniqueSubRange2 const& range_q,
-                           IntersectionStrategy const& intersection_strategy,
+                           UmbrellaStrategy const& umbrella_strategy,
                            no_rescale_policy const& /*robust_policy*/)
         : m_range_p(range_p)
         , m_range_q(range_q)
         , m_side_calc(range_p, range_q,
-                      intersection_strategy.get_side_strategy())
+                      umbrella_strategy.get_side_strategy())
     {}
 
     inline point1_type const& rpi() const { return m_side_calc.get_pi(); }
@@ -354,15 +354,15 @@ template
 <
     typename UniqueSubRange1, typename UniqueSubRange2,
     typename TurnPoint,
-    typename IntersectionStrategy,
+    typename UmbrellaStrategy,
     typename RobustPolicy
 >
 class intersection_info
     : public intersection_info_base<UniqueSubRange1, UniqueSubRange2,
-        TurnPoint, IntersectionStrategy, RobustPolicy>
+        TurnPoint, UmbrellaStrategy, RobustPolicy>
 {
     typedef intersection_info_base<UniqueSubRange1, UniqueSubRange2,
-        TurnPoint, IntersectionStrategy, RobustPolicy> base;
+        TurnPoint, UmbrellaStrategy, RobustPolicy> base;
 
 public:
     typedef segment_intersection_points
@@ -387,8 +387,8 @@ public:
             policies::relate::segments_direction
         > intersection_policy_type;
 
-    typedef IntersectionStrategy intersection_strategy_type;
-    typedef typename IntersectionStrategy::side_strategy_type side_strategy_type;
+    typedef UmbrellaStrategy intersection_strategy_type;
+    typedef typename UmbrellaStrategy::side_strategy_type side_strategy_type;
 
     typedef model::referring_segment<point1_type const> segment_type1;
     typedef model::referring_segment<point2_type const> segment_type2;
@@ -400,18 +400,18 @@ public:
 
     intersection_info(UniqueSubRange1 const& range_p,
                       UniqueSubRange2 const& range_q,
-                      IntersectionStrategy const& intersection_strategy,
+                      UmbrellaStrategy const& umbrella_strategy,
                       RobustPolicy const& robust_policy)
         : base(range_p, range_q,
-               intersection_strategy, robust_policy)
-        , m_result(intersection_strategy.apply(
+               umbrella_strategy, robust_policy)
+        , m_result(umbrella_strategy.apply(
                         segment_type1(range_p.at(0), range_p.at(1)),
                         segment_type2(range_q.at(0), range_q.at(1)),
                         intersection_policy_type(),
                         robust_policy,
                         base::rpi(), base::rpj(),
                         base::rqi(), base::rqj()))
-        , m_intersection_strategy(intersection_strategy)
+        , m_intersection_strategy(umbrella_strategy)
         , m_robust_policy(robust_policy)
     {}
 
@@ -523,7 +523,7 @@ private:
     }
 
     result_type m_result;
-    IntersectionStrategy const& m_intersection_strategy;
+    UmbrellaStrategy const& m_intersection_strategy;
     RobustPolicy const& m_robust_policy;
 };
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_la.hpp
@@ -44,7 +44,7 @@ struct get_turn_info_linear_areal
         typename UniqueSubRange1,
         typename UniqueSubRange2,
         typename TurnInfo,
-        typename IntersectionStrategy,
+        typename UmbrellaStrategy,
         typename RobustPolicy,
         typename OutputIterator
     >
@@ -52,7 +52,7 @@ struct get_turn_info_linear_areal
                 UniqueSubRange1 const& range_p,
                 UniqueSubRange2 const& range_q,
                 TurnInfo const& tp_model,
-                IntersectionStrategy const& strategy,
+                UmbrellaStrategy const& umbrella_strategy,
                 RobustPolicy const& robust_policy,
                 OutputIterator out)
     {
@@ -60,11 +60,11 @@ struct get_turn_info_linear_areal
             <
                 UniqueSubRange1, UniqueSubRange2,
                 typename TurnInfo::point_type,
-                IntersectionStrategy,
+                UmbrellaStrategy,
                 RobustPolicy
             > inters_info;
 
-        inters_info inters(range_p, range_q, strategy, robust_policy);
+        inters_info inters(range_p, range_q, umbrella_strategy, robust_policy);
 
         char const method = inters.d_info().how;
 
@@ -79,7 +79,7 @@ struct get_turn_info_linear_areal
             case 's' : // starts from the middle
                 get_turn_info_for_endpoint<true, true>(range_p, range_q,
                     tp_model, inters, method_none, out,
-                    strategy.get_point_in_point_strategy());
+                    umbrella_strategy.get_point_in_point_strategy());
                 break;
 
             case 'd' : // disjoint: never do anything
@@ -89,30 +89,27 @@ struct get_turn_info_linear_areal
             {
                 if ( get_turn_info_for_endpoint<false, true>(range_p, range_q,
                         tp_model, inters, method_touch_interior, out,
-                        strategy.get_point_in_point_strategy()) )
+                        umbrella_strategy.get_point_in_point_strategy()) )
                 {
                     // do nothing
                 }
                 else
                 {
-                    typedef touch_interior
-                        <
-                            TurnInfo
-                        > policy;
+                    typedef touch_interior<TurnInfo> handler;
 
                     // If Q (1) arrives (1)
                     if ( inters.d_info().arrival[1] == 1 )
                     {
-                        policy::template apply<0>(range_p, range_q, tp,
+                        handler::template apply<0>(range_p, range_q, tp,
                                     inters.i_info(), inters.d_info(),
-                                    inters.sides());
+                                    inters.sides(), umbrella_strategy);
                     }
                     else
                     {
                         // Swap p/q
-                        policy::template apply<1>(range_q, range_p,
+                        handler::template apply<1>(range_q, range_p,
                                     tp, inters.i_info(), inters.d_info(),
-                                    inters.get_swapped_sides());
+                                    inters.get_swapped_sides(), umbrella_strategy);
                     }
 
                     if ( tp.operations[1].operation == operation_blocked )
@@ -127,7 +124,7 @@ struct get_turn_info_linear_areal
                     // this function assumes that 'u' must be set for a spike
                     calculate_spike_operation(tp.operations[0].operation,
                                               inters,
-                                              strategy.get_point_in_point_strategy());
+                                              umbrella_strategy.get_point_in_point_strategy());
                     
                     *out++ = tp;
                 }
@@ -147,14 +144,15 @@ struct get_turn_info_linear_areal
                 // Both touch (both arrive there)
                 if ( get_turn_info_for_endpoint<false, true>(range_p, range_q,
                         tp_model, inters, method_touch, out,
-                        strategy.get_point_in_point_strategy()) )
+                        umbrella_strategy.get_point_in_point_strategy()) )
                 {
                     // do nothing
                 }
                 else 
                 {
                     touch<TurnInfo>::apply(range_p, range_q, tp,
-                        inters.i_info(), inters.d_info(), inters.sides());
+                        inters.i_info(), inters.d_info(), inters.sides(),
+                        umbrella_strategy);
 
                     if ( tp.operations[1].operation == operation_blocked )
                     {
@@ -220,7 +218,7 @@ struct get_turn_info_linear_areal
                     bool ignore_spike
                         = calculate_spike_operation(tp.operations[0].operation,
                                                     inters,
-                                                    strategy.get_point_in_point_strategy());
+                                                    umbrella_strategy.get_point_in_point_strategy());
 
                     if ( ! BOOST_GEOMETRY_CONDITION(handle_spikes)
                       || ignore_spike
@@ -236,7 +234,7 @@ struct get_turn_info_linear_areal
             {
                 if ( get_turn_info_for_endpoint<true, true>(range_p, range_q,
                         tp_model, inters, method_equal, out,
-                        strategy.get_point_in_point_strategy()) )
+                        umbrella_strategy.get_point_in_point_strategy()) )
                 {
                     // do nothing
                 }
@@ -249,7 +247,8 @@ struct get_turn_info_linear_areal
                         // Both equal
                         // or collinear-and-ending at intersection point
                         equal<TurnInfo>::apply(range_p, range_q, tp,
-                            inters.i_info(), inters.d_info(), inters.sides());
+                            inters.i_info(), inters.d_info(), inters.sides(),
+                            umbrella_strategy);
 
                         turn_transformer_ec<false> transformer(method_touch);
                         transformer(tp);
@@ -280,7 +279,7 @@ struct get_turn_info_linear_areal
                 if ( get_turn_info_for_endpoint<true, true>(
                         range_p, range_q,
                         tp_model, inters, method_collinear, out,
-                        strategy.get_point_in_point_strategy()) )
+                        umbrella_strategy.get_point_in_point_strategy()) )
                 {
                     // do nothing
                 }
@@ -297,7 +296,8 @@ struct get_turn_info_linear_areal
                         {
                             // Collinear, but similar thus handled as equal
                             equal<TurnInfo>::apply(range_p, range_q, tp,
-                                inters.i_info(), inters.d_info(), inters.sides());
+                                inters.i_info(), inters.d_info(), inters.sides(),
+                                umbrella_strategy);
 
                             method_replace = method_touch;
                             version = append_equal;
@@ -359,13 +359,13 @@ struct get_turn_info_linear_areal
 
                     if ( range_p.is_first_segment()
                       && equals::equals_point_point(range_p.at(0), tp.point,
-                                                    strategy.get_point_in_point_strategy()) )
+                                                    umbrella_strategy.get_point_in_point_strategy()) )
                     {
                         tp.operations[0].position = position_front;
                     }
                     else if ( range_p.is_last_segment()
                            && equals::equals_point_point(range_p.at(1), tp.point,
-                                                         strategy.get_point_in_point_strategy()) )
+                                                         umbrella_strategy.get_point_in_point_strategy()) )
                     {
                         tp.operations[0].position = position_back;
                     }

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_ll.hpp
@@ -39,7 +39,7 @@ struct get_turn_info_linear_linear
         typename UniqueSubRange1,
         typename UniqueSubRange2,
         typename TurnInfo,
-        typename IntersectionStrategy,
+        typename UmbrellaStrategy,
         typename RobustPolicy,
         typename OutputIterator
     >
@@ -47,7 +47,7 @@ struct get_turn_info_linear_linear
                 UniqueSubRange1 const& range_p,
                 UniqueSubRange2 const& range_q,
                 TurnInfo const& tp_model,
-                IntersectionStrategy const& strategy,
+                UmbrellaStrategy const& umbrella_strategy,
                 RobustPolicy const& robust_policy,
                 OutputIterator out)
     {
@@ -55,11 +55,11 @@ struct get_turn_info_linear_linear
             <
                 UniqueSubRange1, UniqueSubRange2,
                 typename TurnInfo::point_type,
-                IntersectionStrategy,
+                UmbrellaStrategy,
                 RobustPolicy
             > inters_info;
 
-        inters_info inters(range_p, range_q, strategy, robust_policy);
+        inters_info inters(range_p, range_q, umbrella_strategy, robust_policy);
 
         char const method = inters.d_info().how;
 
@@ -75,7 +75,7 @@ struct get_turn_info_linear_linear
                 get_turn_info_for_endpoint<true, true>
                     ::apply(range_p, range_q,
                             tp_model, inters, method_none, out,
-                            strategy.get_point_in_point_strategy());
+                            umbrella_strategy.get_point_in_point_strategy());
                 break;
 
             case 'd' : // disjoint: never do anything
@@ -86,7 +86,7 @@ struct get_turn_info_linear_linear
                 if ( get_turn_info_for_endpoint<false, true>
                         ::apply(range_p, range_q,
                                 tp_model, inters, method_touch_interior, out,
-                                strategy.get_point_in_point_strategy()) )
+                                umbrella_strategy.get_point_in_point_strategy()) )
                 {
                     // do nothing
                 }
@@ -102,14 +102,16 @@ struct get_turn_info_linear_linear
                     {
                         policy::template apply<0>(range_p, range_q, tp,
                                                   inters.i_info(), inters.d_info(),
-                                                  inters.sides());
+                                                  inters.sides(),
+                                                  umbrella_strategy);
                     }
                     else
                     {
                         // Swap p/q
                         policy::template apply<1>(range_q, range_p, tp,
                                                   inters.i_info(), inters.d_info(),
-                                                  inters.get_swapped_sides());
+                                                  inters.get_swapped_sides(),
+                                                  umbrella_strategy);
                     }
                     
                     if ( tp.operations[0].operation == operation_blocked )
@@ -144,14 +146,16 @@ struct get_turn_info_linear_linear
                 if ( get_turn_info_for_endpoint<false, true>
                         ::apply(range_p, range_q,
                                 tp_model, inters, method_touch, out,
-                                strategy.get_point_in_point_strategy()) )
+                                umbrella_strategy.get_point_in_point_strategy()) )
                 {
                     // do nothing
                 }
                 else 
                 {
                     touch<TurnInfo>::apply(range_p, range_q, tp,
-                                           inters.i_info(), inters.d_info(), inters.sides());
+                                           inters.i_info(), inters.d_info(),
+                                           inters.sides(),
+                                           umbrella_strategy);
 
                     // workarounds for touch<> not taking spikes into account starts here
                     // those was discovered empirically
@@ -274,7 +278,7 @@ struct get_turn_info_linear_linear
                 if ( get_turn_info_for_endpoint<true, true>
                         ::apply(range_p, range_q,
                                 tp_model, inters, method_equal, out,
-                                strategy.get_point_in_point_strategy()) )
+                                umbrella_strategy.get_point_in_point_strategy()) )
                 {
                     // do nothing
                 }
@@ -288,7 +292,8 @@ struct get_turn_info_linear_linear
                         // Both equal
                         // or collinear-and-ending at intersection point
                         equal<TurnInfo>::apply(range_p, range_q, tp,
-                            inters.i_info(), inters.d_info(), inters.sides());
+                            inters.i_info(), inters.d_info(), inters.sides(),
+                            umbrella_strategy);
 
                         operation_type spike_op
                             = ( tp.operations[0].operation != operation_continue
@@ -328,7 +333,7 @@ struct get_turn_info_linear_linear
                 if ( get_turn_info_for_endpoint<true, true>
                         ::apply(range_p, range_q,
                                 tp_model, inters,  method_collinear, out,
-                                strategy.get_point_in_point_strategy()) )
+                                umbrella_strategy.get_point_in_point_strategy()) )
                 {
                     // do nothing
                 }
@@ -347,7 +352,8 @@ struct get_turn_info_linear_linear
                         {
                             // Collinear, but similar thus handled as equal
                             equal<TurnInfo>::apply(range_p, range_q, tp,
-                                inters.i_info(), inters.d_info(), inters.sides());
+                                inters.i_info(), inters.d_info(), inters.sides(),
+                                umbrella_strategy);
 
                             method_replace = method_touch;
                             if ( tp.operations[0].operation != operation_continue
@@ -410,7 +416,7 @@ struct get_turn_info_linear_linear
                 // degenerate points
                 if ( BOOST_GEOMETRY_CONDITION(AssignPolicy::include_degenerate) )
                 {
-                    typedef typename IntersectionStrategy::point_in_point_strategy_type
+                    typedef typename UmbrellaStrategy::point_in_point_strategy_type
                         equals_strategy_type;
 
                     only_convert::apply(tp, inters.i_info());

--- a/include/boost/geometry/algorithms/detail/overlay/handle_colocations.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/handle_colocations.hpp
@@ -22,9 +22,11 @@
 
 #include <boost/core/ignore_unused.hpp>
 #include <boost/range.hpp>
+#include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/point_order.hpp>
 #include <boost/geometry/algorithms/detail/overlay/cluster_info.hpp>
 #include <boost/geometry/algorithms/detail/overlay/do_reverse.hpp>
+#include <boost/geometry/algorithms/detail/overlay/get_ring.hpp>
 #include <boost/geometry/algorithms/detail/overlay/is_self_turn.hpp>
 #include <boost/geometry/algorithms/detail/overlay/overlay_type.hpp>
 #include <boost/geometry/algorithms/detail/overlay/sort_by_side.hpp>
@@ -82,6 +84,14 @@ struct turn_operation_index
     signed_size_type op_index; // only 0,1
 };
 
+struct is_discarded
+{
+    template <typename Turn>
+    inline bool operator()(Turn const& turn) const
+    {
+        return turn.discarded;
+    }
+};
 
 template <typename Turns>
 struct less_by_fraction_and_type
@@ -246,7 +256,7 @@ inline void handle_colocation_cluster(Turns& turns,
         turn_type& turn = turns[toi.turn_index];
         turn_operation_type const& op = turn.operations[toi.op_index];
 
-        BOOST_ASSERT(ref_op.seg_id == op.seg_id);
+        BOOST_GEOMETRY_ASSERT(ref_op.seg_id == op.seg_id);
 
         if (ref_op.fraction == op.fraction)
         {
@@ -256,7 +266,7 @@ inline void handle_colocation_cluster(Turns& turns,
             {
                 ref_id = add_turn_to_cluster(ref_turn, cluster_per_segment, cluster_id);
             }
-            BOOST_ASSERT(ref_id != -1);
+            BOOST_GEOMETRY_ASSERT(ref_id != -1);
 
             // ref_turn (both operations) are already added to cluster,
             // so also "op" is already added to cluster,
@@ -504,6 +514,100 @@ inline void discard_interior_exterior_turns(Turns& turns, Clusters& clusters)
     }
 }
 
+template <typename Geometry0, typename Geometry1>
+inline segment_identifier get_preceding_segment_id(segment_identifier const& id,
+        Geometry0 const& geometry0, Geometry1 const& geometry1)
+{
+    segment_identifier result = id;
+
+    if (result.segment_index == 0)
+    {
+        // Assign to segment_count before decrement
+        result.segment_index
+                = id.source_index == 0
+                ? segment_count_on_ring(geometry0, id)
+                : segment_count_on_ring(geometry1, id);
+    }
+
+    result.segment_index--;
+
+    return result;
+}
+
+// Turns marked with method <start> can be generated but are often duplicate,
+// unless (by floating point precision) the preceding touching turn is just missed.
+// This means that all <start> (nearly) colocated with preceding touching turn
+// can be deleted. This is done before colocation itself (because in colocated,
+// they are only discarded, and that can give issues in traversal)
+template <typename Turns, typename Geometry0, typename Geometry1>
+inline void erase_colocated_start_turns(Turns& turns,
+        Geometry0 const& geometry0, Geometry1 const& geometry1)
+{
+    typedef std::pair<segment_identifier, segment_identifier> seg_id_pair;
+    typedef std::map<seg_id_pair, std::size_t> map_type;
+
+    typedef typename boost::range_value<Turns>::type turn_type;
+    typedef typename boost::range_iterator<Turns const>::type turn_it;
+    typedef map_type::const_iterator map_it;
+
+    // Collect starting turns into map
+    map_type preceding_segments;
+    std::size_t turn_index = 0;
+    for (turn_it it = boost::begin(turns); it != boost::end(turns); ++it, ++turn_index)
+    {
+        turn_type const& turn = *it;
+        if (turn.method == method_start)
+        {
+            // Insert identifiers for preceding segments of both operations.
+            // (For self turns geometry1 == geometry2)
+            seg_id_pair const pair(
+                get_preceding_segment_id(turn.operations[0].seg_id, geometry0, geometry1),
+                get_preceding_segment_id(turn.operations[1].seg_id, geometry0, geometry1));
+
+            // There should exist only one turn with such ids
+            BOOST_GEOMETRY_ASSERT(preceding_segments.find(pair) == preceding_segments.end());
+
+            preceding_segments[pair] = turn_index;
+        }
+    }
+
+    if (preceding_segments.empty())
+    {
+        return;
+    }
+
+    // Find touching turns on preceding segment id combinations
+    bool has_discarded = false;
+    for (turn_it it = boost::begin(turns); it != boost::end(turns); ++it)
+    {
+        turn_type const& turn = *it;
+        if (turn.method == method_touch)
+        {
+            seg_id_pair const pair(turn.operations[0].seg_id,
+                    turn.operations[1].seg_id);
+
+            map_it mit = preceding_segments.find(pair);
+
+            if (mit != preceding_segments.end())
+            {
+                // The found touching turn precedes the found starting turn.
+                // (To be completely sure we could verify if turn.point is (nearly) equal)
+                // These turns are duplicate, discard the starting turn.
+                has_discarded = true;
+                turn_type& extra_turn = turns[mit->second];
+                extra_turn.discarded = true;
+            }
+        }
+    }
+
+    if (has_discarded)
+    {
+        turns.erase(std::remove_if(boost::begin(turns), boost::end(turns),
+                                   is_discarded()),
+                    boost::end(turns));
+    }
+}
+
 template
 <
     overlay_type OverlayType,
@@ -537,11 +641,7 @@ inline void set_colocation(Turns& turns, Clusters const& clusters)
             for (set_iterator it = ids.begin(); it != ids.end(); ++it)
             {
                 turn_type& turn = turns[*it];
-
-                if (both_target)
-                {
-                    turn.has_colocated_both = true;
-                }
+                turn.has_colocated_both = true;
             }
         }
     }

--- a/include/boost/geometry/algorithms/detail/overlay/traversal.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/traversal.hpp
@@ -1128,22 +1128,25 @@ public :
                      int previous_op_index,
                      signed_size_type previous_turn_index,
                      segment_identifier const& previous_seg_id,
-                     bool is_start)
+                     bool is_start, bool has_points)
     {
         turn_type const& current_turn = m_turns[turn_index];
 
         if (BOOST_GEOMETRY_CONDITION(target_operation == operation_intersection))
         {
-            bool const back_at_start_cluster
-                    = current_turn.is_clustered()
-                    && m_turns[start_turn_index].cluster_id == current_turn.cluster_id;
-
-            if (turn_index == start_turn_index || back_at_start_cluster)
+            if (has_points)
             {
-                // Intersection can always be finished if returning
-                turn_index = start_turn_index;
-                op_index = start_op_index;
-                return true;
+                bool const back_at_start_cluster
+                        = current_turn.is_clustered()
+                        && m_turns[start_turn_index].cluster_id == current_turn.cluster_id;
+
+                if (turn_index == start_turn_index || back_at_start_cluster)
+                {
+                    // Intersection can always be finished if returning
+                    turn_index = start_turn_index;
+                    op_index = start_op_index;
+                    return true;
+                }
             }
 
             if (! current_turn.is_clustered()

--- a/include/boost/geometry/algorithms/detail/overlay/traversal_ring_creator.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/traversal_ring_creator.hpp
@@ -142,7 +142,7 @@ struct traversal_ring_creator
         if (! m_trav.select_turn(start_turn_index, start_op_index,
                 turn_index, op_index,
                 previous_op_index, previous_turn_index, previous_seg_id,
-                is_start))
+                is_start, current_ring.size() > 1))
         {
             return is_start
                 ? traverse_error_no_next_ip_at_start

--- a/include/boost/geometry/algorithms/detail/overlay/turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/turn_info.hpp
@@ -33,6 +33,7 @@ enum method_type
     method_touch_interior,
     method_collinear,
     method_equal,
+    method_start,
     method_error
 };
 
@@ -92,7 +93,6 @@ struct turn_info
     bool touch_only; // True in case of method touch(interior) and lines do not cross
     signed_size_type cluster_id; // For multiple turns on same location, > 0. Else -1. 0 is unused.
     bool discarded;
-
     bool has_colocated_both; // Colocated with a uu turn (for union) or ii (other)
 
     Container operations;

--- a/include/boost/geometry/strategies/cartesian/intersection.hpp
+++ b/include/boost/geometry/strategies/cartesian/intersection.hpp
@@ -75,6 +75,8 @@ template
 >
 struct cartesian_segments
 {
+    typedef cartesian_tag cs_tag;
+
     typedef side::side_by_triangle<CalculationType> side_strategy_type;
 
     static inline side_strategy_type get_side_strategy()

--- a/include/boost/geometry/strategies/geographic/intersection.hpp
+++ b/include/boost/geometry/strategies/geographic/intersection.hpp
@@ -73,6 +73,8 @@ template
 >
 struct geographic_segments
 {
+    typedef geographic_tag cs_tag;
+
     typedef side::geographic
         <
             FormulaPolicy, Spheroid, CalculationType

--- a/include/boost/geometry/strategies/spherical/intersection.hpp
+++ b/include/boost/geometry/strategies/spherical/intersection.hpp
@@ -89,6 +89,8 @@ template
 >
 struct ecef_segments
 {
+    typedef spherical_tag cs_tag;
+
     typedef side::spherical_side_formula<CalculationType> side_strategy_type;
 
     static inline side_strategy_type get_side_strategy()

--- a/test/algorithms/buffer/buffer_linestring_aimes.cpp
+++ b/test/algorithms/buffer/buffer_linestring_aimes.cpp
@@ -474,6 +474,8 @@ void test_aimes()
 
 int test_main(int, char* [])
 {
+#if defined(BOOST_GEOMETRY_USE_RESCALING)
     test_aimes<bg::model::point<double, 2, bg::cs::cartesian> >();
+#endif
     return 0;
 }

--- a/test/algorithms/buffer/buffer_multi_linestring.cpp
+++ b/test/algorithms/buffer/buffer_multi_linestring.cpp
@@ -141,7 +141,6 @@ void test_all()
     }
 
     {
-#if defined(BOOST_GEOMETRY_USE_RESCALING)
         // Coordinates in one linestring vary so much that
         // length = geometry::math::sqrt(dx * dx + dy * dy); returns a value of inf for length
         // That geometry is skipped for the buffer
@@ -156,7 +155,6 @@ void test_all()
         test_one<multi_linestring_type, polygon>("mysql_2015_04_10b",
             mysql_2015_04_10b, join_round32, end_round32,
             ut_settings::ignore_area(), 0.98, ut_settings::assertions_only());
-#endif
 
         // Two other cases with <inf> for length calculation
         test_one<multi_linestring_type, polygon>("mysql_2015_09_08a",

--- a/test/algorithms/buffer/buffer_multi_polygon.cpp
+++ b/test/algorithms/buffer/buffer_multi_polygon.cpp
@@ -368,26 +368,24 @@ void test_all()
     test_one<multi_polygon_type, polygon_type>("rt_d", rt_d, join_round, end_flat, 18.8726, 0.3);
     test_one<multi_polygon_type, polygon_type>("rt_e", rt_e, join_round, end_flat, 14.1866, 0.3);
 
+#if defined(BOOST_GEOMETRY_USE_RESCALING)
     test_one<multi_polygon_type, polygon_type>("rt_g1", rt_g1, join_round, end_flat, 24.719, 1.0);
+#endif
     test_one<multi_polygon_type, polygon_type>("rt_g3", rt_g3, join_miter, end_flat, 16.5711, 1.0);
 
     test_one<multi_polygon_type, polygon_type>("rt_d", rt_d, join_miter, end_flat, 19.8823, 0.3);
-#if defined(BOOST_GEOMETRY_USE_RESCALING)
     test_one<multi_polygon_type, polygon_type>("rt_e", rt_e, join_miter, end_flat, 15.1198, 0.3);
     test_one<multi_polygon_type, polygon_type>("rt_f", rt_f, join_miter, end_flat, 4.60853, 0.3);
-#endif
     test_one<multi_polygon_type, polygon_type>("rt_g1", rt_g1, join_miter, end_flat, 30.3137, 1.0);
-#if defined(BOOST_GEOMETRY_USE_RESCALING)
     test_one<multi_polygon_type, polygon_type>("rt_g2", rt_g2, join_miter, end_flat, 18.5711, 1.0);
-#endif
 
     test_one<multi_polygon_type, polygon_type>("rt_h", rt_h, join_round, end_flat, 47.6012, 1.0);
     test_one<multi_polygon_type, polygon_type>("rt_h", rt_h, join_miter, end_flat, 61.7058, 1.0);
     test_one<multi_polygon_type, polygon_type>("rt_i", rt_i, join_round, end_flat, 10.7528, 1.0);
 #if defined(BOOST_GEOMETRY_USE_RESCALING)
     test_one<multi_polygon_type, polygon_type>("rt_i", rt_i, join_miter, end_flat, 13.6569, 1.0);
-#endif
     test_one<multi_polygon_type, polygon_type>("rt_j", rt_j, join_round, end_flat, 28.7309, 1.0);
+#endif
     test_one<multi_polygon_type, polygon_type>("rt_j", rt_j, join_miter, end_flat, 35.1421, 1.0);
     test_one<multi_polygon_type, polygon_type>("rt_k", rt_k, join_round, end_flat, 42.0092, 1.0);
     test_one<multi_polygon_type, polygon_type>("rt_k", rt_k, join_miter, end_flat, 48.0563, 1.0);

--- a/test/algorithms/buffer/buffer_polygon.cpp
+++ b/test/algorithms/buffer/buffer_polygon.cpp
@@ -374,7 +374,9 @@ void test_all()
     test_one<polygon_type, polygon_type>("snake4", snake, join_miter, end_flat, 64.44, 0.4);
     test_one<polygon_type, polygon_type>("snake5", snake, join_miter, end_flat, 72, 0.5);
     test_one<polygon_type, polygon_type>("snake6", snake, join_miter, end_flat, 75.44, 0.6);
+#if defined(BOOST_GEOMETRY_USE_RESCALING)
     test_one<polygon_type, polygon_type>("snake16", snake, join_miter, end_flat, 114.24, 1.6);
+#endif
 
     test_one<polygon_type, polygon_type>("funnelgate2", funnelgate, join_miter, end_flat, 120.982, 2.0);
     test_one<polygon_type, polygon_type>("funnelgate3", funnelgate, join_miter, end_flat, 13.0*13.0, 3.0);

--- a/test/algorithms/overlay/overlay_cases.hpp
+++ b/test/algorithms/overlay/overlay_cases.hpp
@@ -796,6 +796,12 @@ static std::string case_precision_15[2] =
     "POLYGON((-1 -1,-1 8,8 8,8 -1,-1 -1),(2 7,2 3,3.99999599999999988 3.00000499999999981,4 7,2 7))"
 };
 
+static std::string case_precision_16[2] =
+{
+    "POLYGON((0 0,0 4,2 4,2 3,4 3,4 0,0 0))",
+    "POLYGON((-1 -1,-1 8,8 8,8 -1,-1 -1),(2 7,2 3,4 2.99999940000000009,4 7,2 7))"
+};
+
 // ticket_17 is keyholed, so has a hole formed by an deliberate intersection
 // This will fail the intersection/traversal process
 static std::string ticket_17[2] = {

--- a/test/algorithms/overlay/overlay_cases.hpp
+++ b/test/algorithms/overlay/overlay_cases.hpp
@@ -783,6 +783,19 @@ static std::string case_precision_13[2] =
     "POLYGON((1 1,9.99999999999999912e-06 1,9.99999999999999912e-06 3,1 3,1 1))"
 };
 
+static std::string case_precision_14[2] =
+{
+    "POLYGON((0 0,0 4,2 4,2 3,4 3,4 0,0 0))",
+    "POLYGON((2 7,4 7,4.00000079999999958 3.00000020000000012,2 3,2 7))"
+};
+
+static std::string case_precision_15[2] =
+{
+    // Needs handling of side_value
+    "POLYGON((0 0,0 4,2 4,2 3,4 3,4 0,0 0))",
+    "POLYGON((-1 -1,-1 8,8 8,8 -1,-1 -1),(2 7,2 3,3.99999599999999988 3.00000499999999981,4 7,2 7))"
+};
+
 // ticket_17 is keyholed, so has a hole formed by an deliberate intersection
 // This will fail the intersection/traversal process
 static std::string ticket_17[2] = {

--- a/test/algorithms/set_operations/difference/difference.cpp
+++ b/test/algorithms/set_operations/difference/difference.cpp
@@ -85,13 +85,11 @@ void test_all()
         1, 5, 8.0,
         1, 5, 8.0);
 
-#if defined(BOOST_GEOMETRY_USE_RESCALING)
     test_one<polygon, polygon, polygon>("star_comb_15",
         star_comb_15[0], star_comb_15[1],
         30, -1, 227.658275102812,
         30, -1, 480.485775259312,
         sym_settings);
-#endif
 
     test_one<polygon, polygon, polygon>("new_hole",
         new_hole[0], new_hole[1],
@@ -122,7 +120,6 @@ void test_all()
         1, 5, 9.0,
         1, 5, 9.0);
 
-#if defined(BOOST_GEOMETRY_USE_RESCALING)
     test_one<polygon, polygon, polygon>("only_hole_intersections1",
         only_hole_intersections[0], only_hole_intersections[1],
         2, 10,  1.9090909,
@@ -134,7 +131,6 @@ void test_all()
         3, 20, 30.9090909,
         4, 16, 10.9090909,
         sym_settings);
-#endif
 
     test_one<polygon, polygon, polygon>("first_within_second",
         first_within_second[1], first_within_second[0],
@@ -271,15 +267,14 @@ void test_all()
         1, 61, 10.2717,
         1, 61, 10.2717);
 
-#if defined(BOOST_GEOMETRY_USE_RESCALING)
     if ( BOOST_GEOMETRY_CONDITION((boost::is_same<ct, double>::value)) )
     {
         test_one<polygon, polygon, polygon>("buffer_mp2",
             buffer_mp2[0], buffer_mp2[1],
             1, 91, 12.09857,
-            1, 155, 24.19714);
+            1, 155, 24.19714,
+            BG_IF_RESCALED(2, 1), -1, 12.09857 + 24.19714);
     }
-#endif
 
     /*** TODO: self-tangencies for difference
     test_one<polygon, polygon, polygon>("wrapped_a",
@@ -297,6 +292,7 @@ void test_all()
         ut_settings settings;
         settings.percentage = BG_IF_RESCALED(0.001, 0.1);
         settings.test_validity = BG_IF_RESCALED(true, false);
+        settings.sym_difference = BG_IF_RESCALED(true, false);
 
         // Isovist - the # output polygons differ per compiler/pointtype, (very) small
         // rings might be discarded. We check area only
@@ -399,22 +395,21 @@ void test_all()
         1, 5, 384.2295081964694,
         tolerance(0.01));
 
-#if defined(BOOST_GEOMETRY_USE_RESCALING)
     // 2011-07-02 / 2014-06-19
     // Interesting FP-precision case.
     // sql server gives: 6.62295817619452E-05
     // PostGIS gives: 0.0 (no output)
     // Boost.Geometry gave results depending on FP-type, and compiler, and operating system.
-    // Since rescaling to integer results are equal w.r.t. compiler/FP type,
+    // With rescaling results are equal w.r.t. compiler/FP type,
     // however, some long spikes are still generated in the resulting difference
+    // Without rescaling there is no output, like PostGIS
     test_one<polygon, polygon, polygon>("ggl_list_20110627_phillip",
         ggl_list_20110627_phillip[0], ggl_list_20110627_phillip[1],
-        if_typed_tt<ct>(1, 1), -1,
-        if_typed_tt<ct>(0.0000000000001105367, 0.000125137888971949),
+        BG_IF_RESCALED(1, 0), -1,
+        BG_IF_RESCALED(if_typed_tt<ct>(0.0000000000001105367, 0.000125137888971949), 0),
         1, -1, 3577.40960816756,
         tolerance(0.01)
         );
-#endif
 
     {
         // With rescaling, difference of output a-b and a sym b is invalid
@@ -438,12 +433,10 @@ void test_all()
         1, 10, 10.03103292,
         0, 0, 0);
 
-#if defined(BOOST_GEOMETRY_USE_RESCALING)
     test_one<polygon, polygon, polygon>("ticket_9081_15",
             ticket_9081_15[0], ticket_9081_15[1],
-            2, 10, 0.0334529710902111,
-            1, 4, 5.3469555172380723e-010);
-#endif
+            2, -1, 0.0334529710902111,
+            BG_IF_RESCALED(1, 0), -1, BG_IF_RESCALED(5.3469555172380723e-010, 0));
 
     test_one<polygon, polygon, polygon>("ticket_9081_314",
             ticket_9081_314[0], ticket_9081_314[1],
@@ -463,12 +456,11 @@ void test_all()
             1, 4,  0.029019232,
             sym_settings);
 
-#if defined(BOOST_GEOMETRY_USE_RESCALING)
     test_one<polygon, polygon, polygon>("ticket_10108_b",
             ticket_10108_b[0], ticket_10108_b[1],
-            1, 5, 1081.68697,
-            1, 5, 1342.65795);
-#endif
+            1, -1, 1081.68697,
+            1, -1, 1342.65795,
+            BG_IF_RESCALED(2, 1), -1, 1081.68697 + 1342.65795);
 
     test_one<polygon, polygon, polygon>("ticket_11725",
         ticket_11725[0], ticket_11725[1],

--- a/test/algorithms/set_operations/difference/test_difference.hpp
+++ b/test/algorithms/set_operations/difference/test_difference.hpp
@@ -187,8 +187,6 @@ std::string test_difference(std::string const& caseid, G1 const& g1, G2 const& g
     return_string << bg::wkt(result);
 
     typename bg::default_area_result<G1>::type const area = bg::area(result);
-    std::size_t const n = expected_point_count >= 0
-                          ? bg::num_points(result) : 0;
 
 #if ! defined(BOOST_GEOMETRY_NO_BOOST_TEST)
 #if ! defined(BOOST_GEOMETRY_TEST_ENABLE_FAILING)
@@ -241,8 +239,10 @@ std::string test_difference(std::string const& caseid, G1 const& g1, G2 const& g
 
 
 #if ! defined(BOOST_GEOMETRY_NO_BOOST_TEST)
+#if defined(BOOST_GEOMETRY_USE_RESCALING)
     if (expected_point_count >= 0)
     {
+        std::size_t const n = bg::num_points(result);
         BOOST_CHECK_MESSAGE(bg::math::abs(int(n) - expected_point_count) < 3,
                 "difference: " << caseid
                 << " #points expected: " << expected_point_count
@@ -250,6 +250,7 @@ std::string test_difference(std::string const& caseid, G1 const& g1, G2 const& g
                 << " type: " << (type_for_assert_message<G1, G2>())
                 );
     }
+#endif
 
     if (expected_count >= 0)
     {
@@ -282,7 +283,6 @@ std::string test_difference(std::string const& caseid, G1 const& g1, G2 const& g
         BOOST_CHECK_LE(area, settings.percentage);
     }
 #endif
-
 
     return return_string.str();
 }

--- a/test/algorithms/set_operations/intersection/intersection.cpp
+++ b/test/algorithms/set_operations/intersection/intersection.cpp
@@ -53,7 +53,7 @@ BOOST_GEOMETRY_REGISTER_LINESTRING_TEMPLATED(std::vector)
 #define TEST_INTERSECTION_WITH(caseid, index1, index2, \
      clips, points, area, settings) \
     (test_one<Polygon, Polygon, Polygon>) \
-    ( #caseid #index1 "_" #index2, caseid[index1], caseid[index2], \
+    ( #caseid "_" #index1 "_" #index2, caseid[index1], caseid[index2], \
      clips, points, area, settings)
 
 template <typename Polygon>
@@ -190,8 +190,8 @@ void test_areal()
 
     test_one<Polygon, Polygon, Polygon>("geos_1",
         geos_1[0], geos_1[1],
-            1, -1, 3461.0214843, // MSVC 14 reports 3461.025390625
-            ut_settings(0.005, false));
+            1, -1, 3461.12321694, // MSVC 14 reports 3461.025390625
+            ut_settings(0.01, false));
 
     // Expectations:
     // In most cases: 0 (no intersection)
@@ -253,13 +253,10 @@ void test_areal()
     TEST_INTERSECTION(ggl_list_20190307_matthieu_1, 2, -1, 0.035136);
     TEST_INTERSECTION(ggl_list_20190307_matthieu_2, 1, -1, 3.64285);
 
-#if defined(BOOST_GEOMETRY_USE_RESCALING)
     test_one<Polygon, Polygon, Polygon>("buffer_rt_f", buffer_rt_f[0], buffer_rt_f[1],
                 1, 4,  0.00029437899183903937, ut_settings(0.01));
-
     test_one<Polygon, Polygon, Polygon>("buffer_rt_g", buffer_rt_g[0], buffer_rt_g[1],
                 1, 0, 2.914213562373);
-#endif
 
     test_one<Polygon, Polygon, Polygon>("ticket_8254", ticket_8254[0], ticket_8254[1],
                 1, 4, 3.635930e-08, ut_settings(0.01));
@@ -283,13 +280,11 @@ void test_areal()
                 ticket_10108_a[0], ticket_10108_a[1],
                 0, 0, 0.0);
 
-#if defined(BOOST_GEOMETRY_USE_RESCALING)
     // msvc  5.6023011e-5
     // mingw 5.6022954e-5
     test_one<Polygon, Polygon, Polygon>("ticket_10108_b",
                 ticket_10108_b[0], ticket_10108_b[1],
             0, 0, 5.6022983e-5, ut_settings(-1.0));
-#endif
 
     test_one<Polygon, Polygon, Polygon>("ticket_10747_a",
                 ticket_10747_a[0], ticket_10747_a[1],
@@ -303,16 +298,23 @@ void test_areal()
     test_one<Polygon, Polygon, Polygon>("ticket_10747_d",
                 ticket_10747_d[0], ticket_10747_d[1],
                 1, 4, 703687777321.0);
+
+    // Delivers very small triangle < 1.0e-13, or zero
     test_one<Polygon, Polygon, Polygon>("ticket_10747_e",
                 ticket_10747_e[0], ticket_10747_e[1],
-                1, 4, 7.0368748575710959e-15);
+                BG_IF_RESCALED(1, 0), -1, 1.0e-13, ut_settings(-1.0));
 
     test_one<Polygon, Polygon, Polygon>("ticket_11576",
                 ticket_11576[0], ticket_11576[1],
                 1, 0, 5.585617332907136e-07);
 
-    test_one<Polygon, Polygon, Polygon>("ticket_9563", ticket_9563[0], ticket_9563[1],
-                1, 8, 129.90381);
+    {
+        // Not yet valid when rescaling is turned off
+        ut_settings settings;
+        settings.test_validity = BG_IF_RESCALED(true, false);
+        test_one<Polygon, Polygon, Polygon>("ticket_9563", ticket_9563[0], ticket_9563[1],
+                    1, 8, 129.90381, settings);
+    }
 
 #if ! defined(BOOST_GEOMETRY_USE_RESCALING)
     // With rescaling the output is empty
@@ -354,6 +356,8 @@ void test_areal()
         0, -1, 0.0);
 
     TEST_INTERSECTION(case_105, 1, 34, 76.0);
+    TEST_INTERSECTION(case_106, 2, -1, 3.5);
+    TEST_INTERSECTION(case_107, 3, -1, 3.0);
 
     TEST_INTERSECTION(case_precision_1, 0, 0, 0.0);
     TEST_INTERSECTION(case_precision_2, 0, 0, 0.0);
@@ -386,8 +390,8 @@ void test_areal()
         TEST_INTERSECTION_WITH(case_precision_13, 1, 0, 1, -1, 2.0, settings);
     }
 
-    TEST_INTERSECTION(case_106, 2, -1, 3.5);
-    TEST_INTERSECTION(case_107, 3, -1, 3.0);
+    TEST_INTERSECTION(case_precision_14, 0, -1, 0.0);
+    TEST_INTERSECTION(case_precision_15, 1, -1, 14.0);
 
     test_one<Polygon, Polygon, Polygon>("mysql_21964049",
         mysql_21964049[0], mysql_21964049[1],

--- a/test/algorithms/set_operations/intersection/intersection_multi.cpp
+++ b/test/algorithms/set_operations/intersection/intersection_multi.cpp
@@ -135,14 +135,14 @@ void test_areal()
         case_107_multi[1], case_107_multi[2],
         3, 13, 3.0);
 
-#if defined(BOOST_GEOMETRY_TEST_ENABLE_FAILING)
+#if ! defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_ENABLE_FAILING)
     {
-        ut_settings ignore_validity; ignore_validity.test_validity = false;
+        ut_settings ignore_validity;
 
-        // One intersection is missing (by rescaling)
+        // Rescaling misses one intersection
         test_one<Polygon, MultiPolygon, MultiPolygon>("case_108_multi",
             case_108_multi[0], case_108_multi[1],
-            5, 33, 7.5,
+            7, -1, 7.5,
             ignore_validity);
     }
 #endif
@@ -326,15 +326,23 @@ void test_areal()
     TEST_INTERSECTION(case_recursive_boxes_82, 5, -1, 8.5);
     TEST_INTERSECTION(case_recursive_boxes_83, 5, -1, 10.25);
     TEST_INTERSECTION(case_recursive_boxes_84, 1, -1, 0.5);
+#if ! defined(BOOST_GEOMETRY_USE_RESCALING)
     TEST_INTERSECTION(case_recursive_boxes_85, 1, -1, 0.25);
+#endif
     TEST_INTERSECTION(case_recursive_boxes_86, 0, -1, 0.0);
     TEST_INTERSECTION(case_recursive_boxes_87, 0, -1, 0.0);
     TEST_INTERSECTION(case_recursive_boxes_88, 4, -1, 3.5);
 
+#if ! defined(BOOST_GEOMETRY_USE_RESCALING)
     TEST_INTERSECTION(case_precision_m1, 1, -1, 14.0);
     TEST_INTERSECTION(case_precision_m2, 2, -1, 15.25);
     TEST_INTERSECTION_REV(case_precision_m1, 1, -1, 14.0);
     TEST_INTERSECTION_REV(case_precision_m2, 2, -1, 15.25);
+#else
+    // Validity: false positives (very small triangles looking like a line)
+    TEST_INTERSECTION_IGNORE(case_precision_m1, 1, -1, 14.0);
+    TEST_INTERSECTION_IGNORE(case_precision_m2, 2, -1, 15.25);
+#endif
 
     test_one<Polygon, MultiPolygon, MultiPolygon>("ggl_list_20120915_h2_a",
         ggl_list_20120915_h2[0], ggl_list_20120915_h2[1],
@@ -354,10 +362,11 @@ void test_areal()
 
     // Very small slice is generated.
     // qcc-arm reports 1.7791215549400884e-14
+    // With rescaling, generates very small triangle
     test_one<Polygon, MultiPolygon, MultiPolygon>("ticket_11018",
         ticket_11018[0], ticket_11018[1],
-        1, 4, BG_IF_RESCALED(1.7791170511070893e-14, 9.896437631745599e-09),
-        ut_settings(0.001)
+        BG_IF_RESCALED(1, 0), 0,
+        1.0e-8, ut_settings(-1)
     );
 
     TEST_INTERSECTION(ticket_12503, 2, 13, 17.375);

--- a/test/algorithms/set_operations/union/union.cpp
+++ b/test/algorithms/set_operations/union/union.cpp
@@ -270,6 +270,7 @@ void test_areal()
     TEST_UNION(case_precision_13, 1, 0, -1, 14.0);
     TEST_UNION(case_precision_14, 1, 0, -1, 22.0);
     TEST_UNION(case_precision_15, 1, 1, -1, 73.0);
+    TEST_UNION(case_precision_16, 1, 1, -1, 73.0);
 
     TEST_UNION_REV(case_precision_1, 1, 0, -1, 22.0);
     TEST_UNION_REV(case_precision_2, 1, 0, -1, 22.0);
@@ -286,6 +287,7 @@ void test_areal()
     TEST_UNION_REV(case_precision_13, 1, 0, -1, 14.0);
     TEST_UNION_REV(case_precision_14, 1, 0, -1, 22.0);
     TEST_UNION_REV(case_precision_15, 1, 1, -1, 73.0);
+    TEST_UNION_REV(case_precision_16, 1, 1, -1, 73.0);
 
     /*
     test_one<Polygon, Polygon, Polygon>(102,

--- a/test/algorithms/set_operations/union/union.cpp
+++ b/test/algorithms/set_operations/union/union.cpp
@@ -268,6 +268,8 @@ void test_areal()
     TEST_UNION(case_precision_11, 1, 1, -1, 73.0);
     TEST_UNION(case_precision_12, 1, 0, -1, 14.0);
     TEST_UNION(case_precision_13, 1, 0, -1, 14.0);
+    TEST_UNION(case_precision_14, 1, 0, -1, 22.0);
+    TEST_UNION(case_precision_15, 1, 1, -1, 73.0);
 
     TEST_UNION_REV(case_precision_1, 1, 0, -1, 22.0);
     TEST_UNION_REV(case_precision_2, 1, 0, -1, 22.0);
@@ -282,6 +284,8 @@ void test_areal()
     TEST_UNION_REV(case_precision_11, 1, 1, -1, 73.0);
     TEST_UNION_REV(case_precision_12, 1, 0, -1, 14.0);
     TEST_UNION_REV(case_precision_13, 1, 0, -1, 14.0);
+    TEST_UNION_REV(case_precision_14, 1, 0, -1, 22.0);
+    TEST_UNION_REV(case_precision_15, 1, 1, -1, 73.0);
 
     /*
     test_one<Polygon, Polygon, Polygon>(102,
@@ -388,8 +392,12 @@ void test_areal()
             ticket_9081_15[0], ticket_9081_15[1],
             1, 0, -1, 0.0403425433);
 
-    test_one<Polygon, Polygon, Polygon>("ticket_9563", ticket_9563[0], ticket_9563[1],
-            1, 0, 13, 150.0);
+    {
+        ut_settings settings;
+        settings.test_validity = BG_IF_RESCALED(true, false);
+        test_one<Polygon, Polygon, Polygon>("ticket_9563", ticket_9563[0], ticket_9563[1],
+                1, 0, 13, 150.0, settings);
+    }
 
     // Float result is OK but a bit larger
     test_one<Polygon, Polygon, Polygon>("ticket_9756", ticket_9756[0], ticket_9756[1],
@@ -416,10 +424,13 @@ void test_areal()
 
     TEST_UNION(issue_566_a, 1, 0, -1, 214.3728);
     TEST_UNION(issue_566_b, 1, 0, -1, 214.3728);
+    TEST_UNION_REV(issue_566_a, 1, 0, -1, 214.3728);
+    TEST_UNION_REV(issue_566_b, 1, 0, -1, 214.3728);
 
     {
         ut_settings ignore_validity;
         ignore_validity.test_validity = false;
+        ignore_validity.percentage = 0.01;
         test_one<Polygon, Polygon, Polygon>("geos_1", geos_1[0], geos_1[1],
                 1, 0, -1, 3461.3203125,
                 ignore_validity);
@@ -431,16 +442,20 @@ void test_areal()
     test_one<Polygon, Polygon, Polygon>("geos_4", geos_4[0], geos_4[1],
             1, 0, -1, 2304.4163115);
 
-    test_one<Polygon, Polygon, Polygon>("buffer_rt_a", buffer_rt_a[0], buffer_rt_a[1],
-                1, 0, 265, 19.280667);
-
     // Robustness issues, followed out buffer-robustness-tests, test them also reverse
-#if defined(BOOST_GEOMETRY_USE_RESCALING)
+    {
+        // Area can vary depending on joining point of nearly parallel lines
+        ut_settings settings;
+        settings.percentage = 0.01;
+        test_one<Polygon, Polygon, Polygon>("buffer_rt_a", buffer_rt_a[0], buffer_rt_a[1],
+                    1, 0, -1, 19.28, settings);
+        test_one<Polygon, Polygon, Polygon>("buffer_rt_a_rev", buffer_rt_a[1], buffer_rt_a[0],
+                    1, 0, -1, 19.28, settings);
+    }
     test_one<Polygon, Polygon, Polygon>("buffer_rt_f", buffer_rt_f[0], buffer_rt_f[1],
                 1, 0, -1, 4.60853);
     test_one<Polygon, Polygon, Polygon>("buffer_rt_f_rev", buffer_rt_f[1], buffer_rt_f[0],
                 1, 0, -1, 4.60853);
-#endif
     test_one<Polygon, Polygon, Polygon>("buffer_rt_g", buffer_rt_g[0], buffer_rt_g[1],
                 1, 0, -1, 16.571);
     test_one<Polygon, Polygon, Polygon>("buffer_rt_g_rev", buffer_rt_g[1], buffer_rt_g[0],
@@ -476,12 +491,10 @@ void test_areal()
                 1, 0, -1, 18.5710);
     test_one<Polygon, Polygon, Polygon>("buffer_rt_q_rev", buffer_rt_q[1], buffer_rt_q[0],
                 1, 0, -1, 18.5710);
-#if defined(BOOST_GEOMETRY_USE_RESCALING)
     test_one<Polygon, Polygon, Polygon>("buffer_rt_r", buffer_rt_r[0], buffer_rt_r[1],
                 1, 0, -1, 21.07612);
     test_one<Polygon, Polygon, Polygon>("buffer_rt_r_rev", buffer_rt_r[1], buffer_rt_r[0],
                 1, 0, -1, 21.07612);
-#endif
     test_one<Polygon, Polygon, Polygon>("buffer_rt_t", buffer_rt_t[0], buffer_rt_t[1],
                 1, 0, -1, 15.6569);
     test_one<Polygon, Polygon, Polygon>("buffer_rt_t_rev", buffer_rt_t[1], buffer_rt_t[0],

--- a/test/algorithms/set_operations/union/union_multi.cpp
+++ b/test/algorithms/set_operations/union/union_multi.cpp
@@ -403,10 +403,9 @@ void test_areal()
     test_one<Polygon, MultiPolygon, MultiPolygon>("ticket_11984",
         ticket_11984[0], ticket_11984[1],
         1, 2, 134, 60071.08077);
-
     test_one<Polygon, MultiPolygon, MultiPolygon>("ticket_12118",
         ticket_12118[0], ticket_12118[1],
-        1, 1, 27, 2221.38713);
+        1, -1, 27, 2221.38713);
 
 #if defined(BOOST_GEOMETRY_TEST_ENABLE_FAILING) || ! defined(BOOST_GEOMETRY_USE_RESCALING)
     // No output if rescaling is done


### PR DESCRIPTION
This PR is another preparation of rescaling:

- adding start turns, which are sometimes necessary in case other turns are missed
- some more decisions based on very small nearly-collineary but not completely situations
- fixing empty output in traversal