### PR TITLE
[intersection] refactor segment-intersection class

### DIFF
--- a/include/boost/geometry/strategies/cartesian/intersection.hpp
+++ b/include/boost/geometry/strategies/cartesian/intersection.hpp
@@ -291,12 +291,13 @@ struct cartesian_segments
     static inline void cramers_rule(D const& dx_a, D const& dy_a,
         D const& dx_b, D const& dy_b, W const& wx, W const& wy,
         // out:
-        ResultType& d, ResultType& da)
+        ResultType& nominator, ResultType& denominator)
     {
         // Cramers rule
-        d = geometry::detail::determinant<ResultType>(dx_a, dy_a, dx_b, dy_b);
-        da = geometry::detail::determinant<ResultType>(dx_b, dy_b, wx, wy);
-        // Ratio is da/d , collinear if d == 0, intersecting if 0 <= r <= 1
+        nominator = geometry::detail::determinant<ResultType>(dx_b, dy_b, wx, wy);
+        denominator = geometry::detail::determinant<ResultType>(dx_a, dy_a, dx_b, dy_b);
+        // Ratio r = nominator/denominator
+        // Collinear if denominator == 0, intersecting if 0 <= r <= 1
         // IntersectionPoint = (x1 + r * dx_a, y1 + r * dy_a)
     }
 
@@ -312,25 +313,26 @@ struct cartesian_segments
               UniqueSubRange2 const& range_q,
               Policy const& policy)
     {
-        // Pass the same ranges both as normal ranges and as robust ranges
+        // Pass the same ranges both as normal ranges and as modelled ranges
         return apply(range_p, range_q, policy, range_p, range_q);
     }
 
-    // Main entry-routine, calculating intersections of segments p / q
+    // Version for non rescaled versions.
+    // The "modelled" parameter might be rescaled (will be removed later)
     template
     <
         typename UniqueSubRange1,
         typename UniqueSubRange2,
         typename Policy,
