### PR TITLE
Support constexpr in points, segment, box, get, dot and cross products.

### DIFF
--- a/.github/workflows/minimal-clang.yml
+++ b/.github/workflows/minimal-clang.yml
@@ -32,28 +32,28 @@ jobs:
 
         include:
           - b2_toolset: clang-3.9
-            b2_cxxstd: 03,11
+            b2_cxxstd: 14
             version: "3.9"
           - b2_toolset: clang-4.0
-            b2_cxxstd: 03,11
+            b2_cxxstd: 14
             version: "4.0"
           - b2_toolset: clang-5.0
-            b2_cxxstd: 03,11,14
+            b2_cxxstd: 14
             version: "5.0"
           - b2_toolset: clang-6.0
-            b2_cxxstd: 03,11,14
+            b2_cxxstd: 14
             version: "6.0"
           - b2_toolset: clang-7
-            b2_cxxstd: 03,11,14,17
+            b2_cxxstd: 14,17
             version: "7"
           - b2_toolset: clang-8
-            b2_cxxstd: 03,11,14,17
+            b2_cxxstd: 14,17
             version: "8"
           - b2_toolset: clang-9
-            b2_cxxstd: 03,11,14,17,2a
+            b2_cxxstd: 14,17,2a
             version: "9"
           - b2_toolset: clang-10
-            b2_cxxstd: 03,11,14,17,2a
+            b2_cxxstd: 14,17,2a
             version: "10"
 
     steps:

--- a/.github/workflows/minimal-gcc.yml
+++ b/.github/workflows/minimal-gcc.yml
@@ -20,7 +20,6 @@ jobs:
       fail-fast: false
       matrix:
         b2_toolset: [
-          gcc-4.8,
           gcc-4.9,
           gcc-5,
           gcc-6,
@@ -30,26 +29,23 @@ jobs:
         ]
 
         include:
-          - b2_toolset: gcc-4.8
-            b2_cxxstd: 03,11
-            version: "4.8"
           - b2_toolset: gcc-4.9
-            b2_cxxstd: 03,11
+            b2_cxxstd: 14
             version: "4.9"
           - b2_toolset: gcc-5
-            b2_cxxstd: 03,11,14
+            b2_cxxstd: 14
             version: "5"
           - b2_toolset: gcc-6
-            b2_cxxstd: 03,11,14
+            b2_cxxstd: 14
             version: "6"
           - b2_toolset: gcc-7
-            b2_cxxstd: 03,11,14,17
+            b2_cxxstd: 14,17
             version: "7"
           - b2_toolset: gcc-8
-            b2_cxxstd: 03,11,14,17
+            b2_cxxstd: 14,17
             version: "8"
           - b2_toolset: gcc-9
-            b2_cxxstd: 03,11,14,17,2a
+            b2_cxxstd: 14,17,2a
             version: "9"
 
     steps:

--- a/include/boost/geometry/arithmetic/dot_product.hpp
+++ b/include/boost/geometry/arithmetic/dot_product.hpp
@@ -4,6 +4,10 @@
 // Copyright (c) 2008-2012 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
