### PR TITLE
Fix deprecated header for floating_point_comparison

### DIFF
--- a/extensions/test/gis/io/wkb/read_wkb.cpp
+++ b/extensions/test/gis/io/wkb/read_wkb.cpp
@@ -13,7 +13,7 @@
 
 #include <boost/test/included/test_exec_monitor.hpp>
 #include <boost/test/included/unit_test.hpp>
-#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 #include <boost/cstdint.hpp>
 #include <boost/geometry/strategies/strategies.hpp>
 

--- a/extensions/test/gis/io/wkb/write_wkb.cpp
+++ b/extensions/test/gis/io/wkb/write_wkb.cpp
@@ -15,7 +15,7 @@
 
 #include <boost/test/included/test_exec_monitor.hpp>
 #include <boost/test/included/unit_test.hpp>
-#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 #include <boost/cstdint.hpp>
 #include <boost/geometry/strategies/strategies.hpp>
 

--- a/extensions/test/index/rtree.cpp
+++ b/extensions/test/index/rtree.cpp
@@ -9,7 +9,7 @@
 
 #include <cstddef>
 
-#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 #include <boost/test/included/test_exec_monitor.hpp>
 
 #include <boost/geometry/geometries/geometries.hpp>

--- a/test/geometry_test_common.hpp
+++ b/test/geometry_test_common.hpp
@@ -67,7 +67,7 @@
 # pragma clang diagnostic ignored "-Wshorten-64-to-32"
 #endif
 
-# include <boost/test/floating_point_comparison.hpp>
+# include <boost/test/tools/floating_point_comparison.hpp>
 #ifndef BOOST_TEST_MODULE
 # include <boost/test/included/test_exec_monitor.hpp>
 //#  include <boost/test/included/prg_exec_monitor.hpp>

--- a/test/io/wkt/wkt_multi.cpp
+++ b/test/io/wkt/wkt_multi.cpp
@@ -24,7 +24,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/concept/requires.hpp>
 
-#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 #include <boost/test/included/test_exec_monitor.hpp>
 
 #include <boost/geometry/geometries/geometries.hpp>


### PR DESCRIPTION
Fixing warning `This header is deprecated. Please use <boost/test/tools/floating_point_comparison.hpp> instead.`