### PR TITLE
Symmetrizing read/write wkt

### DIFF
--- a/doc/html/index.html
+++ b/doc/html/index.html
@@ -140,10 +140,14 @@
 <li class="listitem">
         Yaghyavardhan Singh Khangarot (discrete Frechet and Hausdorff distance)
       </li>
+<li class="listitem">
+        Tinko Bartels (Delaunay triangulation, Voronoi diagram, random point generation,
+        ...)
+      </li>
 </ul></div>
 </div>
 <table xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" width="100%"><tr>
-<td align="left"><p><small>Last revised: February 19, 2019 at 14:49:50 GMT</small></p></td>
+<td align="left"><p><small>Last revised: March 01, 2020 at 20:07:18 GMT</small></p></td>
 <td align="right"><div class="copyright-footer"></div></td>
 </tr></table>
 <hr>

--- a/doc/html/index.html
+++ b/doc/html/index.html
@@ -140,14 +140,10 @@
 <li class="listitem">
         Yaghyavardhan Singh Khangarot (discrete Frechet and Hausdorff distance)
       </li>
-<li class="listitem">
-        Tinko Bartels (Delaunay triangulation, Voronoi diagram, random point generation,
-        ...)
-      </li>
 </ul></div>
 </div>
 <table xmlns:rev="http://www.cs.rpi.edu/~gregod/boost/tools/doc/revision" width="100%"><tr>
-<td align="left"><p><small>Last revised: March 01, 2020 at 20:07:18 GMT</small></p></td>
+<td align="left"><p><small>Last revised: February 19, 2019 at 14:49:50 GMT</small></p></td>
 <td align="right"><div class="copyright-footer"></div></td>
 </tr></table>
 <hr>

--- a/doc/imports.qbk
+++ b/doc/imports.qbk
@@ -153,6 +153,8 @@
 [import src/examples/io/svg.cpp]
 [import src/examples/io/wkt.cpp]
 [import src/examples/io/read_wkt.cpp]
+[import src/examples/io/to_wkt.cpp]
+[import src/examples/io/from_wkt.cpp]
 
 [import src/examples/strategies/buffer_join_round.cpp]
 [import src/examples/strategies/buffer_join_miter.cpp]

--- a/doc/quickref.xml
+++ b/doc/quickref.xml
@@ -715,6 +715,8 @@
     <simplelist type="vert" columns="1">
      <member><link linkend="geometry.reference.io.wkt.read_wkt">read_wkt</link></member>
      <member><link linkend="geometry.reference.io.wkt.wkt">wkt</link></member>
+     <member><link linkend="geometry.reference.io.wkt.to_wkt">to_wkt</link></member>
+     <member><link linkend="geometry.reference.io.wkt.from_wkt">from_wkt</link></member>
     </simplelist>
    </entry>
    <entry valign="top">

--- a/doc/reference/io/from_wkt.qbk
+++ b/doc/reference/io/from_wkt.qbk
@@ -1,0 +1,23 @@
+[/============================================================================
+  Boost.Geometry (aka GGL, Generic Geometry Library)
+  
+  Copyright (c) 2020 Baidyanath Kundu, Haldia, India.
+
+  Use, modification and distribution is subject to the Boost Software License,
+  Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+  http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================/]
+
+[heading Conformance]
+Other libraries refer to this functionality as [*ST_GeomFromText] or [*STGeomFromText].
+That is not done here because Boost.Geometry support more text formats. The name GeomFromText
+is reserved for future usage, which will then have an indication of the used text format.
+
+
+[heading Example]
+[from_wkt]
+
+[heading See also]
+* [link geometry.reference.io.wkt.wkt WKT streaming manipulator]
+* [link geometry.reference.io.wkt.read_wkt Read WKT]
+* [link geometry.reference.io.wkt.to_wkt To WKT]

--- a/doc/reference/io/read_wkt.qbk
+++ b/doc/reference/io/read_wkt.qbk
@@ -19,4 +19,6 @@ is reserved for future usage, which will then have an indication of the used tex
 [read_wkt]
 
 [heading See also]
+* [link geometry.reference.io.wkt.from_wkt From WKT]
+* [link geometry.reference.io.wkt.to_wkt To WKT]
 * [link geometry.reference.io.wkt.wkt WKT streaming manipulator]

--- a/doc/reference/io/to_wkt.qbk
+++ b/doc/reference/io/to_wkt.qbk
@@ -1,0 +1,24 @@
+[/============================================================================
+  Boost.Geometry (aka GGL, Generic Geometry Library)
+
+  Copyright (c) 2009-2014 Barend Gehrels, Amsterdam, the Netherlands.
+
+  Use, modification and distribution is subject to the Boost Software License,
+  Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+  http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================/]
+
+[def __this_function__ to_wkt]
+
+[heading_conformance_ogc __this_function__..AsText]
+[note __this_function__ is not named "AsText" or "as_text" because Boost.Geometry 
+also supports other textformats (svg, dsv)]
+
+[heading Example]
+[to_wkt]
+[to_wkt_output]
+
+[heading See also]
+* [link geometry.reference.io.wkt.read_wkt Read WKT]
+* [link geometry.reference.io.wkt.from_wkt From WKT]
+* [link geometry.reference.io.wkt.wkt WKT streaming manipulator]

--- a/doc/reference/io/to_wkt.qbk
+++ b/doc/reference/io/to_wkt.qbk
@@ -2,6 +2,7 @@
   Boost.Geometry (aka GGL, Generic Geometry Library)
 
   Copyright (c) 2009-2014 Barend Gehrels, Amsterdam, the Netherlands.
