### PR TITLE
Implement relops for arguments always resulting in false.

### DIFF
--- a/include/boost/geometry/algorithms/detail/equals/implementation.hpp
+++ b/include/boost/geometry/algorithms/detail/equals/implementation.hpp
@@ -5,8 +5,8 @@
 // Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 // Copyright (c) 2014-2015 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2014, 2015, 2016, 2017, 2018.
-// Modifications copyright (c) 2014-2018 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014, 2015, 2016, 2017, 2018, 2019.
+// Modifications copyright (c) 2014-2019 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
@@ -275,6 +275,15 @@ private:
     }
 };
 
+struct equals_always_false
+{
+    template <typename Geometry1, typename Geometry2, typename Strategy>
+    static inline bool apply(Geometry1 const& , Geometry2 const& , Strategy const& )
+    {
+        return false;
+    }
+};
+
 
 }} // namespace detail::equals
 #endif // DOXYGEN_NO_DETAIL
@@ -285,73 +294,83 @@ namespace dispatch
 {
 
 template <typename P1, typename P2, std::size_t DimensionCount, bool Reverse>
-struct equals<P1, P2, point_tag, point_tag, DimensionCount, Reverse>
+struct equals<P1, P2, point_tag, point_tag, pointlike_tag, pointlike_tag, DimensionCount, Reverse>
     : detail::equals::point_point<0, DimensionCount>
 {};
 
 template <typename MultiPoint1, typename MultiPoint2, std::size_t DimensionCount, bool Reverse>
-struct equals<MultiPoint1, MultiPoint2, multi_point_tag, multi_point_tag, DimensionCount, Reverse>
+struct equals<MultiPoint1, MultiPoint2, multi_point_tag, multi_point_tag, pointlike_tag, pointlike_tag, DimensionCount, Reverse>
     : detail::equals::equals_by_relate<MultiPoint1, MultiPoint2>
 {};
 
 template <typename MultiPoint, typename Point, std::size_t DimensionCount, bool Reverse>
-struct equals<Point, MultiPoint, point_tag, multi_point_tag, DimensionCount, Reverse>
+struct equals<Point, MultiPoint, point_tag, multi_point_tag, pointlike_tag, pointlike_tag, DimensionCount, Reverse>
     : detail::equals::equals_by_relate<Point, MultiPoint>
 {};
 
 template <typename Box1, typename Box2, std::size_t DimensionCount, bool Reverse>
-struct equals<Box1, Box2, box_tag, box_tag, DimensionCount, Reverse>
+struct equals<Box1, Box2, box_tag, box_tag, areal_tag, areal_tag, DimensionCount, Reverse>
     : detail::equals::box_box<0, DimensionCount>
 {};
 
 
 template <typename Ring1, typename Ring2, bool Reverse>
-struct equals<Ring1, Ring2, ring_tag, ring_tag, 2, Reverse>
+struct equals<Ring1, Ring2, ring_tag, ring_tag, areal_tag, areal_tag, 2, Reverse>
     : detail::equals::equals_by_collection_or_relate<detail::equals::area_check>
 {};
 
 
 template <typename Polygon1, typename Polygon2, bool Reverse>
-struct equals<Polygon1, Polygon2, polygon_tag, polygon_tag, 2, Reverse>
+struct equals<Polygon1, Polygon2, polygon_tag, polygon_tag, areal_tag, areal_tag, 2, Reverse>
     : detail::equals::equals_by_collection_or_relate<detail::equals::area_check>
 {};
 
 
 template <typename Polygon, typename Ring, bool Reverse>
-struct equals<Polygon, Ring, polygon_tag, ring_tag, 2, Reverse>
+struct equals<Polygon, Ring, polygon_tag, ring_tag, areal_tag, areal_tag, 2, Reverse>
     : detail::equals::equals_by_collection_or_relate<detail::equals::area_check>
 {};
 
 
 template <typename Ring, typename Box, bool Reverse>
-struct equals<Ring, Box, ring_tag, box_tag, 2, Reverse>
+struct equals<Ring, Box, ring_tag, box_tag, areal_tag, areal_tag, 2, Reverse>
     : detail::equals::equals_by_collection<detail::equals::area_check>
 {};
 
 
 template <typename Polygon, typename Box, bool Reverse>
-struct equals<Polygon, Box, polygon_tag, box_tag, 2, Reverse>
+struct equals<Polygon, Box, polygon_tag, box_tag, areal_tag, areal_tag, 2, Reverse>
     : detail::equals::equals_by_collection<detail::equals::area_check>
 {};
 
 template <typename Segment1, typename Segment2, std::size_t DimensionCount, bool Reverse>
-struct equals<Segment1, Segment2, segment_tag, segment_tag, DimensionCount, Reverse>
+struct equals<Segment1, Segment2, segment_tag, segment_tag, linear_tag, linear_tag, DimensionCount, Reverse>
     : detail::equals::segment_segment
 {};
 
 template <typename LineString1, typename LineString2, bool Reverse>
-struct equals<LineString1, LineString2, linestring_tag, linestring_tag, 2, Reverse>
+struct equals<LineString1, LineString2, linestring_tag, linestring_tag, linear_tag, linear_tag, 2, Reverse>
     : detail::equals::equals_by_relate<LineString1, LineString2>
 {};
 
 template <typename LineString, typename MultiLineString, bool Reverse>
-struct equals<LineString, MultiLineString, linestring_tag, multi_linestring_tag, 2, Reverse>
+struct equals<LineString, MultiLineString, linestring_tag, multi_linestring_tag, linear_tag, linear_tag, 2, Reverse>
     : detail::equals::equals_by_relate<LineString, MultiLineString>
 {};
 
 template <typename MultiLineString1, typename MultiLineString2, bool Reverse>
-struct equals<MultiLineString1, MultiLineString2, multi_linestring_tag, multi_linestring_tag, 2, Reverse>
+struct equals<MultiLineString1, MultiLineString2, multi_linestring_tag, multi_linestring_tag, linear_tag, linear_tag, 2, Reverse>
     : detail::equals::equals_by_relate<MultiLineString1, MultiLineString2>
+{};
+
+template <typename LineString, typename Segment, bool Reverse>
+struct equals<LineString, Segment, linestring_tag, segment_tag, linear_tag, linear_tag, 2, Reverse>
+    : detail::equals::equals_by_relate<LineString, Segment>
+{};
+
+template <typename MultiLineString, typename Segment, bool Reverse>
+struct equals<MultiLineString, Segment, multi_linestring_tag, segment_tag, linear_tag, linear_tag, 2, Reverse>
+    : detail::equals::equals_by_relate<MultiLineString, Segment>
 {};
 
 
@@ -360,6 +379,7 @@ struct equals
     <
         MultiPolygon1, MultiPolygon2,
         multi_polygon_tag, multi_polygon_tag,
+        areal_tag, areal_tag, 
         2,
         Reverse
     >
@@ -372,6 +392,7 @@ struct equals
     <
         Polygon, MultiPolygon,
         polygon_tag, multi_polygon_tag,
+        areal_tag, areal_tag, 
         2,
         Reverse
     >
@@ -383,12 +404,49 @@ struct equals
     <
         MultiPolygon, Ring,
         multi_polygon_tag, ring_tag,
+        areal_tag, areal_tag, 
         2,
         Reverse
     >
     : detail::equals::equals_by_collection_or_relate<detail::equals::area_check>
 {};
 
+
+// NOTE: degenerated linear geometries, e.g. segment or linestring containing
+//   2 equal points, are considered to be invalid. Though theoretically
+//   degenerated segments and linestrings could be treated as points and
+//   multi-linestrings as multi-points.
+//   This reasoning could also be applied to boxes.
+
+template <typename Geometry1, typename Geometry2, typename Tag1, typename Tag2, std::size_t DimensionCount>
+struct equals<Geometry1, Geometry2, Tag1, Tag2, pointlike_tag, linear_tag, DimensionCount, false>
+    : detail::equals::equals_always_false
+{};
+
+template <typename Geometry1, typename Geometry2, typename Tag1, typename Tag2, std::size_t DimensionCount>
+struct equals<Geometry1, Geometry2, Tag1, Tag2, linear_tag, pointlike_tag, DimensionCount, false>
+    : detail::equals::equals_always_false
+{};
+
+template <typename Geometry1, typename Geometry2, typename Tag1, typename Tag2, std::size_t DimensionCount>
+struct equals<Geometry1, Geometry2, Tag1, Tag2, pointlike_tag, areal_tag, DimensionCount, false>
+    : detail::equals::equals_always_false
+{};
+
+template <typename Geometry1, typename Geometry2, typename Tag1, typename Tag2, std::size_t DimensionCount>
+struct equals<Geometry1, Geometry2, Tag1, Tag2, areal_tag, pointlike_tag, DimensionCount, false>
+    : detail::equals::equals_always_false
+{};
+
+template <typename Geometry1, typename Geometry2, typename Tag1, typename Tag2, std::size_t DimensionCount>
+struct equals<Geometry1, Geometry2, Tag1, Tag2, linear_tag, areal_tag, DimensionCount, false>
+    : detail::equals::equals_always_false
+{};
+
+template <typename Geometry1, typename Geometry2, typename Tag1, typename Tag2, std::size_t DimensionCount>
+struct equals<Geometry1, Geometry2, Tag1, Tag2, areal_tag, linear_tag, DimensionCount, false>
+    : detail::equals::equals_always_false
+{};
 
 } // namespace dispatch
 #endif // DOXYGEN_NO_DISPATCH

