### PR TITLE
Deprecate C++03 in Boost 1.73 as preparation for C+14 switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ![Boost.Geometry](doc/other/logo/logo_bkg.png)
 
+> **CAUTION**: Boost.Geometry in Boost 1.73 deprecates support for the C++03 and will require C++14 from Boost 1.75 onwards (see issue [#590](https://github.com/boostorg/geometry/issues/590)).
+
 Boost.Geometry, part of collection of the [Boost C++ Libraries](http://github.com/boostorg), defines concepts, primitives and algorithms for solving geometry problems.
 
 [![Licence](https://img.shields.io/badge/license-boost-4480cc.png)](http://www.boost.org/LICENSE_1_0.txt)

--- a/doc/compiling.qbk
+++ b/doc/compiling.qbk
@@ -15,6 +15,8 @@
 [def __msvc__ MSVC]
 [def __stlport__ [@http://sourceforge.net/projects/stlport STLport]]
 
+[caution Boost.Geometry in Boost 1.73 deprecates support for the C++03 and will require C++14 from Boost 1.75 onwards]
+
 __boost_geometry__ is a headers-only library. Users only need to include the 
 library headers in their programs in order to be able to access definitions 
 and algorithms provided by the __boost_geometry__ library. No linking against 

--- a/include/boost/geometry/geometry.hpp
+++ b/include/boost/geometry/geometry.hpp
@@ -20,6 +20,15 @@
 #ifndef BOOST_GEOMETRY_GEOMETRY_HPP
 #define BOOST_GEOMETRY_GEOMETRY_HPP
 
+#include <boost/config.hpp>
+#include <boost/config/pragma_message.hpp>
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES) || defined(BOOST_NO_CXX11_HDR_MEMORY)
+#if !defined(BOOST_GEOMETRY_DISABLE_DEPRECATED_03_WARNING)
+BOOST_PRAGMA_MESSAGE("CAUTION: Boost.Geometry in Boost 1.73 deprecates support for the C++03 and will require C++14 from Boost 1.75 onwards.")
+BOOST_PRAGMA_MESSAGE("CAUTION: Define BOOST_GEOMETRY_DISABLE_DEPRECATED_03_WARNING to suppress this message.")
+#endif
+#endif
+
 // Shortcut to include all header files
 
 #include <boost/geometry/core/closure.hpp>


### PR DESCRIPTION
Following discussion in #590, we are identifying support for C++03
as a candidate for removal from future releases of Boost.Geometry.

Issue [deprecation](http://eel.is/c++draft/depr#2) warning during compilation in C++03 conformance mode
Users can define BOOST_GEOMETRY_DISABLE_DEPRECATED_03_WARNING to disable it.

### Tasklist

- [x] Decide between switch to C++11 or to C++14 - C++14 it is 
- [x] Decide which Boost version, 1.74 or 1.75 or later, will require the later C++ version - 1.75 it is
