### PR TITLE
Add custom pack allocator to r-tree constructor

### DIFF
--- a/doc/geometry.qbk
+++ b/doc/geometry.qbk
@@ -119,6 +119,7 @@ Boost.Geometry contains contributions by:
 * Adeel Ahmad (Karney's solution of direct and inverse geodesic problems)
 * Yaghyavardhan Singh Khangarot (discrete Frechet and Hausdorff distance)
 * Tinko Bartels (Delaunay triangulation, Voronoi diagram, random point generation, ...)
+* Caian Benedicto (patch for temporary allocator support)
 
 [include imports.qbk]
 

--- a/include/boost/geometry/index/detail/rtree/pack_create.hpp
+++ b/include/boost/geometry/index/detail/rtree/pack_create.hpp
@@ -3,6 +3,7 @@
 // R-tree initial packing
 //
 // Copyright (c) 2011-2017 Adam Wulkiewicz, Lodz, Poland.
+// Copyright (c) 2020 Caian Benedicto, Campinas, Brazil.
 //
 // This file was modified by Oracle on 2019.
 // Modifications copyright (c) 2019 Oracle and/or its affiliates.

--- a/include/boost/geometry/index/detail/rtree/pack_create.hpp
+++ b/include/boost/geometry/index/detail/rtree/pack_create.hpp
@@ -167,6 +167,19 @@ public:
                        translator_type const& translator,
                        allocators_type & allocators)
     {
+        return apply(first, last, values_count, leafs_level, parameters, translator,
+                     allocators, boost::container::new_allocator<void>());
+    }
+
+    template <typename InIt, typename TmpAlloc> inline static
+    node_pointer apply(InIt first, InIt last,
+                       size_type & values_count,
+                       size_type & leafs_level,
+                       parameters_type const& parameters,
+                       translator_type const& translator,
+                       allocators_type & allocators,
+                       TmpAlloc const& temp_allocator)
+    {
         typedef typename std::iterator_traits<InIt>::difference_type diff_type;
             
         diff_type diff = std::distance(first, last);
@@ -174,7 +187,11 @@ public:
             return node_pointer(0);
 
         typedef std::pair<point_type, InIt> entry_type;
-        std::vector<entry_type> entries;
+        typedef typename boost::container::allocator_traits<TmpAlloc>::
+            template rebind_alloc<entry_type> temp_entry_allocator_type;
+
+        temp_entry_allocator_type temp_entry_allocator(temp_allocator);
+        boost::container::vector<entry_type, temp_entry_allocator_type> entries(temp_entry_allocator);
 
         values_count = static_cast<size_type>(diff);
         entries.reserve(values_count);

--- a/include/boost/geometry/index/rtree.hpp
+++ b/include/boost/geometry/index/rtree.hpp
@@ -439,8 +439,8 @@ public:
     \param parameters        The parameters object.
     \param getter            The function object extracting Indexable from Value.
     \param equal             The function object comparing Values.
-    \param tree_allocator    The allocator object for persistent data in the tree..
-    \param pack_allocator    The temporary allocator object used when packing
+    \param allocator         The allocator object for persistent data in the tree.
+    \param temp_allocator    The temporary allocator object used when packing
 
     \par Throws
     \li If allocator copy constructor throws.
@@ -452,11 +452,11 @@ public:
                  parameters_type const& parameters,
                  indexable_getter const& getter,
                  value_equal const& equal,
-                 allocator_type const& tree_allocator,
-                 PackAlloc const& pack_allocator)
-        : m_members(getter, equal, parameters, tree_allocator)
+                 allocator_type const& allocator,
+                 PackAlloc const& temp_allocator)
+        : m_members(getter, equal, parameters, allocator)
     {
-        pack_construct(first, last, pack_allocator);
+        pack_construct(first, last, temp_allocator);
     }
 
     /*!
@@ -468,8 +468,8 @@ public:
     \param parameters        The parameters object.
     \param getter            The function object extracting Indexable from Value.
     \param equal             The function object comparing Values.
-    \param tree_allocator    The allocator object for persistent data in the tree.
-    \param pack_allocator    The temporary allocator object used when packing.
+    \param allocator         The allocator object for persistent data in the tree.
+    \param temp_allocator    The temporary allocator object used when packing.
 
     \par Throws
     \li If allocator copy constructor throws.
@@ -481,11 +481,11 @@ public:
                           parameters_type const& parameters,
                           indexable_getter const& getter,
                           value_equal const& equal,
-                          allocator_type const& tree_allocator,
-                          PackAlloc const& pack_allocator)
-        : m_members(getter, equal, parameters, tree_allocator)
+                          allocator_type const& allocator,
+                          PackAlloc const& temp_allocator)
+        : m_members(getter, equal, parameters, allocator)
     {
-        pack_construct(::boost::begin(rng), ::boost::end(rng), pack_allocator);
+        pack_construct(::boost::begin(rng), ::boost::end(rng), temp_allocator);
     }
 
     /*!
@@ -493,9 +493,9 @@ public:
 
     The tree is created using packing algorithm and a temporary packing allocator.
 
-    \param first             The beginning of the range of Values.
-    \param last              The end of the range of Values.
-    \param tree_allocator    The allocator object for persistent data in the tree.
+    \param first        The beginning of the range of Values.
+    \param last         The end of the range of Values.
+    \param allocator    The allocator object for persistent data in the tree.
 
     \par Throws
     \li If allocator copy constructor throws.
@@ -504,8 +504,8 @@ public:
     */
     template<typename Iterator>
     inline rtree(Iterator first, Iterator last,
-                 allocator_type const& tree_allocator)
-        : m_members(indexable_getter(), value_equal(), parameters_type(), tree_allocator)
+                 allocator_type const& allocator)
+        : m_members(indexable_getter(), value_equal(), parameters_type(), allocator)
     {
         pack_construct(first, last, boost::container::new_allocator<void>());
     }