+  Copyright (c) 2020 Baidyanath Kundu, Haldia, India.
 
   Use, modification and distribution is subject to the Boost Software License,
   Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at

--- a/doc/reference/io/wkt.qbk
+++ b/doc/reference/io/wkt.qbk
@@ -20,3 +20,5 @@ also supports other textformats (svg, dsv)]
 
 [heading See also]
 * [link geometry.reference.io.wkt.read_wkt Read WKT]
+* [link geometry.reference.io.wkt.from_wkt From WKT]
+* [link geometry.reference.io.wkt.from_wkt To WKT]

--- a/doc/src/examples/io/Jamfile
+++ b/doc/src/examples/io/Jamfile
@@ -17,3 +17,5 @@ project boost-geometry-doc-example-io
 exe svg : svg.cpp ;
 exe wkt : wkt.cpp ;
 exe read_wkt : read_wkt.cpp ;
+exe to_wkt : to_wkt.cpp ;
+exe from_wkt : from_wkt.cpp ;

--- a/doc/src/examples/io/from_wkt.cpp
+++ b/doc/src/examples/io/from_wkt.cpp
@@ -18,11 +18,11 @@
 
 int main()
 {
-    typedef boost::geometry::model::d2::point_xy<double> point_type;
-    typedef boost::geometry::model::box<point_type> box_type;
-    typedef boost::geometry::model::segment<point_type> segment_type;
-    typedef boost::geometry::model::polygon<point_type> polygon_type;
-    typedef boost::geometry::model::linestring<point_type> linestring_type;
+    using point_type = boost::geometry::model::d2::point_xy<double>;
+    using box_type = boost::geometry::model::box<point_type>;
+    using segment_type = boost::geometry::model::segment<point_type>;
+    using polygon_type = boost::geometry::model::polygon<point_type>;
+    using linestring_type = boost::geometry::model::linestring<point_type>;
 
     point_type a;
     box_type d;

--- a/doc/src/examples/io/from_wkt.cpp
+++ b/doc/src/examples/io/from_wkt.cpp
@@ -24,19 +24,13 @@ int main()
     using polygon_type = boost::geometry::model::polygon<point_type>;
     using linestring_type = boost::geometry::model::linestring<point_type>;
 
-    point_type a;
-    box_type d;
-    segment_type e;
-    polygon_type c;
-    linestring_type b;
-    a = boost::geometry::from_wkt<point_type>("POINT(1 2)");
-    d = boost::geometry::from_wkt<box_type>("BOX(0 0,3 3)");
-    e = boost::geometry::from_wkt<segment_type>("SEGMENT(1 0,3 4)");
-    c = boost::geometry::from_wkt<polygon_type>("POLYGON((0 0,0 7,4 2,2 0,0 0))");
-    b = boost::geometry::from_wkt<linestring_type>("LINESTRING(0 0,2 2,3 1)");
+    auto const a = boost::geometry::from_wkt<point_type>("POINT(1 2)");
+    auto const d = boost::geometry::from_wkt<box_type>("BOX(0 0,3 3)");
+    auto const e = boost::geometry::from_wkt<segment_type>("SEGMENT(1 0,3 4)");
+    auto const c = boost::geometry::from_wkt<polygon_type>("POLYGON((0 0,0 7,4 2,2 0,0 0))");
+    auto const b = boost::geometry::from_wkt<linestring_type>("LINESTRING(0 0,2 2,3 1)");
 
     return 0;
 }
 
 //]
-

--- a/doc/src/examples/io/from_wkt.cpp
+++ b/doc/src/examples/io/from_wkt.cpp
@@ -2,6 +2,7 @@
 // QuickBook Example
 
 // Copyright (c) 2014 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2020 Baidyanath Kundu, Haldia, India.
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at

--- a/doc/src/examples/io/from_wkt.cpp
+++ b/doc/src/examples/io/from_wkt.cpp
@@ -1,0 +1,36 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+// QuickBook Example
+
+// Copyright (c) 2014 Barend Gehrels, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+//[from_wkt
+//` Shows the usage of from_wkt
+
+#include <boost/geometry.hpp>
+#include <boost/geometry/geometries/point_xy.hpp>
+#include <boost/geometry/geometries/linestring.hpp>
+#include <boost/geometry/geometries/polygon.hpp>
+
+int main()
+{
+    typedef boost::geometry::model::d2::point_xy<double> point_type;
+    typedef boost::geometry::model::linestring<point_type> linestring_type;
+    typedef boost::geometry::model::polygon<point_type> polygon_type;
+    typedef boost::geometry::model::box<point_type> box_type;
+    typedef boost::geometry::model::segment<point_type> segment_type;
+
+    point_type a = boost::geometry::from_wkt<point_type>("POINT(1 2)");
+    linestring_type b = boost::geometry::from_wkt<linestring_type>("LINESTRING(0 0,2 2,3 1)");
+    polygon_type c = boost::geometry::from_wkt<polygon_type>("POLYGON((0 0,0 7,4 2,2 0,0 0))");
+    box_type d = boost::geometry::from_wkt<box_type>("BOX(0 0,3 3)");
+    segment_type e = boost::geometry::from_wkt<segment_type>("SEGMENT(1 0,3 4)");
+
+    return 0;
+}
+
+//]
+

