### PR TITLE
 Automatically generated, fast floating-point predicates

### DIFF
--- a/extensions/example/Jamfile
+++ b/extensions/example/Jamfile
@@ -13,3 +13,4 @@ project boost-geometry-examples-extensions
     ;
 
 build-project gis ;
+build-project generic_robust_predicates ;

--- a/extensions/example/generic_robust_predicates/Jamfile
+++ b/extensions/example/generic_robust_predicates/Jamfile
@@ -1,0 +1,12 @@
+# Boost.Geometry (aka GGL, Generic Geometry Library)
+
+# Use, modification and distribution is subject to the Boost Software License,
+# Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+
+project boost-geometry-example-extensions-generic_robust_predicates
+    :
+    ;
+
+exe static_side_2d : static_side_2d.cpp ;

--- a/extensions/example/generic_robust_predicates/static_side_2d.cpp
+++ b/extensions/example/generic_robust_predicates/static_side_2d.cpp
@@ -1,0 +1,79 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2020 Tinko Bartels, Berlin, Germany.
+
+// Contributed and/or modified by Tinko Bartels,
+//   as part of Google Summer of Code 2020 program.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+
+#define BOOST_GEOMETRY_NO_BOOST_TEST
+
+#include <iostream>
+
+#include <boost/geometry/core/cs.hpp>
+#include <boost/geometry/geometries/point.hpp>
+
+#include <boost/geometry/extensions/triangulation/strategies/cartesian/side_robust.hpp>
+#include <boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/expressions.hpp>
+#include <boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/stage_a.hpp>
+
+
+namespace bg = boost::geometry;
+using point = bg::model::point<double, 2, bg::cs::cartesian>;
+
+template <typename CalculationType>
+struct side_robust_with_static_filter
+{
+private:
+    using ct = CalculationType;
+    using expression = bg::detail::generic_robust_predicates::orient2d;
+    using filter = bg::detail::generic_robust_predicates::stage_a_static
+            <
+                expression,
+                ct
+            >;
+    filter m_filter;
+public:
+    side_robust_with_static_filter(ct x_max, ct y_max, ct x_min, ct y_min)
+        : m_filter(x_max, y_max, x_max, y_max, x_max, y_max,
+                   x_min, y_min, x_min, y_min, x_min, y_min) {};
+
+    template
+    <
+        typename P1,
+        typename P2,
+        typename P  
+    >
+    inline int apply(P1 const& p1, P2 const& p2, P const& p) const
+    {
+        int sign = m_filter.apply(bg::get<0>(p1),
+                                  bg::get<1>(p1),
+                                  bg::get<0>(p2),
+                                  bg::get<1>(p2),
+                                  bg::get<0>(p),
+                                  bg::get<1>(p));
+        if(sign != bg::detail::generic_robust_predicates::sign_uncertain)
+        {
+            return sign;
+        }
+        else
+        {
+            //fallback if filter fails.
+            return bg::strategy::side::side_robust<double>::apply(p1, p2, p);
+        }
+    }
+};
+
+int main(int argc, char** argv)
+{
+    point p1(0.0, 0.0);
+    point p2(1.0, 1.0);
+    point p (0.0, 1.0);
+    side_robust_with_static_filter<double> static_strategy(2.0, 2.0, 1.0, 1.0);
+    std::cout << "Side value: " << static_strategy.apply(p1, p2, p) << "\n"; 
+    return 0;
+}

--- a/extensions/test/Jamfile
+++ b/extensions/test/Jamfile
@@ -28,3 +28,4 @@ build-project gis ;
 build-project iterators ;
 build-project nsphere ;
 build-project triangulation ;
+build-project generic_robust_predicates ;

--- a/extensions/test/generic_robust_predicates/Jamfile
+++ b/extensions/test/generic_robust_predicates/Jamfile
@@ -1,0 +1,12 @@
+# Boost.Geometry (aka GGL, Generic Geometry Library)
+#
+# Use, modification and distribution is subject to the Boost Software License,
+# Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+test-suite boost-geometry-extensions-generic_robust_predicates
+    :
+    [ run approximate.cpp ]
+    [ run side3d.cpp : : : <debug-symbols>off ]
+    ;
+

--- a/extensions/test/generic_robust_predicates/approximate.cpp
+++ b/extensions/test/generic_robust_predicates/approximate.cpp
@@ -1,0 +1,66 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+// Unit Test
+
+// Copyright (c) 2020 Tinko Bartels, Berlin, Germany.
+
+// Contributed and/or modified by Tinko Bartels,
+//   as part of Google Summer of Code 2020 program.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <array>
+
+#include <geometry_test_common.hpp>
+
+#include <boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/approximate.hpp>
+#include <boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/expression_tree.hpp>
+
+template <typename CalculationType>
+void test_all()
+{
+    using bg::detail::generic_robust_predicates::_1;
+    using bg::detail::generic_robust_predicates::_2;
+    using bg::detail::generic_robust_predicates::_3;
+    using bg::detail::generic_robust_predicates::_4;
+    using bg::detail::generic_robust_predicates::sum;
+    using bg::detail::generic_robust_predicates::difference;
+    using bg::detail::generic_robust_predicates::product;
+    using bg::detail::generic_robust_predicates::max;
+    using bg::detail::generic_robust_predicates::abs;
+    using bg::detail::generic_robust_predicates::post_order;
+    using bg::detail::generic_robust_predicates::approximate_value;
+    using bg::detail::generic_robust_predicates::get_approx;
+    using bg::detail::generic_robust_predicates::approximate_interim;
+    using ct = CalculationType;
+    ct r1 = approximate_value<sum<_1, _2>, ct>(
+            std::array<ct, 2>{1.0, 2.0});
+    BOOST_CHECK_EQUAL(3.0, r1);
+    ct r2 = approximate_value<max<abs<_1>, abs<_2>>, ct>(
+            std::array<ct, 2>{-10.0, 2.0});
+    BOOST_CHECK_EQUAL(10.0, r2);
+
+    using expression = product
+        <
+            difference<_1, _2>,
+            difference<_3, _4>
+        >;
+    using evals = post_order<expression>;
+    std::array<ct, boost::mp11::mp_size<evals>::value> r;
+    std::array<ct, 4> input {5.0, 3.0, 2.0, 8.0};
+    approximate_interim<evals, evals, ct>(r, input);
+    ct r3 = get_approx<evals, typename expression::left, ct>(r, input);
+    BOOST_CHECK_EQUAL(2.0, r3);
+    ct r4 = get_approx<evals, typename expression::right, ct>(r, input);
+    BOOST_CHECK_EQUAL(-6.0, r4);
+    ct r5 = get_approx<evals, expression, ct>(r, input);
+    BOOST_CHECK_EQUAL(-12.0, r5);
+}
+
+
+int test_main(int, char* [])
+{
+    test_all<double>();
+    return 0;
+}

--- a/extensions/test/generic_robust_predicates/side3d.cpp
+++ b/extensions/test/generic_robust_predicates/side3d.cpp
@@ -1,0 +1,76 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+// Unit Test
+
+// Copyright (c) 2020 Tinko Bartels, Berlin, Germany.
+
+// Contributed and/or modified by Tinko Bartels,
+//   as part of Google Summer of Code 2020 program.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <array>
+
+#include <geometry_test_common.hpp>
+
+#include <boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/expressions.hpp>
+#include <boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/stage_a.hpp>
+
+template <typename CalculationType>
+void test_all()
+{
+    using bg::detail::generic_robust_predicates::orient3d;
+    using bg::detail::generic_robust_predicates::stage_a_semi_static;
+    using bg::detail::generic_robust_predicates::stage_a_almost_static;
+    using bg::detail::generic_robust_predicates::stage_a_static;
+    using ct = CalculationType;
+    using semi_static = stage_a_semi_static<orient3d, ct>;
+    BOOST_CHECK_EQUAL(1,
+                      semi_static::apply(1, 0, 0,
+                                         0, 1, 0,
+                                         1, 1, 0,
+                                         0, 0, 1));
+    BOOST_CHECK_EQUAL(-1,
+                      semi_static::apply(1, 0, 0,       
+                                         0, 1, 0,                
+                                         1, 1, 0,                
+                                         0, 0, -1));
+    BOOST_CHECK_EQUAL(0,
+                      semi_static::apply(1, 0, 0,       
+                                         0, 1, 0,                
+                                         1, 1, 0,                
+                                         0, 0, 0));
+    stage_a_static<orient3d, ct> stat(10, 10, 10,
+                                      10, 10, 10,
+                                      10, 10, 10,
+                                      10, 10, 10,
+                                       0,  0,  0,
+                                       0,  0,  0,
+                                       0,  0,  0,
+                                       0,  0,  0);
+    BOOST_CHECK_EQUAL(1, stat.apply(1, 0, 0,
+                                    0, 1, 0,
+                                    1, 1, 0,
+                                    0, 0, 1));
+
+    stage_a_static<orient3d, ct> pessimistic(1e40, 1e40, 1e40,
+                                             1e40, 1e40, 1e40,
+                                             1e40, 1e40, 1e40,
+                                             1e40, 1e40, 1e40, 
+                                             0,    0,    0,  
+                                             0,    0,    0, 
+                                             0,    0,    0,
+                                             0,    0,    0);
+    BOOST_CHECK_EQUAL(bg::detail::generic_robust_predicates::sign_uncertain,
+                      pessimistic.apply(1, 0, 0,
+                                        0, 1, 0,
+                                        1, 1, 0,
+                                        0, 0, 1));
+}
+
+int test_main(int, char* [])
+{
+    test_all<double>();
+    return 0;
+}

