### PR TITLE
[test] update testsuite

### DIFF
--- a/test/algorithms/buffer/buffer_countries.cpp
+++ b/test/algorithms/buffer/buffer_countries.cpp
@@ -239,7 +239,11 @@ int test_main(int, char* [])
 #if ! defined(BOOST_GEOMETRY_TEST_ONLY_ONE_ORDER)
     test_all<false, bg::model::point<default_test_type, 2, bg::cs::cartesian> >();
 #endif
-    
+
+#if defined(BOOST_GEOMETRY_TEST_FAILURES)
+    BoostGeometryWriteExpectedFailures(1, BG_NO_FAILURES);
+#endif
+
     return 0;
 }
 

--- a/test/algorithms/buffer/buffer_linestring.cpp
+++ b/test/algorithms/buffer/buffer_linestring.cpp
@@ -410,5 +410,10 @@ int test_main(int, char* [])
 #if ! defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE)
     test_invalid<true, bg::model::point<long double, 2, bg::cs::cartesian> >();
 #endif
+
+#if defined(BOOST_GEOMETRY_TEST_FAILURES)
+    BoostGeometryWriteExpectedFailures(2, 2);
+#endif
+
     return 0;
 }

--- a/test/algorithms/buffer/buffer_linestring_aimes.cpp
+++ b/test/algorithms/buffer/buffer_linestring_aimes.cpp
@@ -446,12 +446,9 @@ void test_aimes()
         double aimes_width = static_cast<double>(width) / 1000000.0;
         for (int i = 0; i < n; i++)
         {
-#if ! defined(BOOST_GEOMETRY_USE_RESCALING) && ! defined(BOOST_GEOMETRY_TEST_FAILURES)
-            if (i > 10)
-            {
-                // Several cases (11,20,40 etc) are still reported as invalid
-                settings.test_validity = false;
-            }
+#if ! defined(BOOST_GEOMETRY_USE_RESCALING)
+            // Without rescaling, several cases are still reported as invalid
+            settings.set_test_validity(i <= 10);
 #endif
             std::ostringstream name;
             try
@@ -484,6 +481,11 @@ int test_main(int, char* [])
     BoostGeometryWriteTestConfiguration();
 
     test_aimes<bg::model::point<default_test_type, 2, bg::cs::cartesian> >();
+
+#if defined(BOOST_GEOMETRY_TEST_FAILURES)
+    // Non-rescaled reports 22 failures (failures in validity only)
+    BoostGeometryWriteExpectedFailures(BG_NO_FAILURES, 22);
+#endif
 
     return 0;
 }

--- a/test/algorithms/buffer/buffer_multi_linestring.cpp
+++ b/test/algorithms/buffer/buffer_multi_linestring.cpp
@@ -197,9 +197,10 @@ void test_all()
     test_one<multi_linestring_type, polygon>("mysql_23023665_1_20",
             mysql_23023665_1, join_round32, end_flat, 1, 1, 350.1135, 2.0);
 
-#if ! defined(BOOST_GEOMETRY_USE_RESCALING)
+#if ! defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
     {
-        ut_settings settings(10.0);
+        // Cases failing with rescaling
+        ut_settings settings(10.0, false);
         test_one<multi_linestring_type, polygon>("ticket_13444_1",
                 ticket_13444, join_round32, end_round32, 3, 0, 11801.7832, 1.0, settings);
         test_one<multi_linestring_type, polygon>("ticket_13444_3",
@@ -222,5 +223,8 @@ int test_main(int, char* [])
     test_all<false, bg::model::point<default_test_type, 2, bg::cs::cartesian> >();
 #endif
 
+#if defined(BOOST_GEOMETRY_TEST_FAILURES)
+    BoostGeometryWriteExpectedFailures(10, BG_NO_FAILURES);
+#endif
     return 0;
 }

--- a/test/algorithms/buffer/buffer_multi_point.cpp
+++ b/test/algorithms/buffer/buffer_multi_point.cpp
@@ -220,5 +220,9 @@ int test_main(int, char* [])
     std::cout << "Skipping some tests in debug or unknown mode" << std::endl;
 #endif
 
+#if defined(BOOST_GEOMETRY_TEST_FAILURES)
+    BoostGeometryWriteExpectedFailures(BG_NO_FAILURES);
+#endif
+
     return 0;
 }

--- a/test/algorithms/buffer/buffer_multi_polygon.cpp
+++ b/test/algorithms/buffer/buffer_multi_polygon.cpp
@@ -307,6 +307,13 @@ static std::string const mysql_report_2015_07_05_1
 static std::string const mysql_report_2015_07_05_2
     = "MULTIPOLYGON(((19777 -21893,3.22595e+307 6.86823e+307,-40 -13,19777 -21893)),((-1322 4851,8.49998e+307 3.94481e+307,75 -69,8.64636e+307 3.94909e+307,-1.15292e+18 7.20576e+16,-1322 4851)))";
 
