### PR TITLE
Fix call to pj_qsfn in cea

### DIFF
--- a/include/boost/geometry/srs/projections/proj/cea.hpp
+++ b/include/boost/geometry/srs/projections/proj/cea.hpp
@@ -164,7 +164,7 @@ namespace projections
                     par.e = sqrt(par.es);
                     proj_parm.apa = pj_authset<T>(par.es);
 
-                    proj_parm.qp = pj_qsfn(1., par.e, par.one_es);
+                    proj_parm.qp = pj_qsfn(T(1), par.e, par.one_es);
                 }
             }
 


### PR DESCRIPTION
Currently the code does not compile if `T` is different than `double`.