### PR TITLE
Tweaked exception text in case problem is with invalid whitespace

### DIFF
--- a/include/boost/geometry/io/wkt/read.hpp
+++ b/include/boost/geometry/io/wkt/read.hpp
@@ -82,6 +82,12 @@ struct read_wkt_exception : public geometry::exception
             source += "'";
         }
         complete = message + source + " in '" + wkt.substr(0, 100) + "'";
+        // add extra diagnostic message if the problematic token included
+        // common invalid whitespace characters to help users
+        if (it->find_first_of("\t\r\n") != std::string::npos)
+        {
+			complete += "\n(note: newline and tab characters are not allowed in WKT)";
+		}
     }
 
     read_wkt_exception(std::string const& msg, std::string const& wkt)


### PR DESCRIPTION
Clarify exception text in case the parsing error might be the result of the string including tab ('\t') or newline ('\r' or '\n') character. Suggestion for #703 

In my opinion, current exception text can be hard to interpret in this case. Since looking at the output, all whitespace looks similar, it might not be obvious which character is problematic. E.g.
```
Too many tokens at '
' in 'LINESTRING(1.0 2.0, 2.0 1.0)
'
```

or especially:
```
bad lexical cast: source type value could not be interpreted as target at '
' in 'LINESTRING(1.0 2.0, 
 2.0 1.0)'
```
since this looks like a regular line break in my terminal.

