### PR TITLE
Refactor for_each_x and implement new algorithms.

### DIFF
--- a/.github/workflows/minimal-clang.yml
+++ b/.github/workflows/minimal-clang.yml
@@ -32,28 +32,28 @@ jobs:
 
         include:
           - b2_toolset: clang-3.9
-            b2_cxxstd: 03,11
+            b2_cxxstd: 14
             version: "3.9"
           - b2_toolset: clang-4.0
-            b2_cxxstd: 03,11
+            b2_cxxstd: 14
             version: "4.0"
           - b2_toolset: clang-5.0
-            b2_cxxstd: 03,11,14
+            b2_cxxstd: 14
             version: "5.0"
           - b2_toolset: clang-6.0
-            b2_cxxstd: 03,11,14
+            b2_cxxstd: 14
             version: "6.0"
           - b2_toolset: clang-7
-            b2_cxxstd: 03,11,14,17
+            b2_cxxstd: 14,17
             version: "7"
           - b2_toolset: clang-8
-            b2_cxxstd: 03,11,14,17
+            b2_cxxstd: 14,17
             version: "8"
           - b2_toolset: clang-9
-            b2_cxxstd: 03,11,14,17,2a
+            b2_cxxstd: 14,17,2a
             version: "9"
           - b2_toolset: clang-10
-            b2_cxxstd: 03,11,14,17,2a
+            b2_cxxstd: 14,17,2a
             version: "10"
 
     steps:

--- a/.github/workflows/minimal-gcc.yml
+++ b/.github/workflows/minimal-gcc.yml
@@ -20,7 +20,6 @@ jobs:
       fail-fast: false
       matrix:
         b2_toolset: [
-          gcc-4.8,
           gcc-4.9,
           gcc-5,
           gcc-6,
@@ -30,26 +29,23 @@ jobs:
         ]
 
         include:
-          - b2_toolset: gcc-4.8
-            b2_cxxstd: 03,11
-            version: "4.8"
           - b2_toolset: gcc-4.9
-            b2_cxxstd: 03,11
+            b2_cxxstd: 14
             version: "4.9"
           - b2_toolset: gcc-5
-            b2_cxxstd: 03,11,14
+            b2_cxxstd: 14
             version: "5"
           - b2_toolset: gcc-6
-            b2_cxxstd: 03,11,14
+            b2_cxxstd: 14
             version: "6"
           - b2_toolset: gcc-7
-            b2_cxxstd: 03,11,14,17
+            b2_cxxstd: 14,17
             version: "7"
           - b2_toolset: gcc-8
-            b2_cxxstd: 03,11,14,17
+            b2_cxxstd: 14,17
             version: "8"
           - b2_toolset: gcc-9
-            b2_cxxstd: 03,11,14,17,2a
+            b2_cxxstd: 14,17,2a
             version: "9"
 
     steps:

--- a/include/boost/geometry/algorithms/convert.hpp
+++ b/include/boost/geometry/algorithms/convert.hpp
@@ -5,8 +5,8 @@
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 // Copyright (c) 2014 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017-2020.
+// Modifications copyright (c) 2017-2020, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
@@ -34,7 +34,6 @@
 #include <boost/geometry/arithmetic/arithmetic.hpp>
 #include <boost/geometry/algorithms/not_implemented.hpp>
 #include <boost/geometry/algorithms/clear.hpp>
-#include <boost/geometry/algorithms/for_each.hpp>
 #include <boost/geometry/algorithms/detail/assign_box_corners.hpp>
 #include <boost/geometry/algorithms/detail/assign_indexed_point.hpp>
 #include <boost/geometry/algorithms/detail/convert_point_to_point.hpp>

--- a/include/boost/geometry/algorithms/detail/disjoint/areal_areal.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/areal_areal.hpp
@@ -5,8 +5,8 @@
 // Copyright (c) 2009-2014 Mateusz Loskot, London, UK.
 // Copyright (c) 2013-2014 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2013-2019.
-// Modifications copyright (c) 2013-2019, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013-2020.
+// Modifications copyright (c) 2013-2020, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
@@ -30,7 +30,7 @@
 #include <boost/geometry/algorithms/detail/disjoint/linear_linear.hpp>
 #include <boost/geometry/algorithms/detail/disjoint/segment_box.hpp>
 
