### PR TITLE
Fix dangling references for referring_segment and proxy references returned by iterators.

### DIFF
--- a/include/boost/geometry/algorithms/detail/buffer/piece_border.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/piece_border.hpp
@@ -2,6 +2,10 @@
 
 // Copyright (c) 2020 Barend Gehrels, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2020.
+// Modifications copyright (c) 2020, Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -488,7 +492,9 @@ private :
         It it = begin;
         for (It previous = it++; it != end; ++previous, ++it)
         {
-            segment_type const s(*previous, *it);
+            Point const& p0 = *previous;
+            Point const& p1 = *it;
+            segment_type const s(p0, p1);
             radius_type const d = geometry::comparable_distance(center, s);
 
             if (first || d < m_min_comparable_radius)

--- a/include/boost/geometry/algorithms/detail/disjoint/linear_segment_or_box.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/linear_segment_or_box.hpp
@@ -5,8 +5,8 @@
 // Copyright (c) 2009-2014 Mateusz Loskot, London, UK.
 // Copyright (c) 2013-2014 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2013-2019.
-// Modifications copyright (c) 2013-2019, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013-2020.
+// Modifications copyright (c) 2013-2020, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
@@ -131,7 +131,9 @@ struct disjoint_range_segment_or_box
 
             for ( ; it1 != last ; ++it0, ++it1 )
             {
-                range_segment rng_segment(*it0, *it1);
+                point_type const& p0 = *it0;
+                point_type const& p1 = *it1;
+                range_segment rng_segment(p0, p1);
                 if ( !dispatch::disjoint
                          <
                              range_segment, SegmentOrBox

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
@@ -2,8 +2,8 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2013, 2014, 2015, 2017, 2018, 2019.
-// Modifications copyright (c) 2013-2019 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013-2020.
+// Modifications copyright (c) 2013-2020 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -18,7 +18,6 @@
 #include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>
 #include <boost/geometry/algorithms/detail/recalculate.hpp>
 #include <boost/geometry/core/assert.hpp>
-#include <boost/geometry/geometries/segment.hpp> // referring_segment
 #include <boost/geometry/policies/relate/direction.hpp>
 #include <boost/geometry/policies/relate/intersection_points.hpp>
 #include <boost/geometry/policies/relate/tupled.hpp>

--- a/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
@@ -3,8 +3,8 @@
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2014-2017 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2014, 2016, 2017, 2018.
-// Modifications copyright (c) 2014-2018 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014-2020.
+// Modifications copyright (c) 2014-2020 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -448,8 +448,6 @@ public :
 private :
     typedef typename geometry::point_type<Geometry1>::type point1_type;
     typedef typename geometry::point_type<Geometry2>::type point2_type;
-    typedef typename model::referring_segment<point1_type const> segment1_type;
-    typedef typename model::referring_segment<point2_type const> segment2_type;
 
     // It is NOT possible to have section-iterators here
     // because of the logistics of "index" (the section-iterator automatically

--- a/include/boost/geometry/strategies/geographic/intersection.hpp
+++ b/include/boost/geometry/strategies/geographic/intersection.hpp
@@ -2,7 +2,7 @@
 
 // Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
-// Copyright (c) 2016-2019, Oracle and/or its affiliates.
+// Copyright (c) 2016-2020, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -273,16 +273,21 @@ struct geographic_segments
         bool is_b_reversed = b1_lon > b2_lon || b1_lon == b2_lon && get<1>(b1) > get<1>(b2);
         */
 
-        bool const is_p_reversed = get<1>(range_p.at(0)) > get<1>(range_p.at(1));
-        bool const is_q_reversed = get<1>(range_q.at(0)) > get<1>(range_q.at(1));
+        point1_type const& p0 = range_p.at(0);
+        point1_type const& p1 = range_p.at(1);
+        point2_type const& q0 = range_q.at(0);
+        point2_type const& q1 = range_q.at(1);
+
+        bool const is_p_reversed = get<1>(p0) > get<1>(p1);
+        bool const is_q_reversed = get<1>(q0) > get<1>(q1);
 
         // Call apply with original segments and ordered points
-        return apply<Policy>(segment_type1(range_p.at(0), range_p.at(1)),
-                             segment_type2(range_q.at(0), range_q.at(1)),
-                             range_p.at(is_p_reversed ? 1 : 0),
-                             range_p.at(is_p_reversed ? 0 : 1),
-                             range_q.at(is_q_reversed ? 1 : 0),
-                             range_q.at(is_q_reversed ? 0 : 1),
+        return apply<Policy>(segment_type1(p0, p1),
+                             segment_type2(q0, q1),
+                             (is_p_reversed ? p1 : p0),
+                             (is_p_reversed ? p0 : p1),
+                             (is_q_reversed ? q1 : q0),
+                             (is_q_reversed ? q0 : q1),
                              is_p_reversed, is_q_reversed);
     }
 

--- a/include/boost/geometry/strategies/intersection_strategies.hpp
+++ b/include/boost/geometry/strategies/intersection_strategies.hpp
@@ -2,8 +2,8 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2016, 2017.
-// Modifications copyright (c) 2016-2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2016-2020.
+// Modifications copyright (c) 2016-2020, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -13,9 +13,6 @@
 #ifndef BOOST_GEOMETRY_STRATEGIES_INTERSECTION_HPP
 #define BOOST_GEOMETRY_STRATEGIES_INTERSECTION_HPP
 
-
-#include <boost/geometry/core/point_type.hpp>
-#include <boost/geometry/geometries/segment.hpp>
 
 #include <boost/geometry/policies/relate/intersection_points.hpp>
 #include <boost/geometry/policies/relate/direction.hpp>
@@ -54,11 +51,6 @@ struct intersection_strategies
 {
 private :
     // for development BOOST_STATIC_ASSERT((! boost::is_same<RobustPolicy, void>::type::value));
-
-    typedef typename geometry::point_type<Geometry1>::type point1_type;
-    typedef typename geometry::point_type<Geometry2>::type point2_type;
-    typedef typename model::referring_segment<point1_type const> segment1_type;
-    typedef typename model::referring_segment<point2_type const> segment2_type;
 
     typedef segment_intersection_points
     <


### PR DESCRIPTION
A fix for https://github.com/boostorg/geometry/issues/716

It also removes some unneeded typedefs.