### PR TITLE
Adding missing unit tests for geometry models

### DIFF
--- a/test/geometries/Jamfile
+++ b/test/geometries/Jamfile
@@ -4,6 +4,7 @@
 # Copyright (c) 2008-2019 Bruno Lalande, Paris, France.
 # Copyright (c) 2009-2019 Mateusz Loskot, London, UK.
 # Copyright (c) 2014-2019 Adam Wulkiewicz, Lodz, Poland.
+# Copyright (c) 2020 Digvijay Janartha, Hamirpur, India.
 
 # Use, modification and distribution is subject to the Boost Software License,
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -26,7 +27,12 @@ test-suite boost-geometry-geometries
     #]
     [ run custom_linestring.cpp    : : : : geometries_custom_linestring ]
     [ run initialization.cpp       : : : : geometries_initialization ]
+    [ run linestring.cpp           : : : : geometries_linestring ]
+    [ run point.cpp                : : : : geometries_point ]
+    [ run point_xy.cpp             : : : : geometries_point_xy ]
     [ run point_xyz.cpp            : : : : geometries_point_xyz ]
+    [ run polygon.cpp              : : : : geometries_polygon ]
+    [ run ring.cpp                 : : : : geometries_ring ]
     [ run segment.cpp              : : : : geometries_segment ]
     [ run infinite_line.cpp        : : : : geometries_infinite_line ]
     ;

--- a/test/geometries/Jamfile
+++ b/test/geometries/Jamfile
@@ -4,7 +4,6 @@
 # Copyright (c) 2008-2019 Bruno Lalande, Paris, France.
 # Copyright (c) 2009-2019 Mateusz Loskot, London, UK.
 # Copyright (c) 2014-2019 Adam Wulkiewicz, Lodz, Poland.
-# Copyright (c) 2020 Digvijay Janartha, Hamirpur, India.
 
 # Use, modification and distribution is subject to the Boost Software License,
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -28,6 +27,9 @@ test-suite boost-geometry-geometries
     [ run custom_linestring.cpp    : : : : geometries_custom_linestring ]
     [ run initialization.cpp       : : : : geometries_initialization ]
     [ run linestring.cpp           : : : : geometries_linestring ]
+    [ run multi_linestring.cpp     : : : : geometries_multi_linestring ]
+    [ run multi_point.cpp          : : : : geometries_multi_point ]
+    [ run multi_polygon.cpp        : : : : geometries_multi_polygon ]
     [ run point.cpp                : : : : geometries_point ]
     [ run point_xy.cpp             : : : : geometries_point_xy ]
     [ run point_xyz.cpp            : : : : geometries_point_xyz ]

--- a/test/geometries/linestring.cpp
+++ b/test/geometries/linestring.cpp
@@ -50,14 +50,29 @@ void check_linestring(L& to_check, T x, T y, T z)
 }
 
 template <typename P>
-void test_construction()
+void test_default_constructor()
 {
     bg::model::linestring<P> l1(create_linestring<P>());
     check_linestring(l1, 1, 2, 3);
 }
 
 template <typename P>
-void test_compilation()
+void test_copy_constructor()
+{
+    bg::model::linestring<P> l1 = create_linestring<P>();
+    check_linestring(l1, 1, 2, 3);
+}
+
+template <typename P>
+void test_copy_assignment()
+{
+    bg::model::linestring<P> l1(create_linestring<P>()), l2;
+    l2 = l1;
+    check_linestring(l2, 1, 2, 3);
+}
+
+template <typename P>
+void test_concept()
 {   
     typedef bg::model::linestring<P> L;
 
@@ -72,8 +87,10 @@ void test_compilation()
 template <typename P>
 void test_all()
 {   
-    test_construction<P>();
-    test_compilation<P>();
+    test_default_constructor<P>();
+    test_copy_constructor<P>();
+    test_copy_assignment<P>();
+    test_concept<P>();
 }
 
 template <typename P>

--- a/test/geometries/linestring.cpp
+++ b/test/geometries/linestring.cpp
@@ -3,9 +3,6 @@
 
 // Copyright (c) 2020 Digvijay Janartha, Hamirpur, India.
 
-// Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
-// (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
-
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -109,14 +106,24 @@ void test_custom()
     test_custom_linestring<P>(IL);
 }
 
+template <typename CS>
+void test_cs()
+{
+    test_all<bg::model::point<int, 3, CS> >();
+    test_all<bg::model::point<float, 3, CS> >();
+    test_all<bg::model::point<double, 3, CS> >();
+
+    test_custom<bg::model::point<double, 2, CS> >();
+}
+
 
 int test_main(int, char* [])
 {   
-    test_all<bg::model::point<int, 3, bg::cs::cartesian> >();
-    test_all<bg::model::point<float, 3, bg::cs::cartesian> >();
-    test_all<bg::model::point<double, 3, bg::cs::cartesian> >();
+    test_cs<bg::cs::cartesian>();
+    test_cs<bg::cs::spherical<bg::degree> >();
+    test_cs<bg::cs::spherical_equatorial<bg::degree> >();
+    test_cs<bg::cs::geographic<bg::degree> >();
 
-    test_custom<bg::model::point<double, 2, bg::cs::cartesian> >();
     test_custom<bg::model::d2::point_xy<double> >();
 
     return 0;

--- a/test/geometries/linestring.cpp
+++ b/test/geometries/linestring.cpp
@@ -1,0 +1,106 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+// Unit Test
+
+// Copyright (c) 2020 Digvijay Janartha, Hamirpur, India.
+
+// Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
+// (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <iostream>
+
+#include <geometry_test_common.hpp>
+
+#include <boost/core/ignore_unused.hpp>
+#include <boost/geometry/algorithms/make.hpp>
+#include <boost/geometry/algorithms/append.hpp>
+#include <boost/geometry/geometries/point.hpp>
+#include <boost/geometry/geometries/point_xy.hpp>
+#include <boost/geometry/geometries/linestring.hpp>
+#include <boost/geometry/geometries/concepts/linestring_concept.hpp>
+#include <boost/geometry/geometries/adapted/c_array.hpp>
+#include <boost/geometry/geometries/adapted/boost_tuple.hpp>
+#include <boost/geometry/io/dsv/write.hpp>
+
+#include <test_common/test_point.hpp>
+
+BOOST_GEOMETRY_REGISTER_C_ARRAY_CS(cs::cartesian)
+BOOST_GEOMETRY_REGISTER_BOOST_TUPLE_CS(cs::cartesian)
+
+
+template <typename P>
+bg::model::linestring<P> create_linestring()
+{   
+    bg::model::linestring<P> l1;
+    P p1;
+    bg::assign_values(p1, 1, 2, 3);
+    bg::append(l1, p1);
+    return l1;
+}
+
+template <typename L, typename T>
+void check_linestring(L& to_check, T x, T y, T z)
+{
+    BOOST_CHECK_EQUAL(bg::get<0>(to_check[0]), x);
+    BOOST_CHECK_EQUAL(bg::get<1>(to_check[0]), y);
+    BOOST_CHECK_EQUAL(bg::get<2>(to_check[0]), z);
+}
+
+template <typename P>
+void test_construction()
+{
+    bg::model::linestring<P> l1(create_linestring<P>());
+    check_linestring(l1, 1, 2, 3);
+}
+
+template <typename P>
+void test_compilation()
+{   
+    typedef bg::model::linestring<P> L;
+
+    BOOST_CONCEPT_ASSERT( (bg::concepts::ConstLinestring<L>) );
+    BOOST_CONCEPT_ASSERT( (bg::concepts::Linestring<L>) );
+
+    typedef typename bg::coordinate_type<L>::type T;
+    typedef typename bg::point_type<L>::type LP;
+    boost::ignore_unused<T, LP>();
+}
+
+template <typename P>
+void test_all()
+{   
+    test_construction<P>();
+    test_compilation<P>();
+}
+
+template <typename P>
+void test_custom_linestring(std::initializer_list<P> IL)
+{
+    bg::model::linestring<P> l1(IL);
+    std::ostringstream out;
+    out << bg::dsv(l1);
+    BOOST_CHECK_EQUAL(out.str(), "((1, 2), (2, 3), (3, 4))");
+}
+
+template <typename P>
+void test_custom()
+{   
+    std::initializer_list<P> IL = {P(1, 2), P(2, 3), P(3, 4)};
+    test_custom_linestring<P>(IL);
+}
+
+
+int test_main(int, char* [])
+{   
+    test_all<bg::model::point<int, 3, bg::cs::cartesian> >();
+    test_all<bg::model::point<float, 3, bg::cs::cartesian> >();
+    test_all<bg::model::point<double, 3, bg::cs::cartesian> >();
+
+    test_custom<bg::model::point<double, 2, bg::cs::cartesian> >();
+    test_custom<bg::model::d2::point_xy<double> >();
+
+    return 0;
+}

--- a/test/geometries/linestring.cpp
+++ b/test/geometries/linestring.cpp
@@ -27,6 +27,10 @@
 BOOST_GEOMETRY_REGISTER_C_ARRAY_CS(cs::cartesian)
 BOOST_GEOMETRY_REGISTER_BOOST_TUPLE_CS(cs::cartesian)
 
+#ifdef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
+#include <initializer_list>
+#endif//BOOST_NO_CXX11_HDR_INITIALIZER_LIST
+
 
 template <typename P>
 bg::model::linestring<P> create_linestring()
@@ -102,8 +106,10 @@ void test_custom_linestring(std::initializer_list<P> IL)
 template <typename P>
 void test_custom()
 {   
+#ifdef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
     std::initializer_list<P> IL = {P(1, 2), P(2, 3), P(3, 4)};
     test_custom_linestring<P>(IL);
+#endif//BOOST_NO_CXX11_HDR_INITIALIZER_LIST
 }
 
 template <typename CS>

--- a/test/geometries/multi_linestring.cpp
+++ b/test/geometries/multi_linestring.cpp
@@ -28,6 +28,9 @@
 BOOST_GEOMETRY_REGISTER_C_ARRAY_CS(cs::cartesian)
 BOOST_GEOMETRY_REGISTER_BOOST_TUPLE_CS(cs::cartesian)
 
+#ifdef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
+#include <initializer_list>
+#endif//BOOST_NO_CXX11_HDR_INITIALIZER_LIST
 
 template <typename P>
 bg::model::linestring<P> create_linestring()
@@ -122,12 +125,14 @@ void test_custom_multi_linestring(bg::model::linestring<P> IL)
 template <typename P>
 void test_custom()
 {   
+#ifdef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
     std::initializer_list<P> IL1 = {P(1, 1), P(2, 2), P(3, 3)};
     std::initializer_list<P> IL2 = {P(0, 0), P(0, 2), P(0, 3)};
     bg::model::linestring<P> l1;
     bg::append(l1, IL1);
     bg::append(l1, IL2);
     test_custom_multi_linestring<P>(l1);
+#endif//BOOST_NO_CXX11_HDR_INITIALIZER_LIST
 }
 
 template <typename CS>

--- a/test/geometries/multi_linestring.cpp
+++ b/test/geometries/multi_linestring.cpp
@@ -3,9 +3,6 @@
 
 // Copyright (c) 2020 Digvijay Janartha, Hamirpur, India.
 
-// Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
-// (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
-
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -36,7 +33,7 @@ template <typename P>
 bg::model::linestring<P> create_linestring()
 {   
     bg::model::linestring<P> l1;
-    P p1(1, 2, 3);
+    P p1(1, 2);
     bg::append(l1, p1);
     return l1;
 }
@@ -133,14 +130,24 @@ void test_custom()
     test_custom_multi_linestring<P>(l1);
 }
 