@@ -515,8 +515,8 @@ public:
 
     The tree is created using packing algorithm and a temporary packing allocator.
 
-    \param rng               The range of Values.
-    \param tree_allocator    The allocator object for persistent data in the tree.
+    \param rng          The range of Values.
+    \param allocator    The allocator object for persistent data in the tree.
 
     \par Throws
     \li If allocator copy constructor throws.
@@ -525,8 +525,8 @@ public:
     */
     template<typename Range>
     inline explicit rtree(Range const& rng,
-                          allocator_type const& tree_allocator)
-        : m_members(indexable_getter(), value_equal(), parameters_type(), tree_allocator)
+                          allocator_type const& allocator)
+        : m_members(indexable_getter(), value_equal(), parameters_type(), allocator)
     {
         pack_construct(::boost::begin(rng), ::boost::end(rng), boost::container::new_allocator<void>());
     }
@@ -538,8 +538,8 @@ public:
 
     \param first             The beginning of the range of Values.
     \param last              The end of the range of Values.
-    \param tree_allocator    The allocator object for persistent data in the tree.
-    \param pack_allocator    The temporary allocator object used when packing.
+    \param allocator         The allocator object for persistent data in the tree.
+    \param temp_allocator    The temporary allocator object used when packing.
 
     \par Throws
     \li If allocator copy constructor throws.
@@ -548,11 +548,11 @@ public:
     */
     template<typename Iterator, typename PackAlloc>
     inline rtree(Iterator first, Iterator last,
-                 allocator_type const& tree_allocator,
-                 PackAlloc const& pack_allocator)
-        : m_members(indexable_getter(), value_equal(), parameters_type(), tree_allocator)
+                 allocator_type const& allocator,
+                 PackAlloc const& temp_allocator)
+        : m_members(indexable_getter(), value_equal(), parameters_type(), allocator)
     {
-        pack_construct(first, last, pack_allocator);
+        pack_construct(first, last, temp_allocator);
     }
 
     /*!
@@ -561,8 +561,8 @@ public:
     The tree is created using packing algorithm and a temporary packing allocator.
 
     \param rng               The range of Values.
-    \param tree_allocator    The allocator object for persistent data in the tree.
-    \param pack_allocator    The temporary allocator object used when packing.
+    \param allocator         The allocator object for persistent data in the tree.
+    \param temp_allocator    The temporary allocator object used when packing.
 
     \par Throws
     \li If allocator copy constructor throws.
@@ -571,11 +571,11 @@ public:
     */
     template<typename Range, typename PackAlloc>
     inline explicit rtree(Range const& rng,
-                          allocator_type const& tree_allocator,
-                          PackAlloc const& pack_allocator)
-        : m_members(indexable_getter(), value_equal(), parameters_type(), tree_allocator)
+                          allocator_type const& allocator,
+                          PackAlloc const& temp_allocator)
+        : m_members(indexable_getter(), value_equal(), parameters_type(), allocator)
     {
-        pack_construct(::boost::begin(rng), ::boost::end(rng), pack_allocator);
+        pack_construct(::boost::begin(rng), ::boost::end(rng), temp_allocator);
     }
 
     /*!
@@ -1943,7 +1943,7 @@ private:
 
     \param first             The beginning of the range of Values.
     \param last              The end of the range of Values.
-    \param pack_allocator    The temporary allocator object to be used by the packing algorithm.
+    \param temp_allocator    The temporary allocator object to be used by the packing algorithm.
 
     \par Throws
     \li If allocator copy constructor throws.
@@ -1951,13 +1951,13 @@ private:
     \li If allocation throws or returns invalid value.
     */
     template<typename Iterator, typename PackAlloc>
