### PR TITLE
Add GitHub Actions to build test//minimal with Clang, GCC, MSVC

### DIFF
--- a/.github/workflows/minimal-clang.yml
+++ b/.github/workflows/minimal-clang.yml
@@ -1,0 +1,122 @@
+##############################################################################
+# GitHub Actions Workflow for Boost.Geometry to build minimal tests with Clang
+#
+# Copyright (c) 2020 Mateusz Loskot <mateusz@loskot.net>
+#
+# Use, modification and distribution is subject to the Boost Software License,
+# Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+##############################################################################
+name: "clang test//minimal"
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: ${{ matrix.b2_toolset }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        b2_toolset: [
+          clang-3.9,
+          clang-4.0,
+          clang-5.0,
+          clang-6.0,
+          clang-7,
+          clang-8,
+          clang-9,
+          clang-10
+        ]
+
+        include:
+          - b2_toolset: clang-3.9
+            b2_cxxstd: 03,11
+            version: "3.9"
+          - b2_toolset: clang-4.0
+            b2_cxxstd: 03,11
+            version: "4.0"
+          - b2_toolset: clang-5.0
+            b2_cxxstd: 03,11,14
+            version: "5.0"
+          - b2_toolset: clang-6.0
+            b2_cxxstd: 03,11,14
+            version: "6.0"
+          - b2_toolset: clang-7
+            b2_cxxstd: 03,11,14,17
+            version: "7"
+          - b2_toolset: clang-8
+            b2_cxxstd: 03,11,14,17
+            version: "8"
+          - b2_toolset: clang-9
+            b2_cxxstd: 03,11,14,17,2a
+            version: "9"
+          - b2_toolset: clang-10
+            b2_cxxstd: 03,11,14,17,2a
+            version: "10"
+
+    steps:
+      - name: Set up environment
+        id: setenv
+        run: |
+          if [[ "$GITHUB_REF" == *master ]]; then
+            echo "::set-env name=BOOST_BRANCH::master"
+          else
+            echo "::set-env name=BOOST_BRANCH::develop"
+          fi
+          echo "::set-env name=BOOST_SELF::$(basename $GITHUB_WORKSPACE)"
+          echo "::set-env name=BOOST_ROOT::$GITHUB_WORKSPACE/boost-root"
+          echo "::set-output name=boost_self::$(basename $GITHUB_WORKSPACE)"
+          echo "::set-output name=boost_root::$GITHUB_WORKSPACE/boost-root"
+
+      - name: Clone boostorg/boost
+        run: |
+          git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/boost.git $BOOST_ROOT
+          cd $BOOST_ROOT
+          git submodule update -q --init libs/headers
+          git submodule update -q --init tools/boost_install
+          git submodule update -q --init tools/boostdep
+          git submodule update -q --init tools/build
+          mkdir -p libs/$BOOST_SELF
+
+      - uses: actions/checkout@v2
+        with:
+          path: ${{ steps.setenv.outputs.boost_root }}/libs/${{ steps.setenv.outputs.boost_self }}
+
+      - name: Run tools/boostdep/depinst/depinst.py
+        run: |
+          cd $BOOST_ROOT
+          python tools/boostdep/depinst/depinst.py --include benchmark --include example --include examples --include tools $BOOST_SELF
+
+      - name: Install
+        run: |
+          sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main"
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt -q -y update
+          sudo apt -q -y install clang-${{ matrix.version }} g++-multilib
+
+      - name: Bootstrap boostorg/boost
+        run: |
+          gcc --version
+          cd $BOOST_ROOT
+          ./bootstrap.sh --with-toolset=gcc
+          ./b2 headers
+          test -f /usr/local/bin/b2 && rm -rf /usr/local/bin/b2
+          test -f /usr/local/bin/bjam && rm -rf /usr/local/bin/bjam
+          sudo cp $BOOST_ROOT/b2 /usr/local/bin/
+          ls -l /usr/local/bin/b2
+          b2 -v
+
+      - name: Set up clang toolset in ~/user-config.jam
+        run: |
+          export CXX_NAME=clang++-${{ matrix.version }}
+          echo ${CXX_NAME}
+          echo "# $HOME/user-config.jam" > $HOME/user-config.jam
+          echo "using clang : : $(which clang++-${{ matrix.version }}) ;" > ${HOME}/user-config.jam
+          test -f $HOME/user-config.jam && cat $HOME/user-config.jam
+
+      - name: Build libs/geometry/test//minimal
+        run: |
+          cd $BOOST_ROOT
+          $BOOST_ROOT/b2 toolset=clang cxxstd=${{ matrix.b2_cxxstd }} variant=debug,release address-model=32,64 libs/geometry/test//minimal

--- a/.github/workflows/minimal-gcc.yml
+++ b/.github/workflows/minimal-gcc.yml
@@ -1,0 +1,112 @@
+##############################################################################
+# GitHub Actions Workflow for Boost.Geometry to build minimal tests with GCC
+#
+# Copyright (c) 2020 Mateusz Loskot <mateusz@loskot.net>
+#
+# Use, modification and distribution is subject to the Boost Software License,
+# Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+##############################################################################
+name: "gcc test//minimal"
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: ${{ matrix.b2_toolset }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        b2_toolset: [
+          gcc-4.8,
+          gcc-4.9,
+          gcc-5,
+          gcc-6,
+          gcc-7,
+          gcc-8,
+          gcc-9
+        ]
+
+        include:
+          - b2_toolset: gcc-4.8
+            b2_cxxstd: 03,11
+            version: "4.8"
+          - b2_toolset: gcc-4.9
+            b2_cxxstd: 03,11
+            version: "4.9"
+          - b2_toolset: gcc-5
+            b2_cxxstd: 03,11,14
+            version: "5"
+          - b2_toolset: gcc-6
+            b2_cxxstd: 03,11,14
+            version: "6"
+          - b2_toolset: gcc-7
+            b2_cxxstd: 03,11,14,17
+            version: "7"
+          - b2_toolset: gcc-8
+            b2_cxxstd: 03,11,14,17
+            version: "8"
+          - b2_toolset: gcc-9
+            b2_cxxstd: 03,11,14,17,2a
+            version: "9"
+
+    steps:
+      - name: Set up environment
+        id: setenv
+        run: |
+          if [[ "$GITHUB_REF" == *master ]]; then
+            echo "::set-env name=BOOST_BRANCH::master"
+          else
+            echo "::set-env name=BOOST_BRANCH::develop"
+          fi
+          echo "::set-env name=BOOST_SELF::$(basename $GITHUB_WORKSPACE)"
+          echo "::set-env name=BOOST_ROOT::$GITHUB_WORKSPACE/boost-root"
+          echo "::set-output name=boost_self::$(basename $GITHUB_WORKSPACE)"
+          echo "::set-output name=boost_root::$GITHUB_WORKSPACE/boost-root"
+
+      - name: Clone boostorg/boost
+        run: |
+          git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/boost.git $BOOST_ROOT
+          cd $BOOST_ROOT
+          git submodule update -q --init libs/headers
+          git submodule update -q --init tools/boost_install
+          git submodule update -q --init tools/boostdep
+          git submodule update -q --init tools/build
+          mkdir -p libs/$BOOST_SELF
+
+      - uses: actions/checkout@v2
+        with:
+          path: ${{ steps.setenv.outputs.boost_root }}/libs/${{ steps.setenv.outputs.boost_self }}
+
+      - name: Run tools/boostdep/depinst/depinst.py
+        run: |
+          cd $BOOST_ROOT
+          python tools/boostdep/depinst/depinst.py --include benchmark --include example --include examples --include tools $BOOST_SELF
+
+      - name: Install
+        run: |
+          # gcc-4.8 is not available in Bionic anymore
+          sudo add-apt-repository "deb http://dk.archive.ubuntu.com/ubuntu/ xenial main"
+          sudo add-apt-repository "deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe"
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt -q -y update
+          sudo apt -q -y install g++-${{ matrix.version }} g++-${{ matrix.version }}-multilib
+
+      - name: Bootstrap boostorg/boost
+        run: |
+          gcc --version
+          cd $BOOST_ROOT
+          ./bootstrap.sh --with-toolset=gcc
+          ./b2 headers
+          test -f /usr/local/bin/b2 && rm -rf /usr/local/bin/b2
+          test -f /usr/local/bin/bjam && rm -rf /usr/local/bin/bjam
+          sudo cp $BOOST_ROOT/b2 /usr/local/bin/
+          ls -l /usr/local/bin/b2
+          b2 -v
+
+      - name: Build libs/geometry/test//minimal
+        run: |
+          cd $BOOST_ROOT
+          $BOOST_ROOT/b2 toolset=${{ matrix.b2_toolset }} cxxstd=${{ matrix.b2_cxxstd }} variant=debug,release address-model=32,64 libs/geometry/test//minimal

--- a/.github/workflows/minimal-msvc.yml
+++ b/.github/workflows/minimal-msvc.yml
@@ -1,0 +1,80 @@
+##############################################################################
+# GitHub Actions Workflow for Boost.Geometry to build minimal tests with MSVC
+#
+# Copyright (c) 2020 Mateusz Loskot <mateusz@loskot.net>
+#
+# Use, modification and distribution is subject to the Boost Software License,
+# Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+##############################################################################
+name: "msvc test//minimal"
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: ${{ matrix.b2_toolset }}
+    runs-on: windows-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # TODO: Waiting for msvc-14.0, msvc-14.1
+        # https://github.com/actions/virtual-environments/issues/68#issuecomment-596817066
+        b2_toolset: [
+          msvc-14.2
+        ]
+
+        include:
+          - b2_toolset: msvc-14.2
+            b2_cxxstd: 14,17,2a
+
+    steps:
+      - name: Set up environment
+        id: setenv
+        shell: pwsh
+        run: |
+          if ("$GITHUB_REF" -contains "master") {
+            echo "::set-env name=BOOST_BRANCH::master"
+          } else {
+            echo "::set-env name=BOOST_BRANCH::develop"
+          }
+          echo "::set-env name=BOOST_SELF::$((Get-Item $env:GITHUB_WORKSPACE).BaseName)"
+          echo "::set-env name=BOOST_ROOT::$env:GITHUB_WORKSPACE\boost-root"
+          echo "::set-output name=boost_self::$((Get-Item $env:GITHUB_WORKSPACE).BaseName)"
+          echo "::set-output name=boost_root::$env:GITHUB_WORKSPACE\boost-root"
+
+      - name: Clone boostorg/boost
+        shell: pwsh
+        run: |
+          git clone -b $env:BOOST_BRANCH --depth 1 https://github.com/boostorg/boost.git $env:BOOST_ROOT
+          cd $env:BOOST_ROOT
+          git submodule update -q --init libs/headers
+          git submodule update -q --init tools/boost_install
+          git submodule update -q --init tools/boostdep
+          git submodule update -q --init tools/build
+          New-Item -Path libs\$env:BOOST_SELF -ItemType Directory -ErrorAction SilentlyContinue
+
+      - uses: actions/checkout@v2
+        with:
+          path: ${{ steps.setenv.outputs.boost_root }}/libs/${{ steps.setenv.outputs.boost_self }}
+
+      - name: Run tools/boostdep/depinst/depinst.py
+        shell: pwsh
+        run: |
+          cd $env:BOOST_ROOT
+          python tools/boostdep/depinst/depinst.py --include benchmark --include example --include examples --include tools $env:BOOST_SELF
+
+      - name: Bootstrap boostorg/boost
+        shell: pwsh
+        run: |
+          cd $env:BOOST_ROOT
+          .\bootstrap.bat --with-toolset=msvc
+          .\b2 headers
+          .\b2 -v
+
+      - name: Build libs/geometry/test//minimal
+        shell: pwsh
+        run: |
+          cd $env:BOOST_ROOT
+          .\b2 toolset=${{ matrix.b2_toolset }} cxxstd=${{ matrix.b2_cxxstd }} variant=debug,release address-model=32,64 libs/geometry/test//minimal


### PR DESCRIPTION
This is to enable a minimal CI check for the pull requests, to assist
contributors and reviewers, as well as for direct commits and merges.

For each toolset, this runs permutation of `b2 cxxstd=03,11,14,17,2a variant=debug,release address-model=32,64`, with `cxxstd` list tailored according to the actual toolset.

------

The CI for pull requests was discussed in https://lists.boost.org/geometry/2020/03/3791.php