+template <typename CS>
+void test_cs()
+{
+    test_all<bg::model::point<int, 2, CS> >();
+    test_all<bg::model::point<float, 2, CS> >();
+    test_all<bg::model::point<double, 2, CS> >();
+
+    test_custom<bg::model::point<double, 2, CS> >();
+}
+
 
 int test_main(int, char* [])
 {   
-    test_all<bg::model::point<int, 2, bg::cs::cartesian> >();
-    test_all<bg::model::point<float, 2, bg::cs::cartesian> >();
-    test_all<bg::model::point<double, 2, bg::cs::cartesian> >();
+    test_cs<bg::cs::cartesian>();
+    test_cs<bg::cs::spherical<bg::degree> >();
+    test_cs<bg::cs::spherical_equatorial<bg::degree> >();
+    test_cs<bg::cs::geographic<bg::degree> >();
 
-    test_custom<bg::model::point<double, 2, bg::cs::cartesian> >();
     test_custom<bg::model::d2::point_xy<double> >();
 
     return 0;

--- a/test/geometries/multi_linestring.cpp
+++ b/test/geometries/multi_linestring.cpp
@@ -1,0 +1,147 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+// Unit Test
+
+// Copyright (c) 2020 Digvijay Janartha, Hamirpur, India.
+
+// Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
+// (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <iostream>
+
+#include <geometry_test_common.hpp>
+
+#include <boost/core/ignore_unused.hpp>
+#include <boost/geometry/algorithms/make.hpp>
+#include <boost/geometry/algorithms/append.hpp>
+#include <boost/geometry/geometries/point.hpp>
+#include <boost/geometry/geometries/point_xy.hpp>
+#include <boost/geometry/geometries/linestring.hpp>
+#include <boost/geometry/geometries/multi_linestring.hpp>
+#include <boost/geometry/geometries/concepts/multi_linestring_concept.hpp>
+#include <boost/geometry/geometries/adapted/c_array.hpp>
+#include <boost/geometry/geometries/adapted/boost_tuple.hpp>
+#include <boost/geometry/io/dsv/write.hpp>
+
+#include <test_common/test_point.hpp>
+
+BOOST_GEOMETRY_REGISTER_C_ARRAY_CS(cs::cartesian)
+BOOST_GEOMETRY_REGISTER_BOOST_TUPLE_CS(cs::cartesian)
+
+
+template <typename P>
+bg::model::linestring<P> create_linestring()
+{   
+    bg::model::linestring<P> l1;
+    P p1(1, 2, 3);
+    bg::append(l1, p1);
+    return l1;
+}
+
+template <typename P, typename L>
+bg::model::multi_linestring<L> create_multi_linestring()
+{   
+    bg::model::multi_linestring<L> ml1;
+    L l1(create_linestring<P>());
+    ml1.push_back(l1);
+    ml1.push_back(l1);
+    return ml1;
+}
+
+template <typename ML, typename L>
+void check_multi_linestring(ML& to_check, L l1)
+{   
+    ML cur;
+    cur.push_back(l1);
+    cur.push_back(l1);
+
+    std::ostringstream out1, out2;
+    out1 << bg::dsv(to_check);
+    out2 << bg::dsv(cur);
+    BOOST_CHECK_EQUAL(out1.str(), out2.str());
+}
+
+template <typename P, typename L>
+void test_default_constructor()
+{
+    bg::model::multi_linestring<L> ml1(create_multi_linestring<P, L>());
+    check_multi_linestring(ml1, L(create_linestring<P>()));
+}
+
+template <typename P, typename L>
+void test_copy_constructor()
+{
+    bg::model::multi_linestring<L> ml1 = create_multi_linestring<P, L>();
+    check_multi_linestring(ml1, L(create_linestring<P>()));
+}
+
+template <typename P, typename L>
+void test_copy_assignment()
+{
+    bg::model::multi_linestring<L> ml1(create_multi_linestring<P, L>()), ml2;
+    ml2 = ml1;
+    check_multi_linestring(ml2, L(create_linestring<P>()));
+}
+
+template <typename L>
+void test_concept()
+{   
+    typedef bg::model::multi_linestring<L> ML;
+
+    BOOST_CONCEPT_ASSERT( (bg::concepts::ConstMultiLinestring<ML>) );
+    BOOST_CONCEPT_ASSERT( (bg::concepts::MultiLinestring<ML>) );
+
+    typedef typename bg::coordinate_type<ML>::type T;
+    typedef typename bg::point_type<ML>::type PML;
+    boost::ignore_unused<T, PML>();
+}
+
+template <typename P>
+void test_all()
+{   
+    typedef bg::model::linestring<P> L;
+
+    test_default_constructor<P, L>();
+    test_copy_constructor<P, L>();
+    test_copy_assignment<P, L>();
+    test_concept<L>();
+}
+
+template <typename P>
+void test_custom_multi_linestring(bg::model::linestring<P> IL)
+{   
+    typedef bg::model::linestring<P> L;
+    
+    std::initializer_list<L> LIL = {IL};
+    bg::model::multi_linestring<L> ml1(LIL);
+    std::ostringstream out;
+    out << bg::dsv(ml1);
+    BOOST_CHECK_EQUAL(out.str(), "(((1, 1), (2, 2), (3, 3), (0, 0), (0, 2), (0, 3)))");
+}
+
+template <typename P>
+void test_custom()
+{   
+    std::initializer_list<P> IL1 = {P(1, 1), P(2, 2), P(3, 3)};
+    std::initializer_list<P> IL2 = {P(0, 0), P(0, 2), P(0, 3)};
+    bg::model::linestring<P> l1;
+    bg::append(l1, IL1);
+    bg::append(l1, IL2);
+    test_custom_multi_linestring<P>(l1);
+}
+
+
+int test_main(int, char* [])
+{   
+    test_all<bg::model::point<int, 2, bg::cs::cartesian> >();
+    test_all<bg::model::point<float, 2, bg::cs::cartesian> >();
+    test_all<bg::model::point<double, 2, bg::cs::cartesian> >();
+
+    test_custom<bg::model::point<double, 2, bg::cs::cartesian> >();
+    test_custom<bg::model::d2::point_xy<double> >();
+
+    return 0;
+}

--- a/test/geometries/multi_point.cpp
+++ b/test/geometries/multi_point.cpp
@@ -3,9 +3,6 @@
 
 // Copyright (c) 2020 Digvijay Janartha, Hamirpur, India.
 
-// Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
-// (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
-
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -109,14 +106,24 @@ void test_custom()
     test_custom_multi_point<P>(IL);
 }
 
