### PR TITLE
While sorting turns in relops and setops compare also point coordinates.

### DIFF
--- a/include/boost/geometry/algorithms/detail/overlay/follow.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/follow.hpp
@@ -3,8 +3,8 @@
 // Copyright (c) 2007-2014 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2014, 2017, 2018.
-// Modifications copyright (c) 2014-2018 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014, 2017, 2018, 2019.
+// Modifications copyright (c) 2014-2019 Oracle and/or its affiliates.
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -428,6 +428,8 @@ public :
 
         typedef following::action_selector<OverlayType, RemoveSpikes> action;
 
+        typedef typename Strategy::cs_tag cs_tag;
+
         typename Strategy::template point_in_geometry_strategy
             <
                 LineString, Polygon
@@ -442,7 +444,10 @@ public :
 #ifdef BOOST_GEOMETRY_SETOPS_LA_OLD_BEHAVIOR
         std::sort(boost::begin(turns), boost::end(turns), sort_on_segment<turn_type>());
 #else
-        typedef relate::turns::less<0, relate::turns::less_op_linear_areal_single<0> > turn_less;
+        typedef relate::turns::less
+            <
+                0, relate::turns::less_op_linear_areal_single<0>, cs_tag
+            > turn_less;
         std::sort(boost::begin(turns), boost::end(turns), turn_less());
 #endif
 

--- a/include/boost/geometry/algorithms/detail/relate/areal_areal.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/areal_areal.hpp
@@ -235,6 +235,8 @@ struct areal_areal
         if ( BOOST_GEOMETRY_CONDITION(result.interrupt) )
             return;
 
+        typedef typename IntersectionStrategy::cs_tag cs_tag;
+
         typedef typename IntersectionStrategy::template point_in_geometry_strategy
             <
                 Geometry1, Geometry2