--- a/include/boost/geometry/algorithms/detail/equals/interface.hpp
+++ b/include/boost/geometry/algorithms/detail/equals/interface.hpp
@@ -5,8 +5,8 @@
 // Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 // Copyright (c) 2014-2015 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2014, 2015, 2016, 2017.
-// Modifications copyright (c) 2014-2017 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014, 2015, 2016, 2017, 2019.
+// Modifications copyright (c) 2014-2019 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
@@ -52,6 +52,8 @@ template
     typename Geometry2,
     typename Tag1 = typename tag<Geometry1>::type,
     typename Tag2 = typename tag<Geometry2>::type,
+    typename CastedTag1 = typename tag_cast<Tag1, pointlike_tag, linear_tag, areal_tag>::type,
+    typename CastedTag2 = typename tag_cast<Tag2, pointlike_tag, linear_tag, areal_tag>::type,
     std::size_t DimensionCount = dimension<Geometry1>::type::value,
     bool Reverse = reverse_dispatch<Geometry1, Geometry2>::type::value
 >
@@ -64,10 +66,11 @@ template
 <
     typename Geometry1, typename Geometry2,
     typename Tag1, typename Tag2,
+    typename CastedTag1, typename CastedTag2,
     std::size_t DimensionCount
 >
-struct equals<Geometry1, Geometry2, Tag1, Tag2, DimensionCount, true>
-    : equals<Geometry2, Geometry1, Tag2, Tag1, DimensionCount, false>
+struct equals<Geometry1, Geometry2, Tag1, Tag2, CastedTag1, CastedTag2, DimensionCount, true>
+    : equals<Geometry2, Geometry1, Tag2, Tag1, CastedTag2, CastedTag1, DimensionCount, false>
 {
     template <typename Strategy>
     static inline bool apply(Geometry1 const& g1, Geometry2 const& g2, Strategy const& strategy)
@@ -76,6 +79,7 @@ struct equals<Geometry1, Geometry2, Tag1, Tag2, DimensionCount, true>
             <
                 Geometry2, Geometry1,
                 Tag2, Tag1,
+                CastedTag2, CastedTag1,
                 DimensionCount,
                 false
             >::apply(g2, g1, strategy);

--- a/include/boost/geometry/algorithms/detail/relate/de9im.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/de9im.hpp
@@ -2,8 +2,8 @@
 
 // Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2013, 2014, 2015.
-// Modifications copyright (c) 2013-2015 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013, 2014, 2015, 2019.
+// Modifications copyright (c) 2013-2019 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -22,7 +22,6 @@
 #include <boost/tuple/tuple.hpp>
 
 #include <boost/geometry/algorithms/detail/relate/result.hpp>
-#include <boost/geometry/algorithms/not_implemented.hpp>
 #include <boost/geometry/core/topological_dimension.hpp>
 #include <boost/geometry/core/tag.hpp>
 
@@ -318,9 +317,9 @@ struct static_mask_touches_impl
 // Using the above mask the result would be always false
 template <typename Geometry1, typename Geometry2>
 struct static_mask_touches_impl<Geometry1, Geometry2, 0, 0>
-    : not_implemented<typename geometry::tag<Geometry1>::type,
-                      typename geometry::tag<Geometry2>::type>
-{};
+{
+    typedef geometry::detail::relate::false_mask type;
+};
 
 template <typename Geometry1, typename Geometry2>
 struct static_mask_touches_type
@@ -377,12 +376,9 @@ template
     typename Geometry1, typename Geometry2, std::size_t Dim
 >
 struct static_mask_crosses_impl<Geometry1, Geometry2, Dim, Dim, false>
-    : not_implemented
-        <
-            typename geometry::tag<Geometry1>::type,
-            typename geometry::tag<Geometry2>::type
-        >
-{};
+{
+    typedef geometry::detail::relate::false_mask type;
+};
 // dim(G1) == 1 && dim(G2) == 1 - L/L
 template <typename Geometry1, typename Geometry2>
 struct static_mask_crosses_impl<Geometry1, Geometry2, 1, 1, false>
@@ -406,12 +402,9 @@ template
     std::size_t Dim2 = geometry::topological_dimension<Geometry2>::value
 >
 struct static_mask_overlaps_impl
-    : not_implemented
-        <
-            typename geometry::tag<Geometry1>::type,
-            typename geometry::tag<Geometry2>::type
-        >
-{};
+{
+    typedef geometry::detail::relate::false_mask type;
+};
 // dim(G1) == D && dim(G2) == D - P/P A/A
 template <typename Geometry1, typename Geometry2, std::size_t Dim>
 struct static_mask_overlaps_impl<Geometry1, Geometry2, Dim, Dim>

--- a/include/boost/geometry/algorithms/detail/relate/relate_impl.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/relate_impl.hpp
@@ -2,8 +2,8 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2013, 2014, 2015.
-// Modifications copyright (c) 2013-2015 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013, 2014, 2015, 2019.
+// Modifications copyright (c) 2013-2019 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -30,25 +30,19 @@ namespace detail { namespace relate {
 
 struct implemented_tag {};
 
-template <template <typename, typename> class StaticMaskTrait,
-          typename Geometry1,
-          typename Geometry2>
-struct relate_impl
-    : boost::mpl::if_
+template
+<
+    typename Geometry1,
+    typename Geometry2
+>
+struct relate_impl_base
+    : boost::mpl::if_c
         <
-            boost::mpl::or_
+            boost::is_base_of
                 <
-                    boost::is_base_of
-                        <
-                            nyi::not_implemented_tag,
-                            StaticMaskTrait<Geometry1, Geometry2>
-                        >,
-                    boost::is_base_of
-                        <
-                            nyi::not_implemented_tag,
-                            dispatch::relate<Geometry1, Geometry2>
-                        >
-                >,
+                    nyi::not_implemented_tag,
+                    dispatch::relate<Geometry1, Geometry2>
+                >::value,
             not_implemented
                 <
                     typename geometry::tag<Geometry1>::type,
@@ -56,6 +50,16 @@ struct relate_impl
                 >,
             implemented_tag
         >::type
+{};
+
+template
+<
+    typename Geometry1,
+    typename Geometry2,
+    typename StaticMask
+>
+struct relate_impl_dispatch
+    : relate_impl_base<Geometry1, Geometry2>
 {
     template <typename Strategy>
     static inline bool apply(Geometry1 const& g1, Geometry2 const& g2, Strategy const& strategy)
@@ -64,7 +68,7 @@ struct relate_impl
             <
                 Geometry1,
                 Geometry2,
-                typename StaticMaskTrait<Geometry1, Geometry2>::type
+                StaticMask
             >::type handler;
 
         dispatch::relate<Geometry1, Geometry2>::apply(g1, g2, handler, strategy);
@@ -72,6 +76,32 @@ struct relate_impl
         return handler.result();
     }
 };