+template <typename CS>
+void test_cs()
+{
+    test_all<bg::model::point<int, 3, CS> >();
+    test_all<bg::model::point<float, 3, CS> >();
+    test_all<bg::model::point<double, 3, CS> >();
+
+    test_custom<bg::model::point<double, 2, CS> >();
+}
+
 
 int test_main(int, char* [])
 {   
-    test_all<bg::model::point<int, 3, bg::cs::cartesian> >();
-    test_all<bg::model::point<float, 3, bg::cs::cartesian> >();
-    test_all<bg::model::point<double, 3, bg::cs::cartesian> >();
+    test_cs<bg::cs::cartesian>();
+    test_cs<bg::cs::spherical<bg::degree> >();
+    test_cs<bg::cs::spherical_equatorial<bg::degree> >();
+    test_cs<bg::cs::geographic<bg::degree> >();
 
-    test_custom<bg::model::point<double, 2, bg::cs::cartesian> >();
     test_custom<bg::model::d2::point_xy<double> >();
 
     return 0;

--- a/test/geometries/multi_point.cpp
+++ b/test/geometries/multi_point.cpp
@@ -27,6 +27,9 @@
 BOOST_GEOMETRY_REGISTER_C_ARRAY_CS(cs::cartesian)
 BOOST_GEOMETRY_REGISTER_BOOST_TUPLE_CS(cs::cartesian)
 
+#ifdef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
+#include <initializer_list>
+#endif//BOOST_NO_CXX11_HDR_INITIALIZER_LIST
 
 template <typename P>
 bg::model::multi_point<P> create_multi_point()
@@ -102,8 +105,10 @@ void test_custom_multi_point(std::initializer_list<P> IL)
 template <typename P>
 void test_custom()
 {   
+#ifdef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
     std::initializer_list<P> IL = {P(0, 0), P(1, 2), P(2, 0)};
     test_custom_multi_point<P>(IL);
+#endif//BOOST_NO_CXX11_HDR_INITIALIZER_LIST
 }
 
 template <typename CS>

--- a/test/geometries/multi_point.cpp
+++ b/test/geometries/multi_point.cpp
@@ -1,0 +1,123 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+// Unit Test
+
+// Copyright (c) 2020 Digvijay Janartha, Hamirpur, India.
+
+// Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
+// (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <iostream>
+
+#include <geometry_test_common.hpp>
+
+#include <boost/core/ignore_unused.hpp>
+#include <boost/geometry/algorithms/make.hpp>
+#include <boost/geometry/algorithms/append.hpp>
+#include <boost/geometry/geometries/point.hpp>
+#include <boost/geometry/geometries/point_xy.hpp>
+#include <boost/geometry/geometries/multi_point.hpp>
+#include <boost/geometry/geometries/concepts/multi_point_concept.hpp>
+#include <boost/geometry/geometries/adapted/c_array.hpp>
+#include <boost/geometry/geometries/adapted/boost_tuple.hpp>
+#include <boost/geometry/io/dsv/write.hpp>
+
+#include <test_common/test_point.hpp>
+
+BOOST_GEOMETRY_REGISTER_C_ARRAY_CS(cs::cartesian)
+BOOST_GEOMETRY_REGISTER_BOOST_TUPLE_CS(cs::cartesian)
+
+
+template <typename P>
+bg::model::multi_point<P> create_multi_point()
+{   
+    bg::model::multi_point<P> mp1;
+    P p1;
+    bg::assign_values(p1, 1, 2, 3);
+    bg::append(mp1, p1);
+    return mp1;
+}
+
+template <typename L, typename T>
+void check_multi_point(L& to_check, T x, T y, T z)
+{
+    BOOST_CHECK_EQUAL(bg::get<0>(to_check[0]), x);
+    BOOST_CHECK_EQUAL(bg::get<1>(to_check[0]), y);
+    BOOST_CHECK_EQUAL(bg::get<2>(to_check[0]), z);
+}
+
+template <typename P>
+void test_default_constructor()
+{
+    bg::model::multi_point<P> mp1(create_multi_point<P>());
+    check_multi_point(mp1, 1, 2, 3);
+}
+
+template <typename P>
+void test_copy_constructor()
+{
+    bg::model::multi_point<P> mp1 = create_multi_point<P>();
+    check_multi_point(mp1, 1, 2, 3);
+}
+
+template <typename P>
+void test_copy_assignment()
+{
+    bg::model::multi_point<P> mp1(create_multi_point<P>()), mp2;
+    mp2 = mp1;
+    check_multi_point(mp2, 1, 2, 3);
+}
+
+template <typename P>
+void test_concept()
+{   
+    typedef bg::model::multi_point<P> MP;
+
+    BOOST_CONCEPT_ASSERT( (bg::concepts::ConstMultiPoint<MP>) );
+    BOOST_CONCEPT_ASSERT( (bg::concepts::MultiPoint<MP>) );
+
+    typedef typename bg::coordinate_type<MP>::type T;
+    typedef typename bg::point_type<MP>::type MPP;
+    boost::ignore_unused<T, MPP>();
+}
+
+template <typename P>
+void test_all()
+{   
+    test_default_constructor<P>();
+    test_copy_constructor<P>();
+    test_copy_assignment<P>();
+    test_concept<P>();
+}
+
+template <typename P>
+void test_custom_multi_point(std::initializer_list<P> IL)
+{
+    bg::model::multi_point<P> mp1(IL);
+    std::ostringstream out;
+    out << bg::dsv(mp1);
+    BOOST_CHECK_EQUAL(out.str(), "((0, 0), (1, 2), (2, 0))");
+}
+
+template <typename P>
+void test_custom()
+{   
+    std::initializer_list<P> IL = {P(0, 0), P(1, 2), P(2, 0)};
+    test_custom_multi_point<P>(IL);
+}
+
+
+int test_main(int, char* [])
+{   
+    test_all<bg::model::point<int, 3, bg::cs::cartesian> >();
+    test_all<bg::model::point<float, 3, bg::cs::cartesian> >();
+    test_all<bg::model::point<double, 3, bg::cs::cartesian> >();
+
+    test_custom<bg::model::point<double, 2, bg::cs::cartesian> >();
+    test_custom<bg::model::d2::point_xy<double> >();
+
+    return 0;
+}

--- a/test/geometries/multi_polygon.cpp
+++ b/test/geometries/multi_polygon.cpp
@@ -3,9 +3,6 @@
 
 // Copyright (c) 2020 Digvijay Janartha, Hamirpur, India.
 
-// Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
-// (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
-
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -140,14 +137,24 @@ void test_custom()
     test_custom_multi_polygon<P>(RIL);
 }
 