+#if ! defined(BOOST_GEOMETRY_USE_RESCALING) \
+    && defined(BOOST_GEOMETRY_USE_KRAMER_RULE) \
+    && ! defined(BOOST_GEOMETRY_TEST_FAILURES)
+// These testcases are failing for non-rescaled Kramer rule
+#define BOOST_GEOMETRY_EXCLUDE
+#endif
+
 template <bool Clockwise, typename P>
 void test_all()
 {
@@ -396,17 +403,13 @@ void test_all()
     test_one<multi_polygon_type, polygon_type>("rt_d", rt_d, join_miter, end_flat, 19.8823, 0.3);
     test_one<multi_polygon_type, polygon_type>("rt_e", rt_e, join_miter, end_flat, 15.1198, 0.3);
     test_one<multi_polygon_type, polygon_type>("rt_f", rt_f, join_miter, end_flat, 4.60853, 0.3);
-#if defined(BOOST_GEOMETRY_USE_RESCALING) || ! defined(BOOST_GEOMETRY_USE_KRAMER_RULE) || defined(BOOST_GEOMETRY_TEST_FAILURES)
     test_one<multi_polygon_type, polygon_type>("rt_g1", rt_g1, join_miter, end_flat, 30.3137, 1.0);
     test_one<multi_polygon_type, polygon_type>("rt_g2", rt_g2, join_miter, end_flat, 18.5711, 1.0);
-#endif
 
     test_one<multi_polygon_type, polygon_type>("rt_h", rt_h, join_round, end_flat, 47.6012, 1.0);
     test_one<multi_polygon_type, polygon_type>("rt_h", rt_h, join_miter, end_flat, 61.7058, 1.0);
     test_one<multi_polygon_type, polygon_type>("rt_i", rt_i, join_round, end_flat, 10.7528, 1.0);
-#if defined(BOOST_GEOMETRY_USE_RESCALING) || ! defined(BOOST_GEOMETRY_USE_KRAMER_RULE) || defined(BOOST_GEOMETRY_TEST_FAILURES)
     test_one<multi_polygon_type, polygon_type>("rt_i", rt_i, join_miter, end_flat, 13.6569, 1.0);
-#endif
     test_one<multi_polygon_type, polygon_type>("rt_j", rt_j, join_round, end_flat, 28.7309, 1.0);
     test_one<multi_polygon_type, polygon_type>("rt_j", rt_j, join_miter, end_flat, 35.1421, 1.0);
     test_one<multi_polygon_type, polygon_type>("rt_k", rt_k, join_round, end_flat, 42.0092, 1.0);
@@ -437,9 +440,7 @@ void test_all()
     test_one<multi_polygon_type, polygon_type>("rt_p7", rt_p7, join_miter, end_flat, 26.2279, 1.0);
 #endif
 
-#if defined(BOOST_GEOMETRY_USE_RESCALING) || ! defined(BOOST_GEOMETRY_USE_KRAMER_RULE) || defined(BOOST_GEOMETRY_TEST_FAILURES)
     test_one<multi_polygon_type, polygon_type>("rt_p8", rt_p8, join_miter, end_flat, 29.0563, 1.0);
-#endif
     test_one<multi_polygon_type, polygon_type>("rt_p9", rt_p9, join_miter, end_flat, 26.1421, 1.0);
     test_one<multi_polygon_type, polygon_type>("rt_p10", rt_p10, join_miter, end_flat, 23.3995, 1.0);
 
@@ -448,21 +449,19 @@ void test_all()
     test_one<multi_polygon_type, polygon_type>("rt_p13", rt_p13, join_miter, end_flat, 19.9142, 1.0);
     test_one<multi_polygon_type, polygon_type>("rt_p14", rt_p14, join_miter, end_flat, 20.8284, 1.0);
     test_one<multi_polygon_type, polygon_type>("rt_p15", rt_p15, join_miter, end_flat, 23.6569, 1.0);
-#if defined(BOOST_GEOMETRY_USE_KRAMER) || defined(BOOST_GEOMETRY_TEST_FAILURES)
     test_one<multi_polygon_type, polygon_type>("rt_p16", rt_p16, join_miter, end_flat, 23.4853, 1.0);
-#endif
 
     test_one<multi_polygon_type, polygon_type>("rt_p17", rt_p17, join_miter, end_flat, 25.3137, 1.0);
 
-#if defined(BOOST_GEOMETRY_USE_RESCALING) || ! defined(BOOST_GEOMETRY_USE_KRAMER_RULE) || defined(BOOST_GEOMETRY_TEST_FAILURES)
+#if ! defined(BOOST_GEOMETRY_EXCLUDE)
     test_one<multi_polygon_type, polygon_type>("rt_p18", rt_p18, join_miter, end_flat, 23.3137, 1.0);
 #endif
     test_one<multi_polygon_type, polygon_type>("rt_p19", rt_p19, join_miter, end_flat, 25.5637, 1.0);
-#if defined(BOOST_GEOMETRY_USE_RESCALING) || ! defined(BOOST_GEOMETRY_USE_KRAMER_RULE) || defined(BOOST_GEOMETRY_TEST_FAILURES)
+#if ! defined(BOOST_GEOMETRY_EXCLUDE)
     test_one<multi_polygon_type, polygon_type>("rt_p20", rt_p20, join_miter, end_flat, 25.4853, 1.0);
 #endif
     test_one<multi_polygon_type, polygon_type>("rt_p21", rt_p21, join_miter, end_flat, 17.1716, 1.0);
-#if defined(BOOST_GEOMETRY_USE_RESCALING) || ! defined(BOOST_GEOMETRY_USE_KRAMER_RULE) || defined(BOOST_GEOMETRY_TEST_FAILURES)
+#if ! defined(BOOST_GEOMETRY_EXCLUDE)
     test_one<multi_polygon_type, polygon_type>("rt_p22", rt_p22, join_miter, end_flat, 26.5711, 1.0);
 #endif
 
@@ -471,13 +470,11 @@ void test_all()
     test_one<multi_polygon_type, polygon_type>("rt_q2", rt_q2, join_miter, end_flat, 0.9697, -0.25);
 
     test_one<multi_polygon_type, polygon_type>("rt_r", rt_r, join_miter, end_flat, 21.0761, 1.0);
-#if defined(BOOST_GEOMETRY_USE_RESCALING) || ! defined(BOOST_GEOMETRY_USE_KRAMER_RULE) || defined(BOOST_GEOMETRY_TEST_FAILURES)
+#if ! defined(BOOST_GEOMETRY_EXCLUDE)
     test_one<multi_polygon_type, polygon_type>("rt_s1", rt_s1, join_miter, end_flat, 20.4853, 1.0);
 #endif
 
-#if defined(BOOST_GEOMETRY_USE_KRAMER) || defined(BOOST_GEOMETRY_TEST_FAILURES)
     test_one<multi_polygon_type, polygon_type>("rt_s2", rt_s2, join_miter, end_flat, 24.6495, 1.0);
-#endif
 
     test_one<multi_polygon_type, polygon_type>("rt_t1", rt_t, join_miter, end_flat, 15.6569, 1.0);
     test_one<multi_polygon_type, polygon_type>("rt_t2", rt_t, join_miter, end_flat, 0.1679, -0.25);
@@ -496,17 +493,15 @@ void test_all()
 
     test_one<multi_polygon_type, polygon_type>("rt_u8", rt_u8, join_miter, end_flat, 70.9142, 1.0);
     test_one<multi_polygon_type, polygon_type>("rt_u9", rt_u9, join_miter, end_flat, 59.3063, 1.0);
-#if defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
-    test_one<multi_polygon_type, polygon_type>("rt_u10", rt_u10, join_miter, end_flat, 144.0858, 1.0); // PG: 144.085786772487
-#endif
-    test_one<multi_polygon_type, polygon_type>("rt_u10_51", rt_u10, join_miter, end_flat, 0.1674, -0.51); // PG: 0.167380307629637
+    test_one<multi_polygon_type, polygon_type>("rt_u10", rt_u10, join_miter, end_flat, 144.0858, 1.0);
+    test_one<multi_polygon_type, polygon_type>("rt_u10_51", rt_u10, join_miter, end_flat, 0.1674, -0.51);
     test_one<multi_polygon_type, polygon_type>("rt_u10_c_51", rt_u10_c, join_miter, end_flat, 0.066952, -0.51);
 
-
-    // TODO: now one small triangle missing due to clusters/uu turns
-    test_one<multi_polygon_type, polygon_type>("rt_u10_50", rt_u10, join_miter, end_flat, 0.2145, -0.50, ut_settings::ignore_validity()); // PG: 0.214466094067263
-    test_one<multi_polygon_type, polygon_type>("rt_u10_45", rt_u10, join_miter, end_flat, 1.3000, -0.45); // PG: 1.30004221251301
-    test_one<multi_polygon_type, polygon_type>("rt_u10_25", rt_u10, join_miter, end_flat, 9.6682, -0.25); // PG: 9.66820888343117
+    test_one<multi_polygon_type, polygon_type>("rt_u10_51", rt_u10, join_miter, end_flat, 0.1674, -0.51);
+    // TODO: invalid - making a bow-tie
+    test_one<multi_polygon_type, polygon_type>("rt_u10_50", rt_u10, join_miter, end_flat, 0.2145, -0.50, ut_settings::ignore_validity()); // False positive
+    test_one<multi_polygon_type, polygon_type>("rt_u10_45", rt_u10, join_miter, end_flat, 1.3000, -0.45);
+    test_one<multi_polygon_type, polygon_type>("rt_u10_25", rt_u10, join_miter, end_flat, 9.6682, -0.25);
 
     test_one<multi_polygon_type, polygon_type>("rt_u11", rt_u11, join_miter, end_flat, 131.3995, 1.0);
     test_one<multi_polygon_type, polygon_type>("rt_u11_50", rt_u11, join_miter, end_flat, 0.04289, -0.50);
@@ -555,5 +550,9 @@ int test_main(int, char* [])
     test_all<false, bg::model::point<default_test_type, 2, bg::cs::cartesian> >();
 #endif
     
+#if defined(BOOST_GEOMETRY_TEST_FAILURES)
+    BoostGeometryWriteExpectedFailures(1, 9);
+#endif
+
     return 0;
 }

