### PR TITLE
Support tupled-output in difference, sym_difference and union_.

### DIFF
--- a/include/boost/geometry/algorithms/detail/intersection/areal_areal.hpp
+++ b/include/boost/geometry/algorithms/detail/intersection/areal_areal.hpp
@@ -26,7 +26,7 @@ namespace detail { namespace intersection
 template
 <
     typename GeometryOut,
-    typename OutTag = typename detail::intersection::tag
+    typename OutTag = typename geometry::detail::setop_insert_output_tag
                         <
                             typename geometry::detail::output_geometry_value
                                 <
@@ -85,9 +85,10 @@ struct intersection_areal_areal_<TupledOut, tupled_output_tag>
 
         boost::ignore_unused
             <
-                detail::intersection::expect_output_pla
+                geometry::detail::expect_output
                     <
-                        Areal1, Areal2, single_out
+                        Areal1, Areal2, single_out,
+                        point_tag, linestring_tag, polygon_tag
                     >
             >();
 

--- a/include/boost/geometry/algorithms/detail/intersection/multi.hpp
+++ b/include/boost/geometry/algorithms/detail/intersection/multi.hpp
@@ -432,8 +432,8 @@ struct intersection_insert
         TupledOut,
         OverlayType,
         ReverseMultiLinestring, ReverseRing,
-        multi_linestring_tag, ring_tag, detail::intersection::tupled_output_tag,
-        linear_tag, areal_tag, detail::intersection::tupled_output_tag
+        multi_linestring_tag, ring_tag, detail::tupled_output_tag,
+        linear_tag, areal_tag, detail::tupled_output_tag
     > : detail::intersection::intersection_of_multi_linestring_with_areal
             <
                 ReverseRing,
@@ -441,7 +441,19 @@ struct intersection_insert
                 OverlayType,
                 true
             >
-      , detail::intersection::expect_output_pl<MultiLinestring, Ring, TupledOut>
+      , detail::expect_output
+            <
+                MultiLinestring, Ring, TupledOut,
+                // NOTE: points can be the result only in case of intersection.
+                // TODO: union should require L and A
+                typename boost::mpl::if_c
+                    <
+                        (OverlayType == overlay_intersection),
+                        point_tag,
+                        void
+                    >::type,
+                linestring_tag
+            >
 {};
 
 
@@ -458,8 +470,8 @@ struct intersection_insert
         TupledOut,
         OverlayType,
         ReverseMultiLinestring, ReversePolygon,
-        multi_linestring_tag, polygon_tag, detail::intersection::tupled_output_tag,
-        linear_tag, areal_tag, detail::intersection::tupled_output_tag
+        multi_linestring_tag, polygon_tag, detail::tupled_output_tag,
+        linear_tag, areal_tag, detail::tupled_output_tag
     > : detail::intersection::intersection_of_multi_linestring_with_areal
             <
                 ReversePolygon,
@@ -467,7 +479,19 @@ struct intersection_insert
                 OverlayType,
                 true
             >
-    , detail::intersection::expect_output_pl<MultiLinestring, Polygon, TupledOut>
+      , detail::expect_output
+            <
+                MultiLinestring, Polygon, TupledOut,
+                // NOTE: points can be the result only in case of intersection.
+                // TODO: union should require L and A
+                typename boost::mpl::if_c
+                    <
+                        (OverlayType == overlay_intersection),
+                        point_tag,
+                        void
+                    >::type,
+                linestring_tag
+            >
 {};
 
 template
@@ -483,8 +507,8 @@ struct intersection_insert
         TupledOut,
         OverlayType,
         ReversePolygon, ReverseMultiLinestring,
-        polygon_tag, multi_linestring_tag, detail::intersection::tupled_output_tag,
-        areal_tag, linear_tag, detail::intersection::tupled_output_tag
+        polygon_tag, multi_linestring_tag, detail::tupled_output_tag,
+        areal_tag, linear_tag, detail::tupled_output_tag
     > : detail::intersection::intersection_of_areal_with_multi_linestring
             <
                 ReversePolygon,
@@ -492,7 +516,22 @@ struct intersection_insert
                 OverlayType,
                 true
             >
-    , detail::intersection::expect_output_pl<Polygon, MultiLinestring, TupledOut>
+      , detail::expect_output
+            <
+                Polygon, MultiLinestring, TupledOut,
+                // NOTE: points can be the result only in case of intersection.
+                // TODO: union should require L and A
+                // TODO: in general the result of difference should depend on the first argument
+                //       but this specialization calls L/A in reality so the first argument is linear.
+                //       So expect only L for difference?
+                typename boost::mpl::if_c
+                    <
+                        (OverlayType == overlay_intersection),
+                        point_tag,
+                        void
+                    >::type,
+                linestring_tag
+            >
 {};
 
 template
@@ -508,8 +547,8 @@ struct intersection_insert
         TupledOut,
         OverlayType,
         ReverseMultiLinestring, ReverseMultiPolygon,
-        multi_linestring_tag, multi_polygon_tag, detail::intersection::tupled_output_tag,
-        linear_tag, areal_tag, detail::intersection::tupled_output_tag
+        multi_linestring_tag, multi_polygon_tag, detail::tupled_output_tag,
+        linear_tag, areal_tag, detail::tupled_output_tag
     > : detail::intersection::intersection_of_multi_linestring_with_areal
             <
                 ReverseMultiPolygon,
@@ -517,7 +556,19 @@ struct intersection_insert
                 OverlayType,
                 true
             >
-    , detail::intersection::expect_output_pl<MultiLinestring, MultiPolygon, TupledOut>
+      , detail::expect_output
+            <
+                MultiLinestring, MultiPolygon, TupledOut,
+                // NOTE: points can be the result only in case of intersection.
+                // TODO: union should require L and A
+                typename boost::mpl::if_c
+                    <
+                        (OverlayType == overlay_intersection),
+                        point_tag,
+                        void
+                    >::type,
+                linestring_tag
+            >
 {};
 
 

--- a/include/boost/geometry/algorithms/detail/tupled_output.hpp
+++ b/include/boost/geometry/algorithms/detail/tupled_output.hpp
@@ -9,13 +9,17 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_TUPLED_OUTPUT_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_TUPLED_OUTPUT_HPP
 
+#include <boost/geometry/algorithms/convert.hpp>
 #include <boost/geometry/core/config.hpp>
 #include <boost/geometry/core/tag.hpp>
+#include <boost/geometry/core/tag_cast.hpp>
 #include <boost/geometry/core/tags.hpp>
+#include <boost/geometry/geometries/concepts/check.hpp>
 #include <boost/geometry/util/range.hpp>
 #include <boost/geometry/util/tuples.hpp>
 
 #include <boost/mpl/and.hpp>
+#include <boost/mpl/if.hpp>
 #include <boost/range/value_type.hpp>
 #include <boost/type_traits/detail/yes_no_type.hpp>
 #include <boost/type_traits/integral_constant.hpp>
@@ -53,7 +57,7 @@ struct is_multi_geometry
 
 // true for point, linestring or polygon
 template <typename T>
-struct is_multi_geometry_value
+struct is_multi_geometry_element
     : boost::integral_constant
         <
             bool,
@@ -86,23 +90,6 @@ struct is_range
 {};
 
 
-// geometry tag of Rng value_type
-template <typename Rng>
-struct range_value_tag
-    : geometry::tag<typename boost::range_value<Rng>::type>
-{};
-
-// true if geometry tag of Rng is the same as Tag
-template <typename Rng, typename Tag>
-struct is_range_value_tag_same_as
-    : boost::is_same
-        <
-            typename range_value_tag<Rng>::type,
-            Tag
-        >
-{};
-
-
 template <typename T, bool IsRange = is_range<T>::value>
 struct is_tupled_output_element_base
     : boost::integral_constant<bool, false>
@@ -114,12 +101,13 @@ struct is_tupled_output_element_base<T, true>
         <
             bool,
             (is_multi_geometry<T>::value
-            ||
-            ((! is_geometry<T>::value)
-                &&
-                ((is_range_value_tag_same_as<T, point_tag>::value)
-                || (is_range_value_tag_same_as<T, linestring_tag>::value)
-                || (is_range_value_tag_same_as<T, polygon_tag>::value))))
+                ||
+                ((! is_geometry<T>::value)
+                    &&
+                    is_multi_geometry_element
+                        <
+                            typename boost::range_value<T>::type
+                        >::value))
         >
 {};
 
@@ -134,7 +122,7 @@ struct is_tupled_output_element
 
 // true if Output is not a geometry (so e.g. tuple was not adapted to any
 // concept) and at least one of the tuple elements is a multi-geometry or
-// a range of points linestrings or polygons
+// a range of points, linestrings or polygons
 template <typename Output>
 struct is_tupled_output_check
     : boost::mpl::and_
@@ -146,28 +134,15 @@ struct is_tupled_output_check
 {};
 
 
-// true if T is a point, linestring or polygon
-template <typename T>
-struct is_tupled_range_values_element
-    : boost::integral_constant
-        <
-            bool,
-            ((boost::is_same<typename geometry::tag<T>::type, point_tag>::value)
-                || (boost::is_same<typename geometry::tag<T>::type, linestring_tag>::value)
-                || (boost::is_same<typename geometry::tag<T>::type, polygon_tag>::value))
-        >
-{};
-
-
 // true if T is not a geometry (so e.g. tuple was not adapted to any
 // concept) and at least one of the tuple elements is a point, linesting
 // or polygon
 template <typename T>
-struct is_tupled_range_values_check
+struct is_tupled_single_output_check
     : boost::mpl::and_
         <
             boost::is_same<typename geometry::tag<T>::type, void>,
-            geometry::tuples::exists_if<T, is_tupled_range_values_element>
+            geometry::tuples::exists_if<T, is_multi_geometry_element>
         >
 {};
 
@@ -222,15 +197,15 @@ struct is_tupled_output<Output, true>
 
 
 // true if T is boost::tuple, boost::tuples::cons, std::pair or std::tuple
-// and is_tupled_range_values_check defiend above passes
+// and is_tupled_single_output_check defiend above passes
 template <typename T, bool IsTupled = is_tupled<T>::value>
-struct is_tupled_range_values
+struct is_tupled_single_output
     : boost::integral_constant<bool, false>
 {};
 
 template <typename T>
-struct is_tupled_range_values<T, true>
-    : is_tupled_range_values_check<T>
+struct is_tupled_single_output<T, true>
+    : is_tupled_single_output_check<T>
 {};
 
 
@@ -523,6 +498,234 @@ struct output_geometry_access<GeometryOut, Tag, DefaultTag, DefaultTag>
     static T& get(T & v)
     {
         return v;
+    }
+};
+
+
+template <typename Geometry>
+struct output_geometry_concept_check
+{
+    static void apply()
+    {
+        concepts::check<Geometry>();
+    }
+};
+
+template <typename First, typename Second>
+struct output_geometry_concept_check<std::pair<First, Second> >
+{
+    static void apply()
+    {
+        concepts::check<First>();
+        concepts::check<Second>();
+    }
+};
+
+template <typename Tuple,
+          size_t I = 0,
+          size_t N = geometry::tuples::size<Tuple>::value>
+struct output_geometry_concept_check_t
+{
+    static void apply()
+    {
+        concepts::check<typename geometry::tuples::element<I, Tuple>::type>();
+        output_geometry_concept_check_t<Tuple, I + 1, N>::apply();
+    }
+};
+
+template <typename Tuple, size_t N>
+struct output_geometry_concept_check_t<Tuple, N, N>
+{
+    static void apply()
+    {}
+};
+
+template
+<
+    class T0, class T1, class T2, class T3, class T4,
+    class T5, class T6, class T7, class T8, class T9
+>
+struct output_geometry_concept_check<boost::tuple<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> >
+    : output_geometry_concept_check_t<boost::tuple<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> >
+{};
+
+template <typename HT, typename TT>
+struct output_geometry_concept_check<boost::tuples::cons<HT, TT> >
+    : output_geometry_concept_check_t<boost::tuples::cons<HT, TT> >
+{};
+
+#ifdef BOOST_GEOMETRY_CXX11_TUPLE
+
+template <typename ...Ts>
+struct output_geometry_concept_check<std::tuple<Ts...> >
+    : output_geometry_concept_check_t<std::tuple<Ts...> >
+{};
+
+#endif // BOOST_GEOMETRY_CXX11_TUPLE
+
+
+struct tupled_output_tag {};
+
+
+template <typename GeometryOut>
+struct setop_insert_output_tag
+    : boost::mpl::if_c
+        <
+            geometry::detail::is_tupled_single_output<GeometryOut>::value,
+            tupled_output_tag,
+            typename geometry::tag<GeometryOut>::type
+        >
+{};
+
+
+template <typename Geometry1, typename Geometry2, typename TupledOut, bool IsFound, typename Tag>
+struct expect_output_assert_base;
+
+template <typename Geometry1, typename Geometry2, typename TupledOut, bool IsFound>
+struct expect_output_assert_base<Geometry1, Geometry2, TupledOut, IsFound, pointlike_tag>
+{
+    BOOST_MPL_ASSERT_MSG
+        (
+            IsFound, POINTLIKE_GEOMETRY_EXPECTED_IN_TUPLED_OUTPUT,
+            (types<Geometry1, Geometry2, TupledOut>)
+        );
+};
+
+template <typename Geometry1, typename Geometry2, typename TupledOut, bool IsFound>
+struct expect_output_assert_base<Geometry1, Geometry2, TupledOut, IsFound, linear_tag>
+{
+    BOOST_MPL_ASSERT_MSG
+    (
+        IsFound, LINEAR_GEOMETRY_EXPECTED_IN_TUPLED_OUTPUT,
+        (types<Geometry1, Geometry2, TupledOut>)
+    );
+};
+
+template <typename Geometry1, typename Geometry2, typename TupledOut, bool IsFound>
+struct expect_output_assert_base<Geometry1, Geometry2, TupledOut, IsFound, areal_tag>
+{
+    BOOST_MPL_ASSERT_MSG
+    (
+        IsFound, AREAL_GEOMETRY_EXPECTED_IN_TUPLED_OUTPUT,
+        (types<Geometry1, Geometry2, TupledOut>)
+    );
+};
+
+
+template <typename Geometry1, typename Geometry2, typename TupledOut, typename Tag>
+struct expect_output_assert
+    : expect_output_assert_base
+        <
+            Geometry1, Geometry2, TupledOut,
+            geometry::tuples::exists_if
+                <
+                    TupledOut,
+                    is_tag_same_as_pred<Tag>::template pred
+                >::value,
+            typename geometry::tag_cast
+                <
+                    Tag, pointlike_tag, linear_tag, areal_tag
+                >::type
+        >
+{};
+
+template <typename Geometry1, typename Geometry2, typename TupledOut>
+struct expect_output_assert<Geometry1, Geometry2, TupledOut, void>
+{};
+
+template
+<
+    typename Geometry1, typename Geometry2, typename TupledOut,
+    typename Tag1,
+    typename Tag2 = void,
+    typename Tag3 = void
+>
+struct expect_output
+    : expect_output_assert<Geometry1, Geometry2, TupledOut, Tag1>
+    , expect_output_assert<Geometry1, Geometry2, TupledOut, Tag2>
+    , expect_output_assert<Geometry1, Geometry2, TupledOut, Tag3>
+{};
+
+template
+<
+    typename Geometry1, typename Geometry2, typename TupledOut,
+    typename Tag1, typename Tag2
+>
+struct expect_output<Geometry1, Geometry2, TupledOut, Tag1, Tag2, void>
+    : expect_output_assert<Geometry1, Geometry2, TupledOut, Tag1>
+    , expect_output_assert<Geometry1, Geometry2, TupledOut, Tag2>
+{};
+
+template
+<
+    typename Geometry1, typename Geometry2, typename TupledOut,
+    typename Tag1
+>
+struct expect_output<Geometry1, Geometry2, TupledOut, Tag1, void, void>
+    : expect_output_assert<Geometry1, Geometry2, TupledOut, Tag1>
+{};
+
+
+template <typename CastedTag>
+struct casted_tag_to_single_tag;
+
+template <>
+struct casted_tag_to_single_tag<pointlike_tag>
+{
+    typedef point_tag type;
+};
+
+template <>
+struct casted_tag_to_single_tag<linear_tag>
+{
+    typedef linestring_tag type;
+};
+
+template <>
+struct casted_tag_to_single_tag<areal_tag>
+{
+    typedef polygon_tag type;
+};
+
+
+template
+<
+    typename Geometry,
+    typename SingleOut,
+    bool IsMulti = geometry::detail::is_multi_geometry<Geometry>::value
+>
+struct convert_to_output
+{
+    template <typename OutputIterator>
+    static OutputIterator apply(Geometry const& geometry,
+                                OutputIterator oit)
+    {
+        SingleOut single_out;
+        geometry::convert(geometry, single_out);
+        *oit++ = single_out;
+        return oit;
+    }
+};
+
+template
+<
+    typename Geometry,
+    typename SingleOut
+>
+struct convert_to_output<Geometry, SingleOut, true>
+{
+    template <typename OutputIterator>
+    static OutputIterator apply(Geometry const& geometry,
+                                OutputIterator oit)
+    {
+        typedef typename boost::range_iterator<Geometry const>::type iterator;
+        for (iterator it = boost::begin(geometry); it != boost::end(geometry); ++it)
+        {
+            SingleOut single_out;
+            geometry::convert(*it, single_out);
+            *oit++ = single_out;
+        }
+        return oit;
     }
 };
 