+template <typename CS>
+void test_cs()
+{
+    test_all<bg::model::point<int, 2, CS> >();
+    test_all<bg::model::point<float, 2, CS> >();
+    test_all<bg::model::point<double, 2, CS> >();
+
+    test_custom<bg::model::point<double, 2, CS> >();
+}
+
 
 int test_main(int, char* [])
 {   
-    test_all<bg::model::point<int, 2, bg::cs::cartesian> >();
-    test_all<bg::model::point<float, 2, bg::cs::cartesian> >();
-    test_all<bg::model::point<double, 2, bg::cs::cartesian> >();
+    test_cs<bg::cs::cartesian>();
+    test_cs<bg::cs::spherical<bg::degree> >();
+    test_cs<bg::cs::spherical_equatorial<bg::degree> >();
+    test_cs<bg::cs::geographic<bg::degree> >();
 
-    test_custom<bg::model::point<double, 2, bg::cs::cartesian> >();
     test_custom<bg::model::d2::point_xy<double> >();
 
     return 0;

--- a/test/geometries/multi_polygon.cpp
+++ b/test/geometries/multi_polygon.cpp
@@ -28,6 +28,9 @@
 BOOST_GEOMETRY_REGISTER_C_ARRAY_CS(cs::cartesian)
 BOOST_GEOMETRY_REGISTER_BOOST_TUPLE_CS(cs::cartesian)
 
+#ifdef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
+#include <initializer_list>
+#endif//BOOST_NO_CXX11_HDR_INITIALIZER_LIST
 
 template <typename P>
 bg::model::polygon<P> create_polygon()
@@ -131,10 +134,12 @@ void test_custom_multi_polygon(bg::model::polygon<P> IL)
 template <typename P>
 void test_custom()
 {   
+#ifdef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
     std::initializer_list<P> IL = {P(3, 3), P(3, 0), P(0, 0), P(0, 3), P(3, 3)};
     bg::model::ring<P> r1(IL);
     std::initializer_list<bg::model::ring<P> > RIL = {r1};
     test_custom_multi_polygon<P>(RIL);
+#endif//BOOST_NO_CXX11_HDR_INITIALIZER_LIST
 }
 
 template <typename CS>

--- a/test/geometries/multi_polygon.cpp
+++ b/test/geometries/multi_polygon.cpp
@@ -1,0 +1,154 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+// Unit Test
+
+// Copyright (c) 2020 Digvijay Janartha, Hamirpur, India.
+
+// Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
+// (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <iostream>
+
+#include <geometry_test_common.hpp>
+
+#include <boost/core/ignore_unused.hpp>
+#include <boost/geometry/algorithms/make.hpp>
+#include <boost/geometry/algorithms/append.hpp>
+#include <boost/geometry/geometries/point.hpp>
+#include <boost/geometry/geometries/point_xy.hpp>
+#include <boost/geometry/geometries/polygon.hpp>
+#include <boost/geometry/geometries/multi_polygon.hpp>
+#include <boost/geometry/geometries/concepts/multi_polygon_concept.hpp>
+#include <boost/geometry/geometries/adapted/c_array.hpp>
+#include <boost/geometry/geometries/adapted/boost_tuple.hpp>
+#include <boost/geometry/io/dsv/write.hpp>
+
+#include <test_common/test_point.hpp>
+
+BOOST_GEOMETRY_REGISTER_C_ARRAY_CS(cs::cartesian)
+BOOST_GEOMETRY_REGISTER_BOOST_TUPLE_CS(cs::cartesian)
+
+
+template <typename P>
+bg::model::polygon<P> create_polygon()
+{   
+    bg::model::polygon<P> pl1;
+    P p1;
+    P p2;
+    P p3;
+    bg::assign_values(p1, 1, 2);
+    bg::assign_values(p2, 2, 0);
+    bg::assign_values(p3, 0, 0);
+    
+    bg::append(pl1, p1);
+    bg::append(pl1, p2);
+    bg::append(pl1, p3);
+    bg::append(pl1, p1);
+    return pl1;
+}
+
+template <typename P, typename PL>
+bg::model::multi_polygon<PL> create_multi_polygon()
+{
+    bg::model::multi_polygon<PL> mpl1;
+    PL pl1(create_polygon<P>());
+    mpl1.push_back(pl1);
+    mpl1.push_back(pl1);
+    return mpl1;
+}
+
+template <typename MPL, typename PL>
+void check_multi_polygon(MPL& to_check, PL pl1)
+{   
+    MPL cur;
+    cur.push_back(pl1);
+    cur.push_back(pl1);
+
+    std::ostringstream out1, out2;
+    out1 << bg::dsv(to_check);
+    out2 << bg::dsv(cur);
+    BOOST_CHECK_EQUAL(out1.str(), out2.str());
+}
+
+template <typename P, typename PL>
+void test_default_constructor()
+{
+    bg::model::multi_polygon<PL> mpl1(create_multi_polygon<P, PL>());
+    check_multi_polygon(mpl1, PL(create_polygon<P>()));
+}
+
+template <typename P, typename PL>
+void test_copy_constructor()
+{
+    bg::model::multi_polygon<PL> mpl1 = create_multi_polygon<P, PL>();
+    check_multi_polygon(mpl1, PL(create_polygon<P>()));
+}
+
+template <typename P, typename PL>
+void test_copy_assignment()
+{
+    bg::model::multi_polygon<PL> mpl1(create_multi_polygon<P, PL>()), mpl2;
+    mpl2 = mpl1;
+    check_multi_polygon(mpl2, PL(create_polygon<P>()));
+}
+
+template <typename PL>
+void test_concept()
+{   
+    typedef bg::model::multi_polygon<PL> MPL;
+
+    BOOST_CONCEPT_ASSERT( (bg::concepts::ConstMultiPolygon<MPL>) );
+    BOOST_CONCEPT_ASSERT( (bg::concepts::MultiPolygon<MPL>) );
+
+    typedef typename bg::coordinate_type<MPL>::type T;
+    typedef typename bg::point_type<MPL>::type PMPL;
+    boost::ignore_unused<T, PMPL>();
+}
+
+template <typename P>
+void test_all()
+{   
+    typedef bg::model::polygon<P> PL;
+
+    test_default_constructor<P, PL>();
+    test_copy_constructor<P, PL>();
+    test_copy_assignment<P, PL>();
+    test_concept<PL>();
+}
+
+template <typename P>
+void test_custom_multi_polygon(bg::model::polygon<P> IL)
+{   
+    typedef bg::model::polygon<P> PL;
+
+    std::initializer_list<PL> PIL = {IL};
+    bg::model::multi_polygon<PL> mpl1(PIL);
+    std::ostringstream out;
+    out << bg::dsv(mpl1);
+    BOOST_CHECK_EQUAL(out.str(), "((((3, 3), (3, 0), (0, 0), (0, 3), (3, 3))))");
+}
+
+template <typename P>
+void test_custom()
+{   
+    std::initializer_list<P> IL = {P(3, 3), P(3, 0), P(0, 0), P(0, 3), P(3, 3)};
+    bg::model::ring<P> r1(IL);
+    std::initializer_list<bg::model::ring<P> > RIL = {r1};
+    test_custom_multi_polygon<P>(RIL);
+}
+
+
+int test_main(int, char* [])
+{   
+    test_all<bg::model::point<int, 2, bg::cs::cartesian> >();
+    test_all<bg::model::point<float, 2, bg::cs::cartesian> >();
+    test_all<bg::model::point<double, 2, bg::cs::cartesian> >();
+
+    test_custom<bg::model::point<double, 2, bg::cs::cartesian> >();
+    test_custom<bg::model::d2::point_xy<double> >();
+
+    return 0;
+}

--- a/test/geometries/point.cpp
+++ b/test/geometries/point.cpp
@@ -3,9 +3,6 @@
 
 // Copyright (c) 2020 Digvijay Janartha, Hamirpur, India.
 
-// Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
-// (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
-
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -21,13 +18,13 @@
 #include <test_common/test_point.hpp>
 
 
-template <typename T>
-bg::model::point<T, 3, bg::cs::cartesian> create_point()
+template <typename T, typename CS>
+bg::model::point<T, 3, CS> create_point()
 {
     T t1 = 1;
     T t2 = 2;
     T t3 = 3;
-    return bg::model::point<T, 3, bg::cs::cartesian>(t1, t2, t3);
+    return bg::model::point<T, 3, CS>(t1, t2, t3);
 }
 
 template <typename P, typename T>
@@ -38,34 +35,34 @@ void check_point(P& to_check, T x, T y, T z)
     BOOST_CHECK_EQUAL(bg::get<2>(to_check), z);
 }
 