--- a/doc/src/examples/io/from_wkt.cpp
+++ b/doc/src/examples/io/from_wkt.cpp
@@ -18,16 +18,21 @@
 int main()
 {
     typedef boost::geometry::model::d2::point_xy<double> point_type;
-    typedef boost::geometry::model::linestring<point_type> linestring_type;
-    typedef boost::geometry::model::polygon<point_type> polygon_type;
     typedef boost::geometry::model::box<point_type> box_type;
     typedef boost::geometry::model::segment<point_type> segment_type;
+    typedef boost::geometry::model::polygon<point_type> polygon_type;
+    typedef boost::geometry::model::linestring<point_type> linestring_type;
 
-    point_type a = boost::geometry::from_wkt<point_type>("POINT(1 2)");
-    linestring_type b = boost::geometry::from_wkt<linestring_type>("LINESTRING(0 0,2 2,3 1)");
-    polygon_type c = boost::geometry::from_wkt<polygon_type>("POLYGON((0 0,0 7,4 2,2 0,0 0))");
-    box_type d = boost::geometry::from_wkt<box_type>("BOX(0 0,3 3)");
-    segment_type e = boost::geometry::from_wkt<segment_type>("SEGMENT(1 0,3 4)");
+    point_type a;
+    box_type d;
+    segment_type e;
+    polygon_type c;
+    linestring_type b;
+    a = boost::geometry::from_wkt<point_type>("POINT(1 2)");
+    d = boost::geometry::from_wkt<box_type>("BOX(0 0,3 3)");
+    e = boost::geometry::from_wkt<segment_type>("SEGMENT(1 0,3 4)");
+    c = boost::geometry::from_wkt<polygon_type>("POLYGON((0 0,0 7,4 2,2 0,0 0))");
+    b = boost::geometry::from_wkt<linestring_type>("LINESTRING(0 0,2 2,3 1)");
 
     return 0;
 }

--- a/doc/src/examples/io/to_wkt.cpp
+++ b/doc/src/examples/io/to_wkt.cpp
@@ -32,7 +32,7 @@ int main()
     std::cout << boost::geometry::to_wkt(point) << std::endl;
     std::cout << boost::geometry::to_wkt(polygon) << std::endl;
 
-    point_type point_frac = geom::make<point_type>(3.141592654, 2.718281828);
+    point_type point_frac = geom::make<point_type>(3.141592654, 27.18281828);
     geom::model::polygon<point_type> polygon_frac;
     geom::append(geom::exterior_ring(polygon_frac), geom::make<point_type>(0.00000, 0.00000));
     geom::append(geom::exterior_ring(polygon_frac), geom::make<point_type>(0.00000, 4.00001));
@@ -55,7 +55,7 @@ Output:
 [pre
 POINT(3 2)
 POLYGON((0 0,0 4,4 4,4 0,0 0))
-POINT(3.14 2.72)
+POINT(3.14 27.2)
 POLYGON((0 0,0 4,4 4,4 0,0 0))
 ]
 

--- a/doc/src/examples/io/to_wkt.cpp
+++ b/doc/src/examples/io/to_wkt.cpp
@@ -21,7 +21,7 @@ int main()
     namespace geom = boost::geometry;
     typedef geom::model::d2::point_xy<double> point_type;
 
-    point_type point = geom::make<point_type>(3, 6);
+    point_type point = geom::make<point_type>(3, 2);
     geom::model::polygon<point_type> polygon;
     geom::append(geom::exterior_ring(polygon), geom::make<point_type>(0, 0));
     geom::append(geom::exterior_ring(polygon), geom::make<point_type>(0, 4));
@@ -31,6 +31,17 @@ int main()
 
     std::cout << boost::geometry::to_wkt(point) << std::endl;
     std::cout << boost::geometry::to_wkt(polygon) << std::endl;
+
+    point_type point_frac = geom::make<point_type>(3.141592654, 2.718281828);
+    geom::model::polygon<point_type> polygon_frac;
+    geom::append(geom::exterior_ring(polygon_frac), geom::make<point_type>(0.00000, 0.00000));
+    geom::append(geom::exterior_ring(polygon_frac), geom::make<point_type>(0.00000, 4.00001));
+    geom::append(geom::exterior_ring(polygon_frac), geom::make<point_type>(4.00001, 4.00001));
+    geom::append(geom::exterior_ring(polygon_frac), geom::make<point_type>(4.00001, 0.00000));
+    geom::append(geom::exterior_ring(polygon_frac), geom::make<point_type>(0.00000, 0.00000));
+
+    std::cout << boost::geometry::to_wkt(point_frac, 3) << std::endl;
+    std::cout << boost::geometry::to_wkt(polygon_frac, 3) << std::endl;
 
     return 0;
 }
@@ -42,7 +53,9 @@ int main()
 /*`
 Output:
 [pre
-POINT(3 6)
+POINT(3 2)
+POLYGON((0 0,0 4,4 4,4 0,0 0))
+POINT(3.14 2.72)
 POLYGON((0 0,0 4,4 4,4 0,0 0))
 ]
 

--- a/doc/src/examples/io/to_wkt.cpp
+++ b/doc/src/examples/io/to_wkt.cpp
@@ -1,0 +1,51 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+// QuickBook Example
+
+// Copyright (c) 2020 Baidyanath Kundu, Haldia, India.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+//[to_wkt
+//` Shows the usage of to_wkt
+
+#include <iostream>
+
+#include <boost/geometry.hpp>
+#include <boost/geometry/geometries/point_xy.hpp>
+#include <boost/geometry/geometries/polygon.hpp>
+
+int main()
+{
+    namespace geom = boost::geometry;
+    typedef geom::model::d2::point_xy<double> point_type;
+
+    point_type point = geom::make<point_type>(3, 6);
+    geom::model::polygon<point_type> polygon;
+    geom::append(geom::exterior_ring(polygon), geom::make<point_type>(0, 0));
+    geom::append(geom::exterior_ring(polygon), geom::make<point_type>(0, 4));
+    geom::append(geom::exterior_ring(polygon), geom::make<point_type>(4, 4));
+    geom::append(geom::exterior_ring(polygon), geom::make<point_type>(4, 0));
+    geom::append(geom::exterior_ring(polygon), geom::make<point_type>(0, 0));
+
+    std::cout << boost::geometry::to_wkt(point) << std::endl;
+    std::cout << boost::geometry::to_wkt(polygon) << std::endl;
+
+    return 0;
+}
+
+//]
+
+
+//[to_wkt_output
+/*`
+Output:
+[pre
+POINT(3 6)
+POLYGON((0 0,0 4,4 4,4 0,0 0))
+]
+
+
+*/
+//]