--- a/test/algorithms/buffer/buffer_point.cpp
+++ b/test/algorithms/buffer/buffer_point.cpp
@@ -37,5 +37,10 @@ int test_main(int, char* [])
 #if ! defined(BOOST_GEOMETRY_TEST_ONLY_ONE_ORDER)
     test_all<false, bg::model::point<default_test_type, 2, bg::cs::cartesian> >();
 #endif
+
+#if defined(BOOST_GEOMETRY_TEST_FAILURES)
+    BoostGeometryWriteExpectedFailures(BG_NO_FAILURES);
+#endif
+
     return 0;
 }

--- a/test/algorithms/buffer/buffer_polygon.cpp
+++ b/test/algorithms/buffer/buffer_polygon.cpp
@@ -533,7 +533,7 @@ void test_all()
 
     {
         ut_settings settings;
-        settings.test_validity = false;
+        settings.set_test_validity(false);
 
         // Tickets
         test_one<polygon_type, polygon_type>("ticket_10398_1_5", ticket_10398_1, join_miter, end_flat, 494.7192, 0.5, settings);
@@ -591,7 +591,7 @@ void test_all()
         // Test issue 555 as reported (-0.000001) and some variants
         bg::strategy::buffer::join_round jr(180);
         bg::strategy::buffer::end_round er(180);
-#if ! defined(BOOST_GEOMETRY_USE_RESCALING)
+#if ! defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
         // With rescaling the interior ring is missing
         test_one<polygon_type, polygon_type>("issue_555", issue_555, jr, er, 4520.7942, -0.000001);
 #endif
@@ -866,6 +866,10 @@ int test_main(int, char* [])
     test_all<bg::model::point<tt, 2, bg::cs::cartesian> >();
 #endif
 
+#endif
+
+#if defined(BOOST_GEOMETRY_TEST_FAILURES)
+    BoostGeometryWriteExpectedFailures(2, 1);
 #endif
 
     return 0;

--- a/test/algorithms/set_operations/difference/difference.cpp
+++ b/test/algorithms/set_operations/difference/difference.cpp
@@ -59,7 +59,7 @@ void test_all()
 #endif
 
     ut_settings ignore_validity_settings;
-    ignore_validity_settings.test_validity = false;
+    ignore_validity_settings.set_test_validity(false);
 
     test_one<polygon, polygon, polygon>("simplex_normal",
         simplex_normal[0], simplex_normal[1],
@@ -105,12 +105,12 @@ void test_all()
         1, 5, 1.0,
         1, 5, 1.0);
 
-    // The too small one might be discarded (depending on point-type / compiler)
-    // We check area only
+    // Two outputs, but the small one might be discarded
+    // (depending on point-type / compiler)
     test_one<polygon, polygon, polygon>("distance_zero",
         distance_zero[0], distance_zero[1],
-        -1, -1, 8.7048386,
-        -1, -1, 0.0098387,
+        count_set(1, 2), -1, 8.7048386,
+        count_set(1, 2), -1, 0.0098387,
         tolerance(0.001));
 
     test_one<polygon, polygon, polygon>("equal_holes_disjoint",
@@ -249,22 +249,23 @@ void test_all()
     TEST_DIFFERENCE(case_precision_3, 1, 14.0, 1, 8.0, 1);
     TEST_DIFFERENCE(case_precision_4, 1, 14.0, 1, 8.0, 1);
 #if ! defined(BOOST_GEOMETRY_USE_KRAMER_RULE) || defined(BOOST_GEOMETRY_TEST_FAILURES)
-    TEST_DIFFERENCE(case_precision_5, 1, 14.0, 1, 8.0, 1);
-    TEST_DIFFERENCE(case_precision_6, 0, 0.0, 1, 57.0, 1);
+    TEST_DIFFERENCE(case_precision_5, 1, 14.0, 1, 8.0, count_set(1, 2));
+    // Small optional sliver allowed, here and below
+    TEST_DIFFERENCE(case_precision_6, optional(), 0.0, 1, 57.0, count_set(1, 2));
 #endif
     TEST_DIFFERENCE(case_precision_7, 1, 14.0, 1, 8.0, 1);
     TEST_DIFFERENCE(case_precision_8, 0, 0.0, 1, 59.0, 1);
 #if ! defined(BOOST_GEOMETRY_USE_KRAMER_RULE) || defined(BOOST_GEOMETRY_TEST_FAILURES)
-    TEST_DIFFERENCE(case_precision_9, 0, 0.0, 1, 59.0, 1);
-    TEST_DIFFERENCE(case_precision_10, 0, 0.0, 1, 59.0, 1);
-    TEST_DIFFERENCE(case_precision_11, 0, 0.0, 1, 59.0, 1);
+    TEST_DIFFERENCE(case_precision_9, optional(), 0.0, 1, 59.0, count_set(1, 2));
+    TEST_DIFFERENCE(case_precision_10, optional(), 0.0, 1, 59.0, count_set(1, 2));
+    TEST_DIFFERENCE(case_precision_11, optional(), 0.0, 1, 59.0, 1);
 #endif
     TEST_DIFFERENCE(case_precision_12, 1, 12.0, 0, 0.0, 1);
     TEST_DIFFERENCE(case_precision_13, 1, BG_IF_KRAMER(12.00002, 12.0), 0, 0.0, 1);
     TEST_DIFFERENCE(case_precision_14, 1, 14.0, 1, 8.0, 1);
     TEST_DIFFERENCE(case_precision_15, 0, 0.0, 1, 59.0, 1);
 #if ! defined(BOOST_GEOMETRY_USE_KRAMER_RULE) || defined(BOOST_GEOMETRY_TEST_FAILURES)
-    TEST_DIFFERENCE(case_precision_16, 0, 0.0, 1, 59.0, 1);
+    TEST_DIFFERENCE(case_precision_16, optional(), 0.0, 1, 59.0, 1);
 #endif
     TEST_DIFFERENCE(case_precision_17, 0, 0.0, 1, 59.0, 1);
     TEST_DIFFERENCE(case_precision_18, 0, 0.0, 1, 59.0, 1);
@@ -274,13 +275,13 @@ void test_all()
     TEST_DIFFERENCE(case_precision_20, 1, 14.0, 1, 8.0, 1);
     TEST_DIFFERENCE(case_precision_21, 1, 14.0, 1, 7.99999, 1);
 #if ! defined(BOOST_GEOMETRY_USE_KRAMER_RULE) || defined(BOOST_GEOMETRY_TEST_FAILURES)
-    TEST_DIFFERENCE(case_precision_22, 0, 0.0, 1, 59.0, 1);
-    TEST_DIFFERENCE(case_precision_23, 0, 0.0, 1, 59.0, 1);
+    TEST_DIFFERENCE(case_precision_22, optional(), 0.0, 1, 59.0, count_set(1, 2));
+    TEST_DIFFERENCE(case_precision_23, optional(), 0.0, 1, 59.0, count_set(1, 2));
 #endif
     TEST_DIFFERENCE(case_precision_24, 1, 14.0, 1, 8.0, 1);
     TEST_DIFFERENCE(case_precision_25, 1, 14.0, 1, 7.99999, 1);
 #if ! defined(BOOST_GEOMETRY_USE_KRAMER_RULE) || defined(BOOST_GEOMETRY_TEST_FAILURES)
-    TEST_DIFFERENCE(case_precision_26, 0, 0.0, 1, 59.0, 1);
+    TEST_DIFFERENCE(case_precision_26, optional(), 0.0, 1, 59.0, count_set(1, 2));
 #endif
 
     test_one<polygon, polygon, polygon>("winded",
@@ -328,7 +329,7 @@ void test_all()
     {
         ut_settings settings;
         settings.percentage = BG_IF_RESCALED(0.001, 0.1);
-        settings.test_validity = BG_IF_RESCALED(true, false);
+        settings.set_test_validity(BG_IF_RESCALED(true, false));
         settings.sym_difference = BG_IF_RESCALED(true, false);
 
         // Isovist - the # output polygons differ per compiler/pointtype, (very) small
@@ -340,8 +341,8 @@ void test_all()
 
         test_one<polygon, polygon, polygon>("isovist",
             isovist1[0], isovist1[1],
-            -1, -1, 0.279132,
-            -1, -1, 224.8892,
+            ignore_count(), -1, 0.279132,
+            ignore_count(), -1, 224.8892,
             settings);
     }
 
@@ -349,14 +350,14 @@ void test_all()
     {
         ut_settings settings;
         settings.percentage = 0.1;
-        settings.test_validity = false;
+        settings.set_test_validity(false);
 
         // SQL Server gives: 0.28937764436705 and 0.000786406897532288 with 44/35 rings
         // PostGIS gives:    0.30859375       and 0.033203125 with 35/35 rings
         TEST_DIFFERENCE_WITH(geos_1,
-            -1, BG_IF_KRAMER(0.29171, 0.20705),
-            -1, BG_IF_KRAMER(0.00076855, 0.00060440758),
-            -1);
+            ignore_count(), BG_IF_KRAMER(0.29171, 0.20705),
+            ignore_count(), BG_IF_KRAMER(0.00076855, 0.00060440758),
+            ignore_count());
     }
 #endif
 
@@ -365,7 +366,7 @@ void test_all()
 
         ut_settings settings = sym_settings;
         settings.percentage = 0.01;
-        settings.test_validity = false;
+        settings.set_test_validity(false);
 
         // Output polygons for sym difference might be combined
         test_one<polygon, polygon, polygon>("geos_2",
@@ -417,7 +418,7 @@ void test_all()
         // Symmetric difference should output one polygon
         // Using rescaling, it currently outputs two.
         ut_settings settings;
-        settings.test_validity = false;
+        settings.set_test_validity(false);
 
         TEST_DIFFERENCE_WITH(ggl_list_20110820_christophe,
             1, 2.8570121719168924,
@@ -451,7 +452,7 @@ void test_all()
     {
         // With rescaling, difference of output a-b and a sym b is invalid
         ut_settings settings;
-        settings.test_validity = BG_IF_RESCALED(false, true);
+        settings.set_test_validity(BG_IF_RESCALED(false, true));
         TEST_DIFFERENCE_WITH(ggl_list_20190307_matthieu_1,
                 BG_IF_KRAMER(2, 1), 0.18461532,
                 BG_IF_KRAMER(2, 1), 0.617978,
@@ -485,7 +486,7 @@ void test_all()
 
     {
         ut_settings settings;
-        settings.test_validity = BG_IF_RESCALED(true, false);
+        settings.set_test_validity(BG_IF_RESCALED(true, false));
 #if ! defined(BOOST_GEOMETRY_USE_RESCALING) && defined(BOOST_GEOMETRY_USE_KRAMER_RULE)
         const int expected_count = 1; // Wrong, considers all consecutive polygons as one
 #else
@@ -591,7 +592,7 @@ void test_all()
     {
         ut_settings settings;
 #if defined(BOOST_GEOMETRY_USE_KRAMER_RULE)
-        settings.test_validity = BG_IF_RESCALED(true, false);
+        settings.set_test_validity(BG_IF_RESCALED(true, false));
 #endif
         TEST_DIFFERENCE_WITH(issue_566_a, 1, 143.662, BG_IF_RESCALED(1, 0),
                              BG_IF_RESCALED(1.605078e-6, 0.0),
@@ -657,6 +658,10 @@ int test_main(int, char* [])
     std::cout << "Testing TTMATH" << std::endl;
     test_all<bg::model::d2::point_xy<ttmath_big> >();
 #endif
+#endif
+
+#if defined(BOOST_GEOMETRY_TEST_FAILURES)
+    BoostGeometryWriteExpectedFailures(12, 15);
 #endif
 
     return 0;

--- a/test/algorithms/set_operations/difference/difference_multi_spike.cpp
+++ b/test/algorithms/set_operations/difference/difference_multi_spike.cpp
@@ -19,7 +19,7 @@ template <typename P, bool ClockWise, bool Closed>
 void test_spikes_in_ticket_8364()
 {
     ut_settings ignore_validity;
-    ignore_validity.test_validity = false;
+    ignore_validity.set_test_validity(false);
 
     // See: https://svn.boost.org/trac/boost/ticket/8364
     //_TPolygon<T> polygon( "MULTIPOLYGON(((1031 1056,3232 1056,3232 2856,1031 2856)))" );

--- a/test/algorithms/set_operations/difference/test_difference.hpp
+++ b/test/algorithms/set_operations/difference/test_difference.hpp
@@ -19,6 +19,7 @@
 #include <iomanip>
 
 #include <geometry_test_common.hpp>
+#include <count_set.hpp>
 #include <algorithms/check_validity.hpp>
 #include "../setop_output_type.hpp"
 
@@ -58,19 +59,16 @@
 #endif
 
 
-struct ut_settings
+struct ut_settings : ut_base_settings
 {
     double percentage;
     bool sym_difference;
     bool remove_spikes;
 
-    bool test_validity;
-
     ut_settings()
         : percentage(0.0001)
         , sym_difference(true)
         , remove_spikes(false)
-        , test_validity(true)
     {}
 
 };
@@ -134,7 +132,8 @@ void difference_output(std::string const& caseid, G1 const& g1, G2 const& g2, Ou
 
 template <typename OutputType, typename G1, typename G2>
 std::string test_difference(std::string const& caseid, G1 const& g1, G2 const& g2,
-        int expected_count, int expected_rings_count, int expected_point_count,
+        const count_set& expected_count,
+        int expected_rings_count, int expected_point_count,
         double expected_area,
         bool sym,
         ut_settings const& settings)
@@ -190,9 +189,7 @@ std::string test_difference(std::string const& caseid, G1 const& g1, G2 const& g
     typename bg::default_area_result<G1>::type const area = bg::area(result);
 
 #if ! defined(BOOST_GEOMETRY_NO_BOOST_TEST)
-#if ! defined(BOOST_GEOMETRY_TEST_ALWAYS_CHECK_VALIDITY)
-    if (settings.test_validity)
-#endif
+    if (settings.test_validity())
     {
         // std::cout << bg::dsv(result) << std::endl;
         typedef bg::model::multi_polygon<OutputType> result_type;
@@ -247,9 +244,9 @@ std::string test_difference(std::string const& caseid, G1 const& g1, G2 const& g
     }
 #endif
 
-    if (expected_count >= 0)
+    if (! expected_count.empty())
     {
-        BOOST_CHECK_MESSAGE(int(boost::size(result)) == expected_count,
+        BOOST_CHECK_MESSAGE(expected_count.has(boost::size(result)),
                 "difference: " << caseid
                 << " #outputs expected: " << expected_count
                 << " detected: " << result.size()
@@ -284,7 +281,7 @@ std::string test_difference(std::string const& caseid, G1 const& g1, G2 const& g
 
 template <typename OutputType, typename G1, typename G2>
 std::string test_difference(std::string const& caseid, G1 const& g1, G2 const& g2,
-        int expected_count, int expected_point_count,
+        const count_set&  expected_count, int expected_point_count,
         double expected_area,
         bool sym,
         ut_settings const& settings)
@@ -302,15 +299,15 @@ static int counter = 0;
 template <typename OutputType, typename G1, typename G2>
 std::string test_one(std::string const& caseid,
         std::string const& wkt1, std::string const& wkt2,
-        int expected_count1,
+        const count_set& expected_count1,
         int expected_rings_count1,
         int expected_point_count1,
         double expected_area1,
-        int expected_count2,
+        const count_set& expected_count2,
         int expected_rings_count2,
         int expected_point_count2,
         double expected_area2,
-        int expected_count_s,
+        const count_set&  expected_count_s,
         int expected_rings_count_s,
         int expected_point_count_s,
         double expected_area_s,
@@ -354,11 +351,11 @@ std::string test_one(std::string const& caseid,
 template <typename OutputType, typename G1, typename G2>
 std::string test_one(std::string const& caseid,
         std::string const& wkt1, std::string const& wkt2,
-        int expected_count1,
+        const count_set&  expected_count1,
         int expected_rings_count1,
         int expected_point_count1,
         double expected_area1,
-        int expected_count2,
+        const count_set&  expected_count2,
         int expected_rings_count2,
         int expected_point_count2,
         double expected_area2,
@@ -378,13 +375,13 @@ std::string test_one(std::string const& caseid,
 template <typename OutputType, typename G1, typename G2>
 std::string test_one(std::string const& caseid,
         std::string const& wkt1, std::string const& wkt2,
-        int expected_count1,
+        const count_set&  expected_count1,
         int expected_point_count1,
         double expected_area1,
-        int expected_count2,
+        const count_set&  expected_count2,
         int expected_point_count2,
         double expected_area2,
-        int expected_count_s,
+        const count_set&  expected_count_s,
         int expected_point_count_s,
         double expected_area_s,
         ut_settings const& settings = ut_settings())
@@ -399,10 +396,10 @@ std::string test_one(std::string const& caseid,
 template <typename OutputType, typename G1, typename G2>
 std::string test_one(std::string const& caseid,
         std::string const& wkt1, std::string const& wkt2,
-        int expected_count1,
+        const count_set&  expected_count1,
         int expected_point_count1,
         double expected_area1,
-        int expected_count2,
+        const count_set&  expected_count2,
         int expected_point_count2,
         double expected_area2,
         ut_settings const& settings = ut_settings())

--- a/test/algorithms/set_operations/intersection/intersection.cpp
+++ b/test/algorithms/set_operations/intersection/intersection.cpp
@@ -178,7 +178,7 @@ void test_areal()
 
     {
         ut_settings settings(if_typed_tt<ct>(0.01, 0.1));
-        settings.test_validity = BG_IF_RESCALED(true, false);
+        settings.set_test_validity(BG_IF_RESCALED(true, false));
 
         // SQL Server gives: 88.1920416352664
         // PostGIS gives:    88.19203677911
@@ -316,7 +316,7 @@ void test_areal()
     {
         // Not yet valid when rescaling is turned off
         ut_settings settings;
-        settings.test_validity = BG_IF_RESCALED(true, false);
+        settings.set_test_validity(BG_IF_RESCALED(true, false));
         test_one<Polygon, Polygon, Polygon>("ticket_9563", ticket_9563[0], ticket_9563[1],
                     1, 8, 129.90381, settings);
     }
@@ -720,7 +720,7 @@ void test_all()
     boost::ignore_unused<polygon_ccw, polygon_open, polygon_ccw_open>();
 
     ut_settings ignore_validity;
-    ignore_validity.test_validity = false;
+    ignore_validity.set_test_validity(false);
 
     std::string clip = "box(2 2,8 8)";
 
@@ -968,6 +968,12 @@ int test_main(int, char* [])
     test_ticket_10868<boost::long_long_type>("MULTIPOLYGON(((33520458 6878575,33480192 14931538,31446819 18947953,30772384 19615678,30101303 19612322,30114725 16928001,33520458 6878575)))");
 #endif
 #endif
+#endif
+
+#if defined(BOOST_GEOMETRY_TEST_FAILURES)
+    // llb_touch generates a polygon with 1 point and is therefore invalid everywhere
+    // TODO: this should be easy to fix
+    BoostGeometryWriteExpectedFailures(4, 3);
 #endif
 
     return 0;

--- a/test/algorithms/set_operations/intersection/intersection_multi.cpp
+++ b/test/algorithms/set_operations/intersection/intersection_multi.cpp
@@ -37,7 +37,7 @@
     ( #caseid "_rev", caseid[1], caseid[0], clips, points, area)
 
 #define TEST_INTERSECTION_IGNORE(caseid, clips, points, area) \
-    { ut_settings ignore_validity; ignore_validity.test_validity = false; \
+    { ut_settings ignore_validity; ignore_validity.set_test_validity(false); \
     (test_one<Polygon, MultiPolygon, MultiPolygon>) \
     ( #caseid, caseid[0], caseid[1], clips, points, area, ignore_validity); }
 
@@ -509,6 +509,10 @@ int test_main(int, char* [])
     test_all<bg::model::d2::point_xy<ttmath_big> >();
 #endif
 
+#endif
+
+#if defined(BOOST_GEOMETRY_TEST_FAILURES)
+    BoostGeometryWriteExpectedFailures(10, 4);
 #endif
 
     return 0;

--- a/test/algorithms/set_operations/intersection/test_intersection.hpp
+++ b/test/algorithms/set_operations/intersection/test_intersection.hpp
@@ -43,15 +43,14 @@
 #include <algorithms/check_validity.hpp>
 #include "../setop_output_type.hpp"
 
-struct ut_settings
+struct ut_settings : ut_base_settings
 {
     double percentage;
-    bool test_validity;
     bool debug;
 
     explicit ut_settings(double p = 0.0001, bool tv = true)
-        : percentage(p)
-        , test_validity(tv)
+        : ut_base_settings(tv)
+        , percentage(p)
         , debug(false)
     {}
 
@@ -98,9 +97,7 @@ void check_result(IntersectionOutput const& intersection_output,
         }
     }
 
-#if ! defined(BOOST_GEOMETRY_TEST_ALWAYS_CHECK_VALIDITY)
-    if (settings.test_validity)
-#endif
+    if (settings.test_validity())
     {
         std::string message;
         bool const valid = check_validity<IntersectionOutput>

--- a/test/algorithms/set_operations/union/test_union.hpp
+++ b/test/algorithms/set_operations/union/test_union.hpp
@@ -45,16 +45,13 @@
 #  include <boost/geometry/io/svg/svg_mapper.hpp>
 #endif
 
-struct ut_settings
+struct ut_settings : public ut_base_settings
 {
-    double percentage;
-    bool test_validity;
-
     ut_settings()
         : percentage(0.001)
-        , test_validity(true)
     {}
 
+    double percentage;
 };
 
 #if defined(BOOST_GEOMETRY_TEST_CHECK_VALID_INPUT)
@@ -125,9 +122,7 @@ void test_union(std::string const& caseid, G1 const& g1, G2 const& g2,
     }
 #endif
 
-#if ! defined(BOOST_GEOMETRY_TEST_ALWAYS_CHECK_VALIDITY)
-    if (settings.test_validity)
-#endif
+    if (settings.test_validity())
     {
         std::string message;
         bool const valid = check_validity<result_type>::apply(clip, caseid, g1, g2, message);

--- a/test/algorithms/set_operations/union/union.cpp
+++ b/test/algorithms/set_operations/union/union.cpp
@@ -381,7 +381,7 @@ void test_areal()
     {
         ut_settings settings;
         settings.percentage = 0.1;
-        settings.test_validity = BG_IF_RESCALED(true, false);
+        settings.set_test_validity(BG_IF_RESCALED(true, false));
 
         test_one<Polygon, Polygon, Polygon>("isovist",
             isovist1[0], isovist1[1],
@@ -427,7 +427,7 @@ void test_areal()
 
     {
         ut_settings settings;
-        settings.test_validity = BG_IF_RESCALED(true, false);
+        settings.set_test_validity(BG_IF_RESCALED(true, false));
         test_one<Polygon, Polygon, Polygon>("ticket_9563", ticket_9563[0], ticket_9563[1],
                 1, 0, 13, 150.0, settings);
     }
@@ -464,7 +464,7 @@ void test_areal()
     if (! BOOST_GEOMETRY_CONDITION((boost::is_same<ct, float>::value)) )
     {
         ut_settings ignore_validity;
-        ignore_validity.test_validity = false;
+        ignore_validity.set_test_validity(false);
         ignore_validity.percentage = 0.01;
         test_one<Polygon, Polygon, Polygon>("geos_1", geos_1[0], geos_1[1],
                 1, 0, -1, 3461.3203125,
@@ -543,7 +543,7 @@ void test_areal()
                 1, 0, if_typed_tt<ct>(93, 91), 22.815);
 
     test_one<Polygon, Polygon, Polygon>("buffer_mp2", buffer_mp2[0], buffer_mp2[1],
-                1, BG_IF_RESCALED(1, (if_typed<ct, float>(1, 0))), 217, 36.752837);
+                1, -1, 217, 36.752837);
 
     test_one<Polygon, Polygon, Polygon>("mysql_21964079_1",
         mysql_21964079_1[0], mysql_21964079_1[1],
@@ -638,6 +638,10 @@ int test_main(int, char* [])
     std::cout << "Testing TTMATH" << std::endl;
     test_all<bg::model::d2::point_xy<ttmath_big> >();
 #endif
+#endif
+
+#if defined(BOOST_GEOMETRY_TEST_FAILURES)
+    BoostGeometryWriteExpectedFailures(3, 10);
 #endif
 
     return 0;

--- a/test/algorithms/set_operations/union/union_multi.cpp
+++ b/test/algorithms/set_operations/union/union_multi.cpp
@@ -34,7 +34,7 @@
     ( #caseid, caseid[0], caseid[1], clips, holes, points, area)
 
 #define TEST_UNION_IGNORE(caseid, clips, holes, points, area) \
-   { ut_settings ignore_validity; ignore_validity.test_validity = false; \
+   { ut_settings ignore_validity; ignore_validity.set_test_validity(false); \
      test_one<Polygon, MultiPolygon, MultiPolygon> \
      (#caseid, caseid[0], caseid[1], \
      clips, holes, points, area, ignore_validity); }
@@ -390,7 +390,7 @@ void test_areal()
         // Generates either 4 or 3 output polygons
         // With rescaling the result is invalid.
         ut_settings settings;
-        settings.test_validity = BG_IF_RESCALED(false, true);
+        settings.set_test_validity(BG_IF_RESCALED(false, true));
         test_one<Polygon, MultiPolygon, MultiPolygon>("ticket_9081",
             ticket_9081[0], ticket_9081[1],
             BG_IF_RESCALED(4, 3), 0, 31, 0.2187385,
@@ -467,12 +467,9 @@ void test_specific()
     typedef bg::model::polygon<Point, ClockWise, Closed> polygon;
     typedef bg::model::multi_polygon<polygon> multi_polygon;
 
-    ut_settings settings;
-    settings.test_validity = true;
-
     test_one<polygon, multi_polygon, multi_polygon>("ticket_10803",
         ticket_10803[0], ticket_10803[1],
-        1, 0, 9, 2664270, settings);
+        1, 0, 9, 2664270);
 }
 
 
@@ -493,6 +490,10 @@ int test_main(int, char* [])
     test_all<bg::model::d2::point_xy<ttmath_big> >();
 #endif
 
+#endif
+
+#if defined(BOOST_GEOMETRY_TEST_FAILURES)
+    BoostGeometryWriteExpectedFailures(9, 2);
 #endif
 
     return 0;

--- a/test/count_set.hpp
+++ b/test/count_set.hpp
@@ -1,0 +1,108 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2020 Barend Gehrels, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+
+#ifndef GEOMETRY_TEST_COUNT_SET_HPP
+#define GEOMETRY_TEST_COUNT_SET_HPP
+
+#include <boost/foreach.hpp>
+
+#include <set>
+#include <ostream>
+
+// Structure to manage expectations: sometimes the output might have one or
+// two rings, both are fine.
+struct count_set
+{
+    count_set()
+    {
+    }
+
+    count_set(int value)
+    {
+        if (value >= 0)
+        {
+            m_values.insert(static_cast<std::size_t>(value));
+        }
+        else
+        {
+            std::cout << "EMPTY" << std::endl;
+        }
+    }
+
+    count_set(std::size_t value1, std::size_t value2)
+    {
+        m_values.insert(value1);
+        m_values.insert(value2);
+    }
+
+    bool empty() const { return m_values.empty(); }
+
+    bool has(std::size_t value) const
+    {
+        return m_values.count(value) > 0;
+    }
+
+    friend std::ostream &operator<<(std::ostream &os, const count_set& s)
+    {
+       os << "{";
+       BOOST_FOREACH(std::size_t const& value, s.m_values)
+       {
+           os << " " << value;
+       }
+       os << "}";
+       return os;
+    }
+
+    count_set operator+(const count_set& a) const
+    {
+        count_set result;
+        result.m_values = combine(this->m_values, a.m_values);
+        return result;
+    }
+
+private :
+    typedef std::set<std::size_t> set_type;
+    set_type m_values;
+
+    set_type combine(const set_type& a, const set_type& b) const
+    {
+        set_type result;
+        if (a.size() == 1 && b.size() == 1)
+        {
+            // The common scenario, both have one value
+            result.insert(*a.begin() + *b.begin());
+        }
+        else if (a.size() > 1 && b.size() == 1)
+        {
+            // One of them is optional, add the second
+            BOOST_FOREACH(std::size_t const& value, a)
+            {
+                result.insert(value + *b.begin());
+            }
+        }
+        else if (b.size() > 1 && a.size() == 1)
+        {
+            return combine(b, a);
+        }
+        // Else either is empty, or both have values and should be specified
+        return result;
+    }
+};
+
+inline count_set ignore_count()
+{
+    return count_set();
+}
+
+inline count_set optional()
+{
+    return count_set(0, 1);
+}
+
+#endif // GEOMETRY_TEST_COUNT_SET_HPP

--- a/test/geometry_test_common.hpp
+++ b/test/geometry_test_common.hpp
@@ -161,6 +161,33 @@ struct mathematical_policy
 
 };
 
+struct ut_base_settings
+{
+    explicit ut_base_settings(bool val = true)
+        : m_test_validity(true)
+    {
+        set_test_validity(val);
+    }
+
+    inline void set_test_validity(bool val)
+    {
+#if defined(BOOST_GEOMETRY_TEST_FAILURES)
+        boost::ignore_unused(val);
+#else
+        m_test_validity = val;
+#endif
+    }
+
+    inline bool test_validity() const
+    {
+        return m_test_validity;
+    }
+
+private :
+    bool m_test_validity;
+};
+
+
 typedef double default_test_type;
 
 #if defined(BOOST_GEOMETRY_USE_RESCALING)
@@ -198,5 +225,23 @@ inline void BoostGeometryWriteTestConfiguration()
     std::cout << "  - Default test type: " << string_from_type<default_test_type>::name() << std::endl;
     std::cout << std::endl;
 }
+
+#ifdef BOOST_GEOMETRY_TEST_FAILURES
+#define BG_NO_FAILURES 0
+inline void BoostGeometryWriteExpectedFailures(std::size_t for_rescaling,
+                std::size_t for_no_rescaling = BG_NO_FAILURES)
+{
+    boost::ignore_unused(for_rescaling, for_no_rescaling);
+
+#if defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE) && defined(BOOST_GEOMETRY_TEST_ONLY_ONE_ORDER)
+    std::cout << std::endl;
+#if defined(BOOST_GEOMETRY_USE_RESCALING)
+    std::cout << "RESCALED - Expected: " << for_rescaling << " error(s)" << std::endl;
+#else
+    std::cout << "NOT RESCALED - Expected: " << for_no_rescaling << " error(s)" << std::endl;
+#endif
+#endif
+}
+#endif
 
 #endif // GEOMETRY_TEST_GEOMETRY_TEST_COMMON_HPP


### PR DESCRIPTION
- some cases are fixed in the meantime, this is updated
- in `difference` there might be slivers which are still OK, therefore an `count_set` is used there
- when `BOOST_GEOMETRY_TEST_FAILURES` is defined, it also writes expected failures - this makes it much easier to detect improvements (or regressions)
- this also shows insight in the current state, which is more or less in par with the rescaling - this means we might switch in next release (and one or two releases later remove the rescaling code)