-template <typename T>
+template <typename T, typename CS>
 void test_default_constructor()
 {
-    bg::model::point<T, 3, bg::cs::cartesian> p(create_point<T>());
+    bg::model::point<T, 3, CS> p(create_point<T, CS>());
     check_point(p, 1, 2, 3);
 }
 
-template <typename T>
+template <typename T, typename CS>
 void test_copy_constructor()
 {
-    bg::model::point<T, 3, bg::cs::cartesian> p = create_point<T>();
+    bg::model::point<T, 3, CS> p = create_point<T, CS>();
     check_point(p, 1, 2, 3);
 }
 
-template <typename T>
-void test_assignment()
+template <typename T, typename CS>
+void test_copy_assignment()
 {
-    bg::model::point<T, 3, bg::cs::cartesian> p(create_point<T>());
+    bg::model::point<T, 3, CS> p(create_point<T, CS>());
     bg::set<0>(p, 4);
     bg::set<1>(p, 5);
     bg::set<2>(p, 6);
     check_point(p, 4, 5, 6);
 }
 
-template <typename T>
+template <typename T, typename CS>
 void test_concept()
 {
-    typedef bg::model::point<T, 3, bg::cs::cartesian> P;
+    typedef bg::model::point<T, 3, CS> P;
 
     // Compilation tests, all things should compile.
     BOOST_CONCEPT_ASSERT( (bg::concepts::ConstPoint<P>) );
@@ -75,20 +72,30 @@ void test_concept()
     boost::ignore_unused<T1>();
 }
 
-template <typename T>
+template <typename T, typename CS>
 void test_all()
 {
-    test_default_constructor<T>();
-    test_copy_constructor<T>();
-    test_assignment<T>();
-    test_concept<T>();
+    test_default_constructor<T, CS>();
+    test_copy_constructor<T, CS>();
+    test_copy_assignment<T, CS>();
+    test_concept<T, CS>();
 }
 
-int test_main(int, char* [])
+template <typename CS>
+void test_cs()
 {
-    test_all<int>();
-    test_all<float>();
-    test_all<double>();
+    test_all<int, CS>();
+    test_all<float, CS>();
+    test_all<double, CS>();
+}
+
+
+int test_main(int, char* [])
+{   
+    test_cs<bg::cs::cartesian>();
+    test_cs<bg::cs::spherical<bg::degree> >();
+    test_cs<bg::cs::spherical_equatorial<bg::degree> >();
+    test_cs<bg::cs::geographic<bg::degree> >();
 
     return 0;
 }

--- a/test/geometries/point.cpp
+++ b/test/geometries/point.cpp
@@ -1,0 +1,81 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+// Unit Test
+
+// Copyright (c) 2020 Digvijay Janartha, Hamirpur, India.
+
+// Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
+// (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+
+#include <geometry_test_common.hpp>
+
+#include <boost/core/ignore_unused.hpp>
+#include <boost/geometry/geometries/concepts/point_concept.hpp>
+#include <boost/geometry/algorithms/make.hpp>
+#include <boost/geometry/geometries/point.hpp>
+
+#include <test_common/test_point.hpp>
+
+
+template <typename T>
+bg::model::point<T, 3, bg::cs::cartesian> create_point()
+{
+    T t1 = 1;
+    T t2 = 2;
+    T t3 = 3;
+    return bg::model::point<T, 3, bg::cs::cartesian>(t1, t2, t3);
+}
+
+template <typename P, typename T>
+void check_point(P& to_check, T x, T y, T z)
+{
+    BOOST_CHECK_EQUAL(bg::get<0>(to_check), x);
+    BOOST_CHECK_EQUAL(bg::get<1>(to_check), y);
+    BOOST_CHECK_EQUAL(bg::get<2>(to_check), z);
+}
+
+template <typename T>
+void test_construction()
+{
+    bg::model::point<T, 3, bg::cs::cartesian> p(create_point<T>());
+    check_point(p, 1, 2, 3);
+}
+
+template <typename T>
+void test_assignment()
+{
+    bg::model::point<T, 3, bg::cs::cartesian> p(create_point<T>());
+    bg::set<0>(p, 4);
+    bg::set<1>(p, 5);
+    bg::set<2>(p, 6);
+    check_point(p, 4, 5, 6);
+}
+
+template <typename T>
+void test_all()
+{
+    test_construction<T>();
+    test_assignment<T>();
+
+    typedef bg::model::point<T, 3, bg::cs::cartesian> P;
+
+    // Compilation tests, all things should compile.
+    BOOST_CONCEPT_ASSERT( (bg::concepts::ConstPoint<P>) );
+    BOOST_CONCEPT_ASSERT( (bg::concepts::Point<P>) );
+
+    typedef typename bg::coordinate_type<P>::type T1;
+    boost::ignore_unused<T1>();
+}
+
+int test_main(int, char* [])
+{
+    test_all<int>();
+    test_all<float>();
+    test_all<double>();
+
+    return 0;
+}

--- a/test/geometries/point.cpp
+++ b/test/geometries/point.cpp
@@ -14,8 +14,8 @@
 #include <geometry_test_common.hpp>
 
 #include <boost/core/ignore_unused.hpp>
-#include <boost/geometry/geometries/concepts/point_concept.hpp>
 #include <boost/geometry/algorithms/make.hpp>
+#include <boost/geometry/geometries/concepts/point_concept.hpp>
 #include <boost/geometry/geometries/point.hpp>
 
 #include <test_common/test_point.hpp>
@@ -39,9 +39,16 @@ void check_point(P& to_check, T x, T y, T z)
 }
 
 template <typename T>
-void test_construction()
+void test_default_constructor()
 {
     bg::model::point<T, 3, bg::cs::cartesian> p(create_point<T>());
+    check_point(p, 1, 2, 3);
+}
+
+template <typename T>
+void test_copy_constructor()
+{
+    bg::model::point<T, 3, bg::cs::cartesian> p = create_point<T>();
     check_point(p, 1, 2, 3);
 }
 
@@ -56,11 +63,8 @@ void test_assignment()
 }
 
 template <typename T>
-void test_all()
+void test_concept()
 {
-    test_construction<T>();
-    test_assignment<T>();
-
     typedef bg::model::point<T, 3, bg::cs::cartesian> P;
 
     // Compilation tests, all things should compile.
@@ -69,6 +73,15 @@ void test_all()
 
     typedef typename bg::coordinate_type<P>::type T1;
     boost::ignore_unused<T1>();
+}
+
+template <typename T>
+void test_all()
+{
+    test_default_constructor<T>();
+    test_copy_constructor<T>();
+    test_assignment<T>();
+    test_concept<T>();
 }
 
 int test_main(int, char* [])

--- a/test/geometries/point_xy.cpp
+++ b/test/geometries/point_xy.cpp
@@ -3,9 +3,6 @@
 
 // Copyright (c) 2020 Digvijay Janartha, Hamirpur, India.
 
-// Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
-// (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
-
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -52,7 +49,7 @@ void test_copy_constructor()
 }
 
 template <typename T>
