### PR TITLE
Fix: Add headers for touches, covered_by, intersects, overlaps to doc

### DIFF
--- a/doc/doxy/Doxyfile
+++ b/doc/doxy/Doxyfile
@@ -183,18 +183,22 @@ INPUT                  = . .. ../../../../boost/geometry/core \
                          ../../../../boost/geometry/algorithms/detail \
                          ../../../../boost/geometry/algorithms/detail/buffer \
                          ../../../../boost/geometry/algorithms/detail/comparable_distance \
+                         ../../../../boost/geometry/algorithms/detail/covered_by \
                          ../../../../boost/geometry/algorithms/detail/disjoint \
                          ../../../../boost/geometry/algorithms/detail/distance \
                          ../../../../boost/geometry/algorithms/detail/envelope \
                          ../../../../boost/geometry/algorithms/detail/equals \
                          ../../../../boost/geometry/algorithms/detail/expand \
                          ../../../../boost/geometry/algorithms/detail/intersection \
+                         ../../../../boost/geometry/algorithms/detail/intersects \
                          ../../../../boost/geometry/algorithms/detail/is_simple \
                          ../../../../boost/geometry/algorithms/detail/is_valid \
+                         ../../../../boost/geometry/algorithms/detail/overlaps \
                          ../../../../boost/geometry/algorithms/detail/overlay \
                          ../../../../boost/geometry/algorithms/detail/relate \
                          ../../../../boost/geometry/algorithms/detail/relation \
                          ../../../../boost/geometry/algorithms/detail/sections \
+                         ../../../../boost/geometry/algorithms/detail/touches \
                          ../../../../boost/geometry/algorithms/detail/turns \
                          ../../../../boost/geometry/algorithms/detail/within \
                          ../../../../boost/geometry/arithmetic \


### PR DESCRIPTION
I'm sorry for the timing of this rather hastily put together pull request, however, I just now noticed that the documentation pages for covered_by, intersects, overlaps and touches are empty (since 1.65, in 1.64 they still had content) in the online documentation and the next release is already in the release candidate phase.

See https://www.boost.org/doc/libs/1_70_0_beta1/libs/geometry/doc/html/geometry/reference/algorithms/touches.html for example.

The result of this change is that some content shows up in the corresponding generated qbk files for these 4 algorithms which was not the case without the change (they had just 15 lines but no actual content), I'm not sure, though, whether this already fixes the issue. But with the release being so close I thought it might be more helpful to notify you in time with a possibly insufficient commit rather than trying to fully understand the documentation system.