### PR TITLE
[strategies] Do not include karney strategy and parameters by default.

### DIFF
--- a/include/boost/geometry/strategies/geographic/parameters.hpp
+++ b/include/boost/geometry/strategies/geographic/parameters.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2017, Oracle and/or its affiliates.
+// Copyright (c) 2017-2019, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -15,8 +15,8 @@
 #include <boost/geometry/formulas/thomas_inverse.hpp>
 #include <boost/geometry/formulas/vincenty_direct.hpp>
 #include <boost/geometry/formulas/vincenty_inverse.hpp>
-#include <boost/geometry/formulas/karney_direct.hpp>
-#include <boost/geometry/formulas/karney_inverse.hpp>
+//#include <boost/geometry/formulas/karney_direct.hpp>
+//#include <boost/geometry/formulas/karney_inverse.hpp>
 
 #include <boost/mpl/assert.hpp>
 #include <boost/mpl/integral_c.hpp>
@@ -137,7 +137,7 @@ struct vincenty
             >
     {};
 };
-
+/*
 struct karney
 {
     template
@@ -178,7 +178,7 @@ struct karney
             >
     {};
 };
-
+*/
 template <typename FormulaPolicy>
 struct default_order
 {
@@ -203,11 +203,12 @@ template<>
 struct default_order<vincenty>
     : boost::mpl::integral_c<unsigned int, 4>
 {};
-
+/*
 template<>
 struct default_order<karney>
     : boost::mpl::integral_c<unsigned int, 8>
 {};
+*/
 
 }}} // namespace boost::geometry::strategy
 

--- a/include/boost/geometry/strategies/strategies.hpp
+++ b/include/boost/geometry/strategies/strategies.hpp
@@ -118,7 +118,7 @@
 #include <boost/geometry/strategies/geographic/distance_segment_box.hpp>
 #include <boost/geometry/strategies/geographic/distance_thomas.hpp>
 #include <boost/geometry/strategies/geographic/distance_vincenty.hpp>
-#include <boost/geometry/strategies/geographic/distance_karney.hpp>
+//#include <boost/geometry/strategies/geographic/distance_karney.hpp>
 #include <boost/geometry/strategies/geographic/envelope_segment.hpp>
 #include <boost/geometry/strategies/geographic/expand_segment.hpp>
 #include <boost/geometry/strategies/geographic/index.hpp>


### PR DESCRIPTION
The reasons are:
- karney formulas expect degrees so they won't work with strategies right now
- `karney_inverse` requires C++11 (and doesn't compile with older VS because of min/max macros)

Regarding the second bullet, see: https://www.boost.org/development/tests/develop/developer/geometry.html

If this PR is merged the formulas will be reincluded when https://github.com/boostorg/geometry/issues/635 is addressed and the inverse formula is either adapted to C++03 or the standard required by the library is bumped to C++11.