### PR TITLE
Fix MSVC compailation errors in karney_inverse.

### DIFF
--- a/include/boost/geometry/formulas/karney_inverse.hpp
+++ b/include/boost/geometry/formulas/karney_inverse.hpp
@@ -4,6 +4,11 @@
 
 // Contributed and/or modified by Adeel Ahmad, as part of Google Summer of Code 2018 program.
 
+// This file was modified by Oracle on 2019.
+// Modifications copyright (c) 2019 Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -114,9 +119,9 @@ public:
         CT const tol_bisection = tol0 * tol2;
 
         CT const etol2 = c0_1 * tol2 /
-            sqrt(std::max(CT(0.001), std::abs(f)) * std::min(CT(1), CT(1) - f / CT(2)) / c2);
+            sqrt((std::max)(CT(0.001), std::abs(f)) * (std::min)(CT(1), CT(1) - f / CT(2)) / c2);
 
-        CT tiny = std::sqrt(std::numeric_limits<CT>::min());
+        CT tiny = std::sqrt((std::numeric_limits<CT>::min)());
 
         CT const n = f / two_minus_f;
         CT const e2 = f * two_minus_f;
@@ -175,14 +180,14 @@ public:
         sin_beta1 *= one_minus_f;
 
         math::normalize_unit_vector<CT>(sin_beta1, cos_beta1);
-        cos_beta1 = std::max(tiny, cos_beta1);
+        cos_beta1 = (std::max)(tiny, cos_beta1);
 
         CT sin_beta2, cos_beta2;
         math::sin_cos_degrees(lat2, sin_beta2, cos_beta2);
         sin_beta2 *= one_minus_f;
 
         math::normalize_unit_vector<CT>(sin_beta2, cos_beta2);
-        cos_beta2 = std::max(tiny, cos_beta2);
+        cos_beta2 = (std::max)(tiny, cos_beta2);
 
         // If cos_beta1 < -sin_beta1, then cos_beta2 - cos_beta1 is a
         // sensitive measure of the |beta1| - |beta2|. Alternatively,
@@ -237,8 +242,8 @@ public:
             CT sin_sigma2 = sin_beta2;
             CT cos_sigma2 = cos_alpha2 * cos_beta2;
 
-            CT sigma12 = std::atan2(std::max(CT(0), cos_sigma1 * sin_sigma2 - sin_sigma1 * cos_sigma2),
-                                                    cos_sigma1 * cos_sigma2 + sin_sigma1 * sin_sigma2);
+            CT sigma12 = std::atan2((std::max)(CT(0), cos_sigma1 * sin_sigma2 - sin_sigma1 * cos_sigma2),
+                                                      cos_sigma1 * cos_sigma2 + sin_sigma1 * sin_sigma2);
 
             CT dummy;
             meridian_length(n, ep2, sigma12, sin_sigma1, cos_sigma1, dn1,
@@ -670,12 +675,12 @@ public:
                 // Strip near cut.
                 if (f >= c0)
                 {
-                    sin_alpha1 = std::min(CT(1), -CT(x));
+                    sin_alpha1 = (std::min)(CT(1), -CT(x));
                     cos_alpha1 = - math::sqrt(c1 - math::sqr(sin_alpha1));
                 }
                 else
                 {
-                    cos_alpha1 = std::max(CT(x > -tol1 ? c0 : -c1), CT(x));
+                    cos_alpha1 = (std::max)(CT(x > -tol1 ? c0 : -c1), CT(x));
                     sin_alpha1 = math::sqrt(c1 - math::sqr(cos_alpha1));
                 }
             }
@@ -847,11 +852,11 @@ public:
 
 
         // sig12 = sig2 - sig1, limit to [0, pi].
-        sigma12 = atan2(std::max(CT(0), cos_sigma1 * sin_sigma2 - sin_sigma1 * cos_sigma2),
-                                        cos_sigma1 * cos_sigma2 + sin_sigma1 * sin_sigma2);
+        sigma12 = atan2((std::max)(CT(0), cos_sigma1 * sin_sigma2 - sin_sigma1 * cos_sigma2),
+                                          cos_sigma1 * cos_sigma2 + sin_sigma1 * sin_sigma2);
 
         // omg12 = omg2 - omg1, limit to [0, pi].