+// This file was modified by Oracle on 2020.
+// Modifications copyright (c) 2020, Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -34,7 +38,7 @@ struct dot_product_maker
 {
     typedef typename select_coordinate_type<P1, P2>::type coordinate_type;
 
-    static inline coordinate_type apply(P1 const& p1, P2 const& p2)
+    static constexpr coordinate_type apply(P1 const& p1, P2 const& p2)
     {
         return get<Dimension>(p1) * get<Dimension>(p2)
             + dot_product_maker<P1, P2, Dimension+1, DimensionCount>::apply(p1, p2);
@@ -46,7 +50,7 @@ struct dot_product_maker<P1, P2, DimensionCount, DimensionCount>
 {
     typedef typename select_coordinate_type<P1, P2>::type coordinate_type;
 
-    static inline coordinate_type apply(P1 const& p1, P2 const& p2)
+    static constexpr coordinate_type apply(P1 const& p1, P2 const& p2)
     {
         return get<DimensionCount>(p1) * get<DimensionCount>(p2);
     }
@@ -70,7 +74,7 @@ struct dot_product_maker<P1, P2, DimensionCount, DimensionCount>
 
  */
 template <typename Point1, typename Point2>
-inline typename select_coordinate_type<Point1, Point2>::type dot_product(
+constexpr inline typename select_coordinate_type<Point1, Point2>::type dot_product(
         Point1 const& p1, Point2 const& p2)
 {
     BOOST_CONCEPT_ASSERT( (concepts::ConstPoint<Point1>) );

--- a/include/boost/geometry/core/access.hpp
+++ b/include/boost/geometry/core/access.hpp
@@ -4,6 +4,10 @@
 // Copyright (c) 2008-2012 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
+// This file was modified by Oracle on 2020.
+// Modifications copyright (c) 2020, Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -17,7 +21,6 @@
 
 #include <cstddef>
 
-#include <boost/core/ignore_unused.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/type_traits/is_pointer.hpp>
 #include <boost/type_traits/remove_pointer.hpp>
@@ -94,11 +97,11 @@ template
 >
 struct indexed_access_non_pointer
 {
-    static inline CoordinateType get(Geometry const& geometry)
+    static constexpr CoordinateType get(Geometry const& geometry)
     {
         return traits::indexed_access<Geometry, Index, Dimension>::get(geometry);
     }
-    static inline void set(Geometry& b, CoordinateType const& value)
+    static void set(Geometry& b, CoordinateType const& value)
     {
         traits::indexed_access<Geometry, Index, Dimension>::set(b, value);
     }
@@ -113,11 +116,11 @@ template
 >
 struct indexed_access_pointer
 {
-    static inline CoordinateType get(Geometry const* geometry)
+    static constexpr CoordinateType get(Geometry const* geometry)
     {
         return traits::indexed_access<typename boost::remove_pointer<Geometry>::type, Index, Dimension>::get(*geometry);
     }
-    static inline void set(Geometry* geometry, CoordinateType const& value)
+    static void set(Geometry* geometry, CoordinateType const& value)
     {
         traits::indexed_access<typename boost::remove_pointer<Geometry>::type, Index, Dimension>::set(*geometry, value);
     }
@@ -165,11 +168,11 @@ struct indexed_access
 template <typename Point, typename CoordinateType, std::size_t Dimension>
 struct access<point_tag, Point, CoordinateType, Dimension, boost::false_type>
 {
-    static inline CoordinateType get(Point const& point)
+    static constexpr CoordinateType get(Point const& point)
     {
         return traits::access<Point, Dimension>::get(point);
     }
-    static inline void set(Point& p, CoordinateType const& value)
+    static void set(Point& p, CoordinateType const& value)
     {
         traits::access<Point, Dimension>::set(p, value);
     }
@@ -178,11 +181,11 @@ struct access<point_tag, Point, CoordinateType, Dimension, boost::false_type>
 template <typename Point, typename CoordinateType, std::size_t Dimension>
 struct access<point_tag, Point, CoordinateType, Dimension, boost::true_type>
 {
-    static inline CoordinateType get(Point const* point)
+    static constexpr CoordinateType get(Point const* point)
     {
         return traits::access<typename boost::remove_pointer<Point>::type, Dimension>::get(*point);
     }
-    static inline void set(Point* p, CoordinateType const& value)
+    static void set(Point* p, CoordinateType const& value)
     {
         traits::access<typename boost::remove_pointer<Point>::type, Dimension>::set(*p, value);
     }
@@ -266,14 +269,12 @@ struct signature_getset_index_dimension {};
 \qbk{[include reference/core/get_point.qbk]}
 */
 template <std::size_t Dimension, typename Geometry>
-inline typename coordinate_type<Geometry>::type get(Geometry const& geometry
+constexpr inline typename coordinate_type<Geometry>::type get(Geometry const& geometry
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
-        , detail::signature_getset_dimension* dummy = 0
+        , detail::signature_getset_dimension* = 0
 #endif
         )
 {
-    boost::ignore_unused(dummy);
-
     typedef core_dispatch::access
         <
             typename tag<Geometry>::type,
@@ -303,12 +304,10 @@ template <std::size_t Dimension, typename Geometry>
 inline void set(Geometry& geometry
         , typename coordinate_type<Geometry>::type const& value
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
-        , detail::signature_getset_dimension* dummy = 0
+        , detail::signature_getset_dimension* = 0
 #endif
         )
 {
-    boost::ignore_unused(dummy);
-
     typedef core_dispatch::access
         <
             typename tag<Geometry>::type,
@@ -336,14 +335,12 @@ inline void set(Geometry& geometry
 \qbk{[include reference/core/get_box.qbk]}
 */
 template <std::size_t Index, std::size_t Dimension, typename Geometry>
-inline typename coordinate_type<Geometry>::type get(Geometry const& geometry
+constexpr inline typename coordinate_type<Geometry>::type get(Geometry const& geometry
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
-        , detail::signature_getset_index_dimension* dummy = 0
+        , detail::signature_getset_index_dimension* = 0
 #endif
         )
 {
-    boost::ignore_unused(dummy);
-
     typedef core_dispatch::indexed_access
         <
             typename tag<Geometry>::type,
@@ -375,12 +372,10 @@ template <std::size_t Index, std::size_t Dimension, typename Geometry>
 inline void set(Geometry& geometry
         , typename coordinate_type<Geometry>::type const& value
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
-        , detail::signature_getset_index_dimension* dummy = 0
+        , detail::signature_getset_index_dimension* = 0
 #endif
         )
 {
-    boost::ignore_unused(dummy);
-
     typedef core_dispatch::indexed_access
         <
             typename tag<Geometry>::type,

--- a/include/boost/geometry/core/coordinate_dimension.hpp
+++ b/include/boost/geometry/core/coordinate_dimension.hpp
@@ -91,7 +91,7 @@ struct dimension
 \ingroup utility
 */
 template <typename Geometry, int Dimensions>
-inline void assert_dimension()
+constexpr inline void assert_dimension()
 {
     BOOST_STATIC_ASSERT(( static_cast<int>(dimension<Geometry>::value) == Dimensions ));
 }
@@ -101,13 +101,13 @@ inline void assert_dimension()
 \ingroup utility
 */
 template <typename Geometry, int Dimensions>
-inline void assert_dimension_less_equal()
+constexpr inline void assert_dimension_less_equal()
 {
     BOOST_STATIC_ASSERT(( static_cast<int>(dimension<Geometry>::type::value) <= Dimensions ));
 }
 
 template <typename Geometry, int Dimensions>
-inline void assert_dimension_greater_equal()
+constexpr inline void assert_dimension_greater_equal()
 {
     BOOST_STATIC_ASSERT(( static_cast<int>(dimension<Geometry>::type::value) >= Dimensions ));
 }
@@ -117,7 +117,7 @@ inline void assert_dimension_greater_equal()
 \ingroup utility
 */
 template <typename G1, typename G2>
-inline void assert_dimension_equal()
+constexpr inline void assert_dimension_equal()
 {
     BOOST_STATIC_ASSERT(( static_cast<size_t>(dimension<G1>::type::value) == static_cast<size_t>(dimension<G2>::type::value) ));
 }

--- a/include/boost/geometry/geometries/point.hpp
+++ b/include/boost/geometry/geometries/point.hpp
@@ -5,10 +5,10 @@
 // Copyright (c) 2009-2014 Mateusz Loskot, London, UK.
 // Copyright (c) 2014 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2014.
-// Modifications copyright (c) 2014, Oracle and/or its affiliates.
-
+// This file was modified by Oracle on 2014-2020.
+// Modifications copyright (c) 2014-2020, Oracle and/or its affiliates.
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
@@ -21,10 +21,11 @@
 #define BOOST_GEOMETRY_GEOMETRIES_POINT_HPP
 
 #include <cstddef>
+#include <type_traits>
 
-#include <boost/config.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/mpl/int.hpp>
+#include <boost/static_assert.hpp>
 
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/assert.hpp>
@@ -50,37 +51,6 @@ namespace boost { namespace geometry
 namespace model
 {
 
-namespace detail
-{
-
-template <std::size_t DimensionCount, std::size_t Index>
-struct array_assign
-{
-    template <typename T>
-    static inline void apply(T values[], T const& value)
-    {
-        values[Index] = value;
-    }
-};
-
-// Specialization avoiding assigning element [2] for only 2 dimensions
-template <> struct array_assign<2, 2>
-{
-    template <typename T> static inline void apply(T [], T const& ) {}
-};
-
-// Specialization avoiding assigning elements for (rarely used) points in 1 dim
-template <> struct array_assign<1, 1>
-{
-    template <typename T> static inline void apply(T [], T const& ) {}
-};
-
-template <> struct array_assign<1, 2>
-{
-    template <typename T> static inline void apply(T [], T const& ) {}
-};
-
-}
 /*!
 \brief Basic point class, having coordinates defined in a neutral way
 \details Defines a neutral point class, fulfilling the Point Concept.
@@ -118,15 +88,13 @@ class point
 
 public:
 
+    // TODO: constexpr requires LiteralType and until C++20
+    // it has to have trivial destructor which makes access
+    // debugging impossible with constexpr.
+
 #if !defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
-#if !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)
     /// \constructor_default_no_init
-    point() = default;
-#else
-    /// \constructor_default_no_init
-    inline point()
-    {}
-#endif
+    constexpr point() = default;
 #else // defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
     point()
     {
@@ -141,12 +109,12 @@ public:
 #endif
 
     /// @brief Constructor to set one value
-    explicit inline point(CoordinateType const& v0)
+#if ! defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
+    constexpr
+#endif
+    explicit point(CoordinateType const& v0)
+        : m_values{v0}
     {
-        detail::array_assign<DimensionCount, 0>::apply(m_values, v0);
-        detail::array_assign<DimensionCount, 1>::apply(m_values, CoordinateType());
-        detail::array_assign<DimensionCount, 2>::apply(m_values, CoordinateType());
-
 #if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
         m_created = 1;
         std::fill_n(m_values_initialized, (std::min)(std::size_t(3), DimensionCount), 1);
@@ -154,12 +122,12 @@ public:
     }
 
     /// @brief Constructor to set two values
-    inline point(CoordinateType const& v0, CoordinateType const& v1)
+#if ! defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
+    constexpr
+#endif
+    point(CoordinateType const& v0, CoordinateType const& v1)
+        : m_values{ v0, v1 }
     {
-        detail::array_assign<DimensionCount, 0>::apply(m_values, v0);
-        detail::array_assign<DimensionCount, 1>::apply(m_values, v1);
-        detail::array_assign<DimensionCount, 2>::apply(m_values, CoordinateType());
-
 #if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
         m_created = 1;
         std::fill_n(m_values_initialized, (std::min)(std::size_t(3), DimensionCount), 1);
@@ -167,13 +135,13 @@ public:
     }
 
     /// @brief Constructor to set three values
-    inline point(CoordinateType const& v0, CoordinateType const& v1,
-            CoordinateType const& v2)
+#if ! defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
+    constexpr
+#endif
+    point(CoordinateType const& v0, CoordinateType const& v1,
+          CoordinateType const& v2)
+        : m_values{ v0, v1, v2 }
     {
-        detail::array_assign<DimensionCount, 0>::apply(m_values, v0);
-        detail::array_assign<DimensionCount, 1>::apply(m_values, v1);
-        detail::array_assign<DimensionCount, 2>::apply(m_values, v2);
-
 #if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
         m_created = 1;
         std::fill_n(m_values_initialized, (std::min)(std::size_t(3), DimensionCount), 1);
@@ -184,7 +152,10 @@ public:
     /// @tparam K coordinate to get
     /// @return the coordinate
     template <std::size_t K>
-    inline CoordinateType const& get() const
+#if ! defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
+    constexpr
+#endif
+    CoordinateType const& get() const
     {
 #if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
         BOOST_GEOMETRY_ASSERT(m_created == 1);
@@ -198,7 +169,7 @@ public:
     /// @tparam K coordinate to set
     /// @param value value to set
     template <std::size_t K>
-    inline void set(CoordinateType const& value)
+    void set(CoordinateType const& value)
     {
 #if defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
         BOOST_GEOMETRY_ASSERT(m_created == 1);
@@ -277,13 +248,13 @@ template
 >
 struct access<model::point<CoordinateType, DimensionCount, CoordinateSystem>, Dimension>
 {
-    static inline CoordinateType get(
+    static constexpr CoordinateType get(
         model::point<CoordinateType, DimensionCount, CoordinateSystem> const& p)
     {
         return p.template get<Dimension>();
     }
 
-    static inline void set(
+    static void set(
         model::point<CoordinateType, DimensionCount, CoordinateSystem>& p,
         CoordinateType const& value)
     {

--- a/include/boost/geometry/geometries/point_xy.hpp
+++ b/include/boost/geometry/geometries/point_xy.hpp
@@ -4,6 +4,10 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
+// This file was modified by Oracle on 2020.
+// Modifications copyright (c) 2020, Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -15,9 +19,7 @@
 #define BOOST_GEOMETRY_GEOMETRIES_POINT_XY_HPP
 
 #include <cstddef>
-
-#include <boost/config.hpp>
-#include <boost/mpl/int.hpp>
+#include <type_traits>
 
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/geometries/point.hpp>
@@ -46,35 +48,28 @@ template<typename CoordinateType, typename CoordinateSystem = cs::cartesian>
 class point_xy : public model::point<CoordinateType, 2, CoordinateSystem>
 {
 public:
-
-#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
     /// \constructor_default_no_init
-    point_xy() = default;
-#else
-    /// \constructor_default_no_init
-    inline point_xy()
-    {}
-#endif
+    constexpr point_xy() = default;
 
     /// Constructor with x/y values
-    inline point_xy(CoordinateType const& x, CoordinateType const& y)
+    constexpr point_xy(CoordinateType const& x, CoordinateType const& y)
         : model::point<CoordinateType, 2, CoordinateSystem>(x, y)
     {}
 
     /// Get x-value
-    inline CoordinateType const& x() const
+    constexpr CoordinateType const& x() const
     { return this->template get<0>(); }
 
     /// Get y-value
-    inline CoordinateType const& y() const
+    constexpr CoordinateType const& y() const
     { return this->template get<1>(); }
 
     /// Set x-value
-    inline void x(CoordinateType const& v)
+    void x(CoordinateType const& v)
     { this->template set<0>(v); }
 
     /// Set y-value
-    inline void y(CoordinateType const& v)
+    void y(CoordinateType const& v)
     { this->template set<1>(v); }
 };
 
@@ -113,13 +108,13 @@ struct dimension<model::d2::point_xy<CoordinateType, CoordinateSystem> >
 template<typename CoordinateType, typename CoordinateSystem, std::size_t Dimension>
 struct access<model::d2::point_xy<CoordinateType, CoordinateSystem>, Dimension >
 {
-    static inline CoordinateType get(
+    static constexpr CoordinateType get(
         model::d2::point_xy<CoordinateType, CoordinateSystem> const& p)
     {
         return p.template get<Dimension>();
     }
 
-    static inline void set(model::d2::point_xy<CoordinateType, CoordinateSystem>& p,
+    static void set(model::d2::point_xy<CoordinateType, CoordinateSystem>& p,
         CoordinateType const& value)
     {
         p.template set<Dimension>(value);

--- a/include/boost/geometry/geometries/point_xyz.hpp
+++ b/include/boost/geometry/geometries/point_xyz.hpp
@@ -2,6 +2,10 @@
 
 // Copyright (c) 2020 Digvijay Janartha, Hamirpur, India.
 
+// This file was modified by Oracle on 2020.
+// Modifications copyright (c) 2020, Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -10,9 +14,7 @@
 #define BOOST_GEOMETRY_GEOMETRIES_POINT_XYZ_HPP
 
 #include <cstddef>
-
-#include <boost/config.hpp>
-#include <boost/mpl/int.hpp>
+#include <type_traits>
 
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/geometries/point.hpp>
@@ -41,43 +43,36 @@ template<typename CoordinateType, typename CoordinateSystem = cs::cartesian>
 class point_xyz : public model::point<CoordinateType, 3, CoordinateSystem>
 {
 public:
-
-#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
     /// \constructor_default_no_init
-    point_xyz() = default;
-#else
-    /// \constructor_default_no_init
-    inline point_xyz()
-    {}
-#endif
+    constexpr point_xyz() = default;
 
     /// Constructor with x/y/z values
-    inline point_xyz(CoordinateType const& x, CoordinateType const& y, CoordinateType const& z)
+    constexpr point_xyz(CoordinateType const& x, CoordinateType const& y, CoordinateType const& z)
         : model::point<CoordinateType, 3, CoordinateSystem>(x, y, z)
     {}
 
     /// Get x-value
-    inline CoordinateType const& x() const
+    constexpr CoordinateType const& x() const
     { return this->template get<0>(); }
 
     /// Get y-value
-    inline CoordinateType const& y() const
+    constexpr CoordinateType const& y() const
     { return this->template get<1>(); }
 
     /// Get z-value
-    inline CoordinateType const& z() const
+    constexpr CoordinateType const& z() const
     { return this->template get<2>(); }
 
     /// Set x-value
-    inline void x(CoordinateType const& v)
+    void x(CoordinateType const& v)
     { this->template set<0>(v); }
 
     /// Set y-value
-    inline void y(CoordinateType const& v)
+    void y(CoordinateType const& v)
     { this->template set<1>(v); }
     
     /// Set z-value
-    inline void z(CoordinateType const& v)
+    void z(CoordinateType const& v)
     { this->template set<2>(v); }
 };
 
@@ -114,15 +109,15 @@ struct dimension<model::d3::point_xyz<CoordinateType, CoordinateSystem> >
 {};
 
 template<typename CoordinateType, typename CoordinateSystem, std::size_t Dimension>
-struct access<model::d3::point_xyz<CoordinateType, CoordinateSystem>, Dimension >
+struct access<model::d3::point_xyz<CoordinateType, CoordinateSystem>, Dimension>
 {
-    static inline CoordinateType get(
+    static constexpr CoordinateType get(
         model::d3::point_xyz<CoordinateType, CoordinateSystem> const& p)
     {
         return p.template get<Dimension>();
     }
 
-    static inline void set(model::d3::point_xyz<CoordinateType, CoordinateSystem>& p,
+    static void set(model::d3::point_xyz<CoordinateType, CoordinateSystem>& p,
         CoordinateType const& value)
     {
         p.template set<Dimension>(value);

--- a/include/boost/geometry/geometries/segment.hpp
+++ b/include/boost/geometry/geometries/segment.hpp
@@ -4,6 +4,10 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
+// This file was modified by Oracle on 2020.
+// Modifications copyright (c) 2020, Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -15,6 +19,7 @@
 #define BOOST_GEOMETRY_GEOMETRIES_SEGMENT_HPP
 
 #include <cstddef>
+#include <utility>
 
 #include <boost/concept/assert.hpp>
 #include <boost/mpl/if.hpp>
@@ -49,23 +54,15 @@ class segment : public std::pair<Point, Point>
 
 public :
 
-#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
     /// \constructor_default_no_init
-    segment() = default;
-#else
-    /// \constructor_default_no_init
-    inline segment()
-    {}
-#endif
+    constexpr segment() = default;
 
     /*!
         \brief Constructor taking the first and the second point
     */
-    inline segment(Point const& p1, Point const& p2)
-    {
-        this->first = p1;
-        this->second = p2;
-    }
+    constexpr segment(Point const& p1, Point const& p2)
+        : std::pair<Point, Point>(p1, p2)
+    {}
 };
 
 
@@ -137,12 +134,12 @@ struct indexed_access<model::segment<Point>, 0, Dimension>
     typedef model::segment<Point> segment_type;
     typedef typename geometry::coordinate_type<segment_type>::type coordinate_type;
 
-    static inline coordinate_type get(segment_type const& s)
+    static constexpr coordinate_type get(segment_type const& s)
     {
         return geometry::get<Dimension>(s.first);
     }
 
-    static inline void set(segment_type& s, coordinate_type const& value)
+    static void set(segment_type& s, coordinate_type const& value)
     {
         geometry::set<Dimension>(s.first, value);
     }
@@ -155,12 +152,12 @@ struct indexed_access<model::segment<Point>, 1, Dimension>
     typedef model::segment<Point> segment_type;
     typedef typename geometry::coordinate_type<segment_type>::type coordinate_type;
 
-    static inline coordinate_type get(segment_type const& s)
+    static constexpr coordinate_type get(segment_type const& s)
     {
         return geometry::get<Dimension>(s.second);
     }
 
-    static inline void set(segment_type& s, coordinate_type const& value)
+    static void set(segment_type& s, coordinate_type const& value)
     {
         geometry::set<Dimension>(s.second, value);
     }


### PR DESCRIPTION
I was playing with `constexpr`. This PR allows to do something like this:
```
using point = bg::model::point<double, 2, bg::cs::cartesian>;
using point_xy = bg::model::d2::point_xy<double>;
using point_xyz = bg::model::d3::point_xyz<double>;
using box = bg::model::box<point>;
using segment = bg::model::segment<point>;

constexpr point p0 = point{};
constexpr point p1 = point{ 1 };
constexpr point_xy p2 = point_xy{ 1, 2 };
constexpr point_xyz p3 = point_xyz{ 1, 2, 3 };

constexpr double d0 = bg::get<0>(p0);
constexpr double d1 = bg::get<0>(p1);
constexpr double d2 = bg::get<1>(p2);
constexpr double d3 = bg::get<2>(p3);

constexpr double d12 = bg::dot_product(p1, p2);
constexpr point_xyz p33 = bg::cross_product(p3, p3);
    
constexpr box b = box{ p0, p1 };

constexpr double d4 = bg::get<0, 0>(b);

constexpr segment s = segment{ p0, p1 };

constexpr double d5 = bg::get<0, 0>(s);
```

It is possible to call `constexpr cross_product` only if a Point is 3d and is constructible from 3 coordinates. This theoretically is a breaking change because in general case Point could define a ctor taking 3 values being something different than coordinates or having coordinates in a different order than xyz. So we could think about some other mechanism like additional trait for Points creation.

It is possible to create `constexpr model::box` only if Point is convertible from passed argument and copy constructible.

I kept the support for Points with no copy ctor in `model::box` but I don't think this is needed becasue we rely on copy ctors of points in the library in general so one of the `model::box` ctors could be removed. If not, then we should add tests for such points.

Another step could be to support constexpr in point arithmetic operations or maybe even implement operators for points with enable_if, like it is done for vectors in QVM.