+
+template <typename Geometry1, typename Geometry2>
+struct relate_impl_dispatch<Geometry1, Geometry2, detail::relate::false_mask>
+    : relate_impl_base<Geometry1, Geometry2>
+{
+    template <typename Strategy>
+    static inline bool apply(Geometry1 const& , Geometry2 const& , Strategy const& )
+    {
+        return false;
+    }
+};
+
+template
+<
+    template <typename, typename> class StaticMaskTrait,
+    typename Geometry1,
+    typename Geometry2
+>
+struct relate_impl
+    : relate_impl_dispatch
+        <
+            Geometry1,
+            Geometry2,
+            typename StaticMaskTrait<Geometry1, Geometry2>::type
+        >
+{};
 
 }} // namespace detail::relate
 #endif // DOXYGEN_NO_DETAIL

--- a/include/boost/geometry/algorithms/detail/relate/result.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/result.hpp
@@ -3,8 +3,8 @@
 // Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2013-2018.
-// Modifications copyright (c) 2013-2018 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013-2019.
+// Modifications copyright (c) 2013-2019 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -653,6 +653,10 @@ public:
 private:
     Mask const& m_mask;
 };
+
+// --------------- FALSE MASK ----------------
+
+struct false_mask {};
 
 // --------------- COMPILE-TIME MASK ----------------
 