-void test_assignment()
+void test_copy_assignment()
 {
     bg::model::d2::point_xy<T> p(create_point_xy<T>());
     bg::set<0>(p, 4);
@@ -65,7 +62,7 @@ void test_all()
 {
     test_default_constructor<T>();
     test_copy_constructor<T>();
-    test_assignment<T>();
+    test_copy_assignment<T>();
 }
 
 int test_main(int, char* [])

--- a/test/geometries/point_xy.cpp
+++ b/test/geometries/point_xy.cpp
@@ -1,0 +1,70 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+// Unit Test
+
+// Copyright (c) 2020 Digvijay Janartha, Hamirpur, India.
+
+// Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
+// (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+
+#include <geometry_test_common.hpp>
+
+#include <boost/geometry/algorithms/make.hpp>
+
+#include <boost/geometry/geometries/point.hpp>
+#include <boost/geometry/geometries/point_xy.hpp>
+#include <test_common/test_point.hpp>
+
+
+template <typename T>
+bg::model::d2::point_xy<T> create_point_xy()
+{
+    T t1 = 1;
+    T t2 = 2;
+    return bg::model::d2::point_xy<T>(t1, t2);
+}
+
+template <typename P, typename T>
+void check_point_xy(P& to_check, T x, T y)
+{
+    BOOST_CHECK_EQUAL(bg::get<0>(to_check), x);
+    BOOST_CHECK_EQUAL(bg::get<1>(to_check), y);
+    BOOST_CHECK_EQUAL(to_check.x(), x);
+    BOOST_CHECK_EQUAL(to_check.y(), y);
+}
+
+template <typename T>
+void test_construction()
+{
+    bg::model::d2::point_xy<T> p(create_point_xy<T>());
+    check_point_xy(p, 1, 2);
+}
+
+template <typename T>
+void test_assignment()
+{
+    bg::model::d2::point_xy<T> p(create_point_xy<T>());
+    bg::set<0>(p, 4);
+    bg::set<1>(p, 5);
+    check_point_xy(p, 4, 5);
+}
+
+template <typename T>
+void test_all()
+{
+    test_construction<T>();
+    test_assignment<T>();
+}
+
+int test_main(int, char* [])
+{
+    test_all<int>();
+    test_all<float>();
+    test_all<double>();
+
+    return 0;
+}

--- a/test/geometries/point_xy.cpp
+++ b/test/geometries/point_xy.cpp
@@ -14,9 +14,9 @@
 #include <geometry_test_common.hpp>
 
 #include <boost/geometry/algorithms/make.hpp>
-
 #include <boost/geometry/geometries/point.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
+
 #include <test_common/test_point.hpp>
 
 
@@ -38,7 +38,14 @@ void check_point_xy(P& to_check, T x, T y)
 }
 
 template <typename T>
-void test_construction()
+void test_default_constructor()
+{
+    bg::model::d2::point_xy<T> p(create_point_xy<T>());
+    check_point_xy(p, 1, 2);
+}
+
+template <typename T>
+void test_copy_constructor()
 {
     bg::model::d2::point_xy<T> p(create_point_xy<T>());
     check_point_xy(p, 1, 2);
@@ -56,7 +63,8 @@ void test_assignment()
 template <typename T>
 void test_all()
 {
-    test_construction<T>();
+    test_default_constructor<T>();
+    test_copy_constructor<T>();
     test_assignment<T>();
 }
 

--- a/test/geometries/point_xyz.cpp
+++ b/test/geometries/point_xyz.cpp
@@ -3,9 +3,6 @@
 
 // Copyright (c) 2020 Digvijay Janartha, Hamirpur, India.
 
-// Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
-// (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
-
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -55,7 +52,7 @@ void test_copy_constructor()
 }
 
 template <typename T>
-void test_assignment()
+void test_copy_assignment()
 {
     bg::model::d3::point_xyz<T> p(create_point_xyz<T>());
     bg::set<0>(p, 4);
@@ -69,7 +66,7 @@ void test_all()
 {
     test_default_constructor<T>();
     test_copy_constructor<T>();
-    test_assignment<T>();
+    test_copy_assignment<T>();
 }
 
 int test_main(int, char* [])

--- a/test/geometries/point_xyz.cpp
+++ b/test/geometries/point_xyz.cpp
@@ -35,6 +35,9 @@ void check_point_xyz(P& to_check, T x, T y, T z)
     BOOST_CHECK_EQUAL(bg::get<0>(to_check), x);
     BOOST_CHECK_EQUAL(bg::get<1>(to_check), y);
     BOOST_CHECK_EQUAL(bg::get<2>(to_check), z);
+    BOOST_CHECK_EQUAL(to_check.x(), x);
+    BOOST_CHECK_EQUAL(to_check.y(), y);
+    BOOST_CHECK_EQUAL(to_check.z(), z);
 }
 
 template <typename T>

--- a/test/geometries/point_xyz.cpp
+++ b/test/geometries/point_xyz.cpp
@@ -14,9 +14,9 @@
 #include <geometry_test_common.hpp>
 
 #include <boost/geometry/algorithms/make.hpp>
-
 #include <boost/geometry/geometries/point.hpp>
 #include <boost/geometry/geometries/point_xyz.hpp>
+
 #include <test_common/test_point.hpp>
 
 
@@ -35,15 +35,19 @@ void check_point_xyz(P& to_check, T x, T y, T z)
     BOOST_CHECK_EQUAL(bg::get<0>(to_check), x);
     BOOST_CHECK_EQUAL(bg::get<1>(to_check), y);
     BOOST_CHECK_EQUAL(bg::get<2>(to_check), z);
-    BOOST_CHECK_EQUAL(to_check.x(), x);
-    BOOST_CHECK_EQUAL(to_check.y(), y);
-    BOOST_CHECK_EQUAL(to_check.z(), z);
 }
 
 template <typename T>
-void test_construction()
+void test_default_constructor()
 {
     bg::model::d3::point_xyz<T> p(create_point_xyz<T>());
+    check_point_xyz(p, 1, 2, 3);
+}
+
+template <typename T>
+void test_copy_constructor()
+{
+    bg::model::d3::point_xyz<T> p = create_point_xyz<T>();
     check_point_xyz(p, 1, 2, 3);
 }
 
@@ -60,7 +64,8 @@ void test_assignment()
 template <typename T>
 void test_all()
 {
-    test_construction<T>();
+    test_default_constructor<T>();
+    test_copy_constructor<T>();
     test_assignment<T>();
 }
 

