### PR TITLE
resolve c2146 on vs15 with area_result declaration

### DIFF
--- a/include/boost/geometry/algorithms/area_result.hpp
+++ b/include/boost/geometry/algorithms/area_result.hpp
@@ -46,9 +46,10 @@ template
     bool IsUmbrella = strategies::detail::is_umbrella_strategy<Strategy>::value
 >
 struct area_result
-    : decltype(std::declval<Strategy>().area(std::declval<Geometry>()))
-        ::template result_type<Geometry>
-{};
+{
+    typedef decltype(std::declval<Strategy>().area(std::declval<Geometry>())) strategy_type;
+    typedef typename strategy_type::template result_type<Geometry>::type type;
+};
 
 template
 <


### PR DESCRIPTION
Visual Studio 2015 C++14 (Default) we encountered C2146  stating
`error C2146: syntax error: missing ',' before identifier 'result_type'`

reference: 
https://ci.appveyor.com/project/lpranam/astronomy-il73i/branch/develop/job/uo7pirc0s4v9xpb2