--- a/include/boost/geometry/algorithms/detail/touches/implementation.hpp
+++ b/include/boost/geometry/algorithms/detail/touches/implementation.hpp
@@ -5,8 +5,8 @@
 // Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 // Copyright (c) 2013-2015 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2013, 2014, 2015, 2017.
-// Modifications copyright (c) 2013-2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013, 2014, 2015, 2017, 2019.
+// Modifications copyright (c) 2013-2019, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -292,8 +292,8 @@ namespace dispatch {
 
 // P/P
 
-template <typename Geometry1, typename Geometry2, typename Tag2>
-struct touches<Geometry1, Geometry2, point_tag, Tag2, pointlike_tag, pointlike_tag, false>
+template <typename Geometry1, typename Geometry2>
+struct touches<Geometry1, Geometry2, point_tag, point_tag, pointlike_tag, pointlike_tag, false>
 {
     template <typename Strategy>
     static inline bool apply(Geometry1 const& , Geometry2 const& , Strategy const&)
@@ -302,8 +302,18 @@ struct touches<Geometry1, Geometry2, point_tag, Tag2, pointlike_tag, pointlike_t
     }
 };
 
-template <typename Geometry1, typename Geometry2, typename Tag2>
-struct touches<Geometry1, Geometry2, multi_point_tag, Tag2, pointlike_tag, pointlike_tag, false>
+template <typename Geometry1, typename Geometry2>
+struct touches<Geometry1, Geometry2, point_tag, multi_point_tag, pointlike_tag, pointlike_tag, false>
+{
+    template <typename Strategy>
+    static inline bool apply(Geometry1 const& , Geometry2 const& , Strategy const&)
+    {
+        return false;
+    }
+};
+
+template <typename Geometry1, typename Geometry2>
+struct touches<Geometry1, Geometry2, multi_point_tag, multi_point_tag, pointlike_tag, pointlike_tag, false>
 {
     template <typename Strategy>
     static inline bool apply(Geometry1 const&, Geometry2 const&, Strategy const&)
@@ -312,7 +322,7 @@ struct touches<Geometry1, Geometry2, multi_point_tag, Tag2, pointlike_tag, point
     }
 };
 
-// P/*
+// P/L P/A
 
 template <typename Point, typename Geometry, typename Tag2, typename CastedTag2>
 struct touches<Point, Geometry, point_tag, Tag2, pointlike_tag, CastedTag2, false>
@@ -328,6 +338,8 @@ struct touches<MultiPoint, MultiGeometry, multi_point_tag, Tag2, pointlike_tag, 
             MultiGeometry
         >
 {};
+
+// L/P A/P
 
 template <typename Geometry, typename MultiPoint, typename Tag1, typename CastedTag1>
 struct touches<Geometry, MultiPoint, Tag1, multi_point_tag, CastedTag1, pointlike_tag, false>


### PR DESCRIPTION
The purpose is to simplify writing generic code with relational operations. Consider e.g.:

    bg::equals(linestring, polygon);
    bg::touches(point, linestring);
    bg::crosses(point, linestring);
    bg::overlaps(point, linestring);

before: compilation error,
this PR: compiles and always returns `false`.