--- a/test/geometries/polygon.cpp
+++ b/test/geometries/polygon.cpp
@@ -1,0 +1,116 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+// Unit Test
+
+// Copyright (c) 2020 Digvijay Janartha, Hamirpur, India.
+
+// Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
+// (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <iostream>
+
+#include <geometry_test_common.hpp>
+
+#include <boost/core/ignore_unused.hpp>
+#include <boost/geometry/algorithms/make.hpp>
+#include <boost/geometry/algorithms/append.hpp>
+#include <boost/geometry/geometries/point.hpp>
+#include <boost/geometry/geometries/point_xy.hpp>
+#include <boost/geometry/geometries/polygon.hpp>
+#include <boost/geometry/geometries/concepts/polygon_concept.hpp>
+#include <boost/geometry/geometries/adapted/c_array.hpp>
+#include <boost/geometry/geometries/adapted/boost_tuple.hpp>
+#include <boost/geometry/io/dsv/write.hpp>
+
+#include <test_common/test_point.hpp>
+
+BOOST_GEOMETRY_REGISTER_C_ARRAY_CS(cs::cartesian)
+BOOST_GEOMETRY_REGISTER_BOOST_TUPLE_CS(cs::cartesian)
+
+
+template <typename P>
+bg::model::polygon<P> create_polygon()
+{   
+    bg::model::polygon<P> pl1;
+    P p1;
+    P p2;
+    P p3;
+    bg::assign_values(p1, 1, 2);
+    bg::assign_values(p2, 2, 0);
+    bg::assign_values(p3, 0, 0);
+    
+    bg::append(pl1, p1);
+    bg::append(pl1, p2);
+    bg::append(pl1, p3);
+    bg::append(pl1, p1);
+    return pl1;
+}
+
+template <typename PL, typename P>
+void check_polygon(PL& to_check, P p1, P p2, P p3)
+{   
+    std::ostringstream out;
+    out << bg::dsv(to_check);
+    BOOST_CHECK_EQUAL(out.str(), "(((1, 2), (2, 0), (0, 0), (1, 2)))");
+}
+
+template <typename P>
+void test_construction()
+{
+    bg::model::polygon<P> pl1(create_polygon<P>());
+    check_polygon(pl1, P(1, 2), P(2, 0), P(0, 0));
+}
+
+template <typename P>
+void test_compilation()
+{   
+    typedef bg::model::polygon<P> PL;
+
+    BOOST_CONCEPT_ASSERT( (bg::concepts::ConstPolygon<PL>) );
+    BOOST_CONCEPT_ASSERT( (bg::concepts::Polygon<PL>) );
+
+    typedef typename bg::coordinate_type<PL>::type T;
+    typedef typename bg::point_type<PL>::type PPL;
+    boost::ignore_unused<T, PPL>();
+}
+
+template <typename P>
+void test_all()
+{   
+    test_construction<P>();
+    test_compilation<P>();
+}
+
+template <typename P>
+void test_custom_polygon(bg::model::ring<P> IL)
+{   
+    std::initializer_list<bg::model::ring<P> > RIL = {IL};
+    bg::model::polygon<P> pl1(RIL);
+    std::ostringstream out;
+    out << bg::dsv(pl1);
+    BOOST_CHECK_EQUAL(out.str(), "(((2, 2), (2, 0), (0, 0), (0, 2), (2, 2)))");
+}
+
+template <typename P>
+void test_custom()
+{   
+    std::initializer_list<P> IL = {P(2, 2), P(2, 0), P(0, 0), P(0, 2), P(2, 2)};
+    bg::model::ring<P> r1(IL);
+    test_custom_polygon<P>(r1);
+}
+
+
+int test_main(int, char* [])
+{   
+    test_all<bg::model::point<int, 2, bg::cs::cartesian> >();
+    test_all<bg::model::point<float, 2, bg::cs::cartesian> >();
+    test_all<bg::model::point<double, 2, bg::cs::cartesian> >();
+
+    test_custom<bg::model::point<double, 2, bg::cs::cartesian> >();
+    test_custom<bg::model::d2::point_xy<double> >();
+
+    return 0;
+}

--- a/test/geometries/polygon.cpp
+++ b/test/geometries/polygon.cpp
@@ -27,6 +27,9 @@
 BOOST_GEOMETRY_REGISTER_C_ARRAY_CS(cs::cartesian)
 BOOST_GEOMETRY_REGISTER_BOOST_TUPLE_CS(cs::cartesian)
 
+#ifdef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
+#include <initializer_list>
+#endif//BOOST_NO_CXX11_HDR_INITIALIZER_LIST
 
 template <typename P>
 bg::model::polygon<P> create_polygon()
@@ -108,11 +111,13 @@ void test_all()
 template <typename P>
 void test_custom_polygon(bg::model::ring<P> IL)
 {   
+#ifdef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
     std::initializer_list<bg::model::ring<P> > RIL = {IL};
     bg::model::polygon<P> pl1(RIL);
     std::ostringstream out;
     out << bg::dsv(pl1);
     BOOST_CHECK_EQUAL(out.str(), "(((3, 3), (3, 0), (0, 0), (0, 3), (3, 3)))");
+#endif//BOOST_NO_CXX11_HDR_INITIALIZER_LIST
 }
 
 template <typename P>

--- a/test/geometries/polygon.cpp
+++ b/test/geometries/polygon.cpp
@@ -3,9 +3,6 @@
 
 // Copyright (c) 2020 Digvijay Janartha, Hamirpur, India.
 
-// Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
-// (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
-
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -126,14 +123,24 @@ void test_custom()
     test_custom_polygon<P>(r1);
 }
 
+template <typename CS>
+void test_cs()
+{
+    test_all<bg::model::point<int, 2, CS> >();
+    test_all<bg::model::point<float, 2, CS> >();
+    test_all<bg::model::point<double, 2, CS> >();
+
+    test_custom<bg::model::point<double, 2, CS> >();
+}
+
 
 int test_main(int, char* [])
 {   
-    test_all<bg::model::point<int, 2, bg::cs::cartesian> >();
-    test_all<bg::model::point<float, 2, bg::cs::cartesian> >();
-    test_all<bg::model::point<double, 2, bg::cs::cartesian> >();
+    test_cs<bg::cs::cartesian>();
+    test_cs<bg::cs::spherical<bg::degree> >();
+    test_cs<bg::cs::spherical_equatorial<bg::degree> >();
+    test_cs<bg::cs::geographic<bg::degree> >();
 
-    test_custom<bg::model::point<double, 2, bg::cs::cartesian> >();
     test_custom<bg::model::d2::point_xy<double> >();
 
     return 0;

--- a/test/geometries/polygon.cpp
+++ b/test/geometries/polygon.cpp
@@ -52,20 +52,42 @@ bg::model::polygon<P> create_polygon()
 template <typename PL, typename P>
 void check_polygon(PL& to_check, P p1, P p2, P p3)
 {   
-    std::ostringstream out;
-    out << bg::dsv(to_check);
-    BOOST_CHECK_EQUAL(out.str(), "(((1, 2), (2, 0), (0, 0), (1, 2)))");
+    PL cur;
+    bg::append(cur, p1);
+    bg::append(cur, p2);
+    bg::append(cur, p3);
+    bg::append(cur, p1);
+
+    std::ostringstream out1, out2;
+    out1 << bg::dsv(to_check);
+    out2 << bg::dsv(cur);
+    BOOST_CHECK_EQUAL(out1.str(), out2.str());
 }
 
 template <typename P>
-void test_construction()
+void test_default_constructor()
 {
     bg::model::polygon<P> pl1(create_polygon<P>());
     check_polygon(pl1, P(1, 2), P(2, 0), P(0, 0));
 }
 
 template <typename P>
-void test_compilation()
+void test_copy_constructor()
+{
+    bg::model::polygon<P> pl1 = create_polygon<P>();
+    check_polygon(pl1, P(1, 2), P(2, 0), P(0, 0));
+}
+
+template <typename P>
+void test_copy_assignment()
+{
+    bg::model::polygon<P> pl1(create_polygon<P>()), pl2;
+    pl2 = pl1;
+    check_polygon(pl2, P(1, 2), P(2, 0), P(0, 0));
+}
+
+template <typename P>
+void test_concept()
 {   
     typedef bg::model::polygon<P> PL;
 
@@ -80,8 +102,10 @@ void test_compilation()
 template <typename P>
 void test_all()
 {   
-    test_construction<P>();
-    test_compilation<P>();
+    test_default_constructor<P>();
+    test_copy_constructor<P>();
+    test_copy_assignment<P>();
+    test_concept<P>();
 }
 
 template <typename P>
@@ -91,13 +115,13 @@ void test_custom_polygon(bg::model::ring<P> IL)
     bg::model::polygon<P> pl1(RIL);
     std::ostringstream out;
     out << bg::dsv(pl1);
-    BOOST_CHECK_EQUAL(out.str(), "(((2, 2), (2, 0), (0, 0), (0, 2), (2, 2)))");
+    BOOST_CHECK_EQUAL(out.str(), "(((3, 3), (3, 0), (0, 0), (0, 3), (3, 3)))");
 }
 
 template <typename P>
 void test_custom()
 {   
-    std::initializer_list<P> IL = {P(2, 2), P(2, 0), P(0, 0), P(0, 2), P(2, 2)};
+    std::initializer_list<P> IL = {P(3, 3), P(3, 0), P(0, 0), P(0, 3), P(3, 3)};
     bg::model::ring<P> r1(IL);
     test_custom_polygon<P>(r1);
 }

--- a/test/geometries/ring.cpp
+++ b/test/geometries/ring.cpp
@@ -1,0 +1,126 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+// Unit Test
+
+// Copyright (c) 2020 Digvijay Janartha, Hamirpur, India.
+
+// Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
+// (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <iostream>
+
+#include <geometry_test_common.hpp>
+
+#include <boost/core/ignore_unused.hpp>
+#include <boost/geometry/algorithms/make.hpp>
+#include <boost/geometry/algorithms/append.hpp>
+#include <boost/geometry/geometries/point.hpp>
+#include <boost/geometry/geometries/point_xy.hpp>
+#include <boost/geometry/geometries/ring.hpp>
+#include <boost/geometry/geometries/concepts/ring_concept.hpp>
+#include <boost/geometry/geometries/adapted/c_array.hpp>
+#include <boost/geometry/geometries/adapted/boost_tuple.hpp>
+#include <boost/geometry/io/dsv/write.hpp>
+
+#include <test_common/test_point.hpp>
+
+BOOST_GEOMETRY_REGISTER_C_ARRAY_CS(cs::cartesian)
+BOOST_GEOMETRY_REGISTER_BOOST_TUPLE_CS(cs::cartesian)
+
+
+template <typename P>
+bg::model::ring<P> create_ring()
+{   
+    bg::model::ring<P> r1;
+    P p1;
+    P p2;
+    P p3;
+    P p4;
+    bg::assign_values(p1, 2, 2);
+    bg::assign_values(p2, 2, 0);
+    bg::assign_values(p3, 0, 0);
+    bg::assign_values(p4, 0, 2);
+    
+    bg::append(r1, p1);
+    bg::append(r1, p2);
+    bg::append(r1, p3);
+    bg::append(r1, p4);
+    bg::append(r1, p1);
+    return r1;
+}
+
+template <typename P, typename T>
+void check_point(P& to_check, T x, T y)
+{
+    BOOST_CHECK_EQUAL(bg::get<0>(to_check), x);
+    BOOST_CHECK_EQUAL(bg::get<1>(to_check), y);
+}
+
+template <typename R, typename P>
+void check_ring(R& to_check, P p1, P p2, P p3, P p4)
+{   
+    check_point(to_check[0], bg::get<0>(p1), bg::get<1>(p1));
+    check_point(to_check[1], bg::get<0>(p2), bg::get<1>(p2));
+    check_point(to_check[2], bg::get<0>(p3), bg::get<1>(p3));
+    check_point(to_check[3], bg::get<0>(p4), bg::get<1>(p4));
+    check_point(to_check[4], bg::get<0>(p1), bg::get<1>(p1));
+}
+
+template <typename P>
+void test_construction()
+{
+    bg::model::ring<P> r1(create_ring<P>());
+    check_ring(r1, P(2, 2), P(2, 0), P(0, 0), P(0, 2));
+}
+
+template <typename P>
+void test_compilation()
+{   
+    typedef bg::model::ring<P> R;
+
+    BOOST_CONCEPT_ASSERT( (bg::concepts::ConstRing<R>) );
+    BOOST_CONCEPT_ASSERT( (bg::concepts::Ring<R>) );
+
+    typedef typename bg::coordinate_type<R>::type T;
+    typedef typename bg::point_type<R>::type PR;
+    boost::ignore_unused<T, PR>();
+}
+
+template <typename P>
+void test_all()
+{   
+    test_construction<P>();
+    test_compilation<P>();
+}
+
+template <typename P>
+void test_custom_ring(bg::model::ring<P> IL)
+{   
+    bg::model::ring<P> r1(IL);
+    std::ostringstream out;
+    out << bg::dsv(r1);
+    BOOST_CHECK_EQUAL(out.str(), "((3, 3), (3, 0), (0, 0), (0, 3), (3, 3))");
+}
+
+template <typename P>
+void test_custom()
+{   
+    std::initializer_list<P> IL = {P(3, 3), P(3, 0), P(0, 0), P(0, 3), P(3, 3)};
+    test_custom_ring<P>(IL);
+}
+
+
+int test_main(int, char* [])
+{   
+    test_all<bg::model::point<int, 2, bg::cs::cartesian> >();
+    test_all<bg::model::point<float, 2, bg::cs::cartesian> >();
+    test_all<bg::model::point<double, 2, bg::cs::cartesian> >();
+
+    test_custom<bg::model::point<double, 2, bg::cs::cartesian> >();
+    test_custom<bg::model::d2::point_xy<double> >();
+
+    return 0;
+}

--- a/test/geometries/ring.cpp
+++ b/test/geometries/ring.cpp
@@ -3,13 +3,9 @@
 
 // Copyright (c) 2020 Digvijay Janartha, Hamirpur, India.
 
-// Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
-// (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
-
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
-
 
 #include <iostream>
 
@@ -130,14 +126,24 @@ void test_custom()
     test_custom_ring<P>(IL);
 }
 