-    inline void pack_construct(Iterator first, Iterator last, PackAlloc const& pack_allocator)
+    inline void pack_construct(Iterator first, Iterator last, PackAlloc const& temp_allocator)
     {
         typedef detail::rtree::pack<members_holder> pack;
         size_type vc = 0, ll = 0;
         m_members.root = pack::apply(first, last, vc, ll,
                                      m_members.parameters(), m_members.translator(),
-                                     m_members.allocators(), pack_allocator);
+                                     m_members.allocators(), temp_allocator);
         m_members.values_count = vc;
         m_members.leafs_level = ll;
     }

--- a/include/boost/geometry/index/rtree.hpp
+++ b/include/boost/geometry/index/rtree.hpp
@@ -436,11 +436,11 @@ public:
 
     \param first             The beginning of the range of Values.
     \param last              The end of the range of Values.
-    \param pack_allocator    The temporary allocator object used when packing
     \param parameters        The parameters object.
     \param getter            The function object extracting Indexable from Value.
     \param equal             The function object comparing Values.
     \param tree_allocator    The allocator object for persistent data in the tree..
+    \param pack_allocator    The temporary allocator object used when packing
 
     \par Throws
     \li If allocator copy constructor throws.
@@ -449,11 +449,11 @@ public:
     */
     template<typename Iterator, typename PackAlloc>
     inline rtree(Iterator first, Iterator last,
-                 PackAlloc const& pack_allocator,
-                 parameters_type const& parameters = parameters_type(),
-                 indexable_getter const& getter = indexable_getter(),
-                 value_equal const& equal = value_equal(),
-                 allocator_type const& tree_allocator = allocator_type())
+                 parameters_type const& parameters,
+                 indexable_getter const& getter,
+                 value_equal const& equal,
+                 allocator_type const& tree_allocator,
+                 PackAlloc const& pack_allocator)
         : m_members(getter, equal, parameters, tree_allocator)
     {
         pack_construct(first, last, pack_allocator);
@@ -465,11 +465,11 @@ public:
     The tree is created using packing algorithm and a temporary packing allocator.
 
     \param rng               The range of Values.
-    \param pack_allocator    The temporary allocator object used when packing.
     \param parameters        The parameters object.
     \param getter            The function object extracting Indexable from Value.
     \param equal             The function object comparing Values.
     \param tree_allocator    The allocator object for persistent data in the tree.
+    \param pack_allocator    The temporary allocator object used when packing.
 
     \par Throws
     \li If allocator copy constructor throws.
@@ -478,12 +478,102 @@ public:
     */
     template<typename Range, typename PackAlloc>
     inline explicit rtree(Range const& rng,
-                          PackAlloc const& pack_allocator,
-                          parameters_type const& parameters = parameters_type(),
-                          indexable_getter const& getter = indexable_getter(),
-                          value_equal const& equal = value_equal(),
-                          allocator_type const& tree_allocator = allocator_type())
+                          parameters_type const& parameters,
+                          indexable_getter const& getter,
+                          value_equal const& equal,
+                          allocator_type const& tree_allocator,
+                          PackAlloc const& pack_allocator)
         : m_members(getter, equal, parameters, tree_allocator)