-        typename RobustUniqueSubRange1,
-        typename RobustUniqueSubRange2
+        typename ModelledUniqueSubRange1,
+        typename ModelledUniqueSubRange2
     >
     static inline typename Policy::return_type
         apply(UniqueSubRange1 const& range_p,
               UniqueSubRange2 const& range_q,
-              Policy const&,
-              RobustUniqueSubRange1 const& robust_range_p,
-              RobustUniqueSubRange2 const& robust_range_q)
+              Policy const& policy,
+              ModelledUniqueSubRange1 const& modelled_range_p,
+              ModelledUniqueSubRange2 const& modelled_range_q)
     {
         typedef typename UniqueSubRange1::point_type point1_type;
         typedef typename UniqueSubRange2::point_type point2_type;
@@ -338,64 +340,23 @@ struct cartesian_segments
         BOOST_CONCEPT_ASSERT( (concepts::ConstPoint<point1_type>) );
         BOOST_CONCEPT_ASSERT( (concepts::ConstPoint<point2_type>) );
 
-        // Get robust points (to be omitted later)
-        typedef typename RobustUniqueSubRange1::point_type robust_point1_type;
-        typedef typename RobustUniqueSubRange2::point_type robust_point2_type;
-
         point1_type const& p1 = range_p.at(0);
         point1_type const& p2 = range_p.at(1);
         point2_type const& q1 = range_q.at(0);
         point2_type const& q2 = range_q.at(1);
 
-        robust_point1_type const& robust_a1 = robust_range_p.at(0);
-        robust_point1_type const& robust_a2 = robust_range_p.at(1);
-        robust_point2_type const& robust_b1 = robust_range_q.at(0);
-        robust_point2_type const& robust_b2 = robust_range_q.at(1);
-
-        using geometry::detail::equals::equals_point_point;
-        bool const a_is_point = equals_point_point(robust_a1, robust_a2, point_in_point_strategy_type());
-        bool const b_is_point = equals_point_point(robust_b1, robust_b2, point_in_point_strategy_type());
-
-        if(a_is_point && b_is_point)
-        {
-            // Take either a or b
-            model::referring_segment<point1_type const> const d(p1, p2);
-
-            return equals_point_point(robust_a1, robust_b2, point_in_point_strategy_type())
-                ? Policy::degenerate(d, true)
-                : Policy::disjoint()
-                ;
-        }
-
-        side_info sides;
-        sides.set<0>(side_strategy_type::apply(robust_b1, robust_b2, robust_a1),
-                     side_strategy_type::apply(robust_b1, robust_b2, robust_a2));
-
-        if (sides.same<0>())
-        {
-            // Both points are at same side of other segment, we can leave
-            return Policy::disjoint();
-        }
-
-        sides.set<1>(side_strategy_type::apply(robust_a1, robust_a2, robust_b1),
-                     side_strategy_type::apply(robust_a1, robust_a2, robust_b2));
-        
-        if (sides.same<1>())
-        {
-            // Both points are at same side of other segment, we can leave
-            return Policy::disjoint();
-        }
-
-        bool collinear = sides.collinear();
+        // Declare segments, currently necessary for the policies
+        // (segment_crosses, segment_colinear, degenerate, one_degenerate, etc)
+        model::referring_segment<point1_type const> const p(p1, p2);
+        model::referring_segment<point2_type const> const q(q1, q2);
 
         typedef typename select_most_precise
             <
-                typename geometry::coordinate_type<robust_point1_type>::type,
-                typename geometry::coordinate_type<robust_point2_type>::type
-            >::type robust_coordinate_type;
+                typename geometry::coordinate_type<typename ModelledUniqueSubRange1::point_type>::type,
+                typename geometry::coordinate_type<typename ModelledUniqueSubRange1::point_type>::type
+            >::type modelled_coordinate_type;
 
-        typedef segment_ratio<robust_coordinate_type> ratio_type;
-
+        typedef segment_ratio<modelled_coordinate_type> ratio_type;
         segment_intersection_info
             <
                 typename select_calculation_type<point1_type, point2_type, CalculationType>::type,
@@ -407,33 +368,102 @@ struct cartesian_segments
         sinfo.dy_a = get<1>(p2) - get<1>(p1); // distance in y-dir
         sinfo.dy_b = get<1>(q2) - get<1>(q1);
 
-        robust_coordinate_type const robust_dx_a = get<0>(robust_a2) - get<0>(robust_a1);
-        robust_coordinate_type const robust_dx_b = get<0>(robust_b2) - get<0>(robust_b1);
-        robust_coordinate_type const robust_dy_a = get<1>(robust_a2) - get<1>(robust_a1);
-        robust_coordinate_type const robust_dy_b = get<1>(robust_b2) - get<1>(robust_b1);
+        return unified<ratio_type>(sinfo, p, q, policy, modelled_range_p, modelled_range_q);
+    }
+
+    // Implementation for either rescaled or non rescaled versions.
+    template
+    <
+        typename RatioType,
+        typename SegmentInfo,
+        typename Segment1,
+        typename Segment2,
+        typename Policy,
+        typename UniqueSubRange1,
+        typename UniqueSubRange2
+    >
+    static inline typename Policy::return_type
+        unified(SegmentInfo& sinfo,
+                Segment1 const& p, Segment2 const& q, Policy const&,
+                UniqueSubRange1 const& range_p,
+                UniqueSubRange2 const& range_q)
+    {
+        typedef typename UniqueSubRange1::point_type point1_type;
+        typedef typename UniqueSubRange2::point_type point2_type;
+        typedef typename select_most_precise
+            <
+                typename geometry::coordinate_type<point1_type>::type,
+                typename geometry::coordinate_type<point2_type>::type
+            >::type coordinate_type;
+
+        point1_type const& p1 = range_p.at(0);
+        point1_type const& p2 = range_p.at(1);
+        point2_type const& q1 = range_q.at(0);
+        point2_type const& q2 = range_q.at(1);
+
+        using geometry::detail::equals::equals_point_point;
+        bool const p_is_point = equals_point_point(p1, p2, point_in_point_strategy_type());
+        bool const q_is_point = equals_point_point(q1, q2, point_in_point_strategy_type());
+
+        if (p_is_point && q_is_point)
+        {
+            return equals_point_point(p1, q2, point_in_point_strategy_type())
+                ? Policy::degenerate(p, true)
+                : Policy::disjoint()
+                ;
+        }
+
+        side_info sides;
+        sides.set<0>(side_strategy_type::apply(q1, q2, p1),
+                     side_strategy_type::apply(q1, q2, p2));
+
+        if (sides.same<0>())
+        {
+            // Both points are at same side of other segment, we can leave
+            return Policy::disjoint();
+        }
+
+        sides.set<1>(side_strategy_type::apply(p1, p2, q1),
+                     side_strategy_type::apply(p1, p2, q2));
+        
+        if (sides.same<1>())
+        {
+            // Both points are at same side of other segment, we can leave
+            return Policy::disjoint();
+        }
+
+        bool collinear = sides.collinear();
+
+        // Calculate the differences again
+        // (for rescaled version, this is different from dx_p etc)
+        coordinate_type const dx_p = get<0>(p2) - get<0>(p1);
+        coordinate_type const dx_q = get<0>(q2) - get<0>(q1);
+        coordinate_type const dy_p = get<1>(p2) - get<1>(p1);
+        coordinate_type const dy_q = get<1>(q2) - get<1>(q1);
 
         // r: ratio 0-1 where intersection divides A/B
         // (only calculated for non-collinear segments)
         if (! collinear)
         {
-            robust_coordinate_type robust_da0, robust_da;
-            robust_coordinate_type robust_db0, robust_db;
+            coordinate_type denominator_a, nominator_a;
+            coordinate_type denominator_b, nominator_b;
 
-            cramers_rule(robust_dx_a, robust_dy_a, robust_dx_b, robust_dy_b,
-                get<0>(robust_a1) - get<0>(robust_b1),
-                get<1>(robust_a1) - get<1>(robust_b1),
-                robust_da0, robust_da);
+            cramers_rule(dx_p, dy_p, dx_q, dy_q,
+                get<0>(p1) - get<0>(q1),
+                get<1>(p1) - get<1>(q1),
+                nominator_a, denominator_a);
 
-            cramers_rule(robust_dx_b, robust_dy_b, robust_dx_a, robust_dy_a,
-                get<0>(robust_b1) - get<0>(robust_a1),
-                get<1>(robust_b1) - get<1>(robust_a1),
-                robust_db0, robust_db);
+            cramers_rule(dx_q, dy_q, dx_p, dy_p,
+                get<0>(q1) - get<0>(p1),
+                get<1>(q1) - get<1>(p1),
+                nominator_b, denominator_b);
 
-            math::detail::equals_factor_policy<robust_coordinate_type>
-                policy(robust_dx_a, robust_dy_a, robust_dx_b, robust_dy_b);
-            robust_coordinate_type const zero = 0;
-            if (math::detail::equals_by_policy(robust_da0, zero, policy)
-             || math::detail::equals_by_policy(robust_db0, zero, policy))
+            math::detail::equals_factor_policy<coordinate_type>
+                policy(dx_p, dy_p, dx_q, dy_q);
+
+            coordinate_type const zero = 0;
+            if (math::detail::equals_by_policy(denominator_a, zero, policy)
+             || math::detail::equals_by_policy(denominator_b, zero, policy))
             {
                 // If this is the case, no rescaling is done for FP precision.
                 // We set it to collinear, but it indicates a robustness issue.
@@ -443,24 +473,19 @@ struct cartesian_segments
             }
             else
             {
-                sinfo.robust_ra.assign(robust_da, robust_da0);
-                sinfo.robust_rb.assign(robust_db, robust_db0);
+                sinfo.robust_ra.assign(nominator_a, denominator_a);
+                sinfo.robust_rb.assign(nominator_b, denominator_b);
             }
         }
-
-        // Declare segments, currently necessary for the policies
-        // (segment_crosses, segment_colinear, degenerate, one_degenerate, etc)
-        model::referring_segment<point1_type const> const p(p1, p2);
-        model::referring_segment<point2_type const> const q(q1, q2);
 
         if (collinear)
         {
             std::pair<bool, bool> const collinear_use_first
-                    = is_x_more_significant(geometry::math::abs(robust_dx_a),
-                                            geometry::math::abs(robust_dy_a),
-                                            geometry::math::abs(robust_dx_b),
-                                            geometry::math::abs(robust_dy_b),
-                                            a_is_point, b_is_point);
+                    = is_x_more_significant(geometry::math::abs(dx_p),
+                                            geometry::math::abs(dy_p),
+                                            geometry::math::abs(dx_q),
+                                            geometry::math::abs(dy_q),
+                                            p_is_point, q_is_point);
 
             if (collinear_use_first.second)
             {
@@ -469,16 +494,16 @@ struct cartesian_segments
 
                 if (collinear_use_first.first)
                 {
-                    return relate_collinear<0, Policy, ratio_type>(p, q,
-                            robust_a1, robust_a2, robust_b1, robust_b2,
-                            a_is_point, b_is_point);
+                    return relate_collinear<0, Policy, RatioType>(p, q,
+                            p1, p2, q1, q2,
+                            p_is_point, q_is_point);
                 }
                 else
                 {
                     // Y direction contains larger segments (maybe dx is zero)
-                    return relate_collinear<1, Policy, ratio_type>(p, q,
-                            robust_a1, robust_a2, robust_b1, robust_b2,
-                            a_is_point, b_is_point);
+                    return relate_collinear<1, Policy, RatioType>(p, q,
+                            p1, p2, q1, q2,
+                            p_is_point, q_is_point);
                 }
             }
         }
@@ -489,12 +514,12 @@ struct cartesian_segments
 private:
     // first is true if x is more significant
     // second is true if the more significant difference is not 0
-    template <typename RobustCoordinateType>
+    template <typename CoordinateType>
     static inline std::pair<bool, bool>
-        is_x_more_significant(RobustCoordinateType const& abs_robust_dx_a,
-                              RobustCoordinateType const& abs_robust_dy_a,
-                              RobustCoordinateType const& abs_robust_dx_b,
-                              RobustCoordinateType const& abs_robust_dy_b,
+        is_x_more_significant(CoordinateType const& abs_dx_a,
+                              CoordinateType const& abs_dy_a,
+                              CoordinateType const& abs_dx_b,
+                              CoordinateType const& abs_dy_b,
                               bool const a_is_point,
                               bool const b_is_point)
     {
@@ -505,18 +530,18 @@ private:
 
         if (a_is_point)
         {
-            return std::make_pair(abs_robust_dx_b >= abs_robust_dy_b, true);
+            return std::make_pair(abs_dx_b >= abs_dy_b, true);
         }
         else if (b_is_point)
         {
-            return std::make_pair(abs_robust_dx_a >= abs_robust_dy_a, true);
+            return std::make_pair(abs_dx_a >= abs_dy_a, true);
         }
         else
         {
-            RobustCoordinateType const min_dx = (std::min)(abs_robust_dx_a, abs_robust_dx_b);
-            RobustCoordinateType const min_dy = (std::min)(abs_robust_dy_a, abs_robust_dy_b);
+            CoordinateType const min_dx = (std::min)(abs_dx_a, abs_dx_b);
+            CoordinateType const min_dy = (std::min)(abs_dy_a, abs_dy_b);
             return min_dx == min_dy ?
-                    std::make_pair(true, min_dx > RobustCoordinateType(0)) :
+                    std::make_pair(true, min_dx > CoordinateType(0)) :
                     std::make_pair(min_dx > min_dy, true);
         }
     }
@@ -566,13 +591,13 @@ private:
         typename RatioType,
         typename Segment1,
         typename Segment2,
-        typename RobustType1,
-        typename RobustType2
+        typename Type1,
+        typename Type2
     >
     static inline typename Policy::return_type
         relate_collinear(Segment1 const& a, Segment2 const& b,
-                         RobustType1 oa_1, RobustType1 oa_2,
-                         RobustType2 ob_1, RobustType2 ob_2)
+                         Type1 oa_1, Type1 oa_2,
+                         Type2 ob_1, Type2 ob_2)
     {
         // Calculate the ratios where a starts in b, b starts in a
         //         a1--------->a2         (2..7)
@@ -604,8 +629,8 @@ private:
         // b2 is located w.r.t. a at ratio: (5-2)/5=3/5 (on a)
         // a1 is located w.r.t. b at ratio: (2-8)/-3=6/3 (after b ends)
         // a2 is located w.r.t. b at ratio: (7-8)/-3=1/3 (on b)
-        RobustType1 const length_a = oa_2 - oa_1; // no abs, see above
-        RobustType2 const length_b = ob_2 - ob_1;
+        Type1 const length_a = oa_2 - oa_1; // no abs, see above
+        Type2 const length_b = ob_2 - ob_1;
 
         RatioType ra_from(oa_1 - ob_1, length_b);
         RatioType ra_to(oa_2 - ob_1, length_b);
@@ -667,12 +692,12 @@ private:
         typename Policy,
         typename RatioType,
         typename DegenerateSegment,
-        typename RobustType1,
-        typename RobustType2
+        typename Type1,
+        typename Type2
     >
     static inline typename Policy::return_type
         relate_one_degenerate(DegenerateSegment const& degenerate_segment,
-                              RobustType1 d, RobustType2 s1, RobustType2 s2,
+                              Type1 d, Type2 s1, Type2 s2,
                               bool a_degenerate)
     {
         // Calculate the ratios where ds starts in s


### PR DESCRIPTION
This is to avoid using both non-rescaled and rescaled coordinates in one method.

It is completely independent of the other PR created today, and should result in no failures