### PR TITLE
Deleted extra note in point_xy documentation

### DIFF
--- a/doc/reference/geometries/point_xy.qbk
+++ b/doc/reference/geometries/point_xy.qbk
@@ -13,6 +13,3 @@
 [heading Examples]
 [point_xy]
 [point_xy_output]
-
-[include reference/geometries/point_assign_warning.qbk]
-


### PR DESCRIPTION
Documentation page of [point_xy](https://www.boost.org/doc/libs/1_72_0/libs/geometry/doc/html/geometry/reference/models/model_d2_point_xy.html) has same note written twice, so I removed one.