+    {
+        pack_construct(::boost::begin(rng), ::boost::end(rng), pack_allocator);
+    }
+
+    /*!
+    \brief The constructor.
+
+    The tree is created using packing algorithm and a temporary packing allocator.
+
+    \param first             The beginning of the range of Values.
+    \param last              The end of the range of Values.
+    \param tree_allocator    The allocator object for persistent data in the tree.
+
+    \par Throws
+    \li If allocator copy constructor throws.
+    \li If Value copy constructor or copy assignment throws.
+    \li If allocation throws or returns invalid value.
+    */
+    template<typename Iterator>
+    inline rtree(Iterator first, Iterator last,
+                 allocator_type const& tree_allocator)
+        : m_members(indexable_getter(), value_equal(), parameters_type(), tree_allocator)
+    {
+        pack_construct(first, last, boost::container::new_allocator<void>());
+    }
+
+    /*!
+    \brief The constructor.
+
+    The tree is created using packing algorithm and a temporary packing allocator.
+
+    \param rng               The range of Values.
+    \param tree_allocator    The allocator object for persistent data in the tree.
+
+    \par Throws
+    \li If allocator copy constructor throws.
+    \li If Value copy constructor or copy assignment throws.
+    \li If allocation throws or returns invalid value.
+    */
+    template<typename Range>
+    inline explicit rtree(Range const& rng,
+                          allocator_type const& tree_allocator)
+        : m_members(indexable_getter(), value_equal(), parameters_type(), tree_allocator)
+    {
+        pack_construct(::boost::begin(rng), ::boost::end(rng), boost::container::new_allocator<void>());
+    }
+
+    /*!
+    \brief The constructor.
+
+    The tree is created using packing algorithm and a temporary packing allocator.
+
+    \param first             The beginning of the range of Values.
+    \param last              The end of the range of Values.
+    \param tree_allocator    The allocator object for persistent data in the tree.
+    \param pack_allocator    The temporary allocator object used when packing.
+
+    \par Throws
+    \li If allocator copy constructor throws.
+    \li If Value copy constructor or copy assignment throws.
+    \li If allocation throws or returns invalid value.
+    */
+    template<typename Iterator, typename PackAlloc>
+    inline rtree(Iterator first, Iterator last,
+                 allocator_type const& tree_allocator,
+                 PackAlloc const& pack_allocator)
+        : m_members(indexable_getter(), value_equal(), parameters_type(), tree_allocator)
+    {
+        pack_construct(first, last, pack_allocator);
+    }
+
+    /*!
+    \brief The constructor.
+
+    The tree is created using packing algorithm and a temporary packing allocator.
+
+    \param rng               The range of Values.
+    \param tree_allocator    The allocator object for persistent data in the tree.
+    \param pack_allocator    The temporary allocator object used when packing.
+
+    \par Throws
+    \li If allocator copy constructor throws.
+    \li If Value copy constructor or copy assignment throws.
+    \li If allocation throws or returns invalid value.
+    */
+    template<typename Range, typename PackAlloc>
+    inline explicit rtree(Range const& rng,
+                          allocator_type const& tree_allocator,
+                          PackAlloc const& pack_allocator)
+        : m_members(indexable_getter(), value_equal(), parameters_type(), tree_allocator)
     {
         pack_construct(::boost::begin(rng), ::boost::end(rng), pack_allocator);
     }

--- a/include/boost/geometry/index/rtree.hpp
+++ b/include/boost/geometry/index/rtree.hpp
@@ -4,6 +4,7 @@
 //
 // Copyright (c) 2008 Federico J. Fernandez.
 // Copyright (c) 2011-2019 Adam Wulkiewicz, Lodz, Poland.
+// Copyright (c) 2020 Caian Benedicto, Campinas, Brazil.
 //
 // This file was modified by Oracle on 2019.
 // Modifications copyright (c) 2019 Oracle and/or its affiliates.

--- a/include/boost/geometry/index/rtree.hpp
+++ b/include/boost/geometry/index/rtree.hpp
@@ -398,13 +398,7 @@ public:
                  allocator_type const& allocator = allocator_type())
         : m_members(getter, equal, parameters, allocator)
     {
-        typedef detail::rtree::pack<members_holder> pack;
-        size_type vc = 0, ll = 0;
-        m_members.root = pack::apply(first, last, vc, ll,
-                                     m_members.parameters(), m_members.translator(),
-                                     m_members.allocators());
-        m_members.values_count = vc;
-        m_members.leafs_level = ll;
+        pack_construct(first, last, boost::container::new_allocator<void>());
     }
 
     /*!
@@ -431,13 +425,7 @@ public:
                           allocator_type const& allocator = allocator_type())
         : m_members(getter, equal, parameters, allocator)
     {
-        typedef detail::rtree::pack<members_holder> pack;
-        size_type vc = 0, ll = 0;
-        m_members.root = pack::apply(::boost::begin(rng), ::boost::end(rng), vc, ll,
-                                     m_members.parameters(), m_members.translator(),
-                                     m_members.allocators());
-        m_members.values_count = vc;
-        m_members.leafs_level = ll;
+        pack_construct(::boost::begin(rng), ::boost::end(rng), boost::container::new_allocator<void>());
     }
 
     /*!
@@ -1796,6 +1784,32 @@ private:
         detail::rtree::apply_visitor(count_v, *m_members.root);
 
         return count_v.found_count;
+    }
+
+    /*!
+    \brief The constructor TODO.
+
+    The tree is created using packing algorithm.
+
+    \param first             The beginning of the range of Values.
+    \param last              The end of the range of Values.
+    \param pack_allocator    The temporary allocator object to be used by the packing algorithm.
+
+    \par Throws
+    \li If allocator copy constructor throws.
+    \li If Value copy constructor or copy assignment throws.
+    \li If allocation throws or returns invalid value.
+    */
+    template<typename Iterator, typename PackAlloc>
+    inline void pack_construct(Iterator first, Iterator last, PackAlloc const& pack_allocator)
+    {
+        typedef detail::rtree::pack<members_holder> pack;
+        size_type vc = 0, ll = 0;
+        m_members.root = pack::apply(first, last, vc, ll,
+                                     m_members.parameters(), m_members.translator(),
+                                     m_members.allocators(), pack_allocator);
+        m_members.values_count = vc;
+        m_members.leafs_level = ll;
     }
 
     members_holder m_members;