-#include <boost/geometry/iterators/segment_iterator.hpp>
+#include <boost/geometry/algorithms/for_each.hpp>
 
 
 namespace boost { namespace geometry
@@ -51,46 +51,23 @@ inline bool point_on_border_covered_by(Geometry1 const& geometry1,
         && geometry::covered_by(pt, geometry2, strategy);
 }
 
-/*!
-\tparam Strategy point_in_geometry strategy
-*/
-template<typename Geometry, typename Strategy>
-struct check_each_ring_for_within
-{
-    bool not_disjoint;
-    Geometry const& m_geometry;
-    Strategy const& m_strategy;
-
-    inline check_each_ring_for_within(Geometry const& g,
-                                      Strategy const& strategy)
-        : not_disjoint(false)
-        , m_geometry(g)
-        , m_strategy(strategy)
-    {}
-
-    template <typename Range>
-    inline void apply(Range const& range)
-    {
-        not_disjoint = not_disjoint
-                    || point_on_border_covered_by(range, m_geometry, m_strategy);
-    }
-};
-
 
 /*!
 \tparam Strategy point_in_geometry strategy
 */
-template <typename FirstGeometry, typename SecondGeometry, typename Strategy>
-inline bool rings_containing(FirstGeometry const& geometry1,
-                             SecondGeometry const& geometry2,
+template <typename Geometry1, typename Geometry2, typename Strategy>
+inline bool rings_containing(Geometry1 const& geometry1,
+                             Geometry2 const& geometry2,
                              Strategy const& strategy)
 {
-    check_each_ring_for_within
-        <
-            FirstGeometry, Strategy
-        > checker(geometry1, strategy);
-    geometry::detail::for_each_range(geometry2, checker);
-    return checker.not_disjoint;
+    // TODO: This will be removed when IntersectionStrategy is replaced with
+    //       UmbrellaStrategy
+    auto const pgs = strategy.template get_point_in_geometry_strategy<Geometry2, Geometry1>();
+
+    return geometry::detail::any_range_of(geometry2, [&](auto const& range)
+    {
+        return point_on_border_covered_by(range, geometry1, pgs);
+    });
 }
 
 
@@ -117,10 +94,8 @@ struct areal_areal
         // We check that using a point on the border (external boundary),
         // and see if that is contained in the other geometry. And vice versa.
 
-        if ( rings_containing(geometry1, geometry2,
-                              strategy.template get_point_in_geometry_strategy<Geometry2, Geometry1>())
-          || rings_containing(geometry2, geometry1,
-                              strategy.template get_point_in_geometry_strategy<Geometry1, Geometry2>()) )
+        if ( rings_containing(geometry1, geometry2, strategy)
+          || rings_containing(geometry2, geometry1, strategy) )
         {
             return false;
         }
@@ -141,10 +116,12 @@ struct areal_box
                              Box const& box,
                              Strategy const& strategy)
     {
-        if ( ! for_each_segment(geometry::segments_begin(areal),
-                                geometry::segments_end(areal),
-                                box,
-                                strategy.get_disjoint_segment_box_strategy()) )
+        // TODO: This will be removed when UmbrellaStrategy is supported
+        auto const ds = strategy.get_disjoint_segment_box_strategy();
+        if (! geometry::all_segments_of(areal, [&](auto const& s)
+              {
+                  return disjoint_segment_box::apply(s, box, ds);
+              }) )
         {
             return false;
         }
@@ -158,23 +135,6 @@ struct areal_box
             return false;
         }
 
-        return true;
-    }
-
-private:
-    template <typename SegIter, typename Strategy>
-    static inline bool for_each_segment(SegIter first,
-                                        SegIter last,
-                                        Box const& box,
-                                        Strategy const& strategy)
-    {
-        for ( ; first != last ; ++first)
-        {
-            if (! disjoint_segment_box::apply(*first, box, strategy))
-            {
-                return false;
-            }
-        }
         return true;
     }
 };

--- a/include/boost/geometry/algorithms/detail/for_each_range.hpp
+++ b/include/boost/geometry/algorithms/detail/for_each_range.hpp
@@ -4,6 +4,10 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
+// This file was modified by Oracle on 2020.
+// Modifications copyright (c) 2020, Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -15,9 +19,13 @@
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_FOR_EACH_RANGE_HPP
 
 
-#include <boost/mpl/assert.hpp>
+#include <utility>
+
 #include <boost/concept/requires.hpp>
-#include <boost/range.hpp>
+#include <boost/core/addressof.hpp>
+#include <boost/mpl/assert.hpp>
+#include <boost/range/begin.hpp>
+#include <boost/range/end.hpp>
 #include <boost/type_traits/is_const.hpp>
 #include <boost/type_traits/remove_const.hpp>
 
@@ -26,7 +34,9 @@
 #include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/util/add_const_if_c.hpp>
+
 #include <boost/geometry/views/box_view.hpp>