--- a/doc/src/examples/io/wkt.cpp
+++ b/doc/src/examples/io/wkt.cpp
@@ -32,6 +32,17 @@ int main()
     std::cout << boost::geometry::wkt(point) << std::endl;
     std::cout << boost::geometry::wkt(polygon) << std::endl;
 
+    point_type point_frac = geom::make<point_type>(3.141592654, 27.18281828);
+    geom::model::polygon<point_type> polygon_frac;
+    geom::append(geom::exterior_ring(polygon_frac), geom::make<point_type>(0.00000, 0.00000));
+    geom::append(geom::exterior_ring(polygon_frac), geom::make<point_type>(0.00000, 4.00001));
+    geom::append(geom::exterior_ring(polygon_frac), geom::make<point_type>(4.00001, 4.00001));
+    geom::append(geom::exterior_ring(polygon_frac), geom::make<point_type>(4.00001, 0.00000));
+    geom::append(geom::exterior_ring(polygon_frac), geom::make<point_type>(0.00000, 0.00000));
+
+    std::cout << boost::geometry::wkt(point_frac, 3) << std::endl;
+    std::cout << boost::geometry::wkt(polygon_frac, 3) << std::endl;
+
     return 0;
 }
 
@@ -42,7 +53,9 @@ int main()
 /*`
 Output:
 [pre
-POINT(3 6)
+POINT(3 2)
+POLYGON((0 0,0 4,4 4,4 0,0 0))
+POINT(3.14 2.72)
 POLYGON((0 0,0 4,4 4,4 0,0 0))
 ]
 

--- a/doc/src/examples/io/wkt.cpp
+++ b/doc/src/examples/io/wkt.cpp
@@ -32,17 +32,6 @@ int main()
     std::cout << boost::geometry::wkt(point) << std::endl;
     std::cout << boost::geometry::wkt(polygon) << std::endl;
 
-    point_type point_frac = geom::make<point_type>(3.141592654, 2.718281828);
-    geom::model::polygon<point_type> polygon_frac;
-    geom::append(geom::exterior_ring(polygon_frac), geom::make<point_type>(0.00000, 0.00000));
-    geom::append(geom::exterior_ring(polygon_frac), geom::make<point_type>(0.00000, 4.00001));
-    geom::append(geom::exterior_ring(polygon_frac), geom::make<point_type>(4.00001, 4.00001));
-    geom::append(geom::exterior_ring(polygon_frac), geom::make<point_type>(4.00001, 0.00000));
-    geom::append(geom::exterior_ring(polygon_frac), geom::make<point_type>(0.00000, 0.00000));
-
-    std::cout << boost::geometry::wkt(point_frac, 3) << std::endl;
-    std::cout << boost::geometry::wkt(polygon_frac, 3) << std::endl;
-
     return 0;
 }
 

--- a/doc/src/examples/io/wkt.cpp
+++ b/doc/src/examples/io/wkt.cpp
@@ -32,7 +32,7 @@ int main()
     std::cout << boost::geometry::wkt(point) << std::endl;
     std::cout << boost::geometry::wkt(polygon) << std::endl;
 
-    point_type point_frac = geom::make<point_type>(3.141592654, 27.18281828);
+    point_type point_frac = geom::make<point_type>(3.141592654, 2.718281828);
     geom::model::polygon<point_type> polygon_frac;
     geom::append(geom::exterior_ring(polygon_frac), geom::make<point_type>(0.00000, 0.00000));
     geom::append(geom::exterior_ring(polygon_frac), geom::make<point_type>(0.00000, 4.00001));
@@ -55,7 +55,7 @@ Output:
 [pre
 POINT(3 2)
 POLYGON((0 0,0 4,4 4,4 0,0 0))
-POINT(3.14 2.72)
+POINT(3.14 27.2)
 POLYGON((0 0,0 4,4 4,4 0,0 0))
 ]
 

--- a/include/boost/geometry/io/wkt/read.hpp
+++ b/include/boost/geometry/io/wkt/read.hpp
@@ -912,7 +912,6 @@ inline void read_wkt(std::string const& wkt, Geometry& geometry)
 \ingroup wkt
 \tparam Geometry \tparam_geometry
 \param wkt string containing \ref WKT
-\param geometry \param_geometry output geometry
 \ingroup wkt
 \qbk{[include reference/io/from_wkt.qbk]}
 */

--- a/include/boost/geometry/io/wkt/read.hpp
+++ b/include/boost/geometry/io/wkt/read.hpp
@@ -907,6 +907,24 @@ inline void read_wkt(std::string const& wkt, Geometry& geometry)
     dispatch::read_wkt<typename tag<Geometry>::type, Geometry>::apply(wkt, geometry);
 }
 
