### PR TITLE
Remove unused parameters

### DIFF
--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -160,8 +160,7 @@ struct base_turn_handler
             std::size_t index_p, std::size_t index_q,
             TurnInfo& ti)
     {
-        boost::ignore_unused(range_p);
-        boost::ignore_unused(range_q);
+        boost::ignore_unused(range_p, range_q);
         BOOST_GEOMETRY_ASSERT(IndexP + IndexQ == 1);
         BOOST_GEOMETRY_ASSERT(index_p > 0 && index_p <= 2);
         BOOST_GEOMETRY_ASSERT(index_q > 0 && index_q <= 2);

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -154,20 +154,14 @@ struct base_turn_handler
             typename TurnInfo
     >
     static inline void both_collinear(
-            UniqueSubRange1 const&
-#if ! defined(BOOST_GEOMETRY_USE_RESCALING)
-            range_p
-#endif
-            ,
-            UniqueSubRange2 const&
-#if ! defined(BOOST_GEOMETRY_USE_RESCALING)
-            range_q
-#endif
-            ,
+            UniqueSubRange1 const& range_p,
+            UniqueSubRange2 const& range_q,
             UmbrellaStrategy const&,
             std::size_t index_p, std::size_t index_q,
             TurnInfo& ti)
     {
+        boost::ignore_unused(range_p);
+        boost::ignore_unused(range_q);
         BOOST_GEOMETRY_ASSERT(IndexP + IndexQ == 1);
         BOOST_GEOMETRY_ASSERT(index_p > 0 && index_p <= 2);
         BOOST_GEOMETRY_ASSERT(index_q > 0 && index_q <= 2);

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -153,9 +153,18 @@ struct base_turn_handler
             typename UmbrellaStrategy,
             typename TurnInfo
     >
-    static inline void both_collinear(UniqueSubRange1 const& range_p,
-            UniqueSubRange2 const& range_q,
-            UmbrellaStrategy const& umbrella_strategy,
+    static inline void both_collinear(
+            UniqueSubRange1 const&
+#if ! defined(BOOST_GEOMETRY_USE_RESCALING)
+            range_p
+#endif
+            ,
+            UniqueSubRange2 const&
+#if ! defined(BOOST_GEOMETRY_USE_RESCALING)
+            range_q
+#endif
+            ,
+            UmbrellaStrategy const&,
             std::size_t index_p, std::size_t index_q,
             TurnInfo& ti)
     {

--- a/include/boost/geometry/index/detail/algorithms/intersection_content.hpp
+++ b/include/boost/geometry/index/detail/algorithms/intersection_content.hpp
@@ -24,7 +24,7 @@ namespace boost { namespace geometry { namespace index { namespace detail {
 
 // Util to distinguish between default and non-default index strategy
 template <typename Box, typename Strategy>
-inline bool disjoint_box_box(Box const& box1, Box const& box2, Strategy const& strategy)
+inline bool disjoint_box_box(Box const& box1, Box const& box2, Strategy const&)
 {
     return geometry::detail::disjoint::disjoint_box_box(box1, box2,
                 typename Strategy::disjoint_box_box_strategy_type());

--- a/include/boost/geometry/index/parameters.hpp
+++ b/include/boost/geometry/index/parameters.hpp
@@ -304,7 +304,7 @@ struct strategy_type< parameters<Parameters, Strategy> >
 template <typename Parameters>
 struct get_strategy_impl
 {
-    static inline default_strategy apply(Parameters const& parameters)
+    static inline default_strategy apply(Parameters const&)
     {
         return default_strategy();
     }


### PR DESCRIPTION
Remove unused parameters in some algorithms to avoid compilation warnings.