+#include <boost/geometry/views/segment_view.hpp>
 
 
 namespace boost { namespace geometry
@@ -38,47 +48,78 @@ namespace detail { namespace for_each
 {
 
 
-template <typename Range, typename Actor>
-struct fe_range_range
+template <typename Point>
+struct fe_range_point
 {
-    static inline void apply(Range & range, Actor & actor)
+    template <typename Functor>
+    static inline bool apply(Point& point, Functor&& f)
     {
-        actor.apply(range);
+        Point* ptr = boost::addressof(point);
+        return f(std::pair<Point*, Point*>(ptr, ptr + 1));
     }
 };
 
 
-template <typename Polygon, typename Actor>
+template <typename Segment>
+struct fe_range_segment
+{
+    template <typename Functor>
+    static inline bool apply(Segment& segment, Functor&& f)
+    {
+        return f(segment_view<typename boost::remove_const<Segment>::type>(segment));
+    }
+};
+
+
+template <typename Range>
+struct fe_range_range
+{
+    template <typename Functor>
+    static inline bool apply(Range& range, Functor&& f)
+    {
+        return f(range);
+    }
+};
+
+
+template <typename Polygon>
 struct fe_range_polygon
 {
-    static inline void apply(Polygon & polygon, Actor & actor)
+    template <typename Functor>
+    static inline bool apply(Polygon& polygon, Functor&& f)
     {
-        actor.apply(exterior_ring(polygon));
+        return f(exterior_ring(polygon));
 
         // TODO: If some flag says true, also do the inner rings.
         // for convex hull, it's not necessary
     }
 };
 
-template <typename Box, typename Actor>
+template <typename Box>
 struct fe_range_box
 {
-    static inline void apply(Box & box, Actor & actor)
+    template <typename Functor>
+    static inline bool apply(Box& box, Functor&& f)
     {
-        actor.apply(box_view<typename boost::remove_const<Box>::type>(box));
+        return f(box_view<typename boost::remove_const<Box>::type>(box));
     }
 };
 
-template <typename Multi, typename Actor, typename SinglePolicy>
+template <typename Multi, typename SinglePolicy>
 struct fe_range_multi
 {
-    static inline void apply(Multi & multi, Actor & actor)
+    template <typename Functor>
+    static inline bool apply(Multi& multi, Functor&& f)
     {
-        for ( typename boost::range_iterator<Multi>::type
-                it = boost::begin(multi); it != boost::end(multi); ++it)
+        auto const end = boost::end(multi);
+        for (auto it = boost::begin(multi); it != end; ++it)
         {
-            SinglePolicy::apply(*it, actor);
+            if (! SinglePolicy::apply(*it, f))
+            {
+                return false;
+            }
         }
+        return true;
     }
 };
 
@@ -94,7 +135,6 @@ namespace dispatch
 template
 <
     typename Geometry,
-    typename Actor,
     typename Tag = typename tag<Geometry>::type
 >
 struct for_each_range
@@ -107,69 +147,77 @@ struct for_each_range
 };
 
 
-template <typename Linestring, typename Actor>
-struct for_each_range<Linestring, Actor, linestring_tag>
-    : detail::for_each::fe_range_range<Linestring, Actor>
+template <typename Point>
+struct for_each_range<Point, point_tag>
+    : detail::for_each::fe_range_point<Point>
 {};
 
 
-template <typename Ring, typename Actor>
-struct for_each_range<Ring, Actor, ring_tag>
-    : detail::for_each::fe_range_range<Ring, Actor>
+template <typename Segment>
+struct for_each_range<Segment, segment_tag>
+    : detail::for_each::fe_range_segment<Segment>
 {};
 
 
-template <typename Polygon, typename Actor>
-struct for_each_range<Polygon, Actor, polygon_tag>
-    : detail::for_each::fe_range_polygon<Polygon, Actor>
+template <typename Linestring>
+struct for_each_range<Linestring, linestring_tag>
+    : detail::for_each::fe_range_range<Linestring>
 {};
 
 
-template <typename Box, typename Actor>
-struct for_each_range<Box, Actor, box_tag>
-    : detail::for_each::fe_range_box<Box, Actor>
+template <typename Ring>
+struct for_each_range<Ring, ring_tag>
+    : detail::for_each::fe_range_range<Ring>
 {};
 
 
-template <typename MultiPoint, typename Actor>
-struct for_each_range<MultiPoint, Actor, multi_point_tag>
-    : detail::for_each::fe_range_range<MultiPoint, Actor>
+template <typename Polygon>
+struct for_each_range<Polygon, polygon_tag>
+    : detail::for_each::fe_range_polygon<Polygon>
 {};
 
 
-template <typename Geometry, typename Actor>
-struct for_each_range<Geometry, Actor, multi_linestring_tag>
+template <typename Box>
+struct for_each_range<Box, box_tag>
+    : detail::for_each::fe_range_box<Box>
+{};
+
+
+template <typename MultiPoint>
+struct for_each_range<MultiPoint, multi_point_tag>
+    : detail::for_each::fe_range_range<MultiPoint>
+{};
+
+
+template <typename Geometry>
+struct for_each_range<Geometry, multi_linestring_tag>
     : detail::for_each::fe_range_multi
         <
             Geometry,
-            Actor,
             detail::for_each::fe_range_range
                 <
                     typename add_const_if_c
                         <
                             boost::is_const<Geometry>::value,
                             typename boost::range_value<Geometry>::type
-                        >::type,
-                    Actor
+                        >::type
                 >
         >
 {};
 
 
-template <typename Geometry, typename Actor>
-struct for_each_range<Geometry, Actor, multi_polygon_tag>
+template <typename Geometry>
+struct for_each_range<Geometry, multi_polygon_tag>
     : detail::for_each::fe_range_multi
         <
             Geometry,
-            Actor,
             detail::for_each::fe_range_polygon
                 <
                     typename add_const_if_c
                         <
                             boost::is_const<Geometry>::value,
                             typename boost::range_value<Geometry>::type
-                        >::type,
-                    Actor
+                        >::type
                 >
         >
 {};
@@ -181,14 +229,55 @@ struct for_each_range<Geometry, Actor, multi_polygon_tag>
 namespace detail
 {
 
-template <typename Geometry, typename Actor>
-inline void for_each_range(Geometry const& geometry, Actor & actor)
+
+// Currently for Polygons p is checked only for exterior ring
+// Should this function be renamed?
+template <typename Geometry, typename UnaryPredicate>
+inline bool all_ranges_of(Geometry const& geometry, UnaryPredicate p)
 {
-    dispatch::for_each_range
-        <
-            Geometry const,
-            Actor
-        >::apply(geometry, actor);
+    return dispatch::for_each_range<Geometry const>::apply(geometry, p);
+}
+
+
+// Currently for Polygons p is checked only for exterior ring
+// Should this function be renamed?
+template <typename Geometry, typename UnaryPredicate>
+inline bool any_range_of(Geometry const& geometry, UnaryPredicate p)
+{
+    return ! dispatch::for_each_range<Geometry const>::apply(geometry,
+                [&](auto&& range)
+                {
+                    return ! p(range);
+                });
+}
+
+
+// Currently for Polygons p is checked only for exterior ring
+// Should this function be renamed?
+template <typename Geometry, typename UnaryPredicate>
+inline bool none_range_of(Geometry const& geometry, UnaryPredicate p)
+{
+    return dispatch::for_each_range<Geometry const>::apply(geometry,
+                [&](auto&& range)
+                {
+                    return ! p(range);
+                });
+}
+
+
+// Currently for Polygons f is called only for exterior ring
+// Should this function be renamed?
+template <typename Geometry, typename Functor>
+inline Functor for_each_range(Geometry const& geometry, Functor f)
+{
+    dispatch::for_each_range<Geometry const>::apply(geometry,
+        [&](auto&& range)
+        {
+            f(range);
+            // TODO: Implement separate function?
+            return true;
+        });
+    return f;
 }
 
 

--- a/include/boost/geometry/algorithms/for_each.hpp
+++ b/include/boost/geometry/algorithms/for_each.hpp
@@ -45,6 +45,8 @@
 #include <boost/geometry/util/add_const_if_c.hpp>
 #include <boost/geometry/util/range.hpp>
 
+#include <boost/geometry/views/detail/indexed_point_view.hpp>
+
 
 namespace boost { namespace geometry
 {
@@ -54,44 +56,141 @@ namespace detail { namespace for_each
 {
 
 
-struct fe_point_per_point
+struct fe_point_point
 {
     template <typename Point, typename Functor>
-    static inline void apply(Point& point, Functor& f)
+    static inline bool apply(Point& point, Functor&& f)
     {
-        f(point);
+        return f(point);
     }
 };
 
 
-struct fe_point_per_segment
+struct fe_segment_point
 {
     template <typename Point, typename Functor>
-    static inline void apply(Point& , Functor& /*f*/)
+    static inline bool apply(Point& , Functor&& )
     {
         // TODO: if non-const, we should extract the points from the segment
         // and call the functor on those two points
+
+        //model::referring_segment<Point> s(point, point);
+        //return f(s);
+
+        return true;
     }
 };
 
 
-struct fe_range_per_point
+struct fe_point_segment
+{
+    template <typename Segment, typename Functor>
+    static inline bool apply(Segment& s, Functor&& f)
+    {
+        // Or should we guarantee that the type of points is
+        // point_type<Segment>::type ?
+        geometry::detail::indexed_point_view<Segment, 0> p0(s);
+        geometry::detail::indexed_point_view<Segment, 1> p1(s);
+        return f(p0) && f(p1);
+    }
+};
+
+struct fe_segment_segment
+{
+    template <typename Segment, typename Functor>
+    static inline bool apply(Segment& s, Functor&& f)
+    {
+        // Or should we guarantee that the type of segment is
+        // referring_segment<...> ?
+        return f(s);
+    }
+};
+
+
+template <typename Range>
+struct fe_range_value
+{
+    typedef typename add_const_if_c
+        <
+            boost::is_const<Range>::value,
+            typename boost::range_value<Range>::type
+        >::type type;
+};
+
+template <typename Range>
+struct fe_point_type
+{
+    typedef typename add_const_if_c
+        <
+            boost::is_const<Range>::value,
+            typename point_type<Range>::type
+        >::type type;
+};
+
+
+template <typename Range>
+struct fe_point_type_is_referencable
+{
+    static const bool value =
+        boost::is_const<Range>::value
+     || boost::is_same
+            <
+                typename boost::range_reference<Range>::type,
+                typename fe_point_type<Range>::type&
+            >::value;
+};
+
+
+template
+<
+    typename Range,
+    bool UseReferences = fe_point_type_is_referencable<Range>::value
+>
+struct fe_point_call_f
+{
+    template <typename Iterator, typename Functor>
+    static inline bool apply(Iterator it, Functor&& f)
+    {
+        // Implementation for real references (both const and mutable)
+        // and const proxy references.
+        typedef typename fe_point_type<Range>::type point_type;
+        point_type& p = *it;
+        return f(p);
+    }
+};
+
+template <typename Range>
+struct fe_point_call_f<Range, false>
+{
+    template <typename Iterator, typename Functor>
+    static inline bool apply(Iterator it, Functor&& f)
+    {
+        // Implementation for proxy mutable references.
+        // Temporary point has to be created and assigned afterwards.
+        typedef typename fe_point_type<Range>::type point_type;
+        point_type p = *it;
+        bool result = f(p);
+        *it = p;
+        return result;
+    }
+};
+
+
+struct fe_point_range
 {
     template <typename Range, typename Functor>
-    static inline void apply(Range& range, Functor& f)
+    static inline bool apply(Range& range, Functor&& f)
     {
-        // The previous implementation called the std library:
-        // return (std::for_each(boost::begin(range), boost::end(range), f));
-        // But that is not accepted for capturing lambda's.
-        // It needs to do it like that to return the state of Functor f (f is passed by value in std::for_each).
-
-        // So we now loop manually.
-
-        for (typename boost::range_iterator<Range>::type
-                it = boost::begin(range); it != boost::end(range); ++it)
+        auto const end = boost::end(range);
+        for (auto it = boost::begin(range); it != end; ++it)
         {
-            f(*it);
+            if (! fe_point_call_f<Range>::apply(it, f))
+            {
+                return false;
+            }
         }
+
+        return true;
     }
 };
 
@@ -99,106 +198,113 @@ struct fe_range_per_point
 template
 <
     typename Range,
-    typename Point = typename add_const_if_c
-        <
-            boost::is_const<Range>::value,
-            typename point_type<Range>::type
-        >::type,
-    bool UseReferences =
-        ( boost::is_const<Range>::value
-       || boost::is_same
-            <
-                typename boost::range_reference<Range>::type,
-                Point&
-            >::value )
+    bool UseReferences = fe_point_type_is_referencable<Range>::value
 >
-struct fe_range_per_segment_call_f
+struct fe_segment_call_f
 {
     template <typename Iterator, typename Functor>
-    static inline void apply(Iterator it0, Iterator it1, Functor& f)
+    static inline bool apply(Iterator it0, Iterator it1, Functor&& f)
     {
         // Implementation for real references (both const and mutable)
         // and const proxy references.
         // If const proxy references are returned by iterators
         // then const real references here prevents temporary
         // objects from being destroyed.
-        Point& p0 = *it0;
-        Point& p1 = *it1;
-        model::referring_segment<Point> s(p0, p1);
-        f(s);
+        typedef typename fe_point_type<Range>::type point_type;
+        point_type& p0 = *it0;
+        point_type& p1 = *it1;
+        model::referring_segment<point_type> s(p0, p1);
+        return f(s);
     }
 };
 
-template <typename Range, typename Point>
-struct fe_range_per_segment_call_f<Range, Point, false>
+template <typename Range>
+struct fe_segment_call_f<Range, false>
 {
     template <typename Iterator, typename Functor>
-    static inline void apply(Iterator it0, Iterator it1, Functor& f)
+    static inline bool apply(Iterator it0, Iterator it1, Functor&& f)
     {
         // Mutable proxy references returned by iterators.
         // Temporary points have to be created and assigned afterwards.
-        Point p0 = *it0;
-        Point p1 = *it1;
-        model::referring_segment<Point> s(p0, p1);
-        f(s);
+        typedef typename fe_point_type<Range>::type point_type;
+        point_type p0 = *it0;
+        point_type p1 = *it1;
+        model::referring_segment<point_type> s(p0, p1);
+        bool result = f(s);
         *it0 = p0;
         *it1 = p1;
+        return result;
     }
 };
 
 
 template <closure_selector Closure>
-struct fe_range_per_segment_with_closure
+struct fe_segment_range_with_closure
 {
     template <typename Range, typename Functor>
-    static inline void apply(Range& range, Functor& f)
+    static inline bool apply(Range& range, Functor&& f)
     {
-        typedef typename boost::range_iterator<Range>::type iterator_type;
-
-        iterator_type it = boost::begin(range);
-        iterator_type end = boost::end(range);
+        auto it = boost::begin(range);
+        auto const end = boost::end(range);
         if (it == end)
         {
-            return;
+            return true;
         }
 
-        iterator_type previous = it++;
-        while(it != end)
+        auto previous = it++;
+        if (it == end)
         {
-            fe_range_per_segment_call_f<Range>::apply(previous, it, f);
+            return fe_segment_call_f<Range>::apply(previous, previous, f);
+        }
+
+        while (it != end)
+        {
+            if (! fe_segment_call_f<Range>::apply(previous, it, f))
+            {
+                return false;
+            }
             previous = it++;
         }
+
+        return true;
     }
 };
 
 
 template <>
-struct fe_range_per_segment_with_closure<open>
+struct fe_segment_range_with_closure<open>
 {
     template <typename Range, typename Functor>
-    static inline void apply(Range& range, Functor& f)
+    static inline bool apply(Range& range, Functor&& f)
     {
-        fe_range_per_segment_with_closure<closed>::apply(range, f);
+        fe_segment_range_with_closure<closed>::apply(range, f);
 
-        typedef typename boost::range_iterator<Range>::type iterator_type;
-        iterator_type begin = boost::begin(range);
-        iterator_type end = boost::end(range);
+        auto const begin = boost::begin(range);
+        auto end = boost::end(range);
         if (begin == end)
         {
-            return;
+            return true;
+        }
+        
+        --end;
+        
+        if (begin == end)
+        {
+            // single point ranges already handled in closed case above
+            return true;
         }
 
-        fe_range_per_segment_call_f<Range>::apply(--end, begin, f);
+        return fe_segment_call_f<Range>::apply(end, begin, f);
     }
 };
 
 
-struct fe_range_per_segment
+struct fe_segment_range
 {
     template <typename Range, typename Functor>
-    static inline void apply(Range& range, Functor& f)
+    static inline bool apply(Range& range, Functor&& f)
     {
-        fe_range_per_segment_with_closure
+        return fe_segment_range_with_closure
             <
                 closure<Range>::value
             >::apply(range, f);
@@ -206,57 +312,54 @@ struct fe_range_per_segment
 };
 
 
-struct fe_polygon_per_point
+template <typename RangePolicy>
+struct for_each_polygon
 {
     template <typename Polygon, typename Functor>
-    static inline void apply(Polygon& poly, Functor& f)
+    static inline bool apply(Polygon& poly, Functor&& f)
     {
-        fe_range_per_point::apply(exterior_ring(poly), f);
+        if (! RangePolicy::apply(exterior_ring(poly), f))
+        {
+            return false;
+        }
 
         typename interior_return_type<Polygon>::type
             rings = interior_rings(poly);
 
-        for (typename detail::interior_iterator<Polygon>::type
-                it = boost::begin(rings); it != boost::end(rings); ++it)
+        auto const end = boost::end(rings);
+        for (auto it = boost::begin(rings); it != end; ++it)
         {
-            fe_range_per_point::apply(*it, f);
+            // NOTE: Currently lvalue iterator required
+            if (! RangePolicy::apply(*it, f))
+            {
+                return false;
+            }
         }
-    }
 
-};
-
-struct fe_polygon_per_segment
-{
-    template <typename Polygon, typename Functor>
-    static inline void apply(Polygon& poly, Functor& f)
-    {
-        fe_range_per_segment::apply(exterior_ring(poly), f);
-
-        typename interior_return_type<Polygon>::type
-            rings = interior_rings(poly);
-
-        for (typename detail::interior_iterator<Polygon>::type
-                it = boost::begin(rings); it != boost::end(rings); ++it)
-        {
-            fe_range_per_segment::apply(*it, f);
-        }
+        return true;
     }
 
 };
 
 // Implementation of multi, for both point and segment,
 // just calling the single version.
-template <typename Policy>
+template <typename SinglePolicy>
 struct for_each_multi
 {
     template <typename MultiGeometry, typename Functor>
-    static inline void apply(MultiGeometry& multi, Functor& f)
+    static inline bool apply(MultiGeometry& multi, Functor&& f)
     {
-        for (typename boost::range_iterator<MultiGeometry>::type
-                it = boost::begin(multi); it != boost::end(multi); ++it)
+        auto const end = boost::end(multi);
+        for (auto it = boost::begin(multi); it != end; ++it)
         {
-            Policy::apply(*it, f);
+            // NOTE: Currently lvalue iterator required
+            if (! SinglePolicy::apply(*it, f))
+            {
+                return false;
+            }
         }
+
+        return true;
     }
 };
 
@@ -279,57 +382,34 @@ struct for_each_point: not_implemented<Tag>
 
 template <typename Point>
 struct for_each_point<Point, point_tag>
-    : detail::for_each::fe_point_per_point
+    : detail::for_each::fe_point_point
+{};
+
+
+template <typename Segment>
+struct for_each_point<Segment, segment_tag>
+    : detail::for_each::fe_point_segment
 {};
 
 
 template <typename Linestring>
 struct for_each_point<Linestring, linestring_tag>
-    : detail::for_each::fe_range_per_point
+    : detail::for_each::fe_point_range
 {};
 
 
 template <typename Ring>
 struct for_each_point<Ring, ring_tag>
-    : detail::for_each::fe_range_per_point
+    : detail::for_each::fe_point_range
 {};
 
 
 template <typename Polygon>
 struct for_each_point<Polygon, polygon_tag>
-    : detail::for_each::fe_polygon_per_point
-{};
-
-
-template
-<
-    typename Geometry,
-    typename Tag = typename tag_cast<typename tag<Geometry>::type, multi_tag>::type
->
-struct for_each_segment: not_implemented<Tag>
-{};
-
-template <typename Point>
-struct for_each_segment<Point, point_tag>
-    : detail::for_each::fe_point_per_segment
-{};
-
-
-template <typename Linestring>
-struct for_each_segment<Linestring, linestring_tag>
-    : detail::for_each::fe_range_per_segment
-{};
-
-
-template <typename Ring>
-struct for_each_segment<Ring, ring_tag>
-    : detail::for_each::fe_range_per_segment
-{};
-
-
-template <typename Polygon>
-struct for_each_segment<Polygon, polygon_tag>
-    : detail::for_each::fe_polygon_per_segment
+    : detail::for_each::for_each_polygon
+        <
+            detail::for_each::fe_point_range
+        >
 {};
 
 
@@ -340,28 +420,77 @@ struct for_each_point<MultiGeometry, multi_tag>
             // Specify the dispatch of the single-version as policy
             for_each_point
                 <
-                    typename add_const_if_c
+                    typename detail::for_each::fe_range_value
                         <
-                            is_const<MultiGeometry>::value,
-                            typename boost::range_value<MultiGeometry>::type
+                            MultiGeometry
                         >::type
                 >
         >
 {};
 
 
-template <typename MultiGeometry>
-struct for_each_segment<MultiGeometry, multi_tag>
+template
+<
+    typename Geometry,
+    typename Tag = typename tag<Geometry>::type
+>
+struct for_each_segment: not_implemented<Tag>
+{};
+
+template <typename Point>
+struct for_each_segment<Point, point_tag>
+    : detail::for_each::fe_segment_point // empty
+{};
+
+
+template <typename Segment>
+struct for_each_segment<Segment, segment_tag>
+    : detail::for_each::fe_segment_segment
+{};
+
+
+template <typename Linestring>
+struct for_each_segment<Linestring, linestring_tag>
+    : detail::for_each::fe_segment_range
+{};
+
+
+template <typename Ring>
+struct for_each_segment<Ring, ring_tag>
+    : detail::for_each::fe_segment_range
+{};
+
+
+template <typename Polygon>
+struct for_each_segment<Polygon, polygon_tag>
+    : detail::for_each::for_each_polygon
+        <
+            detail::for_each::fe_segment_range
+        >
+{};
+
+
+template <typename MultiPoint>
+struct for_each_segment<MultiPoint, multi_point_tag>
+    : detail::for_each::fe_segment_point // empty
+{};
+
+
+template <typename MultiLinestring>
+struct for_each_segment<MultiLinestring, multi_linestring_tag>
     : detail::for_each::for_each_multi
         <
-            // Specify the dispatch of the single-version as policy
-            for_each_segment
+            detail::for_each::fe_segment_range
+        >
+{};
+
+template <typename MultiPolygon>
+struct for_each_segment<MultiPolygon, multi_polygon_tag>
+    : detail::for_each::for_each_multi
+        <
+            detail::for_each::for_each_polygon
                 <
-                    typename add_const_if_c
-                        <
-                            is_const<MultiGeometry>::value,
-                            typename boost::range_value<MultiGeometry>::type
-                        >::type
+                    detail::for_each::fe_segment_range
                 >
         >
 {};
@@ -369,6 +498,71 @@ struct for_each_segment<MultiGeometry, multi_tag>
 
 } // namespace dispatch
 #endif // DOXYGEN_NO_DISPATCH
+
+
+template<typename Geometry, typename UnaryPredicate>
+inline bool all_points_of(Geometry& geometry, UnaryPredicate p)
+{
+    concepts::check<Geometry>();
+
+    return dispatch::for_each_point<Geometry>::apply(geometry, p);
+}
+
+
+template<typename Geometry, typename UnaryPredicate>
+inline bool all_segments_of(Geometry const& geometry, UnaryPredicate p)
+{
+    concepts::check<Geometry const>();
+
+    return dispatch::for_each_segment<Geometry const>::apply(geometry, p);
+}
+
+
+template<typename Geometry, typename UnaryPredicate>
+inline bool any_point_of(Geometry& geometry, UnaryPredicate p)
+{
+    concepts::check<Geometry>();
+
+    return ! dispatch::for_each_point<Geometry>::apply(geometry, [&](auto&& pt)
+    {
+        return ! p(pt);
+    });
+}
+
+
+template<typename Geometry, typename UnaryPredicate>
+inline bool any_segment_of(Geometry const& geometry, UnaryPredicate p)
+{
+    concepts::check<Geometry const>();
+
+    return ! dispatch::for_each_segment<Geometry const>::apply(geometry, [&](auto&& s)
+    {
+        return ! p(s);
+    });
+}
+
+template<typename Geometry, typename UnaryPredicate>
+inline bool none_point_of(Geometry& geometry, UnaryPredicate p)
+{
+    concepts::check<Geometry>();
+
+    return dispatch::for_each_point<Geometry>::apply(geometry, [&](auto&& pt)
+    {
+        return ! p(pt);
+    });
+}
+
+
+template<typename Geometry, typename UnaryPredicate>
+inline bool none_segment_of(Geometry const& geometry, UnaryPredicate p)
+{
+    concepts::check<Geometry const>();
+
+    return dispatch::for_each_segment<Geometry const>::apply(geometry, [&](auto&& s)
+    {
+        return ! p(s);
+    });
+}
 
 
 /*!
@@ -390,7 +584,12 @@ inline Functor for_each_point(Geometry& geometry, Functor f)
 {
     concepts::check<Geometry>();
 
-    dispatch::for_each_point<Geometry>::apply(geometry, f);
+    dispatch::for_each_point<Geometry>::apply(geometry, [&](auto&& pt)
+    {
+        f(pt);
+        // TODO: Implement separate function?
+        return true;
+    });
     return f;
 }
 
@@ -413,7 +612,12 @@ inline Functor for_each_segment(Geometry& geometry, Functor f)
 {
     concepts::check<Geometry>();
 
-    dispatch::for_each_segment<Geometry>::apply(geometry, f);
+    dispatch::for_each_segment<Geometry>::apply(geometry, [&](auto&& s)
+    {
+        f(s);
+        // TODO: Implement separate function?
+        return true;
+    });
     return f;
 }
 

--- a/test/algorithms/for_each.cpp
+++ b/test/algorithms/for_each.cpp
@@ -3,6 +3,10 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2020.
+// Modifications copyright (c) 2020, Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -42,6 +46,18 @@ void test_all()
             , std::sqrt(2.0)
             , "LINESTRING(10 1,2 2)"
         );
+    test_geometry<bg::model::linestring<P> >
+        (
+            "LINESTRING(1 1)"
+
+            , 1
+            , "LINESTRING(101 1)"
+            , "LINESTRING(101 100)"
+
+            , "((1, 1), (1, 1))"
+            , 0
+            , "LINESTRING(10 1)"
+            );
     test_geometry<bg::model::linestring<P> >
         (
             "LINESTRING EMPTY"

--- a/test/algorithms/touches/touches.cpp
+++ b/test/algorithms/touches/touches.cpp
@@ -133,6 +133,14 @@ void test_all()
             true
         );
 
+    // Ring-Ring
+    test_touches<ring, ring>
+        (
+            "POLYGON((0 0,0 100,100 100,100 0,0 0))",
+            "POLYGON((100 100,100 200,200 200, 200 100,100 100))",
+            true
+        );
+
     // Point-Polygon
     test_touches<P, ring>("POINT(40 50)", "POLYGON((40 40,40 60,60 60,60 40,40 40))", true);
     test_touches<P, polygon>("POINT(40 50)", "POLYGON((40 40,40 60,60 60,60 40,40 40))", true);


### PR DESCRIPTION
I was playing with for_each family of functions and C++14. With the newer standard we can greatly simplify some parts of the code applying some Actor/Policy to Points/Segments/Ranges or checking some predicate for them.
Let me know what you think.

Changes summary:

`for_each_range` now expects functors instead of structs with `apply()` member function.

`for_each_segment` now calls functor also for degenerated ranges for consistency with `segment_iterator`.

New algorithms based on `std::all_of`, `std::any_of` and `std::none_of`
- `all_points_of`, `any_point_of`, `none_point_of`
- `all_segments_of`, `any_segment_of`, `none_segment_of`
- `all_ranges_of`, `any_range_of`, `none_range_of`

New algorithms used in several places in the library.