+/*!
+\brief Parses OGC Well-Known Text (\ref WKT) into a geometry (any geometry) and returns it
+\ingroup wkt
+\tparam Geometry \tparam_geometry
+\param wkt string containing \ref WKT
+\param geometry \param_geometry output geometry
+\ingroup wkt
+\qbk{[include reference/io/from_wkt.qbk]}
+*/
+template <typename Geometry>
+inline Geometry from_wkt(std::string const& wkt)
+{
+    Geometry geometry;
+    geometry::concepts::check<Geometry>();
+    dispatch::read_wkt<typename tag<Geometry>::type, Geometry>::apply(wkt, geometry);
+    return geometry;
+}
+
 }} // namespace boost::geometry
 
 #endif // BOOST_GEOMETRY_IO_WKT_READ_HPP

--- a/include/boost/geometry/io/wkt/read.hpp
+++ b/include/boost/geometry/io/wkt/read.hpp
@@ -4,6 +4,7 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 // Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
+// Copyright (c) 2020 Baidyanath Kundu, Haldia, India
 
 // This file was modified by Oracle on 2014-2020.
 // Modifications copyright (c) 2014-2020 Oracle and/or its affiliates.

--- a/include/boost/geometry/io/wkt/write.hpp
+++ b/include/boost/geometry/io/wkt/write.hpp
@@ -613,7 +613,16 @@ inline wkt_manipulator<Geometry> wkt(Geometry const& geometry)
 \qbk{[include reference/io/to_wkt.qbk]}
 */
 template <typename Geometry>
-inline std::string to_wkt(Geometry const& geometry, int significant_digits = -1)
+inline std::string to_wkt(Geometry const& geometry)
+{
+    concepts::check<Geometry const>();
+    std::string out;
+    dispatch::devarianted_wkt<Geometry>::apply(out, geometry, -1, ! (boost::is_same<typename tag<Geometry>::type, ring_tag>::value));
+    return out;
+}
+
+template <typename Geometry>
+inline std::string to_wkt(Geometry const& geometry, int significant_digits)
 {
     concepts::check<Geometry const>();
     std::string out;

--- a/include/boost/geometry/io/wkt/write.hpp
+++ b/include/boost/geometry/io/wkt/write.hpp
@@ -596,7 +596,7 @@ private:
 \brief Main WKT-streaming function
 \tparam Geometry \tparam_geometry
 \param geometry \param_geometry
-\param 
+\param significant_digits Specifies the no of significant digits to use in the output wkt
 \ingroup wkt
 \qbk{[include reference/io/wkt.qbk]}
 */
@@ -613,6 +613,7 @@ inline wkt_manipulator<Geometry> wkt(Geometry const& geometry, int significant_d
 \brief Main WKT-string formulating function
 \tparam Geometry \tparam_geometry
 \param geometry \param_geometry
+\param significant_digits Specifies the no of significant digits to use in the output wkt
 \ingroup wkt
 \qbk{[include reference/io/to_wkt.qbk]}
 */

--- a/include/boost/geometry/io/wkt/write.hpp
+++ b/include/boost/geometry/io/wkt/write.hpp
@@ -76,23 +76,23 @@ struct output_formatter
     }
 };
 
-template <typename CharT, typename Traits, typename Allocator>
-struct output_formatter<std::basic_string<CharT, Traits, Allocator> >
+template <>
+struct output_formatter<std::string>
 {
     template <typename T>
-    static void append(std::basic_string<CharT, Traits, Allocator>& out, T const& val)
+    static void append(std::string& out, T const& val)
     {
-        std::basic_stringstream<CharT, Traits> ss;
+        std::stringstream ss;
         ss << val;
         out += ss.str();
     }
 
-    static void append(std::basic_string<CharT, Traits, Allocator>& out, CharT c)
+    static void append(std::string& out, char c)
     {
         out += c;
     }
 
-    static void append(std::basic_string<CharT, Traits, Allocator>& out, CharT const* s)
+    static void append(std::string& out, char const* s)
     {
         out += s;
     }

--- a/include/boost/geometry/io/wkt/write.hpp
+++ b/include/boost/geometry/io/wkt/write.hpp
@@ -76,31 +76,31 @@ struct output_formatter
     }
 };
 
