### PR TITLE
Fix/buffer onesided

### DIFF
--- a/doc/release_notes.qbk
+++ b/doc/release_notes.qbk
@@ -20,6 +20,18 @@
 [section:release_notes Release Notes]
 
 [/=================]
+[heading Boost 1.72]
+[/=================]
+
+[*Improvements]
+
+* Various improvements related to robustness of set and relational operation.
+
+[*Bugfixes]
+
+* Fixed errors in generation of asymmetric one-sided buffer
+
+[/=================]
 [heading Boost 1.71]
 [/=================]
 

--- a/include/boost/geometry/algorithms/detail/buffer/buffer_inserter.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/buffer_inserter.hpp
@@ -972,7 +972,7 @@ inline void buffer_inserter(GeometryInput const& geometry_input, OutputIterator 
             end_strategy, point_strategy,
             robust_policy, intersection_strategy.get_side_strategy());
 
-    collection.get_turns();
+    collection.get_turns(distance_strategy);
     collection.classify_turns();
     if (BOOST_GEOMETRY_CONDITION(areal))
     {

--- a/include/boost/geometry/algorithms/detail/buffer/buffer_inserter.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/buffer_inserter.hpp
@@ -97,7 +97,7 @@ struct buffer_range
         typename JoinStrategy,
         typename EndStrategy,
         typename RobustPolicy,
-        typename Strategy
+        typename SideStrategy
     >
     static inline
     void add_join(Collection& collection,
@@ -113,13 +113,13 @@ struct buffer_range
             JoinStrategy const& join_strategy,
             EndStrategy const& end_strategy,
             RobustPolicy const& ,
-            Strategy const& strategy) // side strategy
+            SideStrategy const& side_strategy) // side strategy
     {
         output_point_type intersection_point;
         geometry::assign_zero(intersection_point);
 
         geometry::strategy::buffer::join_selector join
-                = get_join_type(penultimate_input, previous_input, input, strategy);
+                = get_join_type(penultimate_input, previous_input, input, side_strategy);
         if (join == geometry::strategy::buffer::join_convex)
         {
             // Calculate the intersection-point formed by the two sides.
@@ -187,14 +187,14 @@ struct buffer_range
         return arithmetic::similar_direction(p, q);
     }
 
-    template <typename Strategy>
+    template <typename SideStrategy>
     static inline geometry::strategy::buffer::join_selector get_join_type(
             output_point_type const& p0,
             output_point_type const& p1,
             output_point_type const& p2,
-            Strategy const& strategy) // side strategy
+            SideStrategy const& side_strategy)
     {
-        int const side = strategy.apply(p0, p1, p2);
+        int const side = side_strategy.apply(p0, p1, p2);
         return side == -1 ? geometry::strategy::buffer::join_convex
             :  side == 1  ? geometry::strategy::buffer::join_concave
             :  similar_direction(p0, p1, p2)

--- a/include/boost/geometry/algorithms/detail/buffer/buffered_piece_collection.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/buffered_piece_collection.hpp
@@ -547,10 +547,6 @@ struct buffered_piece_collection
             {
                 it->location = inside_buffer;
             }
-            if (it->count_on_original_boundary > 0)
-            {
-                it->location = inside_buffer;
-            }
             if (it->count_within_near_offsetted > 0)
             {
                 // Within can have in rare cases a rounding issue. We don't discard this
@@ -920,7 +916,8 @@ struct buffered_piece_collection
         }
     }
 