-        sin_omega12 = std::max(CT(0), cos_omega1 * sin_omega2 - sin_omega1 * cos_omega2);
+        sin_omega12 = (std::max)(CT(0), cos_omega1 * sin_omega2 - sin_omega1 * cos_omega2);
         cos_omega12 = cos_omega1 * cos_omega2 + sin_omega1 * sin_omega2;
 
         // eta = omg12 - lam120.

--- a/include/boost/geometry/formulas/karney_inverse.hpp
+++ b/include/boost/geometry/formulas/karney_inverse.hpp
@@ -33,6 +33,7 @@
 #include <boost/math/constants/constants.hpp>
 #include <boost/math/special_functions/hypot.hpp>
 
+#include <boost/geometry/util/condition.hpp>
 #include <boost/geometry/util/math.hpp>
 #include <boost/geometry/util/series_expansion.hpp>
 #include <boost/geometry/util/normalize_spheroidal_coordinates.hpp>

--- a/include/boost/geometry/util/series_expansion.hpp
+++ b/include/boost/geometry/util/series_expansion.hpp
@@ -633,16 +633,16 @@ namespace boost { namespace geometry { namespace series_expansion {
     inline void evaluate_coeffs_C3(Coeffs1 &coeffs1, Coeffs2 &coeffs2, CT const& eps)
     {
         CT mult = 1;
-        int offset = 0;
+        size_t offset = 0;
 
-        // l is the index of C3[l].
-        for (size_t l = 1; l < Coeffs1::static_size; ++l)
+        // i is the index of C3[i].
+        for (size_t i = 1; i < Coeffs1::static_size; ++i)
         {
             // Order of polynomial in eps.
-            int m = Coeffs1::static_size - l;
+            size_t m = Coeffs1::static_size - i;
             mult *= eps;
 
-            coeffs1[l] = mult * math::horner_evaluate(eps, coeffs2.begin() + offset,
+            coeffs1[i] = mult * math::horner_evaluate(eps, coeffs2.begin() + offset,
                                                            coeffs2.begin() + offset + m);
 
             offset += m;

--- a/include/boost/geometry/util/series_expansion.hpp
+++ b/include/boost/geometry/util/series_expansion.hpp
@@ -4,6 +4,11 @@
 
 // Contributed and/or modified by Adeel Ahmad, as part of Google Summer of Code 2018 program.
 
+// This file was modified by Oracle on 2019.
+// Modifications copyright (c) 2019 Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)

--- a/test/formulas/Jamfile.v2
+++ b/test/formulas/Jamfile.v2
@@ -1,6 +1,6 @@
 # Boost.Geometry
 #
-# Copyright (c) 2016-2018, Oracle and/or its affiliates.
+# Copyright (c) 2016-2019, Oracle and/or its affiliates.
 #
 # Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 # Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -12,6 +12,7 @@
 test-suite boost-geometry-formulas
     :
     [ run inverse.cpp                        : : : : formulas_inverse ]
+    [ run inverse_karney.cpp                 : : : : formulas_inverse_karney ]
     [ run direct.cpp                         : : : : formulas_direct ]
     [ run direct_accuracy.cpp                : : : : formulas_direct_accuracy ]
     [ run direct_meridian.cpp                : : : : formulas_direct_meridian ]

--- a/test/formulas/inverse_karney.cpp
+++ b/test/formulas/inverse_karney.cpp
@@ -18,10 +18,10 @@
 
 #include "test_formula.hpp"
 #include "inverse_cases.hpp"
+#include "inverse_cases_antipodal.hpp"
+#include "inverse_cases_small_angles.hpp"
 
-#include <boost/geometry/formulas/vincenty_inverse.hpp>
-#include <boost/geometry/formulas/thomas_inverse.hpp>
-#include <boost/geometry/formulas/andoyer_inverse.hpp>
+#include <boost/geometry/formulas/karney_inverse.hpp>
 
 #include <boost/geometry/srs/spheroid.hpp>
 
@@ -50,36 +50,37 @@ void check_inverse(std::string const& name,
 
 void test_all(expected_results const& results)
 {
-    double const d2r = bg::math::d2r<double>();
-    double const r2d = bg::math::r2d<double>();
-
-    double lon1r = results.p1.lon * d2r;
-    double lat1r = results.p1.lat * d2r;
-    double lon2r = results.p2.lon * d2r;
-    double lat2r = results.p2.lat * d2r;
+    double lon1d = results.p1.lon;
+    double lat1d = results.p1.lat;
+    double lon2d = results.p2.lon;
+    double lat2d = results.p2.lat;
 
     // WGS84
     bg::srs::spheroid<double> spheroid(6378137.0, 6356752.3142451793);
 
-    bg::formula::result_inverse<double> result_v, result_t, result_a;
+    bg::formula::result_inverse<double> result_k;
 
-    typedef bg::formula::vincenty_inverse<double, true, true, true, true, true> vi_t;
-    result_v = vi_t::apply(lon1r, lat1r, lon2r, lat2r, spheroid);
-    result_v.azimuth *= r2d;
-    result_v.reverse_azimuth *= r2d;
-    check_inverse("vincenty", results, result_v, results.vincenty, results.reference, 0.0000001);
+    typedef bg::formula::karney_inverse<double, true, true, true, true, true, 8> ka_t;
+    result_k = ka_t::apply(lon1d, lat1d, lon2d, lat2d, spheroid);
+    check_inverse("karney", results, result_k, results.vincenty, results.reference, 0.0000001);
+}
 
-    typedef bg::formula::thomas_inverse<double, true, true, true, true, true> th_t;
-    result_t = th_t::apply(lon1r, lat1r, lon2r, lat2r, spheroid);
-    result_t.azimuth *= r2d;
-    result_t.reverse_azimuth *= r2d;
-    check_inverse("thomas", results, result_t, results.thomas, results.reference, 0.00001);
+template <typename ExpectedResults>
+void test_karney(ExpectedResults const& results)
+{
+    double lon1d = results.p1.lon;
+    double lat1d = results.p1.lat;
+    double lon2d = results.p2.lon;
+    double lat2d = results.p2.lat;
 
-    typedef bg::formula::andoyer_inverse<double, true, true, true, true, true> an_t;
-    result_a = an_t::apply(lon1r, lat1r, lon2r, lat2r, spheroid);
-    result_a.azimuth *= r2d;
-    result_a.reverse_azimuth *= r2d;
-    check_inverse("andoyer", results, result_a, results.andoyer, results.reference, 0.001);
+    // WGS84
+    bg::srs::spheroid<double> spheroid(6378137.0, 6356752.3142451793);
+
+    bg::formula::result_inverse<double> result;
+
+    typedef bg::formula::karney_inverse<double, true, true, true, true, true, 8> ka_t;
+    result = ka_t::apply(lon1d, lat1d, lon2d, lat2d, spheroid);
+    check_inverse("karney", results, result, results.karney, results.karney, 0.0000001);
 }
 
 int test_main(int, char*[])
@@ -87,6 +88,16 @@ int test_main(int, char*[])
     for (size_t i = 0; i < expected_size; ++i)
     {
         test_all(expected[i]);
+    }
+
+    for (size_t i = 0; i < expected_size_antipodal; ++i)
+    {
+        test_karney(expected_antipodal[i]);
+    }
+
+    for (size_t i = 0; i < expected_size_small_angles; ++i)
+    {
+        test_karney(expected_small_angles[i]);
     }
 
     return 0;


### PR DESCRIPTION
Plus warning fix.

Even though this formula requires C++11 and is no longer included by default (see https://github.com/boostorg/geometry/pull/636) it is still tested (in `test/formulas/inverse.cpp`). Without this fix it does not compile with MSVC even when C++11 is supported.