@@ -270,7 +272,7 @@ struct areal_areal
           || may_update<exterior, interior, '2'>(result) )
         {
             // sort turns
-            typedef turns::less<0, turns::less_op_areal_areal<0> > less;
+            typedef turns::less<0, turns::less_op_areal_areal<0>, cs_tag> less;
             std::sort(turns.begin(), turns.end(), less());
 
             /*if ( may_update<interior, exterior, '2'>(result)
@@ -311,7 +313,7 @@ struct areal_areal
           || may_update<exterior, interior, '2', true>(result) )
         {
             // sort turns
-            typedef turns::less<1, turns::less_op_areal_areal<1> > less;
+            typedef turns::less<1, turns::less_op_areal_areal<1>, cs_tag> less;
             std::sort(turns.begin(), turns.end(), less());
 
             /*if ( may_update<interior, exterior, '2', true>(result)

--- a/include/boost/geometry/algorithms/detail/relate/linear_linear.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/linear_linear.hpp
@@ -127,6 +127,8 @@ struct linear_linear
                              Result & result,
                              IntersectionStrategy const& intersection_strategy)
     {
+        typedef typename IntersectionStrategy::cs_tag cs_tag;
+
         // The result should be FFFFFFFFF
         relate::set<exterior, exterior, result_dimension<Geometry1>::value>(result);// FFFFFFFFd, d in [1,9] or T
         if ( BOOST_GEOMETRY_CONDITION( result.interrupt ) )
@@ -186,7 +188,7 @@ struct linear_linear
           || may_update<boundary, boundary, '0'>(result)
           || may_update<boundary, exterior, '0'>(result) )
         {
-            typedef turns::less<0, turns::less_op_linear_linear<0> > less;
+            typedef turns::less<0, turns::less_op_linear_linear<0>, cs_tag> less;
             std::sort(turns.begin(), turns.end(), less());
 
             turns_analyser<turn_type, 0> analyser;
@@ -206,7 +208,7 @@ struct linear_linear
           || may_update<boundary, boundary, '0', true>(result)
           || may_update<boundary, exterior, '0', true>(result) )
         {
-            typedef turns::less<1, turns::less_op_linear_linear<1> > less;
+            typedef turns::less<1, turns::less_op_linear_linear<1>, cs_tag> less;
             std::sort(turns.begin(), turns.end(), less());
 
             turns_analyser<turn_type, 1> analyser;

--- a/test/algorithms/set_operations/difference/Jamfile.v2
+++ b/test/algorithms/set_operations/difference/Jamfile.v2
@@ -4,8 +4,8 @@
 # Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
 # Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 #
-# This file was modified by Oracle on 2014, 2015.
-# Modifications copyright (c) 2014-2015, Oracle and/or its affiliates.
+# This file was modified by Oracle on 2014, 2015, 2019.
+# Modifications copyright (c) 2014-2019, Oracle and/or its affiliates.
 #
 # Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 # Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -16,14 +16,15 @@
 
 test-suite boost-geometry-algorithms-difference
     :
-    [ run difference.cpp                 : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE
-                                             : algorithms_difference ]
-    [ run difference_linear_linear.cpp : : : : algorithms_difference_linear_linear ]
-    [ run difference_areal_linear.cpp  : : : : algorithms_difference_areal_linear ]
-    [ run difference_pl_l.cpp          : : : : algorithms_difference_pl_l ]
-    [ run difference_pl_pl.cpp         : : : : algorithms_difference_pl_pl ]
-    [ run difference_multi.cpp           : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE
-                                             : algorithms_difference_multi ]
+    [ run difference.cpp                      : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE
+                                                  : algorithms_difference ]
+    [ run difference_l_a_sph.cpp            : : : : algorithms_difference_l_a_sph ]
+    [ run difference_linear_linear.cpp      : : : : algorithms_difference_linear_linear ]
+    [ run difference_areal_linear.cpp       : : : : algorithms_difference_areal_linear ]
+    [ run difference_pl_l.cpp               : : : : algorithms_difference_pl_l ]
+    [ run difference_pl_pl.cpp              : : : : algorithms_difference_pl_pl ]
+    [ run difference_multi.cpp                : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE
+                                                  : algorithms_difference_multi ]
     [ run difference_multi_areal_linear.cpp : : : : algorithms_difference_multi_areal_linear ]
     [ run difference_multi_spike.cpp          : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE
                                                   : algorithms_difference_multi_spike ]

--- a/test/algorithms/set_operations/difference/difference_l_a_sph.cpp
+++ b/test/algorithms/set_operations/difference/difference_l_a_sph.cpp
@@ -1,0 +1,36 @@
+// Boost.Geometry
+// Unit Test
+
+// Copyright (c) 2019, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "test_difference.hpp"
+
+void test_all()
+{
+    typedef bg::model::point<double, 2, bg::cs::spherical_equatorial<bg::degree> > point;
+    typedef bg::model::linestring<point> linestring;
+    typedef bg::model::polygon<point> polygon;
+
+    // https://github.com/boostorg/geometry/issues/619
+    
+    test_one_lp<linestring, linestring, polygon>(
+        "issue_619",
+        "LINESTRING(-106.373725 39.638846, -106.373486 39.639362, -106.368378 39.614603)",
+        "POLYGON((-106.374074 39.638593, -106.373626 39.639230, -106.373594 39.639232, "
+                 "-106.373366 39.638502, -106.373299 39.638459, -106.373369 39.638382, "
+                 "-106.374074 39.638593))",
+        2, 5, 0.00044107988528133710);
+}
+
+int test_main(int, char* [])
+{
+    test_all();
+
+    return 0;
+}

--- a/test/to_svg.hpp
+++ b/test/to_svg.hpp
@@ -361,7 +361,15 @@ inline void to_svg(G1 const& g1, G2 const& g2, std::string const& filename, bool
 
     if ( sort )
     {
-        typedef bg::detail::relate::turns::less<> less;
+        typedef bg::detail::relate::turns::less
+            <
+                0,
+                bg::detail::relate::turns::less_op_xxx_linear
+                    <
+                        0, bg::detail::relate::turns::op_to_int<>
+                    >,
+                typename bg::cs_tag<G1>::type
+            > less;
         std::sort(boost::begin(turns), boost::end(turns), less());
     }
 


### PR DESCRIPTION
This is a fix for issue https://github.com/boostorg/geometry/issues/619

Currently only fractions are used to check if points are equal in `relate::turns::less` predicate passed to `std::sort` to sort turns before analysis in relops and setops. This may give wrong results in some cases.