-    inline void get_turns()
+    template <typename DistanceStrategy>
+    inline void get_turns(DistanceStrategy const& distance_strategy)
     {
         for(typename boost::range_iterator<sections_type>::type it
                 = boost::begin(monotonic_sections);
@@ -973,9 +970,11 @@ struct buffered_piece_collection
                 <
                     typename geometry::cs_tag<point_type>::type,
                     turn_vector_type, piece_vector_type,
+                    DistanceStrategy,
                     point_in_geometry_strategy_type,
                     side_strategy_type
                 > visitor(m_turns, m_pieces,
+                          distance_strategy,
                           m_point_in_geometry_strategy,
                           m_side_strategy);
 

--- a/include/boost/geometry/algorithms/detail/buffer/get_piece_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/get_piece_turns.hpp
@@ -19,7 +19,6 @@
 
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/algorithms/equals.hpp>
-#include <boost/geometry/algorithms/expand.hpp>
 #include <boost/geometry/algorithms/detail/disjoint/box_box.hpp>
 #include <boost/geometry/algorithms/detail/overlay/segment_identifier.hpp>
 #include <boost/geometry/algorithms/detail/overlay/get_turn_info.hpp>

--- a/include/boost/geometry/algorithms/detail/buffer/turn_in_piece_visitor.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/turn_in_piece_visitor.hpp
@@ -881,7 +881,7 @@ public:
         static const bool use_soi = use_side_of_intersection<CsTag>::value;
         boost::ignore_unused(use_soi);
 
-        analyse_result analyse_code =
+        analyse_result const analyse_code =
             piece.type == geometry::strategy::buffer::buffered_point
                 ? analyse_turn_wrt_point_piece<use_soi>::apply(turn, piece, m_point_in_geometry_strategy, m_side_strategy)
                 : analyse_turn_wrt_piece<use_soi>::apply(turn, piece, m_side_strategy);

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_for_endpoint.hpp
@@ -55,7 +55,7 @@ namespace detail { namespace overlay {
 // <----|
 
 // |------->         2   0   0   1  -1   F   and        i/i x/u
-//     |------->     2   0   0  -1   1   F   symetric   i/i u/x
+//     |------->     2   0   0  -1   1   F   symmetric  i/i u/x
 // |------->
 //
 //     |------->     2   0   0  -1  -1   T              i/u u/i
@@ -74,7 +74,7 @@ namespace detail { namespace overlay {
 // <-----|
 //
 //       |----->     1  -1   0  -1   0   F   and        u/x
-// |----->           1   0  -1   0  -1   F   symetric   x/u
+// |----->           1   0  -1   0  -1   F   symmetric  x/u
 //       |----->
 
 // D0 or D1 != 0
@@ -82,7 +82,7 @@ namespace detail { namespace overlay {
 //          ^
 //          |
 //          +        1  -1   1  -1   1   F   and        u/x  (P is vertical)
-// |-------->        1   1  -1   1  -1   F   symetric   x/u  (P is horizontal)
+// |-------->        1   1  -1   1  -1   F   symmetric  x/u  (P is horizontal)
 // ^
 // |
 // +

--- a/include/boost/geometry/formulas/sjoberg_intersection.hpp
+++ b/include/boost/geometry/formulas/sjoberg_intersection.hpp
@@ -884,7 +884,7 @@ private:
             //   3. f1-f2 may be 0 which means that the intermediate point is on the vertex
             //      In this case it's not possible to check if this is the correct result
             //   4. f1-f2 may also be 0 in other cases, e.g.
-            //      geodesics are symetrical wrt equator and longitude directions are different
+            //      geodesics are symmetrical wrt equator and longitude directions are different
 
             CT const dbeta_denom = f1 - f2;
             //CT const dbeta_denom = math::abs(f1) + math::abs(f2);

--- a/include/boost/geometry/strategies/cartesian/buffer_end_round.hpp
+++ b/include/boost/geometry/strategies/cartesian/buffer_end_round.hpp
@@ -124,28 +124,29 @@ public :
             double
         >::type promoted_type;
 
-        promoted_type const alpha = calculate_angle<promoted_type>(perp_left_point, ultimate_point);
-
         promoted_type const dist_left = distance.apply(penultimate_point, ultimate_point, buffer_side_left);
         promoted_type const dist_right = distance.apply(penultimate_point, ultimate_point, buffer_side_right);
+        promoted_type const alpha
+                = calculate_angle<promoted_type>(penultimate_point, ultimate_point)
+                    - geometry::math::half_pi<promoted_type>();
+
         if (geometry::math::equals(dist_left, dist_right))
         {
             generate_points(ultimate_point, alpha, dist_left, range_out);
         }
         else
         {
-            promoted_type const two = 2.0;
-            promoted_type dist_half_diff = (dist_left - dist_right) / two;
-
-            if (side == buffer_side_right)
-            {
-                dist_half_diff = -dist_half_diff;
-            }
+            static promoted_type const two = 2.0;
+            promoted_type const dist_average = (dist_left + dist_right) / two;
+            promoted_type const dist_half
+                    = (side == buffer_side_right
+                    ? (dist_right - dist_left)
+                    : (dist_left - dist_right)) / two;
 
             Point shifted_point;
-            set<0>(shifted_point, get<0>(ultimate_point) + dist_half_diff * cos(alpha));
-            set<1>(shifted_point, get<1>(ultimate_point) + dist_half_diff * sin(alpha));
-            generate_points(shifted_point, alpha, (dist_left + dist_right) / two, range_out);
+            set<0>(shifted_point, get<0>(ultimate_point) + dist_half * cos(alpha));
+            set<1>(shifted_point, get<1>(ultimate_point) + dist_half * sin(alpha));
+            generate_points(shifted_point, alpha, dist_average, range_out);
         }
 
         if (m_points_per_circle % 2 == 1)

--- a/test/algorithms/buffer/buffer_linestring.cpp
+++ b/test/algorithms/buffer/buffer_linestring.cpp
@@ -124,6 +124,8 @@ void test_all()
     bg::strategy::buffer::end_round end_round32(32);
     bg::strategy::buffer::join_round join_round32(32);
 
+    const ut_settings settings;
+
     // Simplex (join-type is not relevant)
     test_one<linestring, polygon>("simplex", simplex, join_miter, end_flat, 19.209, 1.5);
     test_one<linestring, polygon>("simplex", simplex, join_miter, end_round, 26.2733, 1.5);
@@ -136,15 +138,15 @@ void test_all()
     test_one<linestring, polygon>("simplex_vertical32", simplex_vertical, join_round32, end_round32, 5.12145, 1);
     test_one<linestring, polygon>("simplex_horizontal32", simplex_horizontal, join_round32, end_round32, 5.12145, 1);
 
-    test_one<linestring, polygon>("simplex_asym_neg", simplex, join_miter, end_flat, 3.202, +1.5, ut_settings(), -1.0);
-    test_one<linestring, polygon>("simplex_asym_pos", simplex, join_miter, end_flat, 3.202, -1.0, ut_settings(), +1.5);
+    test_one<linestring, polygon>("simplex_asym_neg", simplex, join_miter, end_flat, 3.202, +1.5, settings, -1.0);
+    test_one<linestring, polygon>("simplex_asym_pos", simplex, join_miter, end_flat, 3.202, -1.0, settings, +1.5);
     // Do not work yet:
-    //    test_one<linestring, polygon>("simplex_asym_neg", simplex, join_miter, end_round, 3.202, +1.5, ut_settings(), -1.0);
-    //    test_one<linestring, polygon>("simplex_asym_pos", simplex, join_miter, end_round, 3.202, -1.0, ut_settings(), +1.5);
+    //    test_one<linestring, polygon>("simplex_asym_neg", simplex, join_miter, end_round, 3.202, +1.5, settings, -1.0);
+    //    test_one<linestring, polygon>("simplex_asym_pos", simplex, join_miter, end_round, 3.202, -1.0, settings, +1.5);
 
     // Generates (initially) a reversed polygon, with a negative area, which is reversed afterwards in assign_parents
-    test_one<linestring, polygon>("simplex_asym_neg_rev", simplex, join_miter, end_flat, 3.202, +1.0, ut_settings(), -1.5);
-    test_one<linestring, polygon>("simplex_asym_pos_rev", simplex, join_miter, end_flat, 3.202, -1.5, ut_settings(), +1.0);
+    test_one<linestring, polygon>("simplex_asym_neg_rev", simplex, join_miter, end_flat, 3.202, +1.0, settings, -1.5);
+    test_one<linestring, polygon>("simplex_asym_pos_rev", simplex, join_miter, end_flat, 3.202, -1.5, settings, +1.0);
 
     test_one<linestring, polygon>("straight", straight, join_round, end_flat, 38.4187, 1.5);
     test_one<linestring, polygon>("straight", straight, join_miter, end_flat, 38.4187, 1.5);
@@ -161,30 +163,30 @@ void test_all()
     test_one<linestring, polygon>("two_bends", two_bends, join_round, end_flat, 39.235, 1.5);
     test_one<linestring, polygon>("two_bends", two_bends, join_round_by_divide, end_flat, 39.235, 1.5);
     test_one<linestring, polygon>("two_bends", two_bends, join_miter, end_flat, 39.513, 1.5);
-    test_one<linestring, polygon>("two_bends_left", two_bends, join_round, end_flat, 20.028, 1.5, ut_settings(), 0.0);
-    test_one<linestring, polygon>("two_bends_left", two_bends, join_miter, end_flat, 20.225, 1.5, ut_settings(), 0.0);
-    test_one<linestring, polygon>("two_bends_right", two_bends, join_round, end_flat, 19.211, 0.0, ut_settings(), 1.5);
-    test_one<linestring, polygon>("two_bends_right", two_bends, join_miter, end_flat, 19.288, 0.0, ut_settings(), 1.5);
+    test_one<linestring, polygon>("two_bends_left", two_bends, join_round, end_flat, 20.028, 1.5, settings, 0.0);
+    test_one<linestring, polygon>("two_bends_left", two_bends, join_miter, end_flat, 20.225, 1.5, settings, 0.0);
+    test_one<linestring, polygon>("two_bends_right", two_bends, join_round, end_flat, 19.211, 0.0, settings, 1.5);
+    test_one<linestring, polygon>("two_bends_right", two_bends, join_miter, end_flat, 19.288, 0.0, settings, 1.5);
 
     test_one<linestring, polygon>("bend_near_start1", bend_near_start1, join_round, end_flat, 109.2625, 9.0);
     test_one<linestring, polygon>("bend_near_start2", bend_near_start2, join_round, end_flat, 142.8709, 9.0);
 
     // Next (and all similar cases) which a offsetted-one-sided buffer has to be fixed. TODO
-    //test_one<linestring, polygon>("two_bends_neg", two_bends, join_miter, end_flat, 99, +1.5, ut_settings(), -1.0);
-    //test_one<linestring, polygon>("two_bends_pos", two_bends, join_miter, end_flat, 99, -1.5, ut_settings(), +1.0);
-    //test_one<linestring,  polygon>("two_bends_neg", two_bends, join_round, end_flat,99, +1.5, ut_settings(), -1.0);
-    //test_one<linestring, polygon>("two_bends_pos", two_bends, join_round, end_flat, 99, -1.5, ut_settings(), +1.0);
+    //test_one<linestring, polygon>("two_bends_neg", two_bends, join_miter, end_flat, 99, +1.5, settings, -1.0);
+    //test_one<linestring, polygon>("two_bends_pos", two_bends, join_miter, end_flat, 99, -1.5, settings, +1.0);
+    //test_one<linestring,  polygon>("two_bends_neg", two_bends, join_round, end_flat,99, +1.5, settings, -1.0);
+    //test_one<linestring, polygon>("two_bends_pos", two_bends, join_round, end_flat, 99, -1.5, settings, +1.0);
 
     test_one<linestring, polygon>("overlapping150", overlapping, join_round, end_flat, 65.6786, 1.5);
     test_one<linestring, polygon>("overlapping150", overlapping, join_miter, end_flat, 68.140, 1.5);
 
     // Different cases with intersection points on flat and (left/right from line itself)
-    test_one<linestring, polygon>("overlapping_asym_150_010", overlapping, join_round, end_flat, 48.308, 1.5, ut_settings(), 0.25);
-    test_one<linestring, polygon>("overlapping_asym_150_010", overlapping, join_miter, end_flat, 50.770, 1.5, ut_settings(), 0.25);
-    test_one<linestring, polygon>("overlapping_asym_150_075", overlapping, join_round, end_flat, 58.506, 1.5, ut_settings(), 0.75);
-    test_one<linestring, polygon>("overlapping_asym_150_075", overlapping, join_miter, end_flat, 60.985, 1.5, ut_settings(), 0.75);
-    test_one<linestring, polygon>("overlapping_asym_150_100", overlapping, join_round, end_flat, 62.514, 1.5, ut_settings(), 1.0);
-    test_one<linestring, polygon>("overlapping_asym_150_100", overlapping, join_miter, end_flat, 64.984, 1.5, ut_settings(), 1.0);
+    test_one<linestring, polygon>("overlapping_asym_150_010", overlapping, join_round, end_flat, 48.308, 1.5, settings, 0.25);
+    test_one<linestring, polygon>("overlapping_asym_150_010", overlapping, join_miter, end_flat, 50.770, 1.5, settings, 0.25);
+    test_one<linestring, polygon>("overlapping_asym_150_075", overlapping, join_round, end_flat, 58.506, 1.5, settings, 0.75);
+    test_one<linestring, polygon>("overlapping_asym_150_075", overlapping, join_miter, end_flat, 60.985, 1.5, settings, 0.75);
+    test_one<linestring, polygon>("overlapping_asym_150_100", overlapping, join_round, end_flat, 62.514, 1.5, settings, 1.0);
+    test_one<linestring, polygon>("overlapping_asym_150_100", overlapping, join_miter, end_flat, 64.984, 1.5, settings, 1.0);
 
     // Having flat end
     test_one<linestring, polygon>("for_collinear", for_collinear, join_round, end_flat, 68.561, 2.0);
@@ -194,19 +196,19 @@ void test_all()
     test_one<linestring, polygon>("for_collinear2", for_collinear2, join_miter, end_flat, 78.0, 2.0);
 #endif
 
-    test_one<linestring, polygon>("curve", curve, join_round, end_flat, 58.1944, 5.0, ut_settings(), 3.0);
-    test_one<linestring, polygon>("curve", curve, join_miter, end_flat, 58.7371, 5.0, ut_settings(), 3.0);
+    test_one<linestring, polygon>("curve", curve, join_round, end_flat, 58.1944, 5.0, settings, 3.0);
+    test_one<linestring, polygon>("curve", curve, join_miter, end_flat, 58.7371, 5.0, settings, 3.0);
 
     test_one<linestring, polygon>("tripod", tripod, join_miter, end_flat, 74.25, 3.0);
     test_one<linestring, polygon>("tripod", tripod, join_miter, end_round, 116.6336, 3.0);
 
-    test_one<linestring, polygon>("chained2", chained2, join_round, end_flat, 11.3137, 2.5, ut_settings(), 1.5);
-    test_one<linestring, polygon>("chained3", chained3, join_round, end_flat, 16.9706, 2.5, ut_settings(), 1.5);
-    test_one<linestring, polygon>("chained4", chained4, join_round, end_flat, 22.6274, 2.5, ut_settings(), 1.5);
+    test_one<linestring, polygon>("chained2", chained2, join_round, end_flat, 11.3137, 2.5, settings, 1.5);
+    test_one<linestring, polygon>("chained3", chained3, join_round, end_flat, 16.9706, 2.5, settings, 1.5);
+    test_one<linestring, polygon>("chained4", chained4, join_round, end_flat, 22.6274, 2.5, settings, 1.5);
 
-    test_one<linestring, polygon>("field_sprayer1", field_sprayer1, join_round, end_flat, 324.3550, 16.5, ut_settings(), 6.5);
-    test_one<linestring, polygon>("field_sprayer1", field_sprayer1, join_round, end_round, 718.761877, 16.5, ut_settings(), 6.5);
-    test_one<linestring, polygon>("field_sprayer1", field_sprayer1, join_miter, end_round, 718.939628, 16.5, ut_settings(), 6.5);
+    test_one<linestring, polygon>("field_sprayer1", field_sprayer1, join_round, end_flat, 324.3550, 16.5, settings, 6.5);
+    test_one<linestring, polygon>("field_sprayer1", field_sprayer1, join_round, end_round, 718.761877, 16.5, settings, 6.5);
+    test_one<linestring, polygon>("field_sprayer1", field_sprayer1, join_miter, end_round, 718.939628, 16.5, settings, 6.5);
 
     test_one<linestring, polygon>("degenerate0", degenerate0, join_round, end_round, 0.0, 3.0);
     test_one<linestring, polygon>("degenerate1", degenerate1, join_round, end_round, 28.25, 3.0);
@@ -244,8 +246,8 @@ void test_all()
 
         // Testing the asymmetric end caps with odd number of points
         double const d15 = 1.5;
-        test_one<linestring, polygon>("mysql_report_2015_03_02c_asym1", mysql_report_2015_03_02c, join_round(7), end_round(7), 39.714, d10, ut_settings(), d15);
-        test_one<linestring, polygon>("mysql_report_2015_03_02c_asym2", mysql_report_2015_03_02c, join_round(7), end_round(7), 46.116, d15, ut_settings(), d10);
+        test_one<linestring, polygon>("mysql_report_2015_03_02c_asym1", mysql_report_2015_03_02c, join_round(7), end_round(7), 39.714, d10, settings, d15);
+        test_one<linestring, polygon>("mysql_report_2015_03_02c_asym2", mysql_report_2015_03_02c, join_round(7), end_round(7), 46.116, d15, settings, d10);
 
         double const d100 = 10;
         test_one<linestring, polygon>("mysql_report_2015_04_01", mysql_report_2015_04_01, join_round(32), end_round(32), 632.234, d100);
@@ -297,11 +299,9 @@ void test_all()
             27862.733459829971,
             5.9518403867035365);
 
-#if defined(BOOST_GEOMETRY_TEST_FAILURES)
     test_one<linestring, polygon>("mysql_report_2015_09_08a", mysql_report_2015_09_08a, join_round32, end_round32, 0.0, 1.0);
     test_one<linestring, polygon>("mysql_report_2015_09_08b", mysql_report_2015_09_08b, join_round32, end_round32, 0.0, 1099511627778.0);
     test_one<linestring, polygon>("mysql_report_2015_09_08c", mysql_report_2015_09_08c, join_round32, end_round32, 0.0, 0xbe);
-#endif
 
     test_one<linestring, polygon>("mysql_23023665_1", mysql_23023665, join_round32, end_flat, 459.1051, 10);
     test_one<linestring, polygon>("mysql_23023665_2", mysql_23023665, join_round32, end_flat, 6877.7097, 50);
@@ -325,23 +325,48 @@ void test_all()
     test_one<linestring, polygon>("mysql_25662426a_5", mysql_25662426a, join_round32, end_flat, 227.8325, 5.0);
     test_one<linestring, polygon>("mysql_25662426a_10", mysql_25662426a, join_round32, end_flat, 534.1084, 10.0);
 
+    // Asymmetric buffers
+    // Mostly left
+    test_one<linestring, polygon>("mysql_25662426a_mostly_left_05", mysql_25662426a, join_round32, end_round32, 15.6638, 0.5, settings, 0.05);
+    test_one<linestring, polygon>("mysql_25662426a_mostly_left_1", mysql_25662426a, join_round32, end_round32, 32.9553, 1.0, settings, 0.1);
+    test_one<linestring, polygon>("mysql_25662426a_mostly_left_2", mysql_25662426a, join_round32, end_round32, 72.1159, 2.0, settings, 0.2);
+    test_one<linestring, polygon>("mysql_25662426a_mostly_left_3", mysql_25662426a, join_round32, end_round32, 116.3802, 3.0, settings, 0.3);
+    test_one<linestring, polygon>("mysql_25662426a_mostly_left_4", mysql_25662426a, join_round32, end_round32, 165.9298, 4.0, settings, 0.4);
+    test_one<linestring, polygon>("mysql_25662426a_mostly_left_5", mysql_25662426a, join_round32, end_round32, 220.8054, 5.0, settings, 0.5);
+    test_one<linestring, polygon>("mysql_25662426a_mostly_left_10", mysql_25662426a, join_round32, end_round32, 577.3742, 10.0, settings, 1.0);
+
+    // Mostly right
+    test_one<linestring, polygon>("mysql_25662426a_mostly_right_05", mysql_25662426a, join_round32, end_round32, 14.3419, 0.05, settings, 0.5);
+    test_one<linestring, polygon>("mysql_25662426a_mostly_right_1", mysql_25662426a, join_round32, end_round32, 27.1955, 0.1, settings, 1.0);
+    test_one<linestring, polygon>("mysql_25662426a_mostly_right_2", mysql_25662426a, join_round32, end_round32, 43.1821, 0.2, settings, 2.0);
+    test_one<linestring, polygon>("mysql_25662426a_mostly_right_3", mysql_25662426a, join_round32, end_round32, 54.4337, 0.3, settings, 3.0);
+    test_one<linestring, polygon>("mysql_25662426a_mostly_right_4", mysql_25662426a, join_round32, end_round32, 75.6376, 0.4, settings, 4.0);
+    test_one<linestring, polygon>("mysql_25662426a_mostly_right_5", mysql_25662426a, join_round32, end_round32, 102.6952, 0.5, settings, 5.0);
+    test_one<linestring, polygon>("mysql_25662426a_mostly_right_10", mysql_25662426a, join_round32, end_round32, 260.1850, 1.0, settings, 10.0);
+
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
     // Left
-    test_one<linestring, polygon>("mysql_25662426a_1", mysql_25662426a, join_round32, end_round32, 54.9018, 1.0, ut_settings(), 0.0);
-    test_one<linestring, polygon>("mysql_25662426a_2", mysql_25662426a, join_round32, end_round32, 103.6072, 2.0, ut_settings(), 0.0);
-    test_one<linestring, polygon>("mysql_25662426a_3", mysql_25662426a, join_round32, end_round32, 152.1163, 3.0, ut_settings(), 0.0);
-    test_one<linestring, polygon>("mysql_25662426a_4", mysql_25662426a, join_round32, end_round32, 206.4831, 4.0, ut_settings(), 0.0);
-    test_one<linestring, polygon>("mysql_25662426a_5", mysql_25662426a, join_round32, end_round32, 266.8505, 5.0, ut_settings(), 0.0);
-    test_one<linestring, polygon>("mysql_25662426a_10", mysql_25662426a, join_round32, end_round32, 660.7355, 10.0, ut_settings(), 0.0);
+    test_one<linestring, polygon>("mysql_25662426a_left_05", mysql_25662426a, join_round32, end_round32, 14.2803, 0.5, settings, 0.0);
+    test_one<linestring, polygon>("mysql_25662426a_left_1", mysql_25662426a, join_round32, end_round32, 30.1214, 1.0, settings, 0.0);
+    test_one<linestring, polygon>("mysql_25662426a_left_2", mysql_25662426a, join_round32, end_round32, 999.9, 2.0, settings, 0.0);
+    test_one<linestring, polygon>("mysql_25662426a_left_3", mysql_25662426a, join_round32, end_round32, 999.9, 3.0, settings, 0.0);
+    test_one<linestring, polygon>("mysql_25662426a_left_4", mysql_25662426a, join_round32, end_round32, 999.9, 4.0, settings, 0.0);
+    test_one<linestring, polygon>("mysql_25662426a_left_5", mysql_25662426a, join_round32, end_round32, 999.9, 5.0, settings, 0.0);
+    test_one<linestring, polygon>("mysql_25662426a_left_10", mysql_25662426a, join_round32, end_round32, 554.8818, 10.0, settings, 0.0);
 
     // Right
-    test_one<linestring, polygon>("mysql_25662426a_1", mysql_25662426a, join_round32, end_round32, 54.9018, 0.0, ut_settings(), 1.0);
-    test_one<linestring, polygon>("mysql_25662426a_2", mysql_25662426a, join_round32, end_round32, 103.6072, 0.0, ut_settings(), 2.0);
-    test_one<linestring, polygon>("mysql_25662426a_3", mysql_25662426a, join_round32, end_round32, 152.1163, 0.0, ut_settings(), 3.0);
-    test_one<linestring, polygon>("mysql_25662426a_4", mysql_25662426a, join_round32, end_round32, 206.4831, 0.0, ut_settings(), 4.0);
-    test_one<linestring, polygon>("mysql_25662426a_5", mysql_25662426a, join_round32, end_round32, 266.8505, 0.0, ut_settings(), 5.0);
-    test_one<linestring, polygon>("mysql_25662426a_10", mysql_25662426a, join_round32, end_round32, 660.7355, 0.0, ut_settings(), 10.0);
+    test_one<linestring, polygon>("mysql_25662426a_right_05", mysql_25662426a, join_round32, end_round32, 12.9451, 0.0, settings, 0.5);
+    test_one<linestring, polygon>("mysql_25662426a_right_1", mysql_25662426a, join_round32, end_round32, 999.9, 0.0, settings, 1.0);
+    test_one<linestring, polygon>("mysql_25662426a_right_2", mysql_25662426a, join_round32, end_round32, 999.9, 0.0, settings, 2.0);
+    test_one<linestring, polygon>("mysql_25662426a_right_3", mysql_25662426a, join_round32, end_round32, 999.9, 0.0, settings, 3.0);
+    test_one<linestring, polygon>("mysql_25662426a_right_4", mysql_25662426a, join_round32, end_round32, 999.9, 0.0, settings, 4.0);
+    test_one<linestring, polygon>("mysql_25662426a_right_5", mysql_25662426a, join_round32, end_round32, 999.9, 0.0, settings, 5.0);
+    test_one<linestring, polygon>("mysql_25662426a_right_10", mysql_25662426a, join_round32, end_round32, 999.9, 0.0, settings, 10.0);
 #endif
+
+    // Flat end for one-sided buffer
+    test_one<linestring, polygon>("mysql_25662426a_left_05", mysql_25662426a, join_round32, end_flat, 14.0853, 0.5, settings, 0.0);
+    test_one<linestring, polygon>("mysql_25662426a_right_05", mysql_25662426a, join_round32, end_flat, 12.7500, 0.0, settings, 0.5);
 }
 
 template <bool Clockwise, typename P>

--- a/test/algorithms/buffer/buffer_linestring.cpp
+++ b/test/algorithms/buffer/buffer_linestring.cpp
@@ -344,18 +344,20 @@ void test_all()
     test_one<linestring, polygon>("mysql_25662426a_mostly_right_5", mysql_25662426a, join_round32, end_round32, 102.6952, 0.5, settings, 5.0);
     test_one<linestring, polygon>("mysql_25662426a_mostly_right_10", mysql_25662426a, join_round32, end_round32, 260.1850, 1.0, settings, 10.0);
 
-#if defined(BOOST_GEOMETRY_TEST_FAILURES)
     // Left
     test_one<linestring, polygon>("mysql_25662426a_left_05", mysql_25662426a, join_round32, end_round32, 14.2803, 0.5, settings, 0.0);
     test_one<linestring, polygon>("mysql_25662426a_left_1", mysql_25662426a, join_round32, end_round32, 30.1214, 1.0, settings, 0.0);
+#if defined(BOOST_GEOMETRY_TEST_FAILURES)
     test_one<linestring, polygon>("mysql_25662426a_left_2", mysql_25662426a, join_round32, end_round32, 999.9, 2.0, settings, 0.0);
     test_one<linestring, polygon>("mysql_25662426a_left_3", mysql_25662426a, join_round32, end_round32, 999.9, 3.0, settings, 0.0);
     test_one<linestring, polygon>("mysql_25662426a_left_4", mysql_25662426a, join_round32, end_round32, 999.9, 4.0, settings, 0.0);
     test_one<linestring, polygon>("mysql_25662426a_left_5", mysql_25662426a, join_round32, end_round32, 999.9, 5.0, settings, 0.0);
     test_one<linestring, polygon>("mysql_25662426a_left_10", mysql_25662426a, join_round32, end_round32, 554.8818, 10.0, settings, 0.0);
+#endif
 
     // Right
     test_one<linestring, polygon>("mysql_25662426a_right_05", mysql_25662426a, join_round32, end_round32, 12.9451, 0.0, settings, 0.5);
+#if defined(BOOST_GEOMETRY_TEST_FAILURES)
     test_one<linestring, polygon>("mysql_25662426a_right_1", mysql_25662426a, join_round32, end_round32, 999.9, 0.0, settings, 1.0);
     test_one<linestring, polygon>("mysql_25662426a_right_2", mysql_25662426a, join_round32, end_round32, 999.9, 0.0, settings, 2.0);
     test_one<linestring, polygon>("mysql_25662426a_right_3", mysql_25662426a, join_round32, end_round32, 999.9, 0.0, settings, 3.0);

--- a/test/algorithms/buffer/buffer_linestring.cpp
+++ b/test/algorithms/buffer/buffer_linestring.cpp
@@ -347,28 +347,26 @@ void test_all()
     // Left
     test_one<linestring, polygon>("mysql_25662426a_left_05", mysql_25662426a, join_round32, end_round32, 14.2803, 0.5, settings, 0.0);
     test_one<linestring, polygon>("mysql_25662426a_left_1", mysql_25662426a, join_round32, end_round32, 30.1214, 1.0, settings, 0.0);
-#if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    test_one<linestring, polygon>("mysql_25662426a_left_2", mysql_25662426a, join_round32, end_round32, 999.9, 2.0, settings, 0.0);
-    test_one<linestring, polygon>("mysql_25662426a_left_3", mysql_25662426a, join_round32, end_round32, 999.9, 3.0, settings, 0.0);
-    test_one<linestring, polygon>("mysql_25662426a_left_4", mysql_25662426a, join_round32, end_round32, 999.9, 4.0, settings, 0.0);
-    test_one<linestring, polygon>("mysql_25662426a_left_5", mysql_25662426a, join_round32, end_round32, 999.9, 5.0, settings, 0.0);
+    test_one<linestring, polygon>("mysql_25662426a_left_2", mysql_25662426a, join_round32, end_round32, 66.4858, 2.0, ut_settings(0.01, false), 0.0); // It has a self touching point
+    test_one<linestring, polygon>("mysql_25662426a_left_3", mysql_25662426a, join_round32, end_round32, 108.3305, 3.0, settings, 0.0);
+    test_one<linestring, polygon>("mysql_25662426a_left_4", mysql_25662426a, join_round32, end_round32, 155.5128, 4.0, settings, 0.0);
+    test_one<linestring, polygon>("mysql_25662426a_left_5", mysql_25662426a, join_round32, end_round32, 208.1289, 5.0, settings, 0.0);
     test_one<linestring, polygon>("mysql_25662426a_left_10", mysql_25662426a, join_round32, end_round32, 554.8818, 10.0, settings, 0.0);
-#endif
 
     // Right
     test_one<linestring, polygon>("mysql_25662426a_right_05", mysql_25662426a, join_round32, end_round32, 12.9451, 0.0, settings, 0.5);
-#if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    test_one<linestring, polygon>("mysql_25662426a_right_1", mysql_25662426a, join_round32, end_round32, 999.9, 0.0, settings, 1.0);
-    test_one<linestring, polygon>("mysql_25662426a_right_2", mysql_25662426a, join_round32, end_round32, 999.9, 0.0, settings, 2.0);
-    test_one<linestring, polygon>("mysql_25662426a_right_3", mysql_25662426a, join_round32, end_round32, 999.9, 0.0, settings, 3.0);
-    test_one<linestring, polygon>("mysql_25662426a_right_4", mysql_25662426a, join_round32, end_round32, 999.9, 0.0, settings, 4.0);
-    test_one<linestring, polygon>("mysql_25662426a_right_5", mysql_25662426a, join_round32, end_round32, 999.9, 0.0, settings, 5.0);
-    test_one<linestring, polygon>("mysql_25662426a_right_10", mysql_25662426a, join_round32, end_round32, 999.9, 0.0, settings, 10.0);
-#endif
+    test_one<linestring, polygon>("mysql_25662426a_right_1", mysql_25662426a, join_round32, end_round32, 24.3902, 0.0, settings, 1.0);
+    test_one<linestring, polygon>("mysql_25662426a_right_2", mysql_25662426a, join_round32, end_round32, 37.5607, 0.0, settings, 2.0);
+    test_one<linestring, polygon>("mysql_25662426a_right_3", mysql_25662426a, join_round32, end_round32, 46.2741, 0.0, settings, 3.0);
+    test_one<linestring, polygon>("mysql_25662426a_right_4", mysql_25662426a, join_round32, end_round32, 70.2429, 0.0, settings, 4.0);
+    test_one<linestring, polygon>("mysql_25662426a_right_5", mysql_25662426a, join_round32, end_round32, 95.7545, 0.0, settings, 5.0);
+    test_one<linestring, polygon>("mysql_25662426a_right_10", mysql_25662426a, join_round32, end_round32, 244.5337, 0.0, settings, 10.0);
 
     // Flat end for one-sided buffer
     test_one<linestring, polygon>("mysql_25662426a_left_05", mysql_25662426a, join_round32, end_flat, 14.0853, 0.5, settings, 0.0);
     test_one<linestring, polygon>("mysql_25662426a_right_05", mysql_25662426a, join_round32, end_flat, 12.7500, 0.0, settings, 0.5);
+    test_one<linestring, polygon>("mysql_25662426a_left_25", mysql_25662426a, join_round32, end_flat, 82.1318, 2.5, settings, 0.0);
+    test_one<linestring, polygon>("mysql_25662426a_right_25", mysql_25662426a, join_round32, end_flat, 39.0000, 0.0, settings, 2.5);
 }
 
 template <bool Clockwise, typename P>


### PR DESCRIPTION
This PR (not related to rescaling / robustness, but found it when working at it) fixes two related things:

- the end-cap was generated wrongly for one-sided buffers
- turn points were classified wrongly for one-sided buffers