### PR TITLE
[for_each] Fix for_each_segment to avoid incrementing iterator over empty range

### DIFF
--- a/include/boost/geometry/algorithms/for_each.hpp
+++ b/include/boost/geometry/algorithms/for_each.hpp
@@ -110,7 +110,9 @@ struct fe_range_per_segment_with_closure
 
         iterator_type it = boost::begin(range);
         if (it == boost::end(range))
+        {
             return;
+        }
 
         iterator_type previous = it++;
         while(it != boost::end(range))

--- a/include/boost/geometry/algorithms/for_each.hpp
+++ b/include/boost/geometry/algorithms/for_each.hpp
@@ -109,6 +109,9 @@ struct fe_range_per_segment_with_closure
         typedef typename boost::range_iterator<Range>::type iterator_type;
 
         iterator_type it = boost::begin(range);
+        if (it == boost::end(range))
+            return;
+
         iterator_type previous = it++;
         while(it != boost::end(range))
         {

--- a/test/algorithms/for_each.cpp
+++ b/test/algorithms/for_each.cpp
@@ -42,6 +42,18 @@ void test_all()
             , std::sqrt(2.0)
             , "LINESTRING(10 1,2 2)"
         );
+    test_geometry<bg::model::linestring<P> >
+        (
+            "LINESTRING EMPTY"
+
+            , 0
+            , "LINESTRING()"
+            , "LINESTRING()"
+
+            , ""
+            , 0
+            , "LINESTRING()"
+        );
     test_geometry<bg::model::ring<P> >
         (
             "POLYGON((1 1,1 4,4 4,4 1,1 1))"
@@ -53,6 +65,18 @@ void test_all()
             , "((1, 1), (1, 4)) ((1, 4), (4, 4)) ((4, 4), (4, 1)) ((4, 1), (1, 1))"
             , 4 * 3.0
             , "POLYGON((10 1,10 4,4 4,4 1,1 1))"
+        );
+    test_geometry<bg::model::ring<P> >
+        (
+            "POLYGON EMPTY"
+
+            , 0
+            , "POLYGON(())"
+            , "POLYGON(())"
+
+            , ""
+            , 0
+            , "POLYGON(())"
         );
     test_geometry<bg::model::ring<P, true, false> > // open ring
         (


### PR DESCRIPTION
Added test to verifying the fix.
Fixes #624

----

The added tests can reproduce the bug in the current `for_each_segment` implementation without the proposed fix:

```console
bionic:/mnt/d/boost.wsl/libs/geometry/test/algorithms$ g++  -std=gnu++2a -fvisibility-inlines-hidden -fPIC -m64 -pthread -O0 -fno-inline -Wall -g -fvisibility=hidden  -DBOOST_ALL_NO_LIB=1 -DBOOST_NO_AUTO_PTR -I".." -I"../../../.." -I"../../../../boost/geometry/extensions/contrib/ttmath" -c -o "../../../../bin.v2/libs/geometry/test/algorithms/algorithms_for_each.test/gcc-7/debug/threading-multi/visibility-hidden/for_each.o" "for_each.cpp" && g++   -std=gnu++2a -o "../../../../bin.v2/libs/geometry/test/algorithms/algorithms_for_each.test/gcc-7/debug/threading-multi/visibility-hidden/algorithms_for_each" -Wl,--start-group "../../../../bin.v2/libs/geometry/test/algorithms/algorithms_for_each.test/gcc-7/debug/threading-multi/visibility-hidden/for_each.o"  -Wl,-Bstatic  -Wl,-Bdynamic -lrt -Wl,--end-group -fPIC -m64 -pthread -g -fvisibility=hidden -fvisibility-inlines-hidden

bionic:/mnt/d/boost.wsl/libs/geometry/test/algorithms$ ../../../../bin.v2/libs/geometry/test/algorithms/algorithms_for_each.test/gcc-7/debug/threading-multi/visibility-hidden/algorithms_for_each
Running 1 test case...
unknown location(0): fatal error: in "test_main_caller( argc, argv )": memory access violation at address: 0x00000000: no mapping at fault address
../algorithms/test_for_each.hpp(176): last checkpoint

*** 1 failure is detected in the test module "Test Program"
```