--- a/include/boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/almost_static_filter.hpp
+++ b/include/boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/almost_static_filter.hpp
@@ -1,0 +1,133 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2020 Tinko Bartels, Berlin, Germany.
+
+// Contributed and/or modified by Tinko Bartels,
+//   as part of Google Summer of Code 2020 program.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_ALMOST_STATIC_FILTER_HPP
+#define BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_ALMOST_STATIC_FILTER_HPP
+
+#include <array>
+#include <algorithm>
+#include <limits>
+
+#include <boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/expression_tree.hpp>
+
+namespace boost { namespace geometry
+{
+
+namespace detail { namespace generic_robust_predicates
+{
+
+template <typename Filter, std::size_t N, std::size_t End>
+struct make_filter_impl
+{
+    template <typename ExtremaArray, typename ...Reals>
+    static Filter apply(const ExtremaArray& extrema, const Reals&... args)
+    {
+        return make_filter_impl<Filter, N + 1, End>
+            ::apply(extrema, args..., extrema[N]);
+    }
+};
+
+template <typename Filter, std::size_t End>
+struct make_filter_impl<Filter, End, End>
+{
+    template <typename ExtremaArray, typename ...Reals>
+    static Filter apply(const ExtremaArray& extrema, const Reals&... args)
+    {
+        Filter f(args...);
+        return f;
+    }
+};
+
+template
+<
+    typename Expression,
+    typename CalculationType,
+    typename StaticFilter
+>
+class almost_static_filter
+{
+private:
+    using expression_max_argn = max_argn<Expression>;
+    using ct = CalculationType;
+    using extrema_array = std::array<ct, 2 * expression_max_argn::value>;
+    extrema_array m_extrema;
+    StaticFilter m_filter;
+public:
+    const StaticFilter& filter() const { return m_filter; }
+    inline almost_static_filter()
+    {
+        std::fill(m_extrema.begin(),
+                  m_extrema.begin() + m_extrema.size() / 2,
+                  -std::numeric_limits<ct>::infinity());
+        std::fill(m_extrema.begin() + m_extrema.size() / 2,
+                  m_extrema.end(),
+                  std::numeric_limits<ct>::infinity());
+    }
+    template <typename ...Reals>
+    int apply(const Reals&... args) const
+    {
+        return m_filter.apply(args...);
+    }
+
+    template <typename ...Reals>
+    inline void update_extrema(const Reals&... args)
+    {
+        std::array<ct, sizeof...(Reals)> input {{ static_cast<ct>(args)... }};
+        for(int i = 0; i < m_extrema.size() / 2; ++i)
+        {
+            m_extrema[i] = std::max(m_extrema[i], input[i]);
+        }
+        for(int i = m_extrema.size() / 2; i < m_extrema.size(); ++i)
+        {
+            m_extrema[i] = std::min(m_extrema[i], input[i]);
+        }
+    }
+
+    template <typename ...Reals>
+    inline bool update_extrema_check(const Reals&... args)
+    {
+        bool changed = false;
+        std::array<ct, sizeof...(Reals)> input {{ static_cast<ct>(args)... }};
+        for(int i = 0; i < m_extrema.size() / 2; ++i)
+        {
+            if(input[i] > m_extrema[i])
+            {
+                changed = true;
+                m_extrema[i] = input[i];
+            }
+        }
+        for(int i = m_extrema.size() / 2; i < m_extrema.size(); ++i)
+        {
+            if(input[i] < m_extrema[i])
+            {
+                changed = true;
+                m_extrema[i] = input[i];
+            }
+        }
+        return changed;
+    }
+
+    inline void update_filter()
+    {
+        m_filter = make_filter_impl
+                <
+                    StaticFilter,
+                    0,
+                    2 * expression_max_argn::value
+                >::apply(m_extrema);
+    }
+};
+
+}} // namespace detail::generic_robust_predicates
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_ALMOST_STATIC_FILTER_HPP

--- a/include/boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/approximate.hpp
+++ b/include/boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/approximate.hpp
@@ -1,0 +1,478 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2020 Tinko Bartels, Berlin, Germany.
+
+// Contributed and/or modified by Tinko Bartels,
+//   as part of Google Summer of Code 2020 program.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_APPROXIMATE_HPP
+#define BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_APPROXIMATE_HPP
+
+#include <cstddef>
+#include <cmath>
+#include <array>
+
+#include <boost/mp11/integral.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/algorithm.hpp>
+
+#include <boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/expression_tree.hpp>
+
+namespace boost { namespace geometry
+{
+
+namespace detail { namespace generic_robust_predicates
+{
+
+template
+<
+    typename Node,
+    std::size_t N,
+    typename Real,
+    typename InputArr
+>
+struct get_nth_real_impl
+{
+    static inline Real apply(const InputArr& input)
+    {
+        return input[N - 1];
+    }
+};
+
+template
+<
+    typename Node,
+    typename Real,
+    typename InputArr
+>
+struct get_nth_real_impl<Node, 0, Real, InputArr>
+{
+    static inline Real apply(const InputArr&)
+    {
+        return Node::value;
+    }
+};
+
+template
+<
+    typename Node,
+    std::size_t N,
+    typename Real,
+    typename InputArr
+>
+inline Real get_nth_real(const InputArr& input)
+{
+    return get_nth_real_impl<Node, Node::argn, Real, InputArr>::apply(input);
+}
+
+template
+<
+    typename All,
+    typename Node,
+    typename Real,
+    typename Arr,
+    bool is_leaf,
+    typename InputArr
+>
+struct get_approx_impl
+{
+    static inline Real apply(Arr& interim_results, const InputArr& input)
+    {
+        return interim_results[boost::mp11::mp_find<All, Node>::value];
+    }
+};
+
+template
+<
+    typename All,
+    typename Node,
+    typename Real,
+    typename Arr,
+    typename InputArr
+>
+struct get_approx_impl<All, Node, Real, Arr, true, InputArr>
+{
+    static inline Real apply(Arr& interim_results, const InputArr& input)
+    {
+        return get_nth_real<Node, Node::argn, Real, InputArr>(input);
+    }
+};
+
+template
+<
+    typename All,
+    typename Node,
+    typename Real,
+    typename Arr,
+    typename InputArr
+>
+inline Real get_approx(Arr& interim_results, const InputArr& input)
+{
+    return get_approx_impl
+        <
+            All,
+            Node,
+            Real,
+            Arr,
+            is_leaf<Node>::value,
+            InputArr
+        >::apply(interim_results, input);
+}
+
+template
+<
+    typename All,
+    typename Remaining,
+    typename Real,
+    typename Arr,
+    operator_types Op,
+    typename InputArr
+>
+struct approximate_interim_impl {};
+
+template
+<
+    typename All,
+    typename Remaining,
+    typename Real,
+    typename Arr,
+    bool Empty,
+    typename InputArr
+>
+struct approximate_remainder_impl
+{
+    static inline void apply(Arr& interim_results, const InputArr& input)
+    {
+        using node = boost::mp11::mp_front<Remaining>;
+        approximate_interim_impl
+            <
+                All,
+                Remaining,
+                Real,
+                Arr,
+                node::operator_type,
+                InputArr
+            >::apply(interim_results, input);
+    }
+};
+
+template
+<
+    typename All,
+    typename Remaining,
+    typename Real,
+    typename Arr,
+    typename InputArr
+>
+struct approximate_remainder_impl
+    <
+        All,
+        Remaining,
+        Real,
+        Arr,
+        true,
+        InputArr
+    >
+{
+    static inline void apply(Arr& interim_results, const InputArr& input) {}
+};
+
+template
+<
+    typename All,
+    typename Remaining,
+    typename Real,
+    typename Arr,
+    typename InputArr
+>
+inline void approximate_remainder(Arr& interim_results, const InputArr& input)
+{
+    approximate_remainder_impl
+        <
+            All,
+            Remaining,
+            Real,
+            Arr,
+            boost::mp11::mp_empty<Remaining>::value,
+            InputArr
+        >::apply(interim_results, input);
+}
+
+template
+<
+    typename All,
+    typename Remaining,
+    typename Real,
+    typename Arr,
+    typename InputArr
+>
+struct approximate_interim_impl
+    <
+        All,
+        Remaining,
+        Real,
+        Arr,
+        operator_types::product,
+        InputArr
+    >
+{
+    static inline void apply(Arr& interim_results, const InputArr& input)
+    {
+        using node = boost::mp11::mp_front<Remaining>;
+        interim_results[boost::mp11::mp_find<All, node>::value] =
+                  get_approx<All, typename node::left, Real>(interim_results,
+                                                             input)
+                * get_approx<All, typename node::right, Real>(interim_results,
+                                                              input);
+        approximate_remainder
+            <
+                All,
+                boost::mp11::mp_pop_front<Remaining>,
+                Real
+            >(interim_results, input);
+    }
+};
+
+template
+<
+    typename All,
+    typename Remaining,
+    typename Real,
+    typename Arr,
+    typename InputArr
+>
+struct approximate_interim_impl
+    <
+        All,
+        Remaining,
+        Real,
+        Arr,
+        operator_types::max,
+        InputArr
+    >
+{
+    static inline void apply(Arr& interim_results, const InputArr& input)
+    {
+        using node = boost::mp11::mp_front<Remaining>;
+        interim_results[boost::mp11::mp_find<All, node>::value] = std::max(
+                  get_approx<All, typename node::left, Real>(interim_results,
+                                                             input),
+                  get_approx<All, typename node::right, Real>(interim_results,
+                                                              input));
+        approximate_remainder
+            <
+                All,
+                boost::mp11::mp_pop_front<Remaining>,
+                Real
+            >(interim_results, input);
+    }
+};
+
+template
+<
+    typename All,
+    typename Remaining,
+    typename Real,
+    typename Arr,
+    typename InputArr
+>
+struct approximate_interim_impl
+    <
+        All,
+        Remaining,
+        Real,
+        Arr,
+        operator_types::min,
+        InputArr
+    >
+{
+    static inline void apply(Arr& interim_results, const InputArr& input)
+    {
+        using node = boost::mp11::mp_front<Remaining>;
+        interim_results[boost::mp11::mp_find<All, node>::value] = std::min(
+                  get_approx<All, typename node::left, Real>(interim_results,
+                                                             input),
+                  get_approx<All, typename node::right, Real>(interim_results,
+                                                              input));
+        approximate_remainder
+            <
+                All,
+                boost::mp11::mp_pop_front<Remaining>,
+                Real
+            >(interim_results, input);
+    }
+};
+
+template
+<
+    typename All,
+    typename Remaining,
+    typename Real,
+    typename Arr,
+    typename InputArr
+>
+struct approximate_interim_impl
+    <
+        All,
+        Remaining,
+        Real,
+        Arr,
+        operator_types::sum,
+        InputArr
+    >
+{
+    static inline void apply(Arr& interim_results, const InputArr& input)
+    {
+        using node = boost::mp11::mp_front<Remaining>;
+        interim_results[boost::mp11::mp_find<All, node>::value] =
+                  get_approx<All, typename node::left, Real>(interim_results,
+                                                             input)
+                + get_approx<All, typename node::right, Real>(interim_results,
+                                                              input);
+        approximate_remainder
+            <
+                All,
+                boost::mp11::mp_pop_front<Remaining>,
+                Real
+            >(interim_results, input);
+    }
+};
+
+template
+<
+    typename All,
+    typename Remaining,
+    typename Real,
+    typename Arr,
+    typename InputArr
+>
+struct approximate_interim_impl
+    <
+        All,
+        Remaining,
+        Real,
+        Arr,
+        operator_types::difference,
+        InputArr
+    >
+{
+    static inline void apply(Arr& interim_results, const InputArr& input)
+    {
+        using node = boost::mp11::mp_front<Remaining>;
+        interim_results[boost::mp11::mp_find<All, node>::value] =
+                  get_approx<All, typename node::left, Real>(interim_results,
+                                                             input)
+                - get_approx<All, typename node::right, Real>(interim_results,
+                                                              input);
+        approximate_remainder
+            <
+                All,
+                boost::mp11::mp_pop_front<Remaining>,
+                Real
+            >(interim_results, input);
+    }
+};
+
+template
+<
+    typename All,
+    typename Remaining,
+    typename Real,
+    typename Arr,
+    typename InputArr
+>
+struct approximate_interim_impl
+    <
+        All,
+        Remaining,
+        Real,
+        Arr,
+        operator_types::abs,
+        InputArr
+    >
+{
+    static inline void apply(Arr& interim_results, const InputArr& input)
+    {
+        using node = boost::mp11::mp_front<Remaining>;
+        interim_results[boost::mp11::mp_find<All, node>::value] =
+            std::abs(get_approx
+                <
+                    All,
+                    typename node::child,
+                    Real
+                >(interim_results, input));
+        approximate_remainder
+            <
+                All,
+                boost::mp11::mp_pop_front<Remaining>,
+                Real
+            >(interim_results, input);
+    }
+};
+
+template
+<
+    typename All,
+    typename Remaining,
+    typename Real,
+    typename Arr,
+    typename InputArr
+>
+struct approximate_interim_impl
+    <
+        All,
+        Remaining,
+        Real,
+        Arr,
+        operator_types::no_op,
+        InputArr
+    >
+{
+    static inline void apply(Arr& interim_results, const InputArr& input)
+    {
+        approximate_remainder
+            <
+                All,
+                boost::mp11::mp_pop_front<Remaining>,
+                Real
+            >(interim_results, input);
+    }
+};
+
+template
+<
+    typename All,
+    typename Remaining,
+    typename Real,
+    typename Arr,
+    typename InputArr
+>
+inline void approximate_interim(Arr& interim_results, const InputArr& input)
+{
+    approximate_remainder
+        <
+            All,
+            Remaining,
+            Real
+        >(interim_results, input);
+}
+
+template<typename Expression, typename Real, typename InputArr>
+inline Real approximate_value(const InputArr& input)
+{
+    using stack = typename boost::mp11::mp_unique<post_order<Expression>>;
+    using evals = typename boost::mp11::mp_remove_if<stack, is_leaf>;
+    std::array<Real, boost::mp11::mp_size<evals>::value> results;
+        approximate_interim<evals, evals, Real>(results, input);
+    return results.back();
+}
+
+}} // namespace detail::generic_robust_predicates
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_APPROXIMATE_HPP

--- a/include/boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/coefficient_list.hpp
+++ b/include/boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/coefficient_list.hpp
@@ -1,0 +1,471 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2020 Tinko Bartels, Berlin, Germany.
+
+// Contributed and/or modified by Tinko Bartels,
+//   as part of Google Summer of Code 2020 program.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_COEFFICIENT_LIST_HPP
+#define BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_COEFFICIENT_LIST_HPP
+
+#include <cstddef>
+
+#include <boost/mp11/integral.hpp>
+#include <boost/mp11/list.hpp>
+
+#include <boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/static_util.hpp>
+
+namespace boost { namespace geometry
+{
+
+namespace detail { namespace generic_robust_predicates
+{
+
+//only meant to be used in assertions
+template <typename T> using is_mp_int =
+    boost::mp11::mp_same<T, boost::mp11::mp_int<T::value>>;
+
+template <typename L> using is_coeff_list = boost::mp11::mp_and
+    <
+        boost::mp11::mp_all_of<L, is_mp_int>,
+        boost::mp11::mp_similar<L, boost::mp11::mp_list<>>
+    >;
+
+template <typename L>
+struct coeff_truncate_impl
+{
+private:
+    static_assert(is_coeff_list<L>::value, "L must be a coefficient list");
+    using first_nz = boost::mp11::mp_find_if<L, is_not_zero>;
+    using after_second_nz =
+        boost::mp11::mp_min<
+            boost::mp11::mp_size_t<first_nz::value + 2>,
+            boost::mp11::mp_size<L>
+        >;
+    using tail = boost::mp11::mp_erase_c<L, 0, after_second_nz::value>;
+    using head = boost::mp11::mp_erase
+            <
+                L,
+                after_second_nz,
+                boost::mp11::mp_size<L>
+            >;
+    using round_up = boost::mp11::mp_less
+            <
+                boost::mp11::mp_find_if<tail, is_not_zero>,
+                boost::mp11::mp_size<tail>
+            >;
+public:
+    using type = boost::mp11::mp_if
+            <
+                round_up,
+                boost::mp11::mp_push_back<head, boost::mp11::mp_int<1>>,
+                head
+            >;
+    static_assert(is_coeff_list<L>::value, "type should be a coefficient list");
+};
+
+template <typename L> using coeff_truncate = typename coeff_truncate_impl<L>::type;
+
+template <typename L> using app_zero_b =
+    boost::mp11::mp_push_front<L, boost::mp11::mp_int<0>>;
+template <typename L> using app_zero_f =
+    boost::mp11::mp_push_back<L, boost::mp11::mp_int<0>>;
+template <typename L> using mult_by_1_p_eps = coeff_truncate
+        <
+            boost::mp11::mp_transform
+                <
+                    boost::mp11::mp_plus,
+                    app_zero_b<L>,
+                    app_zero_f<L>
+                >
+        >;
+
+template
+<
+    typename L,
+    typename N,
+    typename done = boost::mp11::mp_bool<N::value == 0>
+>
+struct mult_by_1_p_eps_pow_impl
+{
+private:
+    using next = mult_by_1_p_eps<L>;
+public:
+    using type =
+        typename mult_by_1_p_eps_pow_impl
+            <
+                next,
+                boost::mp11::mp_int<N::value - 1>
+            >::type;
+};
+
+template <typename L, typename N>
+struct mult_by_1_p_eps_pow_impl<L, N, boost::mp11::mp_true>
+{
+public:
+    using type = L;
+};
+
+template <typename L, typename N> using mult_by_1_p_eps_pow = coeff_truncate
+        <
+            typename mult_by_1_p_eps_pow_impl<L, N>::type
+        >;
+
+template <typename L> using div_by_1_m_eps_helper =
+    boost::mp11::mp_partial_sum
+        <
+            L,
+            boost::mp11::mp_int<0>,
+            boost::mp11::mp_plus
+        >;
+
+template <typename L> using div_by_1_m_eps = coeff_truncate
+    <
+        boost::mp11::mp_push_back
+            <
+                boost::mp11::mp_pop_back<div_by_1_m_eps_helper<L>>,
+                inc<boost::mp11::mp_back<div_by_1_m_eps_helper<L>>>
+            >
+    >;
+
+template
+<
+    typename L1,
+    typename L2,
+    typename L,
+    typename L1_Empty = typename empty_or_void<L1>::type,
+    typename L2_Empty = typename empty_or_void<L2>::type
+>
+struct coeff_merge_impl {};
+
+template
+<
+    typename L1,
+    typename L2,
+    typename L
+>
+struct coeff_merge_impl
+<
+    L1,
+    L2,
+    L,
+    boost::mp11::mp_false,
+    boost::mp11::mp_false
+>
+{
+    using type = typename coeff_merge_impl
+        <
+            boost::mp11::mp_pop_front<L1>,
+            boost::mp11::mp_pop_front<L2>,
+            boost::mp11::mp_push_back
+                <
+                    L,
+                    boost::mp11::mp_plus
+                        <
+                            boost::mp11::mp_front<L1>,
+                            boost::mp11::mp_front<L2>
+                        >
+                >
+        >::type;
+};
+
+template
+<
+    typename L1,
+    typename L2,
+    typename L
+>
+struct coeff_merge_impl
+    <
+        L1,
+        L2,
+        L,
+        boost::mp11::mp_true,
+        boost::mp11::mp_true
+    >
+{
+    using type = L;
+};
+
+template
+<
+    typename L1,
+    typename L2,
+    typename L
+>
+struct coeff_merge_impl
+    <
+        L1,
+        L2,
+        L,
+        boost::mp11::mp_true,
+        boost::mp11::mp_false
+    >
+{
+    using type = boost::mp11::mp_append<L, L2>;
+};
+
+template
+<
+    typename L1,
+    typename L2,
+    typename L
+>
+struct coeff_merge_impl
+    <
+        L1,
+        L2,
+        L,
+        boost::mp11::mp_false,
+        boost::mp11::mp_true
+    >
+{
+    using type = boost::mp11::mp_append<L, L1>;
+};
+
+template <typename L1, typename L2> using coeff_merge =
+    coeff_truncate
+        <
+            typename coeff_merge_impl
+                <
+                    L1,
+                    L2,
+                    boost::mp11::mp_list<>
+                >::type
+        >;
+
+template
+<
+    typename L1,
+    typename L2,
+    typename L,
+    typename L1_Empty = typename empty_or_void<L1>::type,
+    typename L2_Empty = typename empty_or_void<L2>::type
+>
+struct coeff_max_impl {};
+
+template
+<
+    typename L1,
+    typename L2,
+    typename L
+>
+struct coeff_max_impl<L1, L2, L, boost::mp11::mp_false, boost::mp11::mp_false>
+{
+    using type = typename coeff_max_impl
+        <
+            boost::mp11::mp_if
+                <
+                    boost::mp11::mp_less
+                        <
+                            boost::mp11::mp_front<L1>,
+                            boost::mp11::mp_front<L2>
+                        >,
+                    boost::mp11::mp_list<>,
+                    boost::mp11::mp_pop_front<L1>
+                >,
+            boost::mp11::mp_if
+                <
+                    boost::mp11::mp_less
+                        <
+                            boost::mp11::mp_front<L2>,
+                            boost::mp11::mp_front<L1>
+                        >,
+                    boost::mp11::mp_list<>,
+                    boost::mp11::mp_pop_front<L2>
+                >,
+            boost::mp11::mp_push_back
+                <
+                    L,
+                    boost::mp11::mp_max
+                        <
+                            boost::mp11::mp_front<L1>,
+                            boost::mp11::mp_front<L2>
+                        >
+                >
+        >::type;
+};
+
+template
+<
+    typename L1,
+    typename L2,
+    typename L
+>
+struct coeff_max_impl
+    <
+        L1,
+        L2,
+        L,
+        boost::mp11::mp_true,
+        boost::mp11::mp_true
+    >
+{
+    using type = L;
+};
+
+template
+<
+    typename L1,
+    typename L2,
+    typename L
+>
+struct coeff_max_impl
+    <
+        L1,
+        L2,
+        L,
+        boost::mp11::mp_true,
+        boost::mp11::mp_false
+    >
+{
+    using type = boost::mp11::mp_append<L, L2>;
+};
+
+template
+<
+    typename L1,
+    typename L2,
+    typename L
+>
+struct coeff_max_impl
+    <
+        L1,
+        L2,
+        L,
+        boost::mp11::mp_false,
+        boost::mp11::mp_true
+    >
+{
+    using type = boost::mp11::mp_append<L, L1>;
+};
+
+template <typename L1, typename L2> using coeff_max =
+    coeff_truncate
+        <
+            typename coeff_max_impl
+                <
+                    L1,
+                    L2,
+                    boost::mp11::mp_list<>
+                >::type
+        >;
+
+template
+<
+    typename L,
+    std::size_t Tail_Size =
+          boost::mp11::mp_size<L>::value
+        - boost::mp11::mp_find_if<L, is_not_zero>::value
+>
+struct coeff_round_impl
+{
+private:
+    using first_nz = boost::mp11::mp_find_if<L, is_not_zero>;
+    using tail = boost::mp11::mp_erase_c<L, 0, first_nz::value + 2>;
+    using zero_tail = boost::mp11::mp_same
+        <
+            boost::mp11::mp_find_if<tail, is_not_zero>,
+            boost::mp11::mp_size<tail>
+        >;
+    using head = boost::mp11::mp_erase_c
+        <
+            L,
+            first_nz::value + 2,
+            boost::mp11::mp_size<L>::value
+        >;
+    using minor = boost::mp11::mp_if
+        <
+            zero_tail,
+            boost::mp11::mp_back<head>,
+            inc<boost::mp11::mp_back<head>>
+        >;
+    using major = boost::mp11::mp_at<head, first_nz>;
+    using major_rounded = boost::mp11::mp_int< 1 << log_2_ceil<major>::value >;
+    using minor_rounded = boost::mp11::mp_int
+        <
+            (minor::value / major_rounded::value) * major_rounded::value < minor::value ?
+                  (minor::value / major_rounded::value + 1) * major_rounded::value
+                : (minor::value / major_rounded::value) * major_rounded::value
+        >;
+public:
+    using type = boost::mp11::mp_push_back
+        <
+            boost::mp11::mp_pop_back<head>,
+            minor_rounded
+        >;
+};
+
+template <typename L>
+struct coeff_round_impl<L, 0> { using type = L; };
+
+template <typename L>
+struct coeff_round_impl<L, 1> { using type = L; };
+
+template <typename L> using coeff_round = typename coeff_round_impl<L>::type;
+
+template <typename IV1, typename IV2> using indexed_value_product =
+    boost::mp11::mp_list
+        <
+            boost::mp11::mp_plus
+                <
+                    boost::mp11::mp_first<IV1>,
+                    boost::mp11::mp_first<IV2>
+                >,
+            boost::mp11::mp_int
+                <
+                      boost::mp11::mp_second<IV1>::value
+                    * boost::mp11::mp_second<IV2>::value
+                >
+        >;
+
+template <typename V1> struct add_nested
+{
+    template <typename K, typename V2> using fn =
+        boost::mp11::mp_plus<V1, V2>;
+};
+
+template <typename M, typename IV> using list_product_fold =
+    boost::mp11::mp_map_update_q
+        <
+            M,
+            IV,
+            add_nested< boost::mp11::mp_second<IV> >
+        >;
+
+template<typename IV1, typename IV2> using index_less =
+    boost::mp11::mp_less
+        <
+            boost::mp11::mp_first<IV1>,
+            boost::mp11::mp_first<IV2>
+        >;
+
+template <typename L1, typename L2> using list_product =
+    strip_index
+        <
+            boost::mp11::mp_sort
+                <
+                    boost::mp11::mp_fold
+                        <
+                            boost::mp11::mp_product
+                                <
+                                    indexed_value_product,
+                                    indexed<L1>,
+                                    indexed<L2>
+                                >,
+                            boost::mp11::mp_list<>,
+                            list_product_fold
+                        >,
+                    index_less
+                >
+        >;
+
+}} // namespace detail::generic_robust_predicates
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_COEFFICIENT_LIST_HPP

--- a/include/boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/error_bound.hpp
+++ b/include/boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/error_bound.hpp
@@ -1,0 +1,605 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2020 Tinko Bartels, Berlin, Germany.
+
+// Contributed and/or modified by Tinko Bartels,
+//   as part of Google Summer of Code 2020 program.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_ERROR_BOUND_HPP
+#define BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_ERROR_BOUND_HPP
+
+#include <limits>
+
+#include <boost/mp11/integral.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/map.hpp>
+
+#include <boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/coefficient_list.hpp>
+
+namespace boost { namespace geometry
+{
+
+namespace detail { namespace generic_robust_predicates
+{
+
+template <typename KV> using second_is_coeff_list =
+    is_coeff_list< boost::mp11::mp_second<KV> >;
+
+template <typename EM> using is_error_map = boost::mp11::mp_and
+    <
+        boost::mp11::mp_is_map<EM>,
+        boost::mp11::mp_all_of<EM, second_is_coeff_list>,
+        boost::mp11::mp_similar<EM, boost::mp11::mp_list<>
+    >
+    //TODO: It would be desirable to also validate that the keys are good
+>;
+
+template <typename KV, typename M>
+struct error_map_insert_impl
+{
+private:
+    using key = boost::mp11::mp_front<KV>;
+    using value = boost::mp11::mp_second<KV>;
+    using other_value = typename mp_map_at_second_or_void<M, key>::type;
+    using merged_value = coeff_merge<value, other_value>;
+    using nkv = boost::mp11::mp_list<key, merged_value>;
+public:
+    using type = boost::mp11::mp_map_replace<M, nkv>;
+};
+
+template <typename KV, typename M> using error_map_insert =
+    typename error_map_insert_impl<KV, M>::type;
+
+template <typename M1, typename M2>
+struct add_fold_operator
+{
+public:
+    template <typename M, typename K> using fn = boost::mp11::mp_map_insert
+        <
+            M,
+            boost::mp11::mp_list
+                <
+                    K,
+                    coeff_merge
+                        <
+                            typename mp_map_at_second_or_void<M1, K>::type,
+                            typename mp_map_at_second_or_void<M2, K>::type
+                        >
+                >
+        >;
+};
+
+template <typename M1, typename M2> using add_children = boost::mp11::mp_fold
+    <
+        boost::mp11::mp_set_union
+            <
+                boost::mp11::mp_map_keys<M1>,
+                boost::mp11::mp_map_keys<M2>
+            >,
+        boost::mp11::mp_list<>,
+        add_fold_operator<M1, M2>::template fn
+    >;
+
+template
+<
+    typename Exp,
+    typename EM,
+    typename Out,
+    typename LErr = typename val_or_empty_list<EM, typename Exp::left>::type,
+    typename RErr = typename val_or_empty_list<EM, typename Exp::right>::type,
+    typename skip_decompose =
+        boost::mp11::mp_or
+            <
+                boost::mp11::mp_not
+                    <
+                        boost::mp11::mp_same
+                            <
+                                typename Exp::error_type,
+                                sum_error_type
+                            >
+                    >,
+                boost::mp11::mp_same
+                    <
+                        boost::mp11::mp_list<>,
+                        LErr,
+                        RErr
+                    >
+            >
+>
+struct decompose_add_impl
+{
+private:
+    using decomp_left = typename decompose_add_impl
+        <
+            typename Exp::left,
+            EM,
+            Out
+        >::type;
+    using decomp_right = typename decompose_add_impl
+        <
+            typename Exp::right,
+            EM,
+            decomp_left
+        >::type;
+public:
+    using type = decomp_right;
+};
+
+template
+<
+    typename Exp,
+    typename EM,
+    typename Out,
+    typename LErr,
+    typename RErr
+>
+struct decompose_add_impl
+    <
+        Exp,
+        EM,
+        Out,
+        LErr,
+        RErr,
+        boost::mp11::mp_true
+    >
+{
+    using type = error_map_insert
+        <
+            boost::mp11::mp_list
+                <
+                    Exp,
+                    boost::mp11::mp_list<boost::mp11::mp_int<1>>
+                >,
+            Out
+        >;
+};
+
+template
+<
+    typename Exp,
+    typename EM,
+    typename Out
+>
+using decompose_add = typename decompose_add_impl<Exp, EM, Out>::type;
+
+template
+<
+    typename Exp,
+    typename EM,
+    typename LErr = typename val_or_empty_list<EM, typename Exp::left>::type,
+    typename RErr = typename val_or_empty_list<EM, typename Exp::right>::type,
+    typename Children_Empty =
+        boost::mp11::mp_and
+            <
+                typename empty_or_void<LErr>::type,
+                typename empty_or_void<RErr>::type
+            >
+>
+struct sum_err_impl
+{
+private:
+    static_assert(is_error_map<LErr>::value, "LErr needs to be a valid error map.");
+    static_assert(is_error_map<RErr>::value, "RErr needs to be a valid error map.");
+    using children = add_children<LErr, RErr>;
+    static_assert(
+            is_error_map<children>::value, "children needs to be a valid error map.");
+public:
+    /*
+    using type = boost::mp11::mp_map_insert<
+        children,
+        boost::mp11::mp_list<Exp, boost::mp11::mp_list<boost::mp11::mp_int<1>>>
+    >;*/
+    using type = decompose_add<Exp, EM, children>;
+    static_assert(is_error_map<type>::value, "type needs to be a valid error map.");
+};
+
+template
+<
+    typename Exp,
+    typename EM,
+    typename LErr,
+    typename RErr
+>
+struct sum_err_impl
+    <
+        Exp,
+        EM,
+        LErr,
+        RErr,
+        boost::mp11::mp_true
+    >
+{
+    static_assert(is_error_map<LErr>::value, "LErr needs to be a valid error map.");
+    static_assert(is_error_map<RErr>::value, "RErr needs to be a valid error map.");
+    using type = boost::mp11::mp_list
+        <
+            boost::mp11::mp_list
+                <
+                    Exp,
+                    boost::mp11::mp_list<boost::mp11::mp_int<1>>
+                >
+        >;
+    static_assert(is_error_map<type>::value, "type needs to be a valid error map.");
+};
+
+template <typename Exp, typename EM> using sum_err =
+    typename sum_err_impl<Exp, EM>::type;
+
+template <typename L> using pad_second = boost::mp11::mp_list
+    <
+        boost::mp11::mp_front<L>,
+        boost::mp11::mp_push_front
+            <
+                boost::mp11::mp_second<L>,
+                boost::mp11::mp_int<0>
+            >
+    >;
+
+template <typename L> using pop_front_second = boost::mp11::mp_list
+    <
+        boost::mp11::mp_front<L>,
+        boost::mp11::mp_pop_front<boost::mp11::mp_second<L>>
+    >;
+
+template <typename K, typename V> using increment_first_of_second =
+    boost::mp11::mp_transform_front<V, inc>;
+
+template <typename KV1, typename KV2> using prod_entry_merge =
+    boost::mp11::mp_list
+        <
+            boost::mp11::mp_flatten
+                <
+                    boost::mp11::mp_list
+                        <
+                            boost::mp11::mp_first<KV1>,
+                            boost::mp11::mp_first<KV2>
+                        >
+                >,
+            list_product
+                <
+                    boost::mp11::mp_second<KV1>,
+                    boost::mp11::mp_second<KV2>
+                >
+        >;
+
+template
+<
+    typename Exp,
+    typename EM,
+    typename LErr = typename val_or_empty_list<EM, typename Exp::left>::type,
+    typename RErr = typename val_or_empty_list<EM, typename Exp::right>::type
+>
+struct prod_children_impl
+{
+private:
+    static_assert(is_error_map<LErr>::value, "LErr needs to be a valid error map.");
+    static_assert(is_error_map<RErr>::value, "RErr needs to be a valid error map.");
+    using left = typename Exp::left;
+    using right = typename Exp::right;
+    using padded_lerr = boost::mp11::mp_transform<pad_second, LErr>;
+    using added_left_lerr = decompose_add<left, EM, padded_lerr>;
+    using padded_rerr = boost::mp11::mp_transform<pad_second, RErr>;
+    using added_right_rerr = decompose_add<right, EM, padded_rerr>;
+    using prod = boost::mp11::mp_product
+        <
+            prod_entry_merge,
+            added_left_lerr,
+            added_right_rerr
+        >;
+    using stripped_prod = boost::mp11::mp_transform<pop_front_second, prod>;
+public:
+    using type = stripped_prod;
+    static_assert(is_error_map<type>::value, "type needs to be a valid error map.");
+};
+
+template <typename Exp, typename EM> using prod_children =
+    typename prod_children_impl<Exp, EM>::type;
+
+template
+<
+    typename Exp,
+    typename EM,
+    typename LErr = typename val_or_empty_list<EM, typename Exp::left>::type,
+    typename RErr = typename val_or_empty_list<EM, typename Exp::right>::type
+>
+struct product_err_impl
+{
+private:
+    static_assert(is_error_map<LErr>::value, "LErr needs to be a valid error map.");
+    static_assert(is_error_map<RErr>::value, "RErr needs to be a valid error map.");
+    using children = prod_children<Exp, EM>;
+    static_assert(is_error_map<children>::value, "children needs to be a valid error map.");
+public:
+    using type = boost::mp11::mp_map_insert
+        <
+            children,
+            boost::mp11::mp_list
+                <
+                    Exp,
+                    boost::mp11::mp_list< boost::mp11::mp_int<1> >
+                >
+        >;
+    static_assert(is_error_map<type>::value, "type needs to be a valid error map.");
+};
+
+template <typename Exp, typename EM> using product_err =
+    typename product_err_impl<Exp, EM>::type;
+
+template
+<
+    typename Errors,
+    typename Exp,
+    typename IsSum = boost::mp11::mp_same
+        <
+            typename Exp::error_type,
+            sum_error_type
+        >
+>
+struct sum_or_product_err_impl
+{
+    using type = sum_err<Exp, Errors>;
+};
+
+template
+<
+    typename Errors,
+    typename Exp
+>
+struct sum_or_product_err_impl<Errors, Exp, boost::mp11::mp_false>
+{
+    using type = product_err<Exp, Errors>;
+};
+
+template <typename Errors, typename Exp> using sum_or_product_err =
+    typename sum_or_product_err_impl<Errors, Exp>::type;
+
+template
+<
+    typename Errors,
+    typename Exp
+>
+struct error_fold_impl
+{
+private:
+    using lerr = typename val_or_empty_list<Errors, typename Exp::left>::type;
+    using rerr = typename val_or_empty_list<Errors, typename Exp::right>::type;
+    using err = sum_or_product_err<Errors, Exp>;
+public:
+    using type = boost::mp11::mp_map_insert
+        <
+            Errors,
+            boost::mp11::mp_list<Exp, err>
+        >;
+};
+
+
+template <typename Errors, typename Exp> using error_fold =
+    typename error_fold_impl<Errors, Exp>::type;
+
+template <typename Evals> using evals_error =
+    boost::mp11::mp_fold
+        <
+            Evals,
+            boost::mp11::mp_list<>,
+            error_fold
+        >;
+
+template <typename T> using is_mp_list = boost::mp11::mp_similar
+    <
+        boost::mp11::mp_list<>,
+        T
+    >;
+
+template <typename KV>
+struct list_to_product_impl
+{
+private:
+    using key = boost::mp11::mp_front<KV>;
+    using value = boost::mp11::mp_second<KV>;
+    using multiplications = boost::mp11::mp_int<boost::mp11::mp_size<key>::value - 1>;
+    using nvalue = mult_by_1_p_eps_pow<value, multiplications>;
+    using nkey = boost::mp11::mp_reverse_fold<
+        boost::mp11::mp_pop_back<key>,
+        boost::mp11::mp_back<key>,
+        product
+    >;
+public:
+    using type = boost::mp11::mp_list<nkey, nvalue>;
+};
+
+template <typename KV> using list_to_product = typename list_to_product_impl<KV>::type;
+
+template
+<
+    typename M,
+    typename KV,
+    typename KeyMPList = is_mp_list< boost::mp11::mp_front<KV> >
+>
+struct error_map_list_to_product_fold_impl
+{
+    using type = error_map_insert<list_to_product<KV>, M>;
+};
+
+template <typename M, typename KV>
+struct error_map_list_to_product_fold_impl
+    <
+        M,
+        KV,
+        boost::mp11::mp_false
+    >
+{
+    using type = error_map_insert<KV, M>;
+};
+
+template <typename M, typename KV> using error_map_list_to_product_fold =
+    typename error_map_list_to_product_fold_impl<M, KV>::type;
+
+template <typename M>
+struct error_map_list_to_product_impl
+{
+    using type = boost::mp11::mp_fold
+        <
+            M,
+            boost::mp11::mp_list<>,
+            error_map_list_to_product_fold
+        >;
+};
+
+template <typename M> using error_map_list_to_product =
+    typename error_map_list_to_product_impl<M>::type;
+
+template <typename Expression>
+struct abs_unless_non_negative
+{
+    using type = boost::mp11::mp_if_c
+        <
+            Expression::non_negative,
+            Expression,
+            abs<Expression>
+        >;
+};
+
+template <typename EM, typename KV> using abs_fold =
+    boost::mp11::mp_push_back
+        <
+            EM,
+            boost::mp11::mp_list
+                <
+                    typename abs_unless_non_negative<boost::mp11::mp_front<KV>>
+                        ::type,
+                    boost::mp11::mp_second<KV>
+                >
+        >;
+
+template<typename EM> using abs_all =
+    boost::mp11::mp_fold
+        <
+            EM,
+            boost::mp11::mp_list<>,
+            abs_fold
+        >;
+
+template
+<
+    typename KV1,
+    typename KV2
+>
+struct abs_sum_error_term_impl
+{
+private:
+    using key1 = boost::mp11::mp_front<KV1>;
+    using key2 = boost::mp11::mp_front<KV2>;
+    using nkey = sum<key1, key2>;
+    using val1 = boost::mp11::mp_second<KV1>;
+    using val2 = boost::mp11::mp_second<KV2>;
+    using mval = coeff_max<val1, val2>;
+    static_assert(is_coeff_list<mval>::value, "merged coefficient list fails coefficient list check");
+    using nval = mult_by_1_p_eps<mval>;
+public:
+    using type = boost::mp11::mp_list<nkey, nval>;
+};
+
+template<typename KV1, typename KV2> using abs_sum_error_term = typename abs_sum_error_term_impl<KV1, KV2>::type;
+
+//TODO: The following could be probably optimized for potentially produce better error bounds in some cases
+//      if the error map is treated as a minheap by ordering of epsilon-polynomial.
+template<typename M> using error_map_sum_up =
+    boost::mp11::mp_fold
+        <
+            boost::mp11::mp_pop_front<M>,
+            boost::mp11::mp_first<M>,
+            abs_sum_error_term
+        >;
+
+template<typename M, std::size_t MS = boost::mp11::mp_size<M>::value>
+struct error_map_balanced_sum_up_impl
+{
+private:
+    static constexpr std::size_t mid = MS/2;
+    using left = typename error_map_balanced_sum_up_impl
+        <
+            boost::mp11::mp_erase_c<M, 0, mid>
+        >::type;
+    using right = typename error_map_balanced_sum_up_impl
+        <
+            boost::mp11::mp_erase_c<M, mid, MS>
+        >::type;
+public:
+    using type = abs_sum_error_term<left, right>;
+};
+
+template<typename M>
+struct error_map_balanced_sum_up_impl<M, 1>
+{
+    using type = boost::mp11::mp_front<M>;
+};
+
+template<typename M> using error_map_balanced_sum_up =
+    typename error_map_balanced_sum_up_impl<M>::type;
+
+template
+<
+    typename Real,
+    typename Exp
+>
+struct eps_pow
+{
+    static constexpr Real value =
+          std::numeric_limits<Real>::epsilon()/2.0
+        * eps_pow<Real, boost::mp11::mp_size_t< Exp::value - 1 >>::value;
+};
+
+template <typename Real> struct eps_pow<Real, boost::mp11::mp_size_t<0>>
+{
+    static constexpr Real value = 1.0;
+};
+
+template
+<
+    typename Real,
+    typename L,
+    typename S = boost::mp11::mp_size<L>
+>
+struct eval_eps_polynomial
+{
+private:
+    using last = boost::mp11::mp_back<L>;
+    using s2last = boost::mp11::mp_back< boost::mp11::mp_pop_back<L> >;
+public:
+    static constexpr Real value =
+          s2last::value
+        * eps_pow<Real, boost::mp11::mp_size_t<S::value - 1>>::value
+        + last::value * eps_pow<Real, S>::value;
+};
+
+template
+<
+    typename Real,
+    typename L
+>
+struct eval_eps_polynomial<Real, L, boost::mp11::mp_size_t<1>>
+{
+    static constexpr Real value =
+          boost::mp11::mp_front<L>::value
+        * std::numeric_limits<Real>::epsilon() / 2.0;
+};
+
+template
+<
+    typename Real,
+    typename L
+>
+struct eval_eps_polynomial<Real, L, boost::mp11::mp_size_t<0>>
+{
+    static constexpr Real value = 0;
+};
+
+}} // namespace detail::generic_robust_predicates
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_ERROR_BOUND_HPP

--- a/include/boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/expression_tree.hpp
+++ b/include/boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/expression_tree.hpp
@@ -1,0 +1,250 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2020 Tinko Bartels, Berlin, Germany.
+
+// Contributed and/or modified by Tinko Bartels,
+//   as part of Google Summer of Code 2020 program.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_EXPRESSION_TREE_HPP
+#define BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_EXPRESSION_TREE_HPP
+
+#include <cstddef>
+#include <type_traits>
+
+#include <boost/mp11/algorithm.hpp>
+#include <boost/mp11/integral.hpp>
+#include <boost/mp11/list.hpp>
+
+namespace boost { namespace geometry
+{
+
+namespace detail { namespace generic_robust_predicates
+{
+
+enum class operator_types {
+    sum, difference, product, abs, no_op, max, min
+};
+
+enum class operator_arities { nullary, unary, binary };
+
+constexpr int sign_uncertain = -2;
+
+struct sum_error_type {};
+struct product_error_type {};
+struct no_error_type {};
+
+template <typename... Children>
+struct internal_node
+{
+    static constexpr bool is_leaf = false;
+    static constexpr bool non_negative = false;
+    using all_children = boost::mp11::mp_list<Children...>; //for convenience
+};
+
+template <typename Left, typename Right>
+struct internal_binary_node : internal_node<Left, Right>
+{
+    using left  = Left;
+    using right = Right;
+    static constexpr operator_arities operator_arity = operator_arities::binary;
+};
+
+template <typename Child>
+struct internal_unary_node : internal_node<Child>
+{
+    using child = Child;
+    static constexpr operator_arities operator_arity = operator_arities::unary;
+};
+
+template <typename Left, typename Right>
+struct sum : public internal_binary_node<Left, Right>
+{
+    static constexpr bool sign_exact = Left::is_leaf && Right::is_leaf;
+    static constexpr bool non_negative = Left::non_negative && Right::non_negative;
+    static constexpr operator_types operator_type = operator_types::sum;
+    using error_type = sum_error_type;
+};
+
+template <typename Left, typename Right>
+struct difference : public internal_binary_node<Left, Right>
+{
+    static constexpr bool sign_exact = Left::is_leaf && Right::is_leaf;
+    static constexpr bool non_negative = false;
+    static constexpr operator_types operator_type = operator_types::difference;
+    using error_type = sum_error_type;
+};
+
+template <typename Left, typename Right>
+struct product : public internal_binary_node<Left, Right>
+{
+    static constexpr bool sign_exact = Left::sign_exact && Right::sign_exact;
+    static constexpr bool non_negative =
+           (Left::non_negative && Right::non_negative)
+        || std::is_same<Left, Right>::value;
+    static constexpr operator_types operator_type = operator_types::product;
+    using error_type = product_error_type;
+};
+
+template <typename Left, typename Right>
+struct max : public internal_binary_node<Left, Right>
+{
+    static constexpr bool sign_exact = Left::sign_exact && Right::sign_exact;
+    static constexpr bool non_negative =
+        Left::non_negative || Right::non_negative;
+    static constexpr operator_types operator_type = operator_types::max;
+    using error_type = no_error_type;
+};
+
+template <typename Left, typename Right>
+struct min : public internal_binary_node<Left, Right>
+{
+    static constexpr bool sign_exact = Left::sign_exact && Right::sign_exact;
+    static constexpr bool non_negative =
+        Left::non_negative && Right::non_negative;
+    static constexpr operator_types operator_type = operator_types::min;
+    using error_type = no_error_type;
+};
+
+template <typename Child>
+struct abs : public internal_unary_node<Child>
+{
+    using error_type = no_error_type;
+    static constexpr operator_types operator_type = operator_types::abs;
+    static constexpr bool sign_exact = Child::sign_exact;
+    static constexpr bool non_negative = true;
+};
+
+struct leaf
+{
+    static constexpr bool is_leaf = true;
+    static constexpr bool sign_exact = true;
+    static constexpr bool non_negative = false;
+    static constexpr operator_types operator_type = operator_types::no_op;
+    static constexpr operator_arities operator_arity = operator_arities::nullary;
+};
+
+template <std::size_t Argn>
+struct argument : public leaf
+{
+    static constexpr std::size_t argn = Argn;
+};
+
+template <typename NumberType>
+struct static_constant_interface : public leaf
+{
+    using value_type = NumberType;
+    static constexpr NumberType value = 0; //override
+    static constexpr std::size_t argn = 0;
+};
+
+template <typename Node>
+using is_leaf = boost::mp11::mp_bool<Node::is_leaf>;
+
+template
+<
+    typename In,
+    typename Out,
+    template <typename> class Anchor = is_leaf,
+    bool IsBinary = In::operator_arity == operator_arities::binary,
+    bool AtAnchor = Anchor<In>::value
+>
+struct post_order_impl;
+
+template
+<
+    typename In,
+    typename Out,
+    template <typename> class Anchor,
+    bool IsBinary
+>
+struct post_order_impl<In, Out, Anchor, IsBinary, true>
+{
+    using type = Out;
+};
+
+template <typename In, typename Out, template <typename> class Anchor>
+struct post_order_impl<In, Out, Anchor, true, false>
+{
+    using leftl = typename post_order_impl
+            <
+                typename In::left,
+                boost::mp11::mp_list<>,
+                Anchor
+            >::type;
+    using rightl = typename post_order_impl
+            <
+                typename In::right,
+                boost::mp11::mp_list<>,
+                Anchor
+            >::type;
+    using merged = boost::mp11::mp_append<Out, leftl, rightl>;
+    using type   =
+        boost::mp11::mp_unique<boost::mp11::mp_push_back<merged, In>>;
+};
+
+template <typename In, typename Out, template <typename> class Anchor>
+struct post_order_impl<In, Out, Anchor, false, false>
+{
+    using childl = typename post_order_impl
+            <
+                typename In::child,
+                boost::mp11::mp_list<>,
+                Anchor
+            >::type;
+    using merged = boost::mp11::mp_append<Out, childl>;
+    using type   =
+        boost::mp11::mp_unique<boost::mp11::mp_push_back<merged, In>>;
+};
+
+template <typename In, template <typename> class Anchor = is_leaf>
+using post_order =
+    typename post_order_impl<In, boost::mp11::mp_list<>, Anchor>::type;
+
+template <typename Node, typename IsLeaf = is_leaf<Node>>
+struct max_argn_impl;
+
+template <typename Node> using max_argn = typename max_argn_impl<Node>::type;
+
+template <typename Node>
+struct max_argn_impl<Node, boost::mp11::mp_false>
+{
+private:
+    using children_list = boost::mp11::mp_rename<Node, boost::mp11::mp_list>;
+    using children_max_argn =
+        boost::mp11::mp_transform<max_argn, children_list>;
+public:
+    using type = boost::mp11::mp_max_element
+        <
+            children_max_argn,
+            boost::mp11::mp_less
+        >;
+};
+
+template <typename Node>
+struct max_argn_impl<Node, boost::mp11::mp_true>
+{
+    using type = boost::mp11::mp_size_t<Node::argn>;
+};
+
+using  _1 = argument<1>;
+using  _2 = argument<2>;
+using  _3 = argument<3>;
+using  _4 = argument<4>;
+using  _5 = argument<5>;
+using  _6 = argument<6>;
+using  _7 = argument<7>;
+using  _8 = argument<8>;
+using  _9 = argument<9>;
+using _10 = argument<10>;
+using _11 = argument<11>;
+using _12 = argument<12>;
+
+}} // namespace detail::generic_robust_predicates
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_EXPRESSION_TREE_HPP

--- a/include/boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/expressions.hpp
+++ b/include/boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/expressions.hpp
@@ -1,0 +1,103 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2020 Tinko Bartels, Berlin, Germany.
+
+// Contributed and/or modified by Tinko Bartels,
+//   as part of Google Summer of Code 2020 program.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_EXPRESSIONS_HPP
+#define BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_EXPRESSIONS_HPP
+
+#include <boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/expression_tree.hpp>
+
+namespace boost { namespace geometry
+{
+
+namespace detail { namespace generic_robust_predicates
+{
+
+template
+<
+    typename A11, typename A12,
+    typename A21, typename A22
+>
+using det2x2 = difference
+    <
+        product<A11, A22>,
+        product<A12, A21>
+    >;
+
+using orient2d = det2x2
+        <
+            difference <_1, _5>, difference<_2, _6>,
+            difference <_3, _5>, difference<_4, _6>
+        >;
+
+template
+<
+    typename A11, typename A12, typename A13,
+    typename A21, typename A22, typename A23,
+    typename A31, typename A32, typename A33
+>
+struct det3x3_helper
+{
+private:
+    using minor1 = product<A11, det2x2<A22, A23, A32, A33>>;
+    using minor2 = product<A21, det2x2<A12, A13, A32, A33>>;
+    using minor3 = product<A31, det2x2<A12, A13, A22, A23>>;
+public:
+    using type = sum<minor1, sum<minor2, minor3>>;
+};
+
+template
+<
+    typename A11, typename A12, typename A13,
+    typename A21, typename A22, typename A23,
+    typename A31, typename A32, typename A33
+>
+using det3x3 = typename det3x3_helper
+    <
+        A11, A12, A13,
+        A21, A22, A23,
+        A31, A32, A33
+    >::type;
+
+using orient3d = det3x3
+    <
+        difference<_1, _10>, difference<_2, _11>, difference<_3, _12>,
+        difference<_4, _10>, difference<_5, _11>, difference<_6, _12>,
+        difference<_7, _10>, difference<_8, _11>, difference<_9, _12>
+    >;
+
+struct incircle_helper
+{
+private:
+    using adx = difference<_1, _7>;
+    using ady = difference<_2, _8>;
+    using bdx = difference<_3, _7>;
+    using bdy = difference<_4, _8>;
+    using cdx = difference<_5, _7>;
+    using cdy = difference<_6, _8>;
+    using alift = sum<product<adx, adx>, product<ady, ady>>;
+    using blift = sum<product<bdx, bdx>, product<bdy, bdy>>;
+    using clift = sum<product<cdx, cdx>, product<cdy, cdy>>;
+public:
+    using type = det3x3
+        <
+            alift, adx, ady,
+            blift, bdx, bdy,
+            clift, cdx, cdy
+        >;
+};
+
+using incircle = incircle_helper::type;
+
+}} // namespace detail::generic_robust_predicates
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_EXPRESSIONS_HPP

--- a/include/boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/interval_error_bound.hpp
+++ b/include/boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/interval_error_bound.hpp
@@ -1,0 +1,243 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2020 Tinko Bartels, Berlin, Germany.
+
+// Contributed and/or modified by Tinko Bartels,
+//   as part of Google Summer of Code 2020 program.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_INTERVAL_ERROR_BOUND_HPP
+#define BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_INTERVAL_ERROR_BOUND_HPP
+
+#include <boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/expression_tree.hpp>
+
+namespace boost { namespace geometry
+{
+
+namespace detail { namespace generic_robust_predicates
+{
+
+template <typename Expression, std::size_t max_argn>
+struct interval_min_impl
+{
+    using type = Expression;
+};
+
+template <typename Expression, std::size_t max_argn>
+struct interval_max_impl
+{
+    using type = Expression;
+};
+
+template <typename Left, typename Right, std::size_t max_argn>
+struct interval_min_impl<difference<Left, Right>, max_argn>
+{
+private:
+    using min_left = typename interval_min_impl<Left, max_argn>::type;
+    using max_right = typename interval_max_impl<Right, max_argn>::type;
+public:
+    using type = difference<min_left, max_right>;
+};
+
+template <typename Left, typename Right, std::size_t max_argn>
+struct interval_min_impl<sum<Left, Right>, max_argn>
+{
+private:
+    using min_left = typename interval_min_impl<Left, max_argn>::type;
+    using min_right = typename interval_min_impl<Right, max_argn>::type;
+public:
+    using type = sum<min_left, min_right>;
+};
+
+template <typename Left, typename Right, std::size_t max_argn>
+struct interval_max_impl<difference<Left, Right>, max_argn>
+{
+private:
+    using max_left = typename interval_max_impl<Left, max_argn>::type;
+    using min_right = typename interval_min_impl<Right, max_argn>::type;
+public:
+    using type = difference<max_left, min_right>;
+};
+
+template <typename Left, typename Right, std::size_t max_argn>
+struct interval_max_impl<sum<Left, Right>, max_argn>
+{
+private:
+    using max_left = typename interval_max_impl<Left, max_argn>::type;
+    using max_right = typename interval_max_impl<Right, max_argn>::type;
+public:
+    using type = sum<max_left, max_right>;
+};
+
+template <typename Left, typename Right, std::size_t max_argn>
+struct interval_min_impl<product<Left, Right>, max_argn>
+{
+private:
+    using min_left = typename interval_min_impl<Left, max_argn>::type;
+    using max_left = typename interval_max_impl<Left, max_argn>::type;
+    using min_right = typename interval_min_impl<Right, max_argn>::type;
+    using max_right = typename interval_max_impl<Right, max_argn>::type;
+public:
+    using type = min
+        <
+            min
+                <
+                    product<min_left, min_right>,
+                    product<min_left, max_right>
+                >,
+            min
+                <
+                    product<max_left, min_right>,
+                    product<max_left, max_right>
+                >
+        >;
+};
+
+template <typename Child, std::size_t max_argn>
+struct interval_min_impl<product<Child, Child>, max_argn>
+{
+private:
+    using min_child = typename interval_min_impl<Child, max_argn>::type;
+    using max_child = typename interval_max_impl<Child, max_argn>::type;
+public:
+    using type = min
+        <
+            product<min_child, min_child>,
+            product<max_child, max_child>
+        >;
+};
+
+template <typename Left, typename Right, std::size_t max_argn>
+struct interval_max_impl<product<Left, Right>, max_argn>
+{
+private:
+    using min_left = typename interval_min_impl<Left, max_argn>::type;
+    using max_left = typename interval_max_impl<Left, max_argn>::type;
+    using min_right = typename interval_min_impl<Right, max_argn>::type;
+    using max_right = typename interval_max_impl<Right, max_argn>::type;
+public:
+    using type = max
+        <
+            max
+                <
+                    product<min_left, min_right>,
+                    product<min_left, max_right>
+                >,
+            max
+                <
+                    product<max_left, min_right>,
+                    product<max_left, max_right>
+                >
+        >;
+};
+
+template <typename Child, std::size_t max_argn>
+struct interval_max_impl<product<Child, Child>, max_argn>
+{
+private:
+    using min_child = typename interval_min_impl<Child, max_argn>::type;
+    using max_child = typename interval_max_impl<Child, max_argn>::type;
+public:
+    using type = max
+        <
+            product<min_child, min_child>,
+            product<max_child, max_child>
+        >;
+};
+
+template <typename Child, std::size_t max_argn>
+struct interval_min_impl<abs<Child>, max_argn>
+{
+private:
+    using min_child = typename interval_min_impl<Child, max_argn>::type;
+    using max_child = typename interval_max_impl<Child, max_argn>::type;
+public:
+    using type = min<abs<min_child>, abs<max_child>>;
+};
+
+template <typename Child, std::size_t max_argn>
+struct interval_max_impl<abs<Child>, max_argn>
+{
+private:
+    using min_child = typename interval_min_impl<Child, max_argn>::type;
+    using max_child = typename interval_max_impl<Child, max_argn>::type;
+public:
+    using type = max<abs<min_child>, abs<max_child>>;
+};
+
+template <std::size_t argn, std::size_t max_argn>
+struct interval_min_impl<argument<argn>, max_argn>
+{
+    using type = argument<argn + max_argn>;
+};
+
+template <std::size_t argn, std::size_t max_argn>
+struct interval_max_impl<argument<argn>, max_argn>
+{
+    using type = argument<argn>;
+};
+
+template <typename Expression, std::size_t max_argn>
+struct interval_impl
+{
+    using type = Expression;
+};
+
+template <typename Child, std::size_t max_argn>
+struct interval_impl<abs<Child>, max_argn>
+{
+private:
+    using min_child = typename interval_min_impl<Child, max_argn>::type;
+    using max_child = typename interval_max_impl<Child, max_argn>::type;
+public:
+    using type = max<abs<min_child>, abs<max_child>>;
+};
+
+template <typename Left, typename Right, std::size_t max_argn>
+struct interval_impl<difference<Left, Right>, max_argn>
+{
+private:
+    using left = typename interval_impl<Left, max_argn>::type;
+    using right = typename interval_impl<Right, max_argn>::type;
+public:
+    using type = difference<left, right>;
+};
+
+template <typename Left, typename Right, std::size_t max_argn>
+struct interval_impl<sum<Left, Right>, max_argn>
+{
+private:
+    using left = typename interval_impl<Left, max_argn>::type;
+    using right = typename interval_impl<Right, max_argn>::type;
+public:
+    using type = sum<left, right>;
+};
+
+template <typename Left, typename Right, std::size_t max_argn>
+struct interval_impl<product<Left, Right>, max_argn>
+{
+private:
+    using left = typename interval_impl<Left, max_argn>::type;
+    using right = typename interval_impl<Right, max_argn>::type;
+public:
+    using type = product<left, right>;
+};
+
+template <typename Expression, std::size_t max_argn>
+using interval_min = typename interval_min_impl<Expression, max_argn>::type;
+
+template <typename Expression, std::size_t max_argn>
+using interval_max = typename interval_max_impl<Expression, max_argn>::type;
+
+template <typename Expression>
+using interval =
+    typename interval_impl<Expression, max_argn<Expression>::value>::type;
+
+}} // namespace detail::generic_robust_predicates
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_INTERVAL_ERROR_BOUND_HPP

--- a/include/boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/semi_static_filter.hpp
+++ b/include/boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/semi_static_filter.hpp
@@ -1,0 +1,91 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2020 Tinko Bartels, Berlin, Germany.
+
+// Contributed and/or modified by Tinko Bartels,
+//   as part of Google Summer of Code 2020 program.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_SEMI_STATIC_FILTER_HPP
+#define BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_SEMI_STATIC_FILTER_HPP
+
+#include <array>
+
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/algorithm.hpp>
+#include <boost/mp11/set.hpp>
+
+#include <boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/expression_tree.hpp>
+#include <boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/approximate.hpp>
+
+namespace boost { namespace geometry
+{
+
+namespace detail { namespace generic_robust_predicates
+{
+
+template
+<
+    typename Expression,
+    typename CalculationType,
+    typename ErrorExpression
+>
+struct semi_static_filter
+{
+private:
+    using stack = typename boost::mp11::mp_unique<post_order<Expression>>;
+    using evals = typename boost::mp11::mp_remove_if<stack, is_leaf>;
+    using error_eval_stack = boost::mp11::mp_unique
+        <
+            post_order<ErrorExpression>
+        >;
+    using error_eval_stack_remainder = boost::mp11::mp_set_difference
+        <
+            error_eval_stack,
+            evals
+        >;
+    using all_evals = boost::mp11::mp_append
+        <
+            evals,
+            error_eval_stack_remainder
+        >;
+    using ct = CalculationType;
+public:
+    template <typename ...Reals>
+    static inline int apply(const Reals&... args)
+    {
+        std::array<CalculationType, sizeof...(Reals)> input
+            {{ static_cast<ct>(args)... }};
+        std::array<ct, boost::mp11::mp_size<all_evals>::value> results;
+        approximate_interim<all_evals, all_evals, ct>(results, input);
+        const ct error_bound =
+            get_approx<all_evals, ErrorExpression, ct>(results, input);
+        const ct det =
+            get_approx<all_evals, Expression, ct>(results, input);
+        if (det > error_bound)
+        {
+            return 1;
+        }
+        else if (det < -error_bound)
+        {
+            return -1;
+        }
+        else if (error_bound == 0 && det == 0)
+        {
+            return 0;
+        }
+        else
+        {
+            return sign_uncertain;
+        }
+    }
+};
+
+}} // namespace detail::generic_robust_predicates
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_SEMI_STATIC_FILTER_HPP

--- a/include/boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/stage_a.hpp
+++ b/include/boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/stage_a.hpp
@@ -1,0 +1,141 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2020 Tinko Bartels, Berlin, Germany.
+
+// Contributed and/or modified by Tinko Bartels,
+//   as part of Google Summer of Code 2020 program.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_STAGE_A_HPP
+#define BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_STAGE_A_HPP
+
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/algorithm.hpp>
+#include <boost/mp11/set.hpp>
+
+#include <boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/expression_tree.hpp>
+#include <boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/coefficient_list.hpp>
+#include <boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/error_bound.hpp>
+#include <boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/interval_error_bound.hpp>
+
+#include <boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/semi_static_filter.hpp>
+#include <boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/almost_static_filter.hpp>
+#include <boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/static_filter.hpp>
+
+namespace boost { namespace geometry
+{
+
+namespace detail { namespace generic_robust_predicates
+{
+
+template <typename Expression, typename CalculationType>
+struct stage_a_error_bound_impl
+{
+private:
+    using ct = CalculationType;
+    using root = Expression;
+    using stack = typename boost::mp11::mp_unique<post_order<Expression>>;
+    using evals = typename boost::mp11::mp_remove_if<stack, is_leaf>;
+    using interim_evals = typename boost::mp11::mp_remove
+        <
+            boost::mp11::mp_remove_if<stack, is_leaf>,
+            root
+        >;
+    using interim_errors = evals_error<interim_evals>;
+    using final_children = add_children
+        <
+            boost::mp11::mp_second
+                <
+                    boost::mp11::mp_map_find
+                        <
+                            interim_errors,
+                            typename root::left
+                        >
+                >,
+            boost::mp11::mp_second
+                <
+                    boost::mp11::mp_map_find
+                        <
+                            interim_errors,
+                            typename root::right
+                        >
+                >
+        >;
+    using final_children_ltp = error_map_list_to_product<final_children>;
+    using final_children_ltp_abs = abs_all<final_children_ltp>;
+    using final_children_sum_fold = error_map_balanced_sum_up<final_children_ltp_abs>;
+    using final_coeff = coeff_round
+        <
+            div_by_1_m_eps
+                <
+                    mult_by_1_p_eps
+                        <
+                            boost::mp11::mp_second<final_children_sum_fold>
+                        >
+                >
+        >;
+    static constexpr ct final_coeff_value = eval_eps_polynomial<ct, final_coeff>::value;
+
+    struct final_coeff_constant : public static_constant_interface<ct>
+    {
+        static constexpr ct value = final_coeff_value;
+        static constexpr bool non_negative = true;
+    };
+
+    using error_expression_variable = boost::mp11::mp_front<final_children_sum_fold>;
+public:
+    using type = product<final_coeff_constant, error_expression_variable>;
+};
+
+template
+<
+    typename Expression,
+    typename CalculationType
+>
+using stage_a_error_bound =
+    typename stage_a_error_bound_impl<Expression, CalculationType>::type;
+
+template
+<
+    typename Expression,
+    typename CalculationType
+>
+using stage_a_semi_static = semi_static_filter
+        <
+            Expression,
+            CalculationType,
+            stage_a_error_bound<Expression, CalculationType>
+        >;
+
+template
+<
+    typename Expression,
+    typename CalculationType
+>
+using stage_a_static = static_filter
+        <
+            Expression,
+            CalculationType,
+            interval<stage_a_error_bound<Expression, CalculationType>>
+        >;
+
+template
+<
+    typename Expression,
+    typename CalculationType
+>
+using stage_a_almost_static = almost_static_filter
+        <
+            Expression,
+            CalculationType,
+            stage_a_static<Expression, CalculationType>
+        >;
+
+}} // namespace detail::generic_robust_predicates
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_STAGE_A_HPP

--- a/include/boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/static_filter.hpp
+++ b/include/boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/static_filter.hpp
@@ -1,0 +1,98 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2020 Tinko Bartels, Berlin, Germany.
+
+// Contributed and/or modified by Tinko Bartels,
+//   as part of Google Summer of Code 2020 program.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_STATIC_FILTER_HPP
+#define BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_STATIC_FILTER_HPP
+
+#include <array>
+
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/algorithm.hpp>
+#include <boost/mp11/map.hpp>
+#include <boost/mp11/set.hpp>
+
+#include <boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/stage_a.hpp>
+
+namespace boost { namespace geometry
+{
+
+namespace detail { namespace generic_robust_predicates
+{
+
+template
+<
+    typename Expression,
+    typename CalculationType,
+    typename ErrorExpression
+>
+class static_filter
+{
+private:
+    using ct = CalculationType;
+    using stack = typename boost::mp11::mp_unique<post_order<Expression>>;
+    using evals = typename boost::mp11::mp_remove_if<stack, is_leaf>;
+    using error_eval_stack = boost::mp11::mp_unique
+        <
+            post_order<ErrorExpression>
+        >;
+    ct m_error_bound;
+public:
+    inline static_filter() {}
+
+    ct error_bound() const { return m_error_bound; }
+
+    template <typename ...Reals>
+    inline static_filter(const Reals&... args)
+        : m_error_bound(approximate_value<ErrorExpression, ct>(
+                std::array<ct, sizeof...(Reals)>
+                    {static_cast<ct>(args)...}))
+    {
+        static_assert(sizeof...(Reals) == max_argn<ErrorExpression>::value,
+                      "Number of constructor arguments is incompatible with error expression.");
+    }
+
+    template <typename ...Reals>
+    inline int apply(const Reals&... args) const
+    {
+        std::array<ct, sizeof...(Reals)> input {static_cast<ct>(args)...};
+        std::array<ct, boost::mp11::mp_size<evals>::value> results;
+        approximate_interim<evals, evals, ct>(results, input);
+        const ct det = get_approx<evals, Expression, ct>(results, input);
+        if (det > m_error_bound)
+        {
+            return 1;
+        }
+        else if (det < -m_error_bound)
+        {
+            return -1;
+        }
+        else if (m_error_bound == 0 && det == 0)
+        {
+            return 0;
+        }
+        else
+        {
+            return sign_uncertain;
+        }
+    }
+
+    template <typename ...Reals>
+    inline int operator()(const Reals&... args) const
+    {
+        return apply(args...);
+    }
+};
+
+}} // namespace detail::generic_robust_predicates
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_STATIC_FILTER_HPP

--- a/include/boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/static_util.hpp
+++ b/include/boost/geometry/extensions/generic_robust_predicates/strategies/cartesian/detail/static_util.hpp
@@ -1,0 +1,130 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2020 Tinko Bartels, Berlin, Germany.
+
+// Contributed and/or modified by Tinko Bartels,
+//   as part of Google Summer of Code 2020 program.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_STATIC_UTIL_HPP
+#define BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_STATIC_UTIL_HPP
+
+#include <boost/mp11/integral.hpp>
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/map.hpp>
+
+
+namespace boost { namespace geometry
+{
+
+namespace detail { namespace generic_robust_predicates
+{
+
+template
+<
+    typename LOV,
+    typename Void = boost::mp11::mp_same<LOV, void>
+>
+struct empty_or_void
+{
+    using type = boost::mp11::mp_empty<LOV>;
+};
+
+template <typename LOV>
+struct empty_or_void<LOV, boost::mp11::mp_true>
+{
+    using type = boost::mp11::mp_true;
+};
+
+template <typename N>
+struct log_2_floor_impl
+{
+    using type = typename boost::mp11::mp_plus
+        <
+            typename log_2_floor_impl<boost::mp11::mp_int<N::value / 2>>::type,
+            boost::mp11::mp_int<1>
+        >;
+};
+
+template <>
+struct log_2_floor_impl<boost::mp11::mp_int<1>>
+{
+    using type = boost::mp11::mp_int<0>;
+};
+
+template <typename N> using log_2_floor = typename log_2_floor_impl<N>::type;
+
+template <typename N>
+struct log_2_ceil_impl
+{
+private:
+    using floor = log_2_floor<N>;
+public:
+    using type = boost::mp11::mp_int
+        <
+            (1 << floor::value) == N::value ? floor::value : floor::value + 1
+        >;
+};
+
+template <typename N> using log_2_ceil = typename log_2_ceil_impl<N>::type;
+
+template <typename S> using is_not_zero = boost::mp11::mp_bool<S::value != 0>;
+
+template
+<
+    typename M,
+    typename K,
+    typename Contained = boost::mp11::mp_map_contains<M, K>
+>
+struct mp_map_at_second_or_void
+{
+    using type = void;
+};
+
+template<typename M, typename K>
+struct mp_map_at_second_or_void<M, K, boost::mp11::mp_true>
+{
+    using type = boost::mp11::mp_second<boost::mp11::mp_map_find<M, K>>;
+};
+
+template <typename T> using inc = boost::mp11::mp_int<T::value + 1>;
+
+template <typename L> using indexed = boost::mp11::mp_transform
+    <
+        boost::mp11::mp_list,
+        boost::mp11::mp_iota<boost::mp11::mp_size<L>>,
+        L
+    >;
+
+template <typename L> using strip_index =
+    boost::mp11::mp_transform<boost::mp11::mp_second, L>;
+
+template
+<
+    typename Map,
+    typename Key,
+    typename Contains = boost::mp11::mp_map_contains<Map, Key>
+>
+struct val_or_empty_list
+{
+    using type = boost::mp11::mp_second<boost::mp11::mp_map_find<Map, Key>>;
+};
+
+template
+<
+    typename Map,
+    typename Key
+>
+struct val_or_empty_list<Map, Key, boost::mp11::mp_false>
+{
+    using type = boost::mp11::mp_list<>;
+};
+
+}} // namespace detail::generic_robust_predicates
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_EXTENSIONS_GENERIC_ROBUST_PREDICATES_STRATEGIES_CARTESIAN_DETAIL_STATIC_UTIL_HPP


### PR DESCRIPTION
This pull request contains the first part of my GSoC 2020 project. This code is still work in progress and there might be changes to the interface before the end of GSoC.

The project aims to implement a number of facilities that allow easy creation of fast and robust geometric floating-point predicates, such as, for example, orientation tests (Boost.Geometry currently has a 2d orientation test in the side-strategy). As of writing this, the pull request contains templates to 

- automatically derive error bounds for the approximate evaluation of such expressions
- build static, almost static and semi-static filters from these expressions

I intend to add
- generation of functions for the exact evaluation of arbitrary arithmetic floating-point expressions containing +, - and * using expansion arithmetic
- improvements for the error bound derivation
- an alternative method for error bound derivation
- some additional filters
- automatic detection of reusable interim results between filter stages

The usage of the various templates for the creation of geometric predicates is illustrated in the tests and the example.

This pull request depends on Boost.MP11, which depends on C++11 but has no additional dependencies. The code itself depends on C++14 because of certain constexpr features.