--- a/include/boost/geometry/index/rtree.hpp
+++ b/include/boost/geometry/index/rtree.hpp
@@ -429,6 +429,65 @@ public:
     }
 
     /*!
+    \brief The constructor.
+
+    The tree is created using packing algorithm and a temporary packing allocator.
+
+    \param first             The beginning of the range of Values.
+    \param last              The end of the range of Values.
+    \param pack_allocator    The temporary allocator object used when packing
+    \param parameters        The parameters object.
+    \param getter            The function object extracting Indexable from Value.
+    \param equal             The function object comparing Values.
+    \param tree_allocator    The allocator object for persistent data in the tree..
+
+    \par Throws
+    \li If allocator copy constructor throws.
+    \li If Value copy constructor or copy assignment throws.
+    \li If allocation throws or returns invalid value.
+    */
+    template<typename Iterator, typename PackAlloc>
+    inline rtree(Iterator first, Iterator last,
+                 PackAlloc const& pack_allocator,
+                 parameters_type const& parameters = parameters_type(),
+                 indexable_getter const& getter = indexable_getter(),
+                 value_equal const& equal = value_equal(),
+                 allocator_type const& tree_allocator = allocator_type())
+        : m_members(getter, equal, parameters, tree_allocator)
+    {
+        pack_construct(first, last, pack_allocator);
+    }
+
+    /*!
+    \brief The constructor.
+
+    The tree is created using packing algorithm and a temporary packing allocator.
+
+    \param rng               The range of Values.
+    \param pack_allocator    The temporary allocator object used when packing.
+    \param parameters        The parameters object.
+    \param getter            The function object extracting Indexable from Value.
+    \param equal             The function object comparing Values.
+    \param tree_allocator    The allocator object for persistent data in the tree.
+
+    \par Throws
+    \li If allocator copy constructor throws.
+    \li If Value copy constructor or copy assignment throws.
+    \li If allocation throws or returns invalid value.
+    */
+    template<typename Range, typename PackAlloc>
+    inline explicit rtree(Range const& rng,
+                          PackAlloc const& pack_allocator,
+                          parameters_type const& parameters = parameters_type(),
+                          indexable_getter const& getter = indexable_getter(),
+                          value_equal const& equal = value_equal(),
+                          allocator_type const& tree_allocator = allocator_type())
+        : m_members(getter, equal, parameters, tree_allocator)
+    {
+        pack_construct(::boost::begin(rng), ::boost::end(rng), pack_allocator);
+    }
+
+    /*!
     \brief The destructor.
 
     \par Throws

--- a/include/boost/geometry/index/rtree.hpp
+++ b/include/boost/geometry/index/rtree.hpp
@@ -440,7 +440,7 @@ public:
     \param getter            The function object extracting Indexable from Value.
     \param equal             The function object comparing Values.
     \param allocator         The allocator object for persistent data in the tree.
-    \param temp_allocator    The temporary allocator object used when packing
+    \param temp_allocator    The temporary allocator object used when packing.
 
     \par Throws
     \li If allocator copy constructor throws.


### PR DESCRIPTION
As discussed in #718, it's not currently possible to specify an allocator for the packing process used during the construction of the r-rtee. This is desirable in some situations when dealing with constrained memory systems.

This PR adds overloads for both `bgi::detail::index::rtree::pack` and `bgi::rtree` classes to support the aforementioned allocator without interfering with the existing interfaces.