--- a/include/boost/geometry/algorithms/detail/tupled_output.hpp
+++ b/include/boost/geometry/algorithms/detail/tupled_output.hpp
@@ -667,22 +667,22 @@ struct expect_output<Geometry1, Geometry2, TupledOut, Tag1, void, void>
 
 
 template <typename CastedTag>
-struct casted_tag_to_single_tag;
+struct single_tag_from_base_tag;
 
 template <>
-struct casted_tag_to_single_tag<pointlike_tag>
+struct single_tag_from_base_tag<pointlike_tag>
 {
     typedef point_tag type;
 };
 
 template <>
-struct casted_tag_to_single_tag<linear_tag>
+struct single_tag_from_base_tag<linear_tag>
 {
     typedef linestring_tag type;
 };
 
 template <>
-struct casted_tag_to_single_tag<areal_tag>
+struct single_tag_from_base_tag<areal_tag>
 {
     typedef polygon_tag type;
 };

--- a/include/boost/geometry/algorithms/difference.hpp
+++ b/include/boost/geometry/algorithms/difference.hpp
@@ -75,7 +75,7 @@ template
 >
 struct call_intersection_insert_tupled_base
 {
-    typedef typename geometry::detail::casted_tag_to_single_tag
+    typedef typename geometry::detail::single_tag_from_base_tag
         <
             typename geometry::tag_cast
                 <

--- a/include/boost/geometry/algorithms/difference.hpp
+++ b/include/boost/geometry/algorithms/difference.hpp
@@ -2,8 +2,8 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017, 2019.
-// Modifications copyright (c) 2017, 2019, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017, 2019, 2020.
+// Modifications copyright (c) 2017-2020, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -19,6 +19,7 @@
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/variant_fwd.hpp>
 
+#include <boost/geometry/algorithms/detail/intersection/multi.hpp>
 #include <boost/geometry/algorithms/detail/overlay/intersection_insert.hpp>
 #include <boost/geometry/policies/robustness/get_rescale_policy.hpp>
 #include <boost/geometry/strategies/default_strategy.hpp>
@@ -31,6 +32,146 @@ namespace boost { namespace geometry
 #ifndef DOXYGEN_NO_DETAIL
 namespace detail { namespace difference
 {
+
+template
+<
+    typename Geometry1,
+    typename Geometry2,
+    typename SingleOut,
+    typename OutTag = typename detail::setop_insert_output_tag<SingleOut>::type,
+    bool ReturnGeometry1 = (topological_dimension<Geometry1>::value
+                            > topological_dimension<Geometry2>::value)
+>
+struct call_intersection_insert
+{
+    template
+    <
+        typename OutputIterator,
+        typename RobustPolicy,
+        typename Strategy
+    >
+    static inline OutputIterator apply(Geometry1 const& geometry1,
+                                       Geometry2 const& geometry2,
+                                       RobustPolicy const& robust_policy,
+                                       OutputIterator out,
+                                       Strategy const& strategy)
+    {
+        return geometry::dispatch::intersection_insert
+            <
+                Geometry1, Geometry2,
+                SingleOut,
+                overlay_difference,
+                geometry::detail::overlay::do_reverse<geometry::point_order<Geometry1>::value>::value,
+                geometry::detail::overlay::do_reverse<geometry::point_order<Geometry2>::value, true>::value
+            >::apply(geometry1, geometry2, robust_policy, out, strategy);
+    }
+};
+
+template
+<
+    typename Geometry1,
+    typename Geometry2,
+    typename SingleOut
+>
+struct call_intersection_insert_tupled_base
+{
+    typedef typename geometry::detail::casted_tag_to_single_tag
+        <
+            typename geometry::tag_cast
+                <
+                    typename geometry::tag<Geometry1>::type,
+                    pointlike_tag, linear_tag, areal_tag
+                >::type
+        >::type single_tag;
+
+    typedef detail::expect_output
+        <
+            Geometry1, Geometry2, SingleOut, single_tag
+        > expect_check;
+
+    typedef typename geometry::detail::output_geometry_access
+        <
+            SingleOut, single_tag, single_tag
+        > access;
+};
+
+template
+<
+    typename Geometry1,
+    typename Geometry2,
+    typename SingleOut
+>
+struct call_intersection_insert
+    <
+        Geometry1, Geometry2, SingleOut,
+        detail::tupled_output_tag,
+        false
+    >
+    : call_intersection_insert_tupled_base<Geometry1, Geometry2, SingleOut>
+{
+    typedef call_intersection_insert_tupled_base<Geometry1, Geometry2, SingleOut> base_t;
+
+    template
+    <
+        typename OutputIterator,
+        typename RobustPolicy,
+        typename Strategy
+    >
+    static inline OutputIterator apply(Geometry1 const& geometry1,
+                                       Geometry2 const& geometry2,
+                                       RobustPolicy const& robust_policy,
+                                       OutputIterator out,
+                                       Strategy const& strategy)
+    {
+        base_t::access::get(out) = call_intersection_insert
+            <
+                Geometry1, Geometry2,
+                typename base_t::access::type
+            >::apply(geometry1, geometry2, robust_policy,
+                     base_t::access::get(out), strategy);
+
+        return out;
+    }
+};
+
+template
+<
+    typename Geometry1,
+    typename Geometry2,
+    typename SingleOut
+>
+struct call_intersection_insert
+    <
+        Geometry1, Geometry2, SingleOut,
+        detail::tupled_output_tag,
+        true
+    >
+    : call_intersection_insert_tupled_base<Geometry1, Geometry2, SingleOut>
+{
+    typedef call_intersection_insert_tupled_base<Geometry1, Geometry2, SingleOut> base_t;
+
+    template
+    <
+        typename OutputIterator,
+        typename RobustPolicy,
+        typename Strategy
+    >
+    static inline OutputIterator apply(Geometry1 const& geometry1,
+                                       Geometry2 const& geometry2,
+                                       RobustPolicy const& robust_policy,
+                                       OutputIterator out,
+                                       Strategy const& strategy)
+    {
+        base_t::access::get(out) = geometry::detail::convert_to_output
+            <
+                Geometry1,
+                typename base_t::access::type
+            >::apply(geometry1, base_t::access::get(out));
+
+        return out;
+    }
+};
+
 
 /*!
 \brief_calc2{difference} \brief_strategy
@@ -65,7 +206,8 @@ inline OutputIterator difference_insert(Geometry1 const& geometry1,
 {
     concepts::check<Geometry1 const>();
     concepts::check<Geometry2 const>();
-    concepts::check<GeometryOut>();
+    //concepts::check<GeometryOut>();
+    geometry::detail::output_geometry_concept_check<GeometryOut>::apply();
 
     typedef typename geometry::rescale_overlay_policy_type
         <
@@ -75,16 +217,12 @@ inline OutputIterator difference_insert(Geometry1 const& geometry1,
         >::type rescale_policy_type;
 
     rescale_policy_type robust_policy
-            = geometry::get_rescale_policy<rescale_policy_type>(
-                geometry1, geometry2, strategy);
+        = geometry::get_rescale_policy<rescale_policy_type>(
+            geometry1, geometry2, strategy);
 
-    return geometry::dispatch::intersection_insert
+    return geometry::detail::difference::call_intersection_insert
         <
-            Geometry1, Geometry2,
-            GeometryOut,
-            overlay_difference,
-            geometry::detail::overlay::do_reverse<geometry::point_order<Geometry1>::value>::value,
-            geometry::detail::overlay::do_reverse<geometry::point_order<Geometry2>::value, true>::value
+            Geometry1, Geometry2, GeometryOut
         >::apply(geometry1, geometry2, robust_policy, out, strategy);
 }
 
@@ -146,11 +284,14 @@ struct difference
                              Collection & output_collection,
                              Strategy const& strategy)
     {
-        typedef typename boost::range_value<Collection>::type geometry_out;
+        typedef typename geometry::detail::output_geometry_value
+            <
+                Collection
+            >::type single_out;
 
-        detail::difference::difference_insert<geometry_out>(
+        detail::difference::difference_insert<single_out>(
             geometry1, geometry2,
-            range::back_inserter(output_collection),
+            geometry::detail::output_geometry_back_inserter(output_collection),
             strategy);
     }
 
@@ -165,11 +306,13 @@ struct difference
                              Collection & output_collection,
                              default_strategy)
     {
-        typedef typename boost::range_value<Collection>::type geometry_out;
+        typedef typename strategy::relate::services::default_strategy
+            <
+                Geometry1,
+                Geometry2
+            >::type strategy_type;
         
-        detail::difference::difference_insert<geometry_out>(
-            geometry1, geometry2,
-            range::back_inserter(output_collection));
+        apply(geometry1, geometry2, output_collection, strategy_type());
     }
 };
 

--- a/include/boost/geometry/algorithms/sym_difference.hpp
+++ b/include/boost/geometry/algorithms/sym_difference.hpp
@@ -397,14 +397,14 @@ struct sym_difference_insert
     : detail::expect_output
         <
             Geometry1, Geometry2, GeometryOut,
-            typename detail::casted_tag_to_single_tag<TagIn1>::type,
-            typename detail::casted_tag_to_single_tag<TagIn2>::type
+            typename detail::single_tag_from_base_tag<TagIn1>::type,
+            typename detail::single_tag_from_base_tag<TagIn2>::type
         >
     , detail::sym_difference::sym_difference_different_inputs_tupled_output
         <
             GeometryOut,
-            typename detail::casted_tag_to_single_tag<TagIn1>::type,
-            typename detail::casted_tag_to_single_tag<TagIn2>::type
+            typename detail::single_tag_from_base_tag<TagIn1>::type,
+            typename detail::single_tag_from_base_tag<TagIn2>::type
         >
 {};
 

--- a/include/boost/geometry/algorithms/sym_difference.hpp
+++ b/include/boost/geometry/algorithms/sym_difference.hpp
@@ -2,8 +2,8 @@
 
 // Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2015, 2017, 2019.
-// Modifications copyright (c) 2015-2019 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2015, 2017, 2019, 2020.
+// Modifications copyright (c) 2015-2020 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -29,6 +29,7 @@
 #include <boost/geometry/geometries/multi_polygon.hpp>
 #include <boost/geometry/policies/robustness/get_rescale_policy.hpp>
 #include <boost/geometry/strategies/default_strategy.hpp>
+#include <boost/geometry/strategies/relate.hpp>
 #include <boost/geometry/util/range.hpp>
 
 
@@ -150,6 +151,124 @@ struct sym_difference_areal_areal
 };
 
 
+template
+<
+    typename GeometryOut,
+    typename SingleTag,
+    template <typename, typename, typename> class Algorithm
+>
+struct sym_difference_same_inputs_tupled_output
+{
+    template
+    <
+        typename Geometry1,
+        typename Geometry2,
+        typename RobustPolicy,
+        typename OutputIterator,
+        typename Strategy
+    >
+    static inline OutputIterator apply(Geometry1 const& geometry1,
+                                       Geometry2 const& geometry2,
+                                       RobustPolicy const& robust_policy,
+                                       OutputIterator out,
+                                       Strategy const& strategy)
+    {
+        typedef typename geometry::detail::output_geometry_access
+            <
+                GeometryOut, SingleTag, SingleTag
+            > access;
+
+        access::get(out) = Algorithm
+            <
+                typename access::type, Geometry1, Geometry2
+            >::apply(geometry1, geometry2, robust_policy, access::get(out), strategy);
+
+        return out;
+    }
+};
+
+
+template
+<
+    typename GeometryOut,
+    typename SingleTag1,
+    typename SingleTag2,
+    bool Reverse = (geometry::core_dispatch::top_dim<SingleTag1>::value
+                    > geometry::core_dispatch::top_dim<SingleTag2>::value)
+>
+struct sym_difference_different_inputs_tupled_output
+{
+    template
+    <
+        typename Geometry1,
+        typename Geometry2,
+        typename RobustPolicy,
+        typename OutputIterator,
+        typename Strategy
+    >
+    static inline OutputIterator apply(Geometry1 const& geometry1,
+                                       Geometry2 const& geometry2,
+                                       RobustPolicy const& robust_policy,
+                                       OutputIterator out,
+                                       Strategy const& strategy)
+    {
+        return sym_difference_different_inputs_tupled_output
+            <
+                GeometryOut, SingleTag2, SingleTag1
+            >::apply(geometry2, geometry1, robust_policy, out, strategy);
+    }
+};
+
+template
+<
+    typename GeometryOut,
+    typename SingleTag1,
+    typename SingleTag2
+>
+struct sym_difference_different_inputs_tupled_output
+    <
+        GeometryOut, SingleTag1, SingleTag2, false
+    >
+{
+    template
+    <
+        typename Geometry1,
+        typename Geometry2,
+        typename RobustPolicy,
+        typename OutputIterator,
+        typename Strategy
+    >
+    static inline OutputIterator apply(Geometry1 const& geometry1,
+                                       Geometry2 const& geometry2,
+                                       RobustPolicy const& robust_policy,
+                                       OutputIterator out,
+                                       Strategy const& strategy)
+    {
+        typedef typename geometry::detail::output_geometry_access
+            <
+                GeometryOut, SingleTag1, SingleTag1
+            > access1;
+        typedef typename geometry::detail::output_geometry_access
+            <
+                GeometryOut, SingleTag2, SingleTag2
+            > access2;
+
+        access1::get(out) = compute_difference
+            <
+                typename access1::type
+            >::apply(geometry1, geometry2, robust_policy, access1::get(out), strategy);
+
+        access2::get(out) = geometry::detail::convert_to_output
+            <
+                Geometry2,
+                typename access2::type
+            >::apply(geometry2, access2::get(out));
+
+        return out;
+    }
+};
+
+
 }} // namespace detail::sym_difference
 #endif // DOXYGEN_NO_DETAIL
 
@@ -167,13 +286,13 @@ template
     typename GeometryOut,
     typename TagIn1 = typename geometry::tag_cast
         <
-            typename tag<Geometry1>::type, areal_tag
+            typename tag<Geometry1>::type, pointlike_tag, linear_tag, areal_tag
         >::type,
     typename TagIn2 = typename geometry::tag_cast
         <
-            typename tag<Geometry2>::type, areal_tag
+            typename tag<Geometry2>::type, pointlike_tag, linear_tag, areal_tag
         >::type,
-    typename TagOut = typename geometry::tag<GeometryOut>::type
+    typename TagOut = typename detail::setop_insert_output_tag<GeometryOut>::type
 >
 struct sym_difference_insert
     : detail::sym_difference::sym_difference_generic
@@ -197,6 +316,95 @@ struct sym_difference_insert
     > : detail::sym_difference::sym_difference_areal_areal
         <
             GeometryOut, Areal1, Areal2
+        >
+{};
+
+
+
+template
+<
+    typename PointLike1,
+    typename PointLike2,
+    typename GeometryOut
+>
+struct sym_difference_insert
+    <
+        PointLike1, PointLike2, GeometryOut,
+        pointlike_tag, pointlike_tag, detail::tupled_output_tag
+    >
+    : detail::expect_output<PointLike1, PointLike2, GeometryOut, point_tag>
+    , detail::sym_difference::sym_difference_same_inputs_tupled_output
+        <
+            GeometryOut,
+            point_tag,
+            detail::sym_difference::sym_difference_generic
+        >
+{};
+
+template
+<
+    typename Linear1,
+    typename Linear2,
+    typename GeometryOut
+>
+struct sym_difference_insert
+    <
+        Linear1, Linear2, GeometryOut,
+        linear_tag, linear_tag, detail::tupled_output_tag
+    >
+    : detail::expect_output<Linear1, Linear2, GeometryOut, linestring_tag>
+    , detail::sym_difference::sym_difference_same_inputs_tupled_output
+        <
+            GeometryOut,
+            linestring_tag,
+            detail::sym_difference::sym_difference_generic
+        >
+{};
+
+template
+<
+    typename Areal1,
+    typename Areal2,
+    typename GeometryOut
+>
+struct sym_difference_insert
+    <
+        Areal1, Areal2, GeometryOut,
+        areal_tag, areal_tag, detail::tupled_output_tag
+    >
+    : detail::expect_output<Areal1, Areal2, GeometryOut, polygon_tag>
+    , detail::sym_difference::sym_difference_same_inputs_tupled_output
+        <
+            GeometryOut,
+            polygon_tag,
+            detail::sym_difference::sym_difference_areal_areal
+        >
+{};
+
+template
+<
+    typename Geometry1,
+    typename Geometry2,
+    typename GeometryOut,
+    typename TagIn1,
+    typename TagIn2
+>
+struct sym_difference_insert
+    <
+        Geometry1, Geometry2, GeometryOut,
+        TagIn1, TagIn2, detail::tupled_output_tag
+    >
+    : detail::expect_output
+        <
+            Geometry1, Geometry2, GeometryOut,
+            typename detail::casted_tag_to_single_tag<TagIn1>::type,
+            typename detail::casted_tag_to_single_tag<TagIn2>::type
+        >
+    , detail::sym_difference::sym_difference_different_inputs_tupled_output
+        <
+            GeometryOut,
+            typename detail::casted_tag_to_single_tag<TagIn1>::type,
+            typename detail::casted_tag_to_single_tag<TagIn2>::type
         >
 {};
 
@@ -244,7 +452,8 @@ inline OutputIterator sym_difference_insert(Geometry1 const& geometry1,
 {
     concepts::check<Geometry1 const>();
     concepts::check<Geometry2 const>();
-    concepts::check<GeometryOut>();
+    //concepts::check<GeometryOut>();
+    geometry::detail::output_geometry_concept_check<GeometryOut>::apply();
 
     typedef typename geometry::rescale_overlay_policy_type
         <
@@ -288,10 +497,6 @@ template
 inline OutputIterator sym_difference_insert(Geometry1 const& geometry1,
             Geometry2 const& geometry2, OutputIterator out)
 {
-    concepts::check<Geometry1 const>();
-    concepts::check<Geometry2 const>();
-    concepts::check<GeometryOut>();
-
     typedef typename strategy::intersection::services::default_strategy
         <
             typename cs_tag<GeometryOut>::type
@@ -320,11 +525,14 @@ struct sym_difference
                              Collection & output_collection,
                              Strategy const& strategy)
     {
-        typedef typename boost::range_value<Collection>::type geometry_out;
+        typedef typename geometry::detail::output_geometry_value
+            <
+                Collection
+            >::type single_out;
 
-        detail::sym_difference::sym_difference_insert<geometry_out>(
+        detail::sym_difference::sym_difference_insert<single_out>(
             geometry1, geometry2,
-            range::back_inserter(output_collection),
+            geometry::detail::output_geometry_back_inserter(output_collection),
             strategy);
     }
 
@@ -339,11 +547,12 @@ struct sym_difference
                              Collection & output_collection,
                              default_strategy)
     {
-        typedef typename boost::range_value<Collection>::type geometry_out;
-        
-        detail::sym_difference::sym_difference_insert<geometry_out>(
-            geometry1, geometry2,
-            range::back_inserter(output_collection));
+        typedef typename strategy::relate::services::default_strategy
+            <
+                Geometry1, Geometry2
+            >::type strategy_type;
+
+        apply(geometry1, geometry2, output_collection, strategy_type());
     }
 };
 

--- a/include/boost/geometry/algorithms/union.hpp
+++ b/include/boost/geometry/algorithms/union.hpp
@@ -161,7 +161,7 @@ struct union_insert
         false
     >
 {
-    typedef typename geometry::detail::casted_tag_to_single_tag
+    typedef typename geometry::detail::single_tag_from_base_tag
         <
             CastedTagIn
         >::type single_tag;
@@ -278,7 +278,7 @@ struct union_insert
         false
     >
 {
-    typedef typename geometry::detail::casted_tag_to_single_tag
+    typedef typename geometry::detail::single_tag_from_base_tag
         <
             CastedTagIn1
         >::type single_tag1;
@@ -288,7 +288,7 @@ struct union_insert
             Geometry1, Geometry2, SingleTupledOut, single_tag1
         > expect_check1;
 
-    typedef typename geometry::detail::casted_tag_to_single_tag
+    typedef typename geometry::detail::single_tag_from_base_tag
         <
             CastedTagIn2
         >::type single_tag2;
@@ -347,7 +347,6 @@ inline OutputIterator union_insert(Geometry1 const& geometry1,
 {
     concepts::check<Geometry1 const>();
     concepts::check<Geometry2 const>();
-    //concepts::check<GeometryOut>();
     geometry::detail::output_geometry_concept_check<GeometryOut>::apply();
 
     typename strategy::intersection::services::default_strategy

--- a/include/boost/geometry/algorithms/union.hpp
+++ b/include/boost/geometry/algorithms/union.hpp
@@ -2,8 +2,8 @@
 
 // Copyright (c) 2007-2014 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2014, 2017, 2018, 2019.
-// Modifications copyright (c) 2014-2019 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014, 2017, 2018, 2019, 2020.
+// Modifications copyright (c) 2014-2020 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -18,7 +18,6 @@
 
 #include <boost/range/metafunctions.hpp>
 
-#include <boost/geometry/core/is_areal.hpp>
 #include <boost/geometry/core/point_order.hpp>
 #include <boost/geometry/core/reverse_dispatch.hpp>
 #include <boost/geometry/geometries/concepts/check.hpp>
@@ -28,6 +27,8 @@
 #include <boost/geometry/strategies/default_strategy.hpp>
 #include <boost/geometry/util/range.hpp>
 
+#include <boost/geometry/algorithms/detail/intersection/multi.hpp>
+#include <boost/geometry/algorithms/detail/overlay/intersection_insert.hpp>
 #include <boost/geometry/algorithms/detail/overlay/linear_linear.hpp>
 #include <boost/geometry/algorithms/detail/overlay/pointlike_pointlike.hpp>
 
@@ -44,13 +45,10 @@ template
     typename Geometry1, typename Geometry2, typename GeometryOut,
     typename TagIn1 = typename tag<Geometry1>::type,
     typename TagIn2 = typename tag<Geometry2>::type,
-    typename TagOut = typename tag<GeometryOut>::type,
-    bool Areal1 = geometry::is_areal<Geometry1>::value,
-    bool Areal2 = geometry::is_areal<Geometry2>::value,
-    bool ArealOut = geometry::is_areal<GeometryOut>::value,
-    bool Reverse1 = detail::overlay::do_reverse<geometry::point_order<Geometry1>::value>::value,
-    bool Reverse2 = detail::overlay::do_reverse<geometry::point_order<Geometry2>::value>::value,
-    bool ReverseOut = detail::overlay::do_reverse<geometry::point_order<GeometryOut>::value>::value,
+    typename TagOut = typename detail::setop_insert_output_tag<GeometryOut>::type,
+    typename CastedTagIn1 = typename geometry::tag_cast<TagIn1, areal_tag, linear_tag, pointlike_tag>::type,
+    typename CastedTagIn2 = typename geometry::tag_cast<TagIn2, areal_tag, linear_tag, pointlike_tag>::type,
+    typename CastedTagOut = typename geometry::tag_cast<TagOut, areal_tag, linear_tag, pointlike_tag>::type,
     bool Reverse = geometry::reverse_dispatch<Geometry1, Geometry2>::type::value
 >
 struct union_insert: not_implemented<TagIn1, TagIn2, TagOut>
@@ -63,24 +61,22 @@ template
 <
     typename Geometry1, typename Geometry2, typename GeometryOut,
     typename TagIn1, typename TagIn2, typename TagOut,
-    bool Areal1, bool Areal2, bool ArealOut,
-    bool Reverse1, bool Reverse2, bool ReverseOut
+    typename CastedTagIn1, typename CastedTagIn2, typename CastedTagOut
 >
 struct union_insert
     <
         Geometry1, Geometry2, GeometryOut,
         TagIn1, TagIn2, TagOut,
-        Areal1, Areal2, ArealOut,
-        Reverse1, Reverse2, ReverseOut,
+        CastedTagIn1, CastedTagIn2, CastedTagOut,
         true
-    >: union_insert<Geometry2, Geometry1, GeometryOut>
+    >
 {
     template <typename RobustPolicy, typename OutputIterator, typename Strategy>
     static inline OutputIterator apply(Geometry1 const& g1,
-            Geometry2 const& g2,
-            RobustPolicy const& robust_policy,
-            OutputIterator out,
-            Strategy const& strategy)
+                                       Geometry2 const& g2,
+                                       RobustPolicy const& robust_policy,
+                                       OutputIterator out,
+                                       Strategy const& strategy)
     {
         return union_insert
             <
@@ -93,44 +89,22 @@ struct union_insert
 template
 <
     typename Geometry1, typename Geometry2, typename GeometryOut,
-    typename TagIn1, typename TagIn2, typename TagOut,
-    bool Reverse1, bool Reverse2, bool ReverseOut
+    typename TagIn1, typename TagIn2, typename TagOut
 >
 struct union_insert
     <
         Geometry1, Geometry2, GeometryOut,
         TagIn1, TagIn2, TagOut,
-        true, true, true,
-        Reverse1, Reverse2, ReverseOut,
+        areal_tag, areal_tag, areal_tag,
         false
     > : detail::overlay::overlay
-        <Geometry1, Geometry2, Reverse1, Reverse2, ReverseOut, GeometryOut, overlay_union>
-{};
-
-
-// dispatch for union of non-areal geometries
-template
-<
-    typename Geometry1, typename Geometry2, typename GeometryOut,
-    typename TagIn1, typename TagIn2, typename TagOut,
-    bool Reverse1, bool Reverse2, bool ReverseOut
->
-struct union_insert
-    <
-        Geometry1, Geometry2, GeometryOut,
-        TagIn1, TagIn2, TagOut,
-        false, false, false,
-        Reverse1, Reverse2, ReverseOut,
-        false
-    > : union_insert
         <
-            Geometry1, Geometry2, GeometryOut,
-            typename tag_cast<TagIn1, pointlike_tag, linear_tag>::type,
-            typename tag_cast<TagIn2, pointlike_tag, linear_tag>::type,
-            TagOut,
-            false, false, false,
-            Reverse1, Reverse2, ReverseOut,
-            false
+            Geometry1, Geometry2,
+            detail::overlay::do_reverse<geometry::point_order<Geometry1>::value>::value,
+            detail::overlay::do_reverse<geometry::point_order<Geometry2>::value>::value,
+            detail::overlay::do_reverse<geometry::point_order<GeometryOut>::value>::value,
+            GeometryOut,
+            overlay_union
         >
 {};
 
@@ -139,14 +113,13 @@ struct union_insert
 template
 <
     typename Linear1, typename Linear2, typename LineStringOut,
-    bool Reverse1, bool Reverse2, bool ReverseOut
+    typename TagIn1, typename TagIn2
 >
 struct union_insert
     <
         Linear1, Linear2, LineStringOut,
-        linear_tag, linear_tag, linestring_tag,
-        false, false, false,
-        Reverse1, Reverse2, ReverseOut,
+        TagIn1, TagIn2, linestring_tag,
+        linear_tag, linear_tag, linear_tag,
         false
     > : detail::overlay::linear_linear_linestring
         <
@@ -159,20 +132,185 @@ struct union_insert
 template
 <
     typename PointLike1, typename PointLike2, typename PointOut,
-    bool Reverse1, bool Reverse2, bool ReverseOut
+    typename TagIn1, typename TagIn2
 >
 struct union_insert
     <
         PointLike1, PointLike2, PointOut,
-        pointlike_tag, pointlike_tag, point_tag,
-        false, false, false,
-        Reverse1, Reverse2, ReverseOut,
+        TagIn1, TagIn2, point_tag,
+        pointlike_tag, pointlike_tag, pointlike_tag,
         false
     > : detail::overlay::union_pointlike_pointlike_point
         <
             PointLike1, PointLike2, PointOut
         >
 {};
+
+
+template
+<
+    typename Geometry1, typename Geometry2, typename SingleTupledOut,
+    typename TagIn1, typename TagIn2,
+    typename CastedTagIn
+>
+struct union_insert
+    <
+        Geometry1, Geometry2, SingleTupledOut,
+        TagIn1, TagIn2, detail::tupled_output_tag,
+        CastedTagIn, CastedTagIn, detail::tupled_output_tag,
+        false
+    >
+{
+    typedef typename geometry::detail::casted_tag_to_single_tag
+        <
+            CastedTagIn
+        >::type single_tag;
+
+    typedef detail::expect_output
+        <
+            Geometry1, Geometry2, SingleTupledOut, single_tag
+        > expect_check;
+
+    typedef typename geometry::detail::output_geometry_access
+        <
+            SingleTupledOut, single_tag, single_tag
+        > access;
+
+    template <typename RobustPolicy, typename OutputIterator, typename Strategy>
+    static inline OutputIterator apply(Geometry1 const& g1,
+                                       Geometry2 const& g2,
+                                       RobustPolicy const& robust_policy,
+                                       OutputIterator out,
+                                       Strategy const& strategy)
+    {
+        access::get(out) = union_insert
+            <
+                Geometry2, Geometry1, typename access::type
+            >::apply(g2, g1, robust_policy, access::get(out), strategy);
+
+        return out;
+    }
+};
+
+
+template
+<
+    typename Geometry1, typename Geometry2, typename SingleTupledOut,
+    typename SingleTag1, typename SingleTag2,
+    bool Geometry1LesserTopoDim = (topological_dimension<Geometry1>::value
+                                    < topological_dimension<Geometry2>::value)
+>
+struct union_insert_tupled_different
+{
+    typedef typename geometry::detail::output_geometry_access
+        <
+            SingleTupledOut, SingleTag1, SingleTag1
+        > access1;
+
+    typedef typename geometry::detail::output_geometry_access
+        <
+            SingleTupledOut, SingleTag2, SingleTag2
+        > access2;
+
+    template <typename RobustPolicy, typename OutputIterator, typename Strategy>
+    static inline OutputIterator apply(Geometry1 const& g1,
+                                       Geometry2 const& g2,
+                                       RobustPolicy const& robust_policy,
+                                       OutputIterator out,
+                                       Strategy const& strategy)
+    {
+        access1::get(out) = geometry::dispatch::intersection_insert
+            <
+                Geometry1, Geometry2,
+                typename access1::type,
+                overlay_difference,
+                geometry::detail::overlay::do_reverse<geometry::point_order<Geometry1>::value>::value,
+                geometry::detail::overlay::do_reverse<geometry::point_order<Geometry2>::value, true>::value
+            >::apply(g1, g2, robust_policy, access1::get(out), strategy);
+
+        access2::get(out) = geometry::detail::convert_to_output
+            <
+                Geometry2,
+                typename access2::type
+            >::apply(g2, access2::get(out));
+
+        return out;
+    }
+};
+
+
+template
+<
+    typename Geometry1, typename Geometry2, typename SingleTupledOut,
+    typename SingleTag1, typename SingleTag2
+>
+struct union_insert_tupled_different
+    <
+        Geometry1, Geometry2, SingleTupledOut, SingleTag1, SingleTag2, false
+    >
+{
+    template <typename RobustPolicy, typename OutputIterator, typename Strategy>
+    static inline OutputIterator apply(Geometry1 const& g1,
+                                       Geometry2 const& g2,
+                                       RobustPolicy const& robust_policy,
+                                       OutputIterator out,
+                                       Strategy const& strategy)
+    {
+        return union_insert_tupled_different
+            <
+                Geometry2, Geometry1, SingleTupledOut, SingleTag2, SingleTag1, true
+            >::apply(g2, g1, robust_policy, out, strategy);
+    }
+};
+
+
+template
+<
+    typename Geometry1, typename Geometry2, typename SingleTupledOut,
+    typename TagIn1, typename TagIn2,
+    typename CastedTagIn1, typename CastedTagIn2
+>
+struct union_insert
+    <
+        Geometry1, Geometry2, SingleTupledOut,
+        TagIn1, TagIn2, detail::tupled_output_tag,
+        CastedTagIn1, CastedTagIn2, detail::tupled_output_tag,
+        false
+    >
+{
+    typedef typename geometry::detail::casted_tag_to_single_tag
+        <
+            CastedTagIn1
+        >::type single_tag1;
+
+    typedef detail::expect_output
+        <
+            Geometry1, Geometry2, SingleTupledOut, single_tag1
+        > expect_check1;
+
+    typedef typename geometry::detail::casted_tag_to_single_tag
+        <
+            CastedTagIn2
+        >::type single_tag2;
+
+    typedef detail::expect_output
+        <
+            Geometry1, Geometry2, SingleTupledOut, single_tag2
+        > expect_check2;
+
+    template <typename RobustPolicy, typename OutputIterator, typename Strategy>
+    static inline OutputIterator apply(Geometry1 const& g1,
+                                       Geometry2 const& g2,
+                                       RobustPolicy const& robust_policy,
+                                       OutputIterator out,
+                                       Strategy const& strategy)
+    {
+        return union_insert_tupled_different
+            <
+                Geometry1, Geometry2, SingleTupledOut, single_tag1, single_tag2
+            >::apply(g1, g2, robust_policy, out, strategy);
+    }
+};
 
 
 } // namespace dispatch
@@ -209,7 +347,8 @@ inline OutputIterator union_insert(Geometry1 const& geometry1,
 {
     concepts::check<Geometry1 const>();
     concepts::check<Geometry2 const>();
-    concepts::check<GeometryOut>();
+    //concepts::check<GeometryOut>();
+    geometry::detail::output_geometry_concept_check<GeometryOut>::apply();
 
     typename strategy::intersection::services::default_strategy
         <
@@ -253,7 +392,10 @@ struct union_
                              Collection & output_collection,
                              Strategy const& strategy)
     {
-        typedef typename boost::range_value<Collection>::type geometry_out;
+        typedef typename geometry::detail::output_geometry_value
+            <
+                Collection
+            >::type single_out;
 
         typedef typename geometry::rescale_overlay_policy_type
             <
@@ -268,9 +410,9 @@ struct union_
 
         dispatch::union_insert
            <
-               Geometry1, Geometry2, geometry_out
+               Geometry1, Geometry2, single_out
            >::apply(geometry1, geometry2, robust_policy,
-                    range::back_inserter(output_collection),
+                    geometry::detail::output_geometry_back_inserter(output_collection),
                     strategy);
     }
 
@@ -312,7 +454,14 @@ struct union_
     {
         concepts::check<Geometry1 const>();
         concepts::check<Geometry2 const>();
-        concepts::check<typename boost::range_value<Collection>::type>();
+        //concepts::check<typename boost::range_value<Collection>::type>();
+        geometry::detail::output_geometry_concept_check
+            <
+                typename geometry::detail::output_geometry_value
+                    <
+                        Collection
+                    >::type
+            >::apply();
 
         resolve_strategy::union_::apply(geometry1, geometry2,
                                         output_collection,

--- a/test/algorithms/set_operations/difference/Jamfile
+++ b/test/algorithms/set_operations/difference/Jamfile
@@ -18,15 +18,16 @@ test-suite boost-geometry-algorithms-difference
     :
     [ run difference.cpp                      : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE
                                                   : algorithms_difference ]
+    [ run difference_areal_linear.cpp       : : : : algorithms_difference_areal_linear ]
     [ run difference_l_a_sph.cpp            : : : : algorithms_difference_l_a_sph ]
     [ run difference_linear_linear.cpp      : : : : algorithms_difference_linear_linear ]
-    [ run difference_areal_linear.cpp       : : : : algorithms_difference_areal_linear ]
-    [ run difference_pl_a.cpp               : : : : algorithms_difference_pl_a ]
-    [ run difference_pl_l.cpp               : : : : algorithms_difference_pl_l ]
-    [ run difference_pl_pl.cpp              : : : : algorithms_difference_pl_pl ]
     [ run difference_multi.cpp                : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE
                                                   : algorithms_difference_multi ]
     [ run difference_multi_areal_linear.cpp : : : : algorithms_difference_multi_areal_linear ]
     [ run difference_multi_spike.cpp          : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE
                                                   : algorithms_difference_multi_spike ]
+    [ run difference_pl_a.cpp               : : : : algorithms_difference_pl_a ]
+    [ run difference_pl_l.cpp               : : : : algorithms_difference_pl_l ]
+    [ run difference_pl_pl.cpp              : : : : algorithms_difference_pl_pl ]
+    [ run difference_tupled.cpp             : : : : algorithms_difference_tupled ]
     ;

--- a/test/algorithms/set_operations/difference/difference_tupled.cpp
+++ b/test/algorithms/set_operations/difference/difference_tupled.cpp
@@ -1,0 +1,407 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2020, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+#include <geometry_test_common.hpp>
+
+#include <boost/geometry/algorithms/correct.hpp>
+#include <boost/geometry/algorithms/equals.hpp>
+#include <boost/geometry/algorithms/difference.hpp>
+#include <boost/geometry/geometries/geometries.hpp>
+#include <boost/geometry/io/wkt/wkt.hpp>
+#include <boost/geometry/strategies/cartesian/area.hpp>
+#include <boost/geometry/strategies/cartesian/intersection.hpp>
+#include <boost/geometry/strategies/cartesian/point_in_poly_winding.hpp>
+#include <boost/geometry/strategies/cartesian/point_in_point.hpp>
+
+#include <boost/tuple/tuple.hpp>
+
+typedef bg::model::point<double, 2, bg::cs::cartesian> Pt;
+typedef bg::model::linestring<Pt> Ls;
+typedef bg::model::polygon<Pt> Po;
+typedef bg::model::ring<Pt> R;
+typedef bg::model::multi_point<Pt> MPt;
+typedef bg::model::multi_linestring<Ls> MLs;
+typedef bg::model::multi_polygon<Po> MPo;
+
+#ifdef BOOST_GEOMETRY_CXX11_TUPLE
+
+#include <tuple>
+
+#endif
+
+template <typename G>
+inline void check(std::string const& wkt1,
+                  std::string const& wkt2,
+                  G const& g,
+                  std::string const& expected)
+{
+    G expect;
+    bg::read_wkt(expected, expect);
+    bg::correct(expect);
+    if (! boost::empty(g) || ! boost::empty(expect))
+    {
+        BOOST_CHECK_MESSAGE(
+            // Commented out becasue the output in reversed case may be slightly different
+            //   e.g. different number of duplicated points in MultiPoint
+            //boost::size(g) == boost::size(expect) &&
+            bg::equals(g, expect),
+            wkt1 << " \\ " << wkt2 << " -> " << bg::wkt(g)
+                 << " different than expected: " << expected
+        );
+    }
+}
+
+template <int I>
+inline void check(std::string const& wkt1,
+                  std::string const& wkt2,
+                  boost::tuple<MPt, MLs, MPo> const& tup,
+                  std::string const& out_str)
+{
+    check(wkt1, wkt2, boost::get<I>(tup), out_str);
+}
+
+template <int I>
+inline void check(std::string const& wkt1,
+                  std::string const& wkt2,
+                  std::pair<MPt, MLs> const& pair,
+                  std::string const& out_str)
+{
+    if (BOOST_GEOMETRY_CONDITION(I == 0))
+        check(wkt1, wkt2, pair.first, out_str);
+    else
+        check(wkt1, wkt2, pair.second, out_str);
+}
+
+#ifdef BOOST_GEOMETRY_CXX11_TUPLE
+
+template <int I>
+inline void check(std::string const& wkt1,
+                  std::string const& wkt2,
+                  std::tuple<MPt, MLs, MPo> const& tup,
+                  std::string const& out_str)
+{
+    check(wkt1, wkt2, std::get<I>(tup), out_str);
+}
+
+#endif
+
+template <typename Geometry>
+struct out_id
+    : boost::mpl::if_c
+        <
+            boost::is_base_of<bg::pointlike_tag, typename bg::tag<Geometry>::type>::value,
+            boost::mpl::int_<0>,
+            typename boost::mpl::if_c
+                <
+                    boost::is_base_of<bg::linear_tag, typename bg::tag<Geometry>::type>::value,
+                    boost::mpl::int_<1>,
+                    boost::mpl::int_<2>
+                >::type
+        >::type
+{};
+
+template <typename In1, typename In2, typename Tup>
+inline void test_one(std::string const& in1_str,
+                     std::string const& in2_str,
+                     std::string const& out1_str,
+                     std::string const& out2_str)
+{
+    In1 in1;
+    bg::read_wkt(in1_str, in1);
+    bg::correct(in1);
+
+    In2 in2;
+    bg::read_wkt(in2_str, in2);
+    bg::correct(in2);
+
+    {
+        Tup result;
+        bg::difference(in1, in2, result);
+        check<out_id<In1>::value>(in1_str, in2_str, result, out1_str);
+    }
+    {
+        Tup result;
+        bg::difference(in2, in1, result);
+        check<out_id<In2>::value>(in2_str, in1_str, result, out2_str);
+    }
+}
+
+template <typename Tup>
+inline void test_pp()
+{
+    test_one<Pt, Pt, Tup>(
+        "POINT(0 0)",
+        "POINT(0 0)",
+        "MULTIPOINT()",
+        "MULTIPOINT()");
+
+    test_one<Pt, Pt, Tup>(
+        "POINT(0 0)",
+        "POINT(1 1)",
+        "MULTIPOINT(0 0)",
+        "MULTIPOINT(1 1)");
+
+    test_one<Pt, MPt, Tup>(
+        "POINT(0 0)",
+        "MULTIPOINT(0 0, 1 1)",
+        "MULTIPOINT()",
+        "MULTIPOINT(1 1)");
+
+    test_one<Pt, MPt, Tup>(
+        "POINT(2 2)",
+        "MULTIPOINT(0 0, 1 1)",
+        "MULTIPOINT(2 2)",
+        "MULTIPOINT(0 0, 1 1)");
+
+    test_one<MPt, MPt, Tup>(
+        "MULTIPOINT(0 0, 1 1, 2 2)",
+        "MULTIPOINT(1 1, 3 3, 4 4)",
+        "MULTIPOINT(0 0, 2 2)",
+        "MULTIPOINT(3 3, 4 4)");
+}
+
+template <typename Tup>
+inline void test_pl()
+{
+    test_one<Pt, Ls, Tup>(
+        "POINT(0 0)",
+        "LINESTRING(0 0, 1 1)",
+        "MULTIPOINT()",
+        "MULTILINESTRING((0 0, 1 1))");
+
+    test_one<Pt, MLs, Tup>(
+        "POINT(0 1)",
+        "MULTILINESTRING((0 0, 1 1),(1 1, 2 2),(4 4, 5 5))",
+        "MULTIPOINT(0 1)",
+        "MULTILINESTRING((0 0, 1 1),(1 1, 2 2),(4 4, 5 5))");
+
+    test_one<MPt, Ls, Tup>(
+        "MULTIPOINT(0 0, 1 1, 2 2, 3 3)",
+        "LINESTRING(0 0, 1 1)",
+        "MULTIPOINT(2 2, 3 3)",
+        "MULTILINESTRING((0 0, 1 1))");
+
+    test_one<MPt, MLs, Tup>(
+        "MULTIPOINT(0 0, 1 1, 2 2, 3 3)",
+        "MULTILINESTRING((0 0, 1 1),(1 1, 2 2),(4 4, 5 5))",
+        "MULTIPOINT(3 3)",
+        "MULTILINESTRING((0 0, 1 1),(1 1, 2 2),(4 4, 5 5))");
+}
+
+template <typename Tup>
+inline void test_pa()
+{
+    test_one<Pt, R, Tup>(
+        "POINT(0 0)",
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))",
+        "MULTIPOINT()",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0)))");
+
+    test_one<Pt, Po, Tup>(
+        "POINT(0 0)",
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0))",
+        "MULTIPOINT()",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)))");
+
+    test_one<Pt, Po, Tup>(
+        "POINT(3 3)",
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0))",
+        "MULTIPOINT(3 3)",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)))");
+
+    test_one<Pt, MPo, Tup>(
+        "POINT(2 2)",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)),((0 0, 1 2, 2 2, 2 1, 0 0)))",
+        "MULTIPOINT()",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)),((0 0, 1 2, 2 2, 2 1, 0 0)))");
+
+    test_one<Pt, MPo, Tup>(
+        "POINT(3 3)",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)),((0 0, 1 2, 2 2, 2 1, 0 0)))",
+        "MULTIPOINT(3 3)",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)),((0 0, 1 2, 2 2, 2 1, 0 0)))");
+
+    test_one<Pt, MPo, Tup>(
+        "POINT(6 6)",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)),((0 0, 1 2, 2 2, 2 1, 0 0)))",
+        "MULTIPOINT(6 6)",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)),((0 0, 1 2, 2 2, 2 1, 0 0)))");
+
+    test_one<MPt, R, Tup>(
+        "MULTIPOINT(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6)",
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))",
+        "MULTIPOINT(6 6)",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0)))");
+
+    test_one<MPt, Po, Tup>(
+        "MULTIPOINT(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6)",
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0))",
+        "MULTIPOINT(1 1, 2 2, 3 3, 6 6)",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)))");
+
+    test_one<MPt, MPo, Tup>(
+        "MULTIPOINT(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6)",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)),((0 0, 1 2, 2 2, 2 1, 0 0)))",
+        "MULTIPOINT(3 3, 6 6)",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)),((0 0, 1 2, 2 2, 2 1, 0 0)))");
+}
+
+template <typename Tup>
+inline void test_ll()
+{
+    test_one<Ls, Ls, Tup>(
+        "LINESTRING(0 0, 1 0, 2 1, 3 0)",
+        "LINESTRING(0 0, 1 0, 3 0, 4 0)",
+        "MULTILINESTRING((1 0, 2 1, 3 0))",
+        "MULTILINESTRING((1 0, 3 0, 4 0))");
+
+    test_one<Ls, MLs, Tup>(
+        "LINESTRING(0 0, 1 0, 2 1, 3 0)",
+        "MULTILINESTRING((0 0, 1 0, 3 0),(2 1, 2 2))",
+        "MULTILINESTRING((1 0, 2 1, 3 0))",
+        "MULTILINESTRING((1 0, 3 0),(2 1, 2 2))");
+
+    test_one<MLs, MLs, Tup>(
+        "MULTILINESTRING((0 0, 1 0, 2 1),(2 1, 3 0))",
+        "MULTILINESTRING((0 0, 1 0, 3 0),(2 1, 2 2))",
+        "MULTILINESTRING((1 0, 2 1),(2 1, 3 0))",
+        "MULTILINESTRING((1 0, 3 0),(2 1, 2 2))");
+
+    test_one<Ls, Ls, Tup>(
+        "LINESTRING(0 0, 0 5, 5 5, 5 0, 0 0)",
+        "LINESTRING(0 0, 0 1, 6 1, 5 2, 5 5, 5 6, 4 5, 4 7, 7 7, 7 0, 0 0)",
+        "MULTILINESTRING((0 1, 0 5, 5 5),(5 2, 5 0))",
+        "MULTILINESTRING((0 1, 6 1, 5 2),(5 5, 5 6, 4 5, 4 7, 7 7, 7 0, 5 0))");
+
+    test_one<MLs, MLs, Tup>(
+        "MULTILINESTRING((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0))",
+        "MULTILINESTRING((0 0, 1 4, 5 4, 5 1, 4 1, 0 0),(0 0, 2 1, 2 2, 1 2, 0 0))",
+        "MULTILINESTRING((0 0, 0 5, 5 5, 5 4),(5 1, 5 0, 0 0),(4 4, 4 1))",
+        "MULTILINESTRING((4 4, 5 4),(5 1, 4 1),(0 0, 2 1, 2 2, 1 2, 0 0))");
+}
+
+template <typename Tup>
+inline void test_la()
+{
+    test_one<Ls, R, Tup>(
+        "LINESTRING(0 2, -4 1, 0 0, 5 0, 9 1, 5 2, 9 3, 5 5, 4 9, 4 5, 3 3, 2 5, 2 9, 0 5)",
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))",
+        "MULTILINESTRING((0 2, -4 1, 0 0),(5 0, 9 1, 5 2, 9 3, 5 5, 4 9, 4 5),(2 5, 2 9, 0 5))",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0)))");
+
+    test_one<Ls, Po, Tup>(
+        "LINESTRING(1 4, -4 1, 0 0, 5 0, 9 1, 5 2, 9 3, 5 5, 4 9, 4 5, 3 3, 2 5, 2 9, 0 5)",
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0))",
+        "MULTILINESTRING((0 3.4, -4 1, 0 0),(5 0, 9 1, 5 2, 9 3, 5 5, 4 9, 4 5),(3.5 4, 3 3, 2.5 4),(2 5, 2 9, 0 5))",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)))");
+
+    test_one<MLs, R, Tup>(
+        "MULTILINESTRING((0 2, -4 1, 0 0, 5 0, 9 1, 5 2, 9 3, 5 5, 4 9), (4 9, 4 5, 3 3, 2 5, 2 9, 0 5))",
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))",
+        "MULTILINESTRING((0 2, -4 1, 0 0),(5 0, 9 1, 5 2, 9 3, 5 5, 4 9),(4 9, 4 5),(2 5, 2 9, 0 5))",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0)))");
+
+    test_one<MLs, Po, Tup>(
+        "MULTILINESTRING((1 4, -4 1, 0 0, 5 0, 9 1, 5 2, 9 3, 5 5, 4 9), (4 9, 4 5, 3 3, 2 5, 2 9, 0 5))",
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0))",
+        "MULTILINESTRING((0 3.4, -4 1, 0 0),(5 0, 9 1, 5 2, 9 3, 5 5, 4 9),(4 9, 4 5),(3.5 4, 3 3, 2.5 4),(2 5, 2 9, 0 5))",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)))");
+
+    test_one<MLs, MPo, Tup>(
+        "MULTILINESTRING((1 4, -4 1, 0 0, 5 0, 9 1, 5 2, 9 3, 5 5, 4 9), (4 9, 4 5, 4 4, 2 2, 2 5, 1 9, 0 5))",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)),((0 0, 1 2, 2 2, 2 1, 0 0)))",
+        "MULTILINESTRING((0 3.4, -4 1, 0 0),(5 0, 9 1, 5 2, 9 3, 5 5, 4 9),(4 9, 4 5),(4 4, 2 2, 2 4),(2 5, 1 9, 0 5))",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)),((0 0, 1 2, 2 2, 2 1, 0 0)))");
+
+    test_one<Ls, R, Tup>(
+        "LINESTRING(0 0, 0 5, 5 5, 5 0, 0 0)",
+        "POLYGON((0 0, 0 1, 6 1, 5 2, 5 5, 5 6, 4 5, 4 7, 7 7, 7 0, 0 0))",
+        "MULTILINESTRING((0 1, 0 5, 5 5),(5 2, 5 1))",
+        "MULTIPOLYGON(((0 0, 0 1, 6 1, 5 2, 5 5, 5 6, 4 5, 4 7, 7 7, 7 0, 0 0)))");
+
+    test_one<MLs, Po, Tup>(
+        "MULTILINESTRING((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0))",
+        "POLYGON((0 0, 1 4, 5 4, 5 1, 4 1, 0 0),(0 0, 2 1, 2 2, 1 2, 0 0))",
+        "MULTILINESTRING((0 0, 0 5, 5 5, 5 4),(5 1, 5 0, 0 0))",
+        "MULTIPOLYGON(((0 0, 1 4, 5 4, 5 1, 4 1, 0 0),(0 0, 2 1, 2 2, 1 2, 0 0)))");
+}
+
+template <typename Tup>
+inline void test_aa()
+{
+    test_one<R, R, Tup>(
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))",
+        "POLYGON((0 0, 0 1, 6 1, 5 2, 5 5, 5 6, 4 5, 4 7, 7 7, 7 0, 0 0))",
+        "MULTIPOLYGON(((0 1,0 5,5 5,5 1,0 1)))",
+        "MULTIPOLYGON(((5 1,6 1,5 2,5 5,5 6,4 5,4 7,7 7,7 0,5 0,5 1)))");
+
+    test_one<R, MPo, Tup>(
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))",
+        "MULTIPOLYGON(((0 0, 0 1, 6 1, 6 0, 0 0)),"
+                     "((6 1, 5 2, 5 5, 5 6, 4 5, 4 7, 7 7, 7 1, 6 1)))",
+        "MULTIPOLYGON(((0 1,0 5,5 5,5 1,0 1)))",
+        "MULTIPOLYGON(((5 1,6 1,6 0,5 0,5 1)),((5 2,5 5,5 6,4 5,4 7,7 7,7 1,6 1,5 2)))");
+
+    test_one<Po, Po, Tup>(
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0))",
+        "POLYGON((0 0, 1 4, 5 4, 5 1, 4 1, 0 0),(0 0, 2 1, 2 2, 1 2, 0 0))",
+        "MULTIPOLYGON(((5 1,5 0,0 0,4 1,5 1)),((5 4,1 4,0 0,0 5,5 5,5 4)))",
+        "MULTIPOLYGON(((1 4,4 4,4 1,0 0,1 4),(0 0,2 1,2 2,1 2,0 0)))");
+
+    test_one<Po, MPo, Tup>(
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0))",
+        "MULTIPOLYGON(((0 0, 1 4, 5 4, 5 1, 4 1, 0 0),(0 0, 2 1, 2 2, 1 2, 0 0)),"
+                     "((5 0, 5 1, 6 1, 6 4, 5 4, 3 6, 2 5, 2 7, 7 7, 7 0 5 0)))",
+        "MULTIPOLYGON(((4 5,5 4,1 4,0 0,0 5,4 5)),((5 1,5 0,0 0,4 1,5 1)))",
+        "MULTIPOLYGON(((5 0,5 1,6 1,6 4,5 4,5 5,4 5,3 6,2 5,2 7,7 7,7 0,5 0)),"
+                     "((1 4,4 4,4 1,0 0,1 4),(0 0,2 1,2 2,1 2,0 0)))");
+
+    test_one<MPo, MPo, Tup>(
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)),"
+                     "((2 6, 2 8, 8 8, 8 5, 7 5, 7 6, 2 6)))",
+        "MULTIPOLYGON(((0 0, 1 4, 5 4, 5 1, 4 1, 0 0),(0 0, 2 1, 2 2, 1 2, 0 0)),"
+                     "((5 0, 5 1, 6 1, 6 4, 5 4, 3 6, 2 5, 2 7, 7 7, 7 0 5 0)))",
+        "MULTIPOLYGON(((4 5,5 4,1 4,0 0,0 5,4 5)),"
+                     "((5 1,5 0,0 0,4 1,5 1)),"
+                     "((2 7,2 8,8 8,8 5,7 5,7 6,7 7,2 7)))",
+        "MULTIPOLYGON(((1 4,4 4,4 1,0 0,1 4),(0 0,2 1,2 2,1 2,0 0)),"
+                     "((5 1,6 1,6 4,5 4,5 5,4 5,3 6,7 6,7 5,7 0,5 0,5 1)),"
+                     "((3 6,2 5,2 6,3 6)))");
+}
+
+template <typename Tup>
+inline void test_pair()
+{
+    test_pp<Tup>();
+    test_pl<Tup>();
+    test_ll<Tup>();
+}
+
+template <typename Tup>
+inline void test_tuple()
+{
+    test_pp<Tup>();
+    test_pl<Tup>();
+    test_pa<Tup>();
+    test_ll<Tup>();
+    test_la<Tup>();
+    test_aa<Tup>();
+}
+
+int test_main(int, char* [])
+{
+    test_pair<std::pair<MPt, MLs> >();
+    test_tuple<boost::tuple<MPt, MLs, MPo> >();
+
+#ifdef BOOST_GEOMETRY_CXX11_TUPLE
+    test_tuple<std::tuple<MPt, MLs, MPo> >();
+#endif
+
+    return 0;
+}

--- a/test/algorithms/set_operations/sym_difference/Jamfile
+++ b/test/algorithms/set_operations/sym_difference/Jamfile
@@ -4,8 +4,8 @@
 # Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
 # Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 #
-# This file was modified by Oracle on 2014, 2015.
-# Modifications copyright (c) 2014-2015, Oracle and/or its affiliates.
+# This file was modified by Oracle on 2014, 2015, 2020.
+# Modifications copyright (c) 2014-2020, Oracle and/or its affiliates.
 #
 # Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 # Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -16,6 +16,7 @@
 
 test-suite boost-geometry-algorithms-sym_difference
     :
-    [ run sym_difference_areal_areal.cpp : : : : algorithms_sym_difference_areal_areal ]
+    [ run sym_difference_areal_areal.cpp   : : : : algorithms_sym_difference_areal_areal ]
     [ run sym_difference_linear_linear.cpp : : : : algorithms_sym_difference_linear_linear ]
+	[ run sym_difference_tupled.cpp        : : : : algorithms_sym_difference_tupled ]
     ;

--- a/test/algorithms/set_operations/sym_difference/sym_difference_tupled.cpp
+++ b/test/algorithms/set_operations/sym_difference/sym_difference_tupled.cpp
@@ -1,0 +1,383 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2020, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+#include <geometry_test_common.hpp>
+
+#include <boost/geometry/algorithms/correct.hpp>
+#include <boost/geometry/algorithms/equals.hpp>
+#include <boost/geometry/algorithms/sym_difference.hpp>
+#include <boost/geometry/geometries/geometries.hpp>
+#include <boost/geometry/io/wkt/wkt.hpp>
+#include <boost/geometry/strategies/cartesian/area.hpp>
+#include <boost/geometry/strategies/cartesian/intersection.hpp>
+#include <boost/geometry/strategies/cartesian/point_in_poly_winding.hpp>
+#include <boost/geometry/strategies/cartesian/point_in_point.hpp>
+
+#include <boost/tuple/tuple.hpp>
+
+typedef bg::model::point<double, 2, bg::cs::cartesian> Pt;
+typedef bg::model::linestring<Pt> Ls;
+typedef bg::model::polygon<Pt> Po;
+typedef bg::model::ring<Pt> R;
+typedef bg::model::multi_point<Pt> MPt;
+typedef bg::model::multi_linestring<Ls> MLs;
+typedef bg::model::multi_polygon<Po> MPo;
+
+#ifdef BOOST_GEOMETRY_CXX11_TUPLE
+
+#include <tuple>
+
+#endif
+
+template <typename G>
+inline void check(std::string const& wkt1,
+                  std::string const& wkt2,
+                  G const& g,
+                  std::string const& expected)
+{
+    G expect;
+    bg::read_wkt(expected, expect);
+    bg::correct(expect);
+    if (! boost::empty(g) || ! boost::empty(expect))
+    {
+        BOOST_CHECK_MESSAGE(
+            // Commented out becasue the output in reversed case may be slightly different
+            //   e.g. different number of duplicated points in MultiPoint
+            //boost::size(g) == boost::size(expect) &&
+            bg::equals(g, expect),
+            wkt1 << " ^ " << wkt2 << " -> " << bg::wkt(g)
+                 << " different than expected: " << expected
+        );
+    }
+}
+
+inline void check(std::string const& wkt1,
+                  std::string const& wkt2,
+                  boost::tuple<MPt, MLs, MPo> const& tup,
+                  std::string const& out_p_str,
+                  std::string const& out_l_str,
+                  std::string const& out_a_str)
+{
+    check(wkt1, wkt2, boost::get<0>(tup), out_p_str);
+    check(wkt1, wkt2, boost::get<1>(tup), out_l_str);
+    check(wkt1, wkt2, boost::get<2>(tup), out_a_str);
+}
+
+inline void check(std::string const& wkt1,
+                  std::string const& wkt2,
+                  std::pair<MPt, MLs> const& pair,
+                  std::string const& out_p_str,
+                  std::string const& out_l_str,
+                  std::string const& )
+{
+    check(wkt1, wkt2, pair.first, out_p_str);
+    check(wkt1, wkt2, pair.second, out_l_str);
+}
+
+#ifdef BOOST_GEOMETRY_CXX11_TUPLE
+
+inline void check(std::string const& wkt1,
+                  std::string const& wkt2,
+                  std::tuple<MPt, MLs, MPo> const& tup,
+                  std::string const& out_p_str,
+                  std::string const& out_l_str,
+                  std::string const& out_a_str)
+{
+    check(wkt1, wkt2, std::get<0>(tup), out_p_str);
+    check(wkt1, wkt2, std::get<1>(tup), out_l_str);
+    check(wkt1, wkt2, std::get<2>(tup), out_a_str);
+}
+
+#endif
+
+template <typename In1, typename In2, typename Tup>
+inline void test_one(std::string const& in1_str,
+                     std::string const& in2_str,
+                     std::string const& out_p_str = "MULTIPOINT()",
+                     std::string const& out_l_str = "MULTILINESTRING()",
+                     std::string const& out_a_str = "MULTIPOLYGON()")
+{
+    In1 in1;
+    bg::read_wkt(in1_str, in1);
+    bg::correct(in1);
+
+    In2 in2;
+    bg::read_wkt(in2_str, in2);
+    bg::correct(in2);
+
+    {
+        Tup result;
+        bg::sym_difference(in1, in2, result);
+        check(in1_str, in2_str, result, out_p_str, out_l_str, out_a_str);
+    }
+    {
+        Tup result;
+        bg::sym_difference(in2, in1, result);
+        check(in1_str, in2_str, result, out_p_str, out_l_str, out_a_str);
+    }
+}
+
+template <typename Tup>
+inline void test_pp()
+{
+    test_one<Pt, Pt, Tup>(
+        "POINT(0 0)",
+        "POINT(0 0)",
+        "MULTIPOINT()");
+
+    test_one<Pt, MPt, Tup>(
+        "POINT(0 0)",
+        "MULTIPOINT(0 0, 1 1)",
+        "MULTIPOINT(1 1)");
+
+    test_one<MPt, MPt, Tup>(
+        "MULTIPOINT(0 0, 1 1, 2 2)",
+        "MULTIPOINT(1 1, 2 2, 3 3)",
+        "MULTIPOINT(0 0, 3 3)");
+}
+
+template <typename Tup>
+inline void test_pl()
+{
+    test_one<Pt, Ls, Tup>(
+        "POINT(0 0)",
+        "LINESTRING(0 0, 1 1)",
+        "MULTIPOINT()",
+        "MULTILINESTRING((0 0, 1 1))");
+
+    test_one<Pt, MLs, Tup>(
+        "POINT(1 1)",
+        "MULTILINESTRING((0 0, 1 1),(1 1, 2 2),(4 4, 5 5))",
+        "MULTIPOINT()",
+        "MULTILINESTRING((0 0, 1 1),(1 1, 2 2),(4 4, 5 5))");
+
+    test_one<MPt, Ls, Tup>(
+        "MULTIPOINT(0 0, 1 1, 2 2, 3 3)",
+        "LINESTRING(0 0, 1 1)",
+        "MULTIPOINT(2 2, 3 3)",
+        "MULTILINESTRING((0 0, 1 1))");
+
+    test_one<MPt, MLs, Tup>(
+        "MULTIPOINT(0 0, 1 1, 2 2, 3 3)",
+        "MULTILINESTRING((0 0, 1 1),(1 1, 2 2),(4 4, 5 5))",
+        "MULTIPOINT(3 3)",
+        "MULTILINESTRING((0 0, 1 1),(1 1, 2 2),(4 4, 5 5))");
+}
+
+template <typename Tup>
+inline void test_pa()
+{
+    test_one<Pt, R, Tup>(
+        "POINT(0 0)",
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))",
+        "MULTIPOINT()",
+        "MULTILINESTRING()",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0)))");
+
+    test_one<Pt, Po, Tup>(
+        "POINT(0 0)",
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0))",
+        "MULTIPOINT()",
+        "MULTILINESTRING()",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)))");
+
+    test_one<Pt, MPo, Tup>(
+        "POINT(0 0)",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)),((0 0, 1 2, 2 2, 2 1, 0 0)))",
+        "MULTIPOINT()",
+        "MULTILINESTRING()",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)),((0 0, 1 2, 2 2, 2 1, 0 0)))");
+
+    test_one<MPt, R, Tup>(
+        "MULTIPOINT(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6)",
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))",
+        "MULTIPOINT(6 6)",
+        "MULTILINESTRING()",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0)))");
+
+    test_one<MPt, Po, Tup>(
+        "MULTIPOINT(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6)",
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0))",
+        "MULTIPOINT(1 1, 2 2, 3 3, 6 6)",
+        "MULTILINESTRING()",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)))");
+
+    test_one<MPt, MPo, Tup>(
+        "MULTIPOINT(0 0, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6)",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)),((0 0, 1 2, 2 2, 2 1, 0 0)))",
+        "MULTIPOINT(3 3, 6 6)",
+        "MULTILINESTRING()",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)),((0 0, 1 2, 2 2, 2 1, 0 0)))");
+}
+
+template <typename Tup>
+inline void test_ll()
+{
+    test_one<Ls, Ls, Tup>(
+        "LINESTRING(0 0, 1 0, 2 1, 3 0)",
+        "LINESTRING(0 0, 1 0, 3 0, 4 0)",
+        "MULTIPOINT()",
+        "MULTILINESTRING((1 0, 2 1, 3 0),(1 0, 3 0, 4 0))");
+
+    test_one<Ls, MLs, Tup>(
+        "LINESTRING(0 0, 1 0, 2 1, 3 0)",
+        "MULTILINESTRING((0 0, 1 0, 3 0),(2 1, 2 2))",
+        "MULTIPOINT()",
+        "MULTILINESTRING((1 0, 2 1, 3 0),(1 0, 3 0),(2 1, 2 2))");
+
+    test_one<MLs, MLs, Tup>(
+        "MULTILINESTRING((0 0, 1 0, 2 1),(2 1, 3 0))",
+        "MULTILINESTRING((0 0, 1 0, 3 0),(2 1, 2 2))",
+        "MULTIPOINT()",
+        "MULTILINESTRING((1 0, 2 1),(2 1, 3 0),(1 0, 3 0),(2 1, 2 2))");
+
+    test_one<Ls, Ls, Tup>(
+        "LINESTRING(0 0, 0 5, 5 5, 5 0, 0 0)",
+        "LINESTRING(0 0, 0 1, 6 1, 5 2, 5 5, 5 6, 4 5, 4 7, 7 7, 7 0, 0 0)",
+        "MULTIPOINT()",
+        "MULTILINESTRING((0 1, 0 5, 5 5),(5 2, 5 0),(0 1, 6 1, 5 2), (5 5, 5 6, 4 5, 4 7, 7 7, 7 0, 5 0))");
+
+    test_one<MLs, MLs, Tup>(
+        "MULTILINESTRING((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0))",
+        "MULTILINESTRING((0 0, 1 4, 5 4, 5 1, 4 1, 0 0),(0 0, 2 1, 2 2, 1 2, 0 0))",
+        "MULTIPOINT()",
+        "MULTILINESTRING((0 0, 0 5, 5 5, 5 4),(5 1, 5 0, 0 0),(4 1, 4 4),(4 4, 5 4),(5 1, 4 1),(0 0, 2 1, 2 2, 1 2, 0 0))");
+}
+
+template <typename Tup>
+inline void test_la()
+{
+    test_one<Ls, R, Tup>(
+        "LINESTRING(0 2, -4 1, 0 0, 5 0, 9 1, 5 2, 9 3, 5 5, 4 9, 4 5, 3 3, 2 5, 2 9, 0 5)",
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))",
+        "MULTIPOINT()",
+        "MULTILINESTRING((0 2, -4 1, 0 0),(5 0, 9 1, 5 2, 9 3, 5 5, 4 9, 4 5),(2 5, 2 9, 0 5))",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0)))");
+
+    test_one<Ls, Po, Tup>(
+        "LINESTRING(1 4, -4 1, 0 0, 5 0, 9 1, 5 2, 9 3, 5 5, 4 9, 4 5, 3 3, 2 5, 2 9, 0 5)",
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0))",
+        "MULTIPOINT()",
+        "MULTILINESTRING((0 3.4, -4 1, 0 0),(5 0, 9 1, 5 2, 9 3, 5 5, 4 9, 4 5),(3.5 4, 3 3, 2.5 4),(2 5, 2 9, 0 5))",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)))");
+
+    test_one<MLs, R, Tup>(
+        "MULTILINESTRING((0 2, -4 1, 0 0, 5 0, 9 1, 5 2, 9 3, 5 5, 4 9), (4 9, 4 5, 3 3, 2 5, 2 9, 0 5))",
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))",
+        "MULTIPOINT()",
+        "MULTILINESTRING((0 2, -4 1, 0 0),(5 0, 9 1, 5 2, 9 3, 5 5, 4 9),(4 9, 4 5),(2 5, 2 9, 0 5))",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0)))");
+
+    test_one<MLs, Po, Tup>(
+        "MULTILINESTRING((1 4, -4 1, 0 0, 5 0, 9 1, 5 2, 9 3, 5 5, 4 9), (4 9, 4 5, 3 3, 2 5, 2 9, 0 5))",
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0))",
+        "MULTIPOINT()",
+        "MULTILINESTRING((0 3.4, -4 1, 0 0),(5 0, 9 1, 5 2, 9 3, 5 5, 4 9),(4 9, 4 5),(3.5 4, 3 3, 2.5 4),(2 5, 2 9, 0 5))",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)))");
+
+    test_one<MLs, MPo, Tup>(
+        "MULTILINESTRING((1 4, -4 1, 0 0, 5 0, 9 1, 5 2, 9 3, 5 5, 4 9), (4 9, 4 5, 4 4, 2 2, 2 5, 1 9, 0 5))",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)),((0 0, 1 2, 2 2, 2 1, 0 0)))",
+        "MULTIPOINT()",
+        "MULTILINESTRING((0 3.4, -4 1, 0 0),(5 0, 9 1, 5 2, 9 3, 5 5, 4 9),(4 9, 4 5),(4 4, 2 2, 2 4),(2 5, 1 9, 0 5))",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)),((0 0, 1 2, 2 2, 2 1, 0 0)))");
+
+    test_one<Ls, R, Tup>(
+        "LINESTRING(0 0, 0 5, 5 5, 5 0, 0 0)",
+        "POLYGON((0 0, 0 1, 6 1, 5 2, 5 5, 5 6, 4 5, 4 7, 7 7, 7 0, 0 0))",
+        "MULTIPOINT()",
+        "MULTILINESTRING((0 1, 0 5, 5 5),(5 2, 5 1))",
+        "MULTIPOLYGON(((0 0, 0 1, 6 1, 5 2, 5 5, 5 6, 4 5, 4 7, 7 7, 7 0, 0 0)))");
+
+    test_one<MLs, Po, Tup>(
+        "MULTILINESTRING((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0))",
+        "POLYGON((0 0, 1 4, 5 4, 5 1, 4 1, 0 0),(0 0, 2 1, 2 2, 1 2, 0 0))",
+        "MULTIPOINT()",
+        "MULTILINESTRING((0 0, 0 5, 5 5, 5 4),(5 1, 5 0, 0 0))",
+        "MULTIPOLYGON(((0 0, 1 4, 5 4, 5 1, 4 1, 0 0),(0 0, 2 1, 2 2, 1 2, 0 0)))");
+}
+
+template <typename Tup>
+inline void test_aa()
+{
+    test_one<R, R, Tup>(
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))",
+        "POLYGON((0 0, 0 1, 6 1, 5 2, 5 5, 5 6, 4 5, 4 7, 7 7, 7 0, 0 0))",
+        "MULTIPOINT()",
+        "MULTILINESTRING()",
+        "MULTIPOLYGON(((4 5,4 7,7 7,7 0,5 0,5 1,0 1,0 5,4 5),(5 5,5 6,4 5,5 5),(5 2,5 1,6 1,5 2)))");
+
+    test_one<R, MPo, Tup>(
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))",
+        "MULTIPOLYGON(((0 0, 0 1, 6 1, 6 0, 0 0)),"
+                     "((6 1, 5 2, 5 5, 5 6, 4 5, 4 7, 7 7, 7 1, 6 1)))",
+        "MULTIPOINT()",
+        "MULTILINESTRING()",
+        "MULTIPOLYGON(((4 5,4 7,7 7,7 1,6 1,5 2,5 1,0 1,0 5,4 5),(5 5,5 6,4 5,5 5)),"
+                     "((5 1,6 1,6 0,5 0,5 1)))");
+
+    test_one<Po, Po, Tup>(
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0))",
+        "POLYGON((0 0, 1 4, 5 4, 5 1, 4 1, 0 0),(0 0, 2 1, 2 2, 1 2, 0 0))",
+        "MULTIPOINT()",
+        "MULTILINESTRING()",
+        "MULTIPOLYGON(((4 1,5 1,5 0,0 0,0 5,5 5,5 4,4 4,4 1),(0 0,2 1,2 2,1 2,0 0)))");
+
+    test_one<Po, MPo, Tup>(
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0))",
+        "MULTIPOLYGON(((0 0, 1 4, 5 4, 5 1, 4 1, 0 0),(0 0, 2 1, 2 2, 1 2, 0 0)),"
+                     "((5 0, 5 1, 6 1, 6 4, 5 4, 3 6, 2 5, 2 7, 7 7, 7 0 5 0)))",
+        "MULTIPOINT()",
+        "MULTILINESTRING()",
+        "MULTIPOLYGON(((0 0,0 5,2 5,2 7,7 7,7 0,0 0),"
+                        "(4 4,4 1,5 1,6 1,6 4,4 4),(5 4,5 5,4 5,5 4),"
+                        "(0 0,2 1,2 2,1 2,0 0),(4 5,3 6,2 5,4 5)))");
+
+    test_one<MPo, MPo, Tup>(
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)),"
+                     "((2 6, 2 8, 8 8, 8 5, 7 5, 7 6, 2 6)))",
+        "MULTIPOLYGON(((0 0, 1 4, 5 4, 5 1, 4 1, 0 0),(0 0, 2 1, 2 2, 1 2, 0 0)),"
+                     "((5 0, 5 1, 6 1, 6 4, 5 4, 3 6, 2 5, 2 7, 7 7, 7 0 5 0)))",
+        "MULTIPOINT()",
+        "MULTILINESTRING()",
+        "MULTIPOLYGON(((0 0,0 5,4 5,3 6,7 6,7 7,2 7,2 8,8 8,8 5,7 5,7 0,0 0),"
+                        "(4 4,4 1,5 1,6 1,6 4,4 4),(5 4,5 5,4 5,5 4),(0 0,2 1,2 2,1 2,0 0)),"
+                     "((2 5,2 6,3 6,2 5)))");
+}
+
+template <typename Tup>
+inline void test_pair()
+{
+    test_pp<Tup>();
+    test_pl<Tup>();
+    test_ll<Tup>();
+}
+
+template <typename Tup>
+inline void test_tuple()
+{
+    test_pp<Tup>();
+    test_pl<Tup>();
+    test_pa<Tup>();
+    test_ll<Tup>();
+    test_la<Tup>();
+    test_aa<Tup>();
+}
+
+int test_main(int, char* [])
+{
+    test_pair<std::pair<MPt, MLs> >();
+    test_tuple<boost::tuple<MPt, MLs, MPo> >();
+
+#ifdef BOOST_GEOMETRY_CXX11_TUPLE
+    test_tuple<std::tuple<MPt, MLs, MPo> >();
+#endif
+
+    return 0;
+}

--- a/test/algorithms/set_operations/union/Jamfile
+++ b/test/algorithms/set_operations/union/Jamfile
@@ -4,8 +4,8 @@
 # Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
 # Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 #
-# This file was modified by Oracle on 2014, 2015, 2017, 2018.
-# Modifications copyright (c) 2014-2018, Oracle and/or its affiliates.
+# This file was modified by Oracle on 2014, 2015, 2017, 2018, 2020.
+# Modifications copyright (c) 2014-2020, Oracle and/or its affiliates.
 #
 # Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 # Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -24,4 +24,5 @@ test-suite boost-geometry-algorithms-union
     [ run union_multi.cpp         : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE
                                         : algorithms_union_multi ]
     [ run union_pl_pl.cpp         : : : : algorithms_union_pl_pl ]
+	[ run union_tupled.cpp        : : : : algorithms_union_tupled ]
     ;

--- a/test/algorithms/set_operations/union/union_tupled.cpp
+++ b/test/algorithms/set_operations/union/union_tupled.cpp
@@ -1,0 +1,388 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2020, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+#include <geometry_test_common.hpp>
+
+#include <boost/geometry/algorithms/correct.hpp>
+#include <boost/geometry/algorithms/equals.hpp>
+#include <boost/geometry/algorithms/union.hpp>
+#include <boost/geometry/geometries/geometries.hpp>
+#include <boost/geometry/io/wkt/wkt.hpp>
+#include <boost/geometry/strategies/cartesian/area.hpp>
+#include <boost/geometry/strategies/cartesian/intersection.hpp>
+#include <boost/geometry/strategies/cartesian/point_in_poly_winding.hpp>
+#include <boost/geometry/strategies/cartesian/point_in_point.hpp>
+
+#include <boost/tuple/tuple.hpp>
+
+typedef bg::model::point<double, 2, bg::cs::cartesian> Pt;
+typedef bg::model::linestring<Pt> Ls;
+typedef bg::model::polygon<Pt> Po;
+typedef bg::model::ring<Pt> R;
+typedef bg::model::multi_point<Pt> MPt;
+typedef bg::model::multi_linestring<Ls> MLs;
+typedef bg::model::multi_polygon<Po> MPo;
+
+#ifdef BOOST_GEOMETRY_CXX11_TUPLE
+
+#include <tuple>
+
+#endif
+
+template <typename G>
+inline void check(std::string const& wkt1,
+                  std::string const& wkt2,
+                  G const& g,
+                  std::string const& expected)
+{
+    G expect;
+    bg::read_wkt(expected, expect);
+    bg::correct(expect);
+    if (! boost::empty(g) || ! boost::empty(expect))
+    {
+        BOOST_CHECK_MESSAGE(
+            // Commented out becasue the output in reversed case may be slightly different
+            //   e.g. different number of duplicated points in MultiPoint
+            //boost::size(g) == boost::size(expect) &&
+            bg::equals(g, expect),
+            wkt1 << " + " << wkt2 << " -> " << bg::wkt(g)
+                 << " different than expected: " << expected
+        );
+    }
+}
+
+inline void check(std::string const& wkt1,
+                  std::string const& wkt2,
+                  boost::tuple<MPt, MLs, MPo> const& tup,
+                  std::string const& out_p_str,
+                  std::string const& out_l_str,
+                  std::string const& out_a_str)
+{
+    check(wkt1, wkt2, boost::get<0>(tup), out_p_str);
+    check(wkt1, wkt2, boost::get<1>(tup), out_l_str);
+    check(wkt1, wkt2, boost::get<2>(tup), out_a_str);
+}
+
+inline void check(std::string const& wkt1,
+                  std::string const& wkt2,
+                  std::pair<MPt, MLs> const& pair,
+                  std::string const& out_p_str,
+                  std::string const& out_l_str,
+                  std::string const& )
+{
+    check(wkt1, wkt2, pair.first, out_p_str);
+    check(wkt1, wkt2, pair.second, out_l_str);
+}
+
+#ifdef BOOST_GEOMETRY_CXX11_TUPLE
+
+inline void check(std::string const& wkt1,
+                  std::string const& wkt2,
+                  std::tuple<MPt, MLs, MPo> const& tup,
+                  std::string const& out_p_str,
+                  std::string const& out_l_str,
+                  std::string const& out_a_str)
+{
+    check(wkt1, wkt2, std::get<0>(tup), out_p_str);
+    check(wkt1, wkt2, std::get<1>(tup), out_l_str);
+    check(wkt1, wkt2, std::get<2>(tup), out_a_str);
+}
+
+#endif
+
+template <typename In1, typename In2, typename Tup>
+inline void test_one(std::string const& in1_str,
+                     std::string const& in2_str,
+                     std::string const& out_p_str = "MULTIPOINT()",
+                     std::string const& out_l_str = "MULTILINESTRING()",
+                     std::string const& out_a_str = "MULTIPOLYGON()")
+{
+    In1 in1;
+    bg::read_wkt(in1_str, in1);
+    bg::correct(in1);
+
+    In2 in2;
+    bg::read_wkt(in2_str, in2);
+    bg::correct(in2);
+
+    {
+        Tup result;
+        bg::union_(in1, in2, result);
+        check(in1_str, in2_str, result, out_p_str, out_l_str, out_a_str);
+    }
+    {
+        Tup result;
+        bg::union_(in2, in1, result);
+        check(in1_str, in2_str, result, out_p_str, out_l_str, out_a_str);
+    }
+}
+
+template <typename Tup>
+inline void test_pp()
+{
+    test_one<Pt, Pt, Tup>(
+        "POINT(0 0)",
+        "POINT(0 0)",
+        "MULTIPOINT(0 0)");
+
+    test_one<Pt, MPt, Tup>(
+        "POINT(0 0)",
+        "MULTIPOINT(0 0, 1 1)",
+        "MULTIPOINT(0 0, 1 1)");
+
+    test_one<MPt, MPt, Tup>(
+        "MULTIPOINT(0 0, 1 1, 2 2)",
+        "MULTIPOINT(1 1, 2 2, 3 3)",
+        "MULTIPOINT(0 0, 1 1, 2 2, 3 3)");
+}
+
+template <typename Tup>
+inline void test_pl()
+{
+    test_one<Pt, Ls, Tup>(
+        "POINT(0 0)",
+        "LINESTRING(0 0, 1 1)",
+        "MULTIPOINT()",
+        "MULTILINESTRING((0 0, 1 1))");
+
+    test_one<Pt, Ls, Tup>(
+        "POINT(2 2)",
+        "LINESTRING(0 0, 1 1)",
+        "MULTIPOINT(2 2)",
+        "MULTILINESTRING((0 0, 1 1))");
+
+    test_one<Pt, MLs, Tup>(
+        "POINT(1 1)",
+        "MULTILINESTRING((0 0, 1 1),(1 1, 2 2),(4 4, 5 5))",
+        "MULTIPOINT()",
+        "MULTILINESTRING((0 0, 1 1),(1 1, 2 2),(4 4, 5 5))");
+
+    test_one<MPt, Ls, Tup>(
+        "MULTIPOINT(0 0, 1 1, 2 2, 3 3)",
+        "LINESTRING(0 0, 1 1)",
+        "MULTIPOINT(2 2, 3 3)",
+        "MULTILINESTRING((0 0, 1 1))");
+
+    test_one<MPt, MLs, Tup>(
+        "MULTIPOINT(0 0, 1 1, 2 2, 3 3)",
+        "MULTILINESTRING((0 0, 1 1),(1 1, 2 2),(4 4, 5 5))",
+        "MULTIPOINT(3 3)",
+        "MULTILINESTRING((0 0, 1 1),(1 1, 2 2),(4 4, 5 5))");
+}
+
+template <typename Tup>
+inline void test_pa()
+{
+    test_one<Pt, R, Tup>(
+        "POINT(0 0)",
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))",
+        "MULTIPOINT()",
+        "MULTILINESTRING()",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0)))");
+
+    test_one<Pt, Po, Tup>(
+        "POINT(2 2)",
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0))",
+        "MULTIPOINT(2 2)",
+        "MULTILINESTRING()",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)))");
+
+    test_one<Pt, MPo, Tup>(
+        "POINT(2 2)",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)),((0 0, 1 2, 2 2, 2 1, 0 0)))",
+        "MULTIPOINT()",
+        "MULTILINESTRING()",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)),((0 0, 1 2, 2 2, 2 1, 0 0)))");
+
+    test_one<MPt, R, Tup>(
+        "MULTIPOINT(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6)",
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))",
+        "MULTIPOINT(6 6)",
+        "MULTILINESTRING()",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0)))");
+
+    test_one<MPt, Po, Tup>(
+        "MULTIPOINT(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6)",
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0))",
+        "MULTIPOINT(1 1, 2 2, 3 3, 6 6)",
+        "MULTILINESTRING()",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)))");
+
+    test_one<MPt, MPo, Tup>(
+        "MULTIPOINT(0 0, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6)",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)),((0 0, 1 2, 2 2, 2 1, 0 0)))",
+        "MULTIPOINT(3 3, 6 6)",
+        "MULTILINESTRING()",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)),((0 0, 1 2, 2 2, 2 1, 0 0)))");
+}
+
+template <typename Tup>
+inline void test_ll()
+{
+    test_one<Ls, Ls, Tup>(
+        "LINESTRING(0 0, 1 0, 2 1, 3 0)",
+        "LINESTRING(0 0, 1 0, 3 0, 4 0)",
+        "MULTIPOINT()",
+        "MULTILINESTRING((0 0,1 0,2 1,3 0),(1 0,3 0,4 0))");
+
+    test_one<Ls, MLs, Tup>(
+        "LINESTRING(0 0, 1 0, 2 1, 3 0)",
+        "MULTILINESTRING((0 0, 1 0, 3 0),(2 1, 2 2))",
+        "MULTIPOINT()",
+        "MULTILINESTRING((0 0,1 0,2 1,3 0),(1 0,3 0),(2 1,2 2))");
+
+    test_one<MLs, MLs, Tup>(
+        "MULTILINESTRING((0 0, 1 0, 2 1),(2 1, 3 0))",
+        "MULTILINESTRING((0 0, 1 0, 3 0),(2 1, 2 2))",
+        "MULTIPOINT()",
+        "MULTILINESTRING((0 0,1 0,3 0),(2 1,2 2),(1 0,2 1),(2 1,3 0))");
+
+    test_one<Ls, Ls, Tup>(
+        "LINESTRING(0 0, 0 5, 5 5, 5 0, 0 0)",
+        "LINESTRING(0 0, 0 1, 6 1, 5 2, 5 5, 5 6, 4 5, 4 7, 7 7, 7 0, 0 0)",
+        "MULTIPOINT()",
+        "MULTILINESTRING((0 0,0 5,5 5,5 0,0 0),(0 1,6 1,5 2),"
+                        "(5 5,5 6,4 5,4 7,7 7,7 0,5 0))");
+
+    test_one<MLs, MLs, Tup>(
+        "MULTILINESTRING((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0))",
+        "MULTILINESTRING((0 0, 1 4, 5 4, 5 1, 4 1, 0 0),(0 0, 2 1, 2 2, 1 2, 0 0))",
+        "MULTIPOINT()",
+        "MULTILINESTRING((0 0,1 4,5 4,5 1,4 1,0 0),(0 0,2 1,2 2,1 2,0 0),"
+                        "(0 0,0 5,5 5,5 4),(5 1,5 0,0 0),(4 1,4 4))");
+}
+
+template <typename Tup>
+inline void test_la()
+{
+    test_one<Ls, R, Tup>(
+        "LINESTRING(0 2, -4 1, 0 0, 5 0, 9 1, 5 2, 9 3, 5 5, 4 9, 4 5, 3 3, 2 5, 2 9, 0 5)",
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))",
+        "MULTIPOINT()",
+        "MULTILINESTRING((0 2, -4 1, 0 0),(5 0, 9 1, 5 2, 9 3, 5 5, 4 9, 4 5),(2 5, 2 9, 0 5))",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0)))");
+
+    test_one<Ls, Po, Tup>(
+        "LINESTRING(1 4, -4 1, 0 0, 5 0, 9 1, 5 2, 9 3, 5 5, 4 9, 4 5, 3 3, 2 5, 2 9, 0 5)",
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0))",
+        "MULTIPOINT()",
+        "MULTILINESTRING((0 3.4, -4 1, 0 0),(5 0, 9 1, 5 2, 9 3, 5 5, 4 9, 4 5),(3.5 4, 3 3, 2.5 4),(2 5, 2 9, 0 5))",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)))");
+
+    test_one<MLs, R, Tup>(
+        "MULTILINESTRING((0 2, -4 1, 0 0, 5 0, 9 1, 5 2, 9 3, 5 5, 4 9), (4 9, 4 5, 3 3, 2 5, 2 9, 0 5))",
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))",
+        "MULTIPOINT()",
+        "MULTILINESTRING((0 2, -4 1, 0 0),(5 0, 9 1, 5 2, 9 3, 5 5, 4 9),(4 9, 4 5),(2 5, 2 9, 0 5))",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0)))");
+
+    test_one<MLs, Po, Tup>(
+        "MULTILINESTRING((1 4, -4 1, 0 0, 5 0, 9 1, 5 2, 9 3, 5 5, 4 9), (4 9, 4 5, 3 3, 2 5, 2 9, 0 5))",
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0))",
+        "MULTIPOINT()",
+        "MULTILINESTRING((0 3.4, -4 1, 0 0),(5 0, 9 1, 5 2, 9 3, 5 5, 4 9),(4 9, 4 5),(3.5 4, 3 3, 2.5 4),(2 5, 2 9, 0 5))",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)))");
+
+    test_one<MLs, MPo, Tup>(
+        "MULTILINESTRING((1 4, -4 1, 0 0, 5 0, 9 1, 5 2, 9 3, 5 5, 4 9), (4 9, 4 5, 4 4, 2 2, 2 5, 1 9, 0 5))",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)),((0 0, 1 2, 2 2, 2 1, 0 0)))",
+        "MULTIPOINT()",
+        "MULTILINESTRING((0 3.4, -4 1, 0 0),(5 0, 9 1, 5 2, 9 3, 5 5, 4 9),(4 9, 4 5),(4 4, 2 2, 2 4),(2 5, 1 9, 0 5))",
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)),((0 0, 1 2, 2 2, 2 1, 0 0)))");
+
+    test_one<Ls, R, Tup>(
+        "LINESTRING(0 0, 0 5, 5 5, 5 0, 0 0)",
+        "POLYGON((0 0, 0 1, 6 1, 5 2, 5 5, 5 6, 4 5, 4 7, 7 7, 7 0, 0 0))",
+        "MULTIPOINT()",
+        "MULTILINESTRING((0 1, 0 5, 5 5),(5 2, 5 1))",
+        "MULTIPOLYGON(((0 0, 0 1, 6 1, 5 2, 5 5, 5 6, 4 5, 4 7, 7 7, 7 0, 0 0)))");
+
+    test_one<MLs, Po, Tup>(
+        "MULTILINESTRING((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0))",
+        "POLYGON((0 0, 1 4, 5 4, 5 1, 4 1, 0 0),(0 0, 2 1, 2 2, 1 2, 0 0))",
+        "MULTIPOINT()",
+        "MULTILINESTRING((0 0, 0 5, 5 5, 5 4),(5 1, 5 0, 0 0))",
+        "MULTIPOLYGON(((0 0, 1 4, 5 4, 5 1, 4 1, 0 0),(0 0, 2 1, 2 2, 1 2, 0 0)))");
+}
+
+template <typename Tup>
+inline void test_aa()
+{
+    test_one<R, R, Tup>(
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))",
+        "POLYGON((0 0, 0 1, 6 1, 5 2, 5 5, 5 6, 4 5, 4 7, 7 7, 7 0, 0 0))",
+        "MULTIPOINT()",
+        "MULTILINESTRING()",
+        "MULTIPOLYGON(((0 5,4 5,4 7,7 7,7 0,0 0,0 5),(5 1,6 1,5 2,5 1),(5 5,5 6,4 5,5 5)))");
+
+    test_one<R, MPo, Tup>(
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))",
+        "MULTIPOLYGON(((0 0, 0 1, 6 1, 6 0, 0 0)),"
+                     "((6 1, 5 2, 5 5, 5 6, 4 5, 4 7, 7 7, 7 1, 6 1)))",
+        "MULTIPOINT()",
+        "MULTILINESTRING()",
+        "MULTIPOLYGON(((0 5,4 5,4 7,7 7,7 1,6 1,6 0,0 0,0 5),(5 1,6 1,5 2,5 1),(5 5,5 6,4 5,5 5)))");
+
+    test_one<Po, Po, Tup>(
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0))",
+        "POLYGON((0 0, 1 4, 5 4, 5 1, 4 1, 0 0),(0 0, 2 1, 2 2, 1 2, 0 0))",
+        "MULTIPOINT()",
+        "MULTILINESTRING()",
+        "MULTIPOLYGON(((5 0,0 0,0 5,5 5,5 0),(0 0,2 1,2 2,1 2,0 0)))");
+
+    test_one<Po, MPo, Tup>(
+        "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0))",
+        "MULTIPOLYGON(((0 0, 1 4, 5 4, 5 1, 4 1, 0 0),(0 0, 2 1, 2 2, 1 2, 0 0)),"
+                     "((5 0, 5 1, 6 1, 6 4, 5 4, 3 6, 2 5, 2 7, 7 7, 7 0 5 0)))",
+        "MULTIPOINT()",
+        "MULTILINESTRING()",
+        "MULTIPOLYGON(((2 5,2 7,7 7,7 0,0 0,0 5,2 5),(4 5,3 6,2 5,4 5),"
+                      "(5 4,5 1,6 1,6 4,5 4),(0 0,2 1,2 2,1 2,0 0)))");
+
+    test_one<MPo, MPo, Tup>(
+        "MULTIPOLYGON(((0 0, 0 5, 5 5, 5 0, 0 0),(0 0, 4 1, 4 4, 1 4, 0 0)),"
+                     "((2 6, 2 8, 8 8, 8 5, 7 5, 7 6, 2 6)))",
+        "MULTIPOLYGON(((0 0, 1 4, 5 4, 5 1, 4 1, 0 0),(0 0, 2 1, 2 2, 1 2, 0 0)),"
+                     "((5 0, 5 1, 6 1, 6 4, 5 4, 3 6, 2 5, 2 7, 7 7, 7 0 5 0)))",
+        "MULTIPOINT()",
+        "MULTILINESTRING()",
+        "MULTIPOLYGON(((0 0,0 5,2 5,2 7,2 8,8 8,8 5,7 5,7 0,0 0),"
+                      "(5 4,5 1,6 1,6 4,5 4),(0 0,2 1,2 2,1 2,0 0),(4 5,3 6,2 5,4 5)))");
+}
+
+template <typename Tup>
+inline void test_pair()
+{
+    test_pp<Tup>();
+    test_pl<Tup>();
+    test_ll<Tup>();
+}
+
+template <typename Tup>
+inline void test_tuple()
+{
+    test_pp<Tup>();
+    test_pl<Tup>();
+    test_pa<Tup>();
+    test_ll<Tup>();
+    test_la<Tup>();
+    test_aa<Tup>();
+}
+
+int test_main(int, char* [])
+{
+    test_pair<std::pair<MPt, MLs> >();
+    test_tuple<boost::tuple<MPt, MLs, MPo> >();
+
+#ifdef BOOST_GEOMETRY_CXX11_TUPLE
+    test_tuple<std::tuple<MPt, MLs, MPo> >();
+#endif
+
+    return 0;
+}


### PR DESCRIPTION
This is a followup PR after https://github.com/boostorg/geometry/pull/650

It adds support for tupled-output in the rest of set operations. The interface is the same for all of them and allows the user to use the same output type. Here is an example:
```
polygon po1, po2;
bg::read_wkt("POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))", po1);
bg::read_wkt("POLYGON((0 0, 0 1, 6 1, 5 2, 5 5, 5 6, 4 5, 4 7, 7 7, 7 0, 0 0))", po2);
bg::correct(po1);
bg::correct(po2);

std::tuple<multi_point, multi_linestring, multi_polygon> d, i, sd, u;
bg::difference(po1, po2, d);
bg::intersection(po1, po2, i);
bg::sym_difference(po1, po2, sd);
bg::union_(po1, po2, u);

auto print_result = [&](char op, auto const& res) {
    std::cout << bg::wkt(po1) << ' ' << op << ' ' << bg::wkt(po2) << '\n'
                << bg::wkt(std::get<0>(res)) << '\n'
                << bg::wkt(std::get<1>(res)) << '\n'
                << bg::wkt(std::get<2>(res)) << '\n'
                << std::endl;
};

print_result('-', d);
print_result('*', i);
print_result('^', sd);
print_result('+', u);
```
![image](https://user-images.githubusercontent.com/1226951/79127903-f06bec00-7da2-11ea-9669-92c6064fe3a0.png)

The output is:
```
POLYGON((0 0,0 5,5 5,5 0,0 0)) - POLYGON((0 0,0 1,6 1,5 2,5 5,5 6,4 5,4 7,7 7,7 0,0 0))
MULTIPOINT()
MULTILINESTRING()
MULTIPOLYGON(((0 1,0 5,5 5,5 1,0 1)))
```
![image](https://user-images.githubusercontent.com/1226951/79128046-2c9f4c80-7da3-11ea-9e6a-ed617ca38d2c.png)

```
POLYGON((0 0,0 5,5 5,5 0,0 0)) * POLYGON((0 0,0 1,6 1,5 2,5 5,5 6,4 5,4 7,7 7,7 0,0 0))
MULTIPOINT((4 5))
MULTILINESTRING((5 5,5 2))
MULTIPOLYGON(((0 1,5 1,5 0,0 0,0 1)))
```
![image](https://user-images.githubusercontent.com/1226951/79128203-6e2ff780-7da3-11ea-8d6c-6ff7c07d63c2.png)

```
POLYGON((0 0,0 5,5 5,5 0,0 0)) ^ POLYGON((0 0,0 1,6 1,5 2,5 5,5 6,4 5,4 7,7 7,7 0,0 0))
MULTIPOINT()
MULTILINESTRING()
MULTIPOLYGON(((4 5,4 7,7 7,7 0,5 0,5 1,0 1,0 5,4 5),(5 5,5 6,4 5,5 5),(5 2,5 1,6 1,5 2)))
```
![image](https://user-images.githubusercontent.com/1226951/79128256-7f790400-7da3-11ea-9cb9-b87db9579189.png)

```
POLYGON((0 0,0 5,5 5,5 0,0 0)) + POLYGON((0 0,0 1,6 1,5 2,5 5,5 6,4 5,4 7,7 7,7 0,0 0))
MULTIPOINT()
MULTILINESTRING()
MULTIPOLYGON(((0 5,4 5,4 7,7 7,7 0,0 0,0 5),(5 1,6 1,5 2,5 1),(5 5,5 6,4 5,5 5)))
```
![image](https://user-images.githubusercontent.com/1226951/79128278-86a01200-7da3-11ea-87ea-33afc9c4a3f7.png)

Note that in this case the set operations other than intersection can produce only multi polygon but this is not the case when the input has different topological dimention. E.g. when a linestring and a polygon is passed into union the result will be a polygon and the difference of the linestring and the polygon. So the use of tupled output will have more sense.