+template <typename CS>
+void test_cs()
+{
+    test_all<bg::model::point<int, 2, CS> >();
+    test_all<bg::model::point<float, 2, CS> >();
+    test_all<bg::model::point<double, 2, CS> >();
+
+    test_custom<bg::model::point<double, 2, CS> >();
+}
+
 
 int test_main(int, char* [])
 {   
-    test_all<bg::model::point<int, 2, bg::cs::cartesian> >();
-    test_all<bg::model::point<float, 2, bg::cs::cartesian> >();
-    test_all<bg::model::point<double, 2, bg::cs::cartesian> >();
+    test_cs<bg::cs::cartesian>();
+    test_cs<bg::cs::spherical<bg::degree> >();
+    test_cs<bg::cs::spherical_equatorial<bg::degree> >();
+    test_cs<bg::cs::geographic<bg::degree> >();
 
-    test_custom<bg::model::point<double, 2, bg::cs::cartesian> >();
     test_custom<bg::model::d2::point_xy<double> >();
 
     return 0;

--- a/test/geometries/ring.cpp
+++ b/test/geometries/ring.cpp
@@ -10,6 +10,7 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+
 #include <iostream>
 
 #include <geometry_test_common.hpp>
@@ -70,14 +71,29 @@ void check_ring(R& to_check, P p1, P p2, P p3, P p4)
 }
 
 template <typename P>
-void test_construction()
+void test_default_constructor()
 {
     bg::model::ring<P> r1(create_ring<P>());
     check_ring(r1, P(2, 2), P(2, 0), P(0, 0), P(0, 2));
 }
 
 template <typename P>
-void test_compilation()
+void test_copy_constructor()
+{
+    bg::model::ring<P> r1 = create_ring<P>();
+    check_ring(r1, P(2, 2), P(2, 0), P(0, 0), P(0, 2));
+}
+
+template <typename P>
+void test_copy_assignment()
+{
+    bg::model::ring<P> r1(create_ring<P>()), r2;
+    r2 = r1;
+    check_ring(r2, P(2, 2), P(2, 0), P(0, 0), P(0, 2));
+}
+
+template <typename P>
+void test_concept()
 {   
     typedef bg::model::ring<P> R;
 
@@ -92,8 +108,10 @@ void test_compilation()
 template <typename P>
 void test_all()
 {   
-    test_construction<P>();
-    test_compilation<P>();
+    test_default_constructor<P>();
+    test_copy_constructor<P>();
+    test_copy_assignment<P>();
+    test_concept<P>();
 }
 
 template <typename P>

--- a/test/geometries/ring.cpp
+++ b/test/geometries/ring.cpp
@@ -27,6 +27,9 @@
 BOOST_GEOMETRY_REGISTER_C_ARRAY_CS(cs::cartesian)
 BOOST_GEOMETRY_REGISTER_BOOST_TUPLE_CS(cs::cartesian)
 
+#ifdef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
+#include <initializer_list>
+#endif//BOOST_NO_CXX11_HDR_INITIALIZER_LIST
 
 template <typename P>
 bg::model::ring<P> create_ring()
@@ -122,8 +125,10 @@ void test_custom_ring(bg::model::ring<P> IL)
 template <typename P>
 void test_custom()
 {   
+#ifdef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
     std::initializer_list<P> IL = {P(3, 3), P(3, 0), P(0, 0), P(0, 3), P(3, 3)};
     test_custom_ring<P>(IL);
+#endif//BOOST_NO_CXX11_HDR_INITIALIZER_LIST
 }
 
 template <typename CS>


### PR DESCRIPTION
This PR is meant to fix #673. I have added unit tests for all the geometry models. Test includes working of default and copy constructors, assignment operator and custom test using `std::initializer_list`. I have covered tests for all the coordinate systems. I have tested all the files locally using GCC 7.4.