### PR TITLE
Add missing headers to precise_math.hpp

### DIFF
--- a/extensions/test/headers/Jamfile
+++ b/extensions/test/headers/Jamfile
@@ -48,3 +48,4 @@ alias ext_algebra : [ generate_self_contained_headers extensions/algebra ] ;
 alias ext_algorithms : [ generate_self_contained_headers extensions/algorithms ] ;
 alias ext_index : [ generate_self_contained_headers extensions/index ] ;
 alias ext_gis : [ generate_self_contained_headers extensions/gis ] ;
+alias ext_triangulation : [ generate_self_contained_headers extensions/triangulation ] ;

--- a/include/boost/geometry/extensions/triangulation/strategies/cartesian/detail/precise_math.hpp
+++ b/include/boost/geometry/extensions/triangulation/strategies/cartesian/detail/precise_math.hpp
@@ -13,7 +13,11 @@
 #define BOOST_GEOMETRY_EXTENSIONS_TRIANGULATION_STRATEGIES_CARTESIAN_DETAIL_PRECISE_MATH_HPP
 
 #include<numeric>
+#include<cmath>
+#include<limits>
 #include<array>
+
+#include <boost/geometry/core/access.hpp>
 
 // The following code is based on "Adaptive Precision Floating-Point Arithmetic
 // and Fast Robust Geometric Predicates" by Richard Shewchuk,


### PR DESCRIPTION
I noticed these two missing includes when I tried to use the header on its own.