### PR TITLE
Fix MSVC warning C4127: conditional expression is constant

### DIFF
--- a/include/boost/geometry/algorithms/detail/overlay/follow.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/follow.hpp
@@ -30,6 +30,8 @@
 #include <boost/geometry/algorithms/detail/relate/turns.hpp>
 #include <boost/geometry/algorithms/detail/tupled_output.hpp>
 
+#include <boost/geometry/util/condition.hpp>
+
 namespace boost { namespace geometry
 {
 
@@ -487,7 +489,7 @@ public :
                     strategy, robust_policy,
                     linear::get(out));
             }
-            else if (FollowIsolatedPoints
+            else if (BOOST_GEOMETRY_CONDITION(FollowIsolatedPoints)
                   && following::is_touching(*it, *iit, entered))
             {
                 debug_traverse(*it, *iit, "-> Isolated point");
@@ -519,7 +521,7 @@ public :
         {
             *linear::get(out)++ = current_piece;
         }
-        else if (FollowIsolatedPoints
+        else if (BOOST_GEOMETRY_CONDITION(FollowIsolatedPoints)
               && current_piece_size == 1)
         {
             action::template isolated_point

--- a/include/boost/geometry/algorithms/detail/overlay/follow_linear_linear.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/follow_linear_linear.hpp
@@ -39,6 +39,7 @@
 #include <boost/geometry/algorithms/convert.hpp>
 #include <boost/geometry/algorithms/not_implemented.hpp>
 
+#include <boost/geometry/util/condition.hpp>
 
 namespace boost { namespace geometry
 {
@@ -243,7 +244,7 @@ protected:
                               linear::get(oit));
             }
         }
-        else if ( FollowIsolatedPoints
+        else if ( BOOST_GEOMETRY_CONDITION(FollowIsolatedPoints)
                   && is_isolated_point(*it, *op_it, entered) )
         {
             detail::turns::debug_turn(*it, *op_it, "-> Isolated point");
@@ -253,7 +254,7 @@ protected:
                     typename pointlike::type
                 >(it->point, pointlike::get(oit));
         }
-        else if ( FollowContinueTurns
+        else if ( BOOST_GEOMETRY_CONDITION(FollowContinueTurns)
                   && is_staying_inside(*it, *op_it, entered) )
         {
             detail::turns::debug_turn(*it, *op_it, "-> Staying inside");


### PR DESCRIPTION
Fixes #727 

-----

MWE that triggers the warning

```cpp
#include <deque>
#include <boost/geometry.hpp>
namespace bg = boost::geometry;
int main()
{
    using line_t = bg::model::linestring<bg::model::d2::point_xy<double>>;
    line_t green, blue;

    bg::read_wkt("LINESTRING(0 0, 2 0)", green);
    bg::read_wkt("LINESTRING(-1 -1, -1 2)", blue);

    std::deque<line_t> output;
    bg::union_(green, blue, output);
    bg::intersection(green, blue, output);
}
```

------

It's worth to be aware usage of the macro

https://github.com/boostorg/geometry/blob/cff2ee9d6c30afba4fe6cf64b3d65080372f8a5d/include/boost/geometry/util/condition.hpp#L35

may trigger the MSVC [code analysis warning C6319](https://docs.microsoft.com/en-us/cpp/code-quality/c6319).