-template <typename CharT, typename Traits, typename Allocator>
-struct output_formatter<std::basic_string<CharT, Traits, Allocator>>
+template <typename CharT, typename Traits>
+struct output_formatter<std::basic_string<CharT, Traits>>
 {
     template <typename T>
-    static void append(std::basic_string<CharT, Traits, Allocator>& out, T const& val)
+    static void append(std::basic_string<CharT, Traits>& out, T const& val)
     {
-        std::basic_stringstream<CharT, Traits, Allocator> ss;
+        std::basic_stringstream<CharT, Traits> ss;
         ss << val;
         out += ss.str();
     }
 
-    static void append(std::basic_string<CharT, Traits, Allocator>& out, CharT c)
+    static void append(std::basic_string<CharT, Traits>& out, CharT c)
     {
         out += c;
     }
 
-    static void append(std::basic_string<CharT, Traits, Allocator>& out, const CharT* s)
+    static void append(std::basic_string<CharT, Traits>& out, CharT const* s)
     {
         out += s;
     }
 
-    template <typename AppendCharT, typename AppendTraits, typename AppendAllocator>
+    template <typename AppendCharT, typename AppendTraits>
     static void append(
-        std::basic_string<CharT, Traits, Allocator>& out, 
-        std::basic_string<AppendCharT, AppendTraits, AppendAllocator> const& str
+        std::basic_string<CharT, Traits>& out, 
+        std::basic_string<AppendCharT, AppendTraits> const& str
         )
     {
         out += str;

--- a/include/boost/geometry/io/wkt/write.hpp
+++ b/include/boost/geometry/io/wkt/write.hpp
@@ -83,10 +83,11 @@ struct output_formatter<std::string>
     template <typename T>
     static void append(std::string& out, T const& val, int significant_digits = -1)
     {
+        BOOST_STATIC_ASSERT((boost::is_arithmetic<T>::value));
         std::stringstream ss;
         if(std::numeric_limits<T>::is_specialized)
         {
-            if(significant_digits==-1)
+            if(significant_digits < 0)
                 ss.precision(std::numeric_limits<T>::digits10);
             else
                 ss.precision(significant_digits);
@@ -112,9 +113,10 @@ struct output_formatter<std::ostream>
     template <typename T>
     static void append(std::ostream& out, T const& val, int significant_digits = -1)
     {
+        BOOST_STATIC_ASSERT((boost::is_arithmetic<T>::value));
         if(std::numeric_limits<T>::is_specialized)
         {
-            if(significant_digits==-1)
+            if(significant_digits < 0)
                 out.precision(std::numeric_limits<T>::digits10);
             else
                 out.precision(significant_digits);

--- a/include/boost/geometry/io/wkt/write.hpp
+++ b/include/boost/geometry/io/wkt/write.hpp
@@ -76,34 +76,25 @@ struct output_formatter
     }
 };
 
-template <typename CharT, typename Traits>
-struct output_formatter<std::basic_string<CharT, Traits>>
+template <typename CharT, typename Traits, typename Allocator>
+struct output_formatter<std::basic_string<CharT, Traits, Allocator> >
 {
     template <typename T>
-    static void append(std::basic_string<CharT, Traits>& out, T const& val)
+    static void append(std::basic_string<CharT, Traits, Allocator>& out, T const& val)
     {
         std::basic_stringstream<CharT, Traits> ss;
         ss << val;
         out += ss.str();
     }
 
-    static void append(std::basic_string<CharT, Traits>& out, CharT c)
+    static void append(std::basic_string<CharT, Traits, Allocator>& out, CharT c)
     {
         out += c;
     }
 
-    static void append(std::basic_string<CharT, Traits>& out, CharT const* s)
+    static void append(std::basic_string<CharT, Traits, Allocator>& out, CharT const* s)
     {
         out += s;
-    }
-
-    template <typename AppendCharT, typename AppendTraits>
-    static void append(
-        std::basic_string<CharT, Traits>& out, 
-        std::basic_string<AppendCharT, AppendTraits> const& str
-        )
-    {
-        out += str;
     }
 };
 

--- a/include/boost/geometry/io/wkt/write.hpp
+++ b/include/boost/geometry/io/wkt/write.hpp
@@ -86,7 +86,7 @@ struct output_formatter<std::string>
         BOOST_STATIC_ASSERT((boost::is_arithmetic<T>::value));
         std::stringstream ss;
         if(significant_digits >= 0)
-                ss.precision(significant_digits);
+            ss.precision(significant_digits);
         else if(std::numeric_limits<T>::is_specialized)
             ss.precision(std::numeric_limits<T>::digits10);
         ss << val;

--- a/include/boost/geometry/io/wkt/write.hpp
+++ b/include/boost/geometry/io/wkt/write.hpp
@@ -106,6 +106,33 @@ struct output_formatter<std::string>
     }
 };
 
+template <>
+struct output_formatter<std::ostream>
+{
+    template <typename T>
+    static void append(std::ostream& out, T const& val, int significant_digits = -1)
+    {
+        if(std::numeric_limits<T>::is_specialized)
+        {
+            if(significant_digits==-1)
+                out.precision(std::numeric_limits<T>::digits10);
+            else
+                out.precision(significant_digits);
+        }
+        out << val;
+    }
+
+    static void append(std::ostream& out, char c, int = -1)
+    {
+        out << c;
+    }
+
+    static void append(std::ostream& out, char const* s, int = -1)
+    {
+        out << s;
+    }
+};
+
 template <typename P, int I, int Count>
 struct stream_coordinate
 {

--- a/include/boost/geometry/io/wkt/write.hpp
+++ b/include/boost/geometry/io/wkt/write.hpp
@@ -104,34 +104,6 @@ struct output_formatter<std::string>
     }
 };
 
-template <>
-struct output_formatter<std::ostream>
-{
-    template <typename T>
-    static void append(std::ostream& out, T const& val, int significant_digits = -1)
-    {
-        BOOST_STATIC_ASSERT((boost::is_arithmetic<T>::value));
-        if(std::numeric_limits<T>::is_specialized)
-        {
-            if(significant_digits < 0)
-                out.precision(std::numeric_limits<T>::digits10);
-            else
-                out.precision(significant_digits);
-        }
-        out << val;
-    }
-
-    static void append(std::ostream& out, char c, int = -1)
-    {
-        out << c;
-    }
-
-    static void append(std::ostream& out, char const* s, int = -1)
-    {
-        out << s;
-    }
-};
-
 template <typename P, int I, int Count>
 struct stream_coordinate
 {

--- a/include/boost/geometry/io/wkt/write.hpp
+++ b/include/boost/geometry/io/wkt/write.hpp
@@ -85,10 +85,14 @@ struct output_formatter<std::string>
     {
         BOOST_STATIC_ASSERT((boost::is_arithmetic<T>::value));
         std::stringstream ss;
-        if(significant_digits >= 0)
+        if (significant_digits >= 0)
+        {
             ss.precision(significant_digits);
-        else if(std::numeric_limits<T>::is_specialized)
+        }
+        else if (std::numeric_limits<T>::is_specialized)
+        {
             ss.precision(std::numeric_limits<T>::digits10);
+        }
         ss << val;
         out += ss.str();
     }
@@ -203,7 +207,7 @@ struct wkt_range
         iterator_type end = boost::end(range);
         for (iterator_type it = begin; it != end; ++it)
         {
-            if(!first)
+            if (!first)
             {
                 output_formatter<Output>::append(out, ",");
             }

--- a/include/boost/geometry/io/wkt/write.hpp
+++ b/include/boost/geometry/io/wkt/write.hpp
@@ -187,12 +187,6 @@ struct wkt_range
 {
     template <typename Output>
     static inline void apply(Output& out,
-            rings = interior_rings(poly);
-        for (typename detail::interior_iterator<Polygon const>::type
-                it = boost::begin(rings); it != boost::end(rings); ++it)
-        {
-            output_formatter<Output>::append(out, ",");
-            wkt_sequence<ring>::apply(out, *it, force_closure);
                 Range const& range, bool force_closure = ForceClosurePossible)
     {
         typedef typename boost::range_iterator<Range const>::type iterator_type;
@@ -621,7 +615,7 @@ inline std::string to_wkt(Geometry const& geometry)
 {
     concepts::check<Geometry const>();
     std::string out;
-    dispatch::devarianted_wkt<Geometry>::apply(out, geometry, !(boost::is_same<typename tag<Geometry>::type, ring_tag>::value));
+    dispatch::devarianted_wkt<Geometry>::apply(out, geometry, ! (boost::is_same<typename tag<Geometry>::type, ring_tag>::value));
     return out;
 }
 

--- a/include/boost/geometry/io/wkt/write.hpp
+++ b/include/boost/geometry/io/wkt/write.hpp
@@ -85,13 +85,10 @@ struct output_formatter<std::string>
     {
         BOOST_STATIC_ASSERT((boost::is_arithmetic<T>::value));
         std::stringstream ss;
-        if(std::numeric_limits<T>::is_specialized)
-        {
-            if(significant_digits < 0)
-                ss.precision(std::numeric_limits<T>::digits10);
-            else
+        if(significant_digits >= 0)
                 ss.precision(significant_digits);
-        }
+        else if(std::numeric_limits<T>::is_specialized)
+            ss.precision(std::numeric_limits<T>::digits10);
         ss << val;
         out += ss.str();
     }

--- a/include/boost/geometry/io/wkt/write.hpp
+++ b/include/boost/geometry/io/wkt/write.hpp
@@ -568,10 +568,8 @@ public:
 
     // Boost.Geometry, by default, closes polygons explictly, but not rings
     // NOTE: this might change in the future!
-    inline wkt_manipulator(Geometry const& g, int significant_digits = -1,
-                           bool force_closure = ! is_ring)
+    inline wkt_manipulator(Geometry const& g, bool force_closure = ! is_ring)
         : m_geometry(g)
-        , m_significant_digits(significant_digits)
         , m_force_closure(force_closure)
     {}
 
@@ -580,14 +578,13 @@ public:
             std::basic_ostream<Char, Traits>& out,
             wkt_manipulator const& m)
     {
-        dispatch::devarianted_wkt<Geometry>::apply(out, m.m_geometry, m.m_significant_digits, m.m_force_closure);
+        dispatch::devarianted_wkt<Geometry>::apply(out, m.m_geometry, -1, m.m_force_closure);
         out.flush();
         return out;
     }
 
 private:
     Geometry const& m_geometry;
-    int m_significant_digits;
     bool m_force_closure;
 };
 /*!
@@ -599,11 +596,11 @@ private:
 \qbk{[include reference/io/wkt.qbk]}
 */
 template <typename Geometry>
-inline wkt_manipulator<Geometry> wkt(Geometry const& geometry, int significant_digits = -1)
+inline wkt_manipulator<Geometry> wkt(Geometry const& geometry)
 {
     concepts::check<Geometry const>();
 
-    return wkt_manipulator<Geometry>(geometry, significant_digits);
+    return wkt_manipulator<Geometry>(geometry);
 }
 
 

--- a/test/io/wkt/wkt.cpp
+++ b/test/io/wkt/wkt.cpp
@@ -49,16 +49,6 @@ void check_wkt(G const& geometry, std::string const& expected)
 }
 
 template <typename G>
-void check_precise_wkt(G const& geometry, std::string const& expected,
-            int significant_digits)
-{
-    std::ostringstream out;
-    out << bg::wkt(geometry, significant_digits);
-    BOOST_CHECK_EQUAL(boost::to_upper_copy(out.str()),
-                      boost::to_upper_copy(expected));
-}
-
-template <typename G>
 void check_to_wkt(G const& geometry, std::string const& expected)
 {
     std::string out_string;
@@ -259,7 +249,19 @@ void test_wkt_output_iterator(std::string const& wkt)
     bg::read_wkt<G>(wkt, std::back_inserter(geometry));
 }
 
-
+void test_precise_to_wkt()
+{
+    typedef boost::geometry::model::d2::point_xy<double> point_type;
+    point_type point = boost::geometry::make<point_type>(1.2345, 6.7890);
+    boost::geometry::model::polygon<point_type> polygon;
+    boost::geometry::append(boost::geometry::exterior_ring(polygon), boost::geometry::make<point_type>(0.00000, 0.00000));
+    boost::geometry::append(boost::geometry::exterior_ring(polygon), boost::geometry::make<point_type>(0.00000, 4.00001));
+    boost::geometry::append(boost::geometry::exterior_ring(polygon), boost::geometry::make<point_type>(4.00001, 4.00001));
+    boost::geometry::append(boost::geometry::exterior_ring(polygon), boost::geometry::make<point_type>(4.00001, 0.00000));
+    boost::geometry::append(boost::geometry::exterior_ring(polygon), boost::geometry::make<point_type>(0.00000, 0.00000));
+    check_precise_to_wkt(point,"POINT(1.23 6.79)",3);
+    check_precise_to_wkt(polygon,"POLYGON((0 0,0 4,4 4,4 0,0 0))",3);
+}
 
 #ifndef GEOMETRY_TEST_MULTI
 template <typename T>
@@ -377,20 +379,7 @@ int test_main(int, char* [])
 {
     test_all<double>();
     test_all<int>();
-
-    typedef boost::geometry::model::d2::point_xy<double> point_type;
-    point_type point = boost::geometry::make<point_type>(1.2345, 6.7890);
-    boost::geometry::model::polygon<point_type> polygon;
-    boost::geometry::append(boost::geometry::exterior_ring(polygon), boost::geometry::make<point_type>(0.00000, 0.00000));
-    boost::geometry::append(boost::geometry::exterior_ring(polygon), boost::geometry::make<point_type>(0.00000, 4.00001));
-    boost::geometry::append(boost::geometry::exterior_ring(polygon), boost::geometry::make<point_type>(4.00001, 4.00001));
-    boost::geometry::append(boost::geometry::exterior_ring(polygon), boost::geometry::make<point_type>(4.00001, 0.00000));
-    boost::geometry::append(boost::geometry::exterior_ring(polygon), boost::geometry::make<point_type>(0.00000, 0.00000));
-    check_precise_wkt(point,"POINT(1.23 6.79)",3);
-    check_precise_wkt(polygon,"POLYGON((0 0,0 4,4 4,4 0,0 0))",3);
-    check_precise_to_wkt(point,"POINT(1.23 6.79)",3);
-    check_precise_to_wkt(polygon,"POLYGON((0 0,0 4,4 4,4 0,0 0))",3);
-
+    test_precise_to_wkt();
 
 #if defined(HAVE_TTMATH)
     test_all<ttmath_big>();

--- a/test/io/wkt/wkt.cpp
+++ b/test/io/wkt/wkt.cpp
@@ -48,6 +48,15 @@ void check_wkt(G const& geometry, std::string const& expected)
 }
 
 template <typename G>
+void check_to_wkt(G const& geometry, std::string const& expected)
+{
+    std::string out_string;
+    out_string = bg::to_wkt(geometry);
+    BOOST_CHECK_EQUAL(boost::to_upper_copy(out_string),
+                      boost::to_upper_copy(expected));
+}
+
+template <typename G>
 void test_wkt(std::string const& wkt, std::string const& expected,
               std::size_t n, double len = 0, double ar = 0, double peri = 0)
 {
@@ -75,6 +84,8 @@ void test_wkt(std::string const& wkt, std::string const& expected,
 
     check_wkt(geometry, expected);
     check_wkt(boost::variant<G>(geometry), expected);
+    check_to_wkt(geometry, expected);
+    check_to_wkt(boost::variant<G>(geometry), expected);
 }
 
 template <typename G>
@@ -94,6 +105,11 @@ void test_relaxed_wkt(std::string const& wkt, std::string const& expected)
     out << bg::wkt(geometry);
 
     BOOST_CHECK_EQUAL(boost::to_upper_copy(out.str()), boost::to_upper_copy(expected));
+
+    std::string out_string;
+    out_string = bg::to_wkt(geometry);
+
+    BOOST_CHECK_EQUAL(boost::to_upper_copy(out_string), boost::to_upper_copy(expected));
 }
 
 

--- a/test/io/wkt/wkt.cpp
+++ b/test/io/wkt/wkt.cpp
@@ -85,7 +85,7 @@ void test_wkt_read_write(std::string const& wkt, std::string const& expected,
 
     bg::read_wkt(wkt, geometry);
 
-    /*
+    #ifdef BOOST_GEOMETRY_TEST_DEBUG
     std::cout << "n=" << bg::num_points(geometry)
         << " dim=" << bg::topological_dimension<G>::value
         << " length=" << bg::length(geometry)
@@ -93,7 +93,7 @@ void test_wkt_read_write(std::string const& wkt, std::string const& expected,
         << " perimeter=" << bg::perimeter(geometry)
         << std::endl << "\t\tgeometry=" << dsv(geometry)
         << std::endl;
-    */
+    #endif
 
     BOOST_CHECK_EQUAL(bg::num_points(geometry), n);
     if (n > 0)
@@ -115,7 +115,7 @@ void test_wkt_to_from(std::string const& wkt, std::string const& expected,
 
     geometry = bg::from_wkt<G>(wkt);
 
-    /*
+    #ifdef BOOST_GEOMETRY_TEST_DEBUG
     std::cout << "n=" << bg::num_points(geometry)
         << " dim=" << bg::topological_dimension<G>::value
         << " length=" << bg::length(geometry)
@@ -123,7 +123,7 @@ void test_wkt_to_from(std::string const& wkt, std::string const& expected,
         << " perimeter=" << bg::perimeter(geometry)
         << std::endl << "\t\tgeometry=" << dsv(geometry)
         << std::endl;
-    */
+    #endif
 
     BOOST_CHECK_EQUAL(bg::num_points(geometry), n);
     if (n > 0)


### PR DESCRIPTION
This PR fixes #654 . It adds the following:

- `to_wkt`: This function converts the given geometry to wkt string and returns it instead of modifying a stringstream taken as input like `wkt`.
- `from_wkt`: This function returns the geometry obtained by parsing a wkt string instead of taking in a geometry variable as parameter and storing the geometry in it.
- tests: Tests for both `to_wkt` and `from_wkt` are provided with basically follow the template of already implemented `read_wkt` and `wkt` tests.
- examples and documentation: Example usage of both have been added and documentation has been updated.

This PR is now ready to be reviewed and then merged.