### PR TITLE
Fix/buffer mp

### DIFF
--- a/include/boost/geometry/algorithms/detail/buffer/buffer_policies.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/buffer_policies.hpp
@@ -198,6 +198,7 @@ struct piece_get_box
     template <typename Box, typename Piece>
     static inline void apply(Box& total, Piece const& piece)
     {
+        assert_coordinate_type_equal(total, piece.m_piece_border.m_envelope);
         typedef typename strategy::expand::services::default_strategy
             <
                 box_tag, typename cs_tag<Box>::type
@@ -212,11 +213,13 @@ struct piece_get_box
 };
 
 template <typename DisjointBoxBoxStrategy>
-struct piece_ovelaps_box
+struct piece_overlaps_box
 {
     template <typename Box, typename Piece>
     static inline bool apply(Box const& box, Piece const& piece)
     {
+        assert_coordinate_type_equal(box, piece.m_piece_border.m_envelope);
+
         if (piece.type == strategy::buffer::buffered_flat_end
             || piece.type == strategy::buffer::buffered_concave)
         {
@@ -245,16 +248,18 @@ struct turn_get_box
             <
                 point_tag, typename cs_tag<Box>::type
             >::type expand_strategy_type;
+        assert_coordinate_type_equal(total, turn.point);
         geometry::expand(total, turn.point, expand_strategy_type());
     }
 };
 
 template <typename DisjointPointBoxStrategy>
-struct turn_ovelaps_box
+struct turn_overlaps_box
 {
     template <typename Box, typename Turn>
     static inline bool apply(Box const& box, Turn const& turn)
     {
+        assert_coordinate_type_equal(turn.point, box);
         return ! geometry::detail::disjoint::disjoint_point_box(turn.point, box,
                                                                 DisjointPointBoxStrategy());
     }

--- a/include/boost/geometry/algorithms/detail/buffer/turn_in_original_visitor.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/turn_in_original_visitor.hpp
@@ -15,6 +15,7 @@
 
 
 #include <boost/core/ignore_unused.hpp>
+#include <boost/geometry/core/coordinate_type.hpp>
 
 #include <boost/geometry/algorithms/detail/buffer/buffer_policies.hpp>
 #include <boost/geometry/algorithms/expand.hpp>
@@ -35,6 +36,7 @@ struct original_get_box
     template <typename Box, typename Original>
     static inline void apply(Box& total, Original const& original)
     {
+        assert_coordinate_type_equal(total, original.m_box);
         typedef typename strategy::expand::services::default_strategy
             <
                 box_tag, typename cs_tag<Box>::type
@@ -45,11 +47,12 @@ struct original_get_box
 };
 
 template <typename DisjointBoxBoxStrategy>
-struct original_ovelaps_box
+struct original_overlaps_box
 {
     template <typename Box, typename Original>
     static inline bool apply(Box const& box, Original const& original)
     {
+        assert_coordinate_type_equal(box, original.m_box);
         return ! detail::disjoint::disjoint_box_box(box, original.m_box,
                                                     DisjointBoxBoxStrategy());
     }
@@ -65,7 +68,7 @@ struct include_turn_policy
 };
 
 template <typename DisjointPointBoxStrategy>
-struct turn_in_original_ovelaps_box
+struct turn_in_original_overlaps_box
 {
     template <typename Box, typename Turn>
     static inline bool apply(Box const& box, Turn const& turn)

--- a/include/boost/geometry/algorithms/detail/overlay/assign_parents.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/assign_parents.hpp
@@ -16,6 +16,7 @@
 
 #include <boost/range.hpp>
 
+#include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/algorithms/envelope.hpp>
 #include <boost/geometry/algorithms/expand.hpp>
 #include <boost/geometry/algorithms/detail/partition.hpp>
@@ -131,16 +132,18 @@ struct ring_info_helper_get_box
     template <typename Box, typename InputItem>
     static inline void apply(Box& total, InputItem const& item)
     {
+        assert_coordinate_type_equal(total, item.envelope);
         geometry::expand(total, item.envelope, BoxExpandStrategy());
     }
 };
 
 template <typename DisjointBoxBoxStrategy>
-struct ring_info_helper_ovelaps_box
+struct ring_info_helper_overlaps_box
 {
     template <typename Box, typename InputItem>
     static inline bool apply(Box const& box, InputItem const& item)
     {
+        assert_coordinate_type_equal(box, item.envelope);
         return ! geometry::detail::disjoint::disjoint_box_box(
                     box, item.envelope, DisjointBoxBoxStrategy());
     }
@@ -336,7 +339,7 @@ inline void assign_parents(Geometry1 const& geometry1,
             <
                 typename Strategy::expand_box_strategy_type
             > expand_box_type;
-        typedef ring_info_helper_ovelaps_box
+        typedef ring_info_helper_overlaps_box
             <
                 typename Strategy::disjoint_box_box_strategy_type
             > overlaps_box_type;

--- a/include/boost/geometry/algorithms/detail/overlay/get_distance_measure.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_distance_measure.hpp
@@ -35,50 +35,26 @@ struct distance_measure
         : measure(T())
     {}
 
-    bool is_small() const { return false; }
-    bool is_zero() const { return false; }
-    bool is_positive() const { return false; }
-    bool is_negative() const { return false; }
-};
-
-template <typename T>
-struct distance_measure_floating
-{
-    T measure;
-
-    distance_measure_floating()
-        : measure(T())
-    {}
-
     // Returns true if the distance measure is small.
     // This is an arbitrary boundary, to enable some behaviour
     // (for example include or exclude turns), which are checked later
     // with other conditions.
-    bool is_small() const { return std::abs(measure) < 1.0e-3; }
+    bool is_small() const { return geometry::math::abs(measure) < 1.0e-3; }
 
     // Returns true if the distance measure is absolutely zero
-    bool is_zero() const { return measure == 0.0; }
+    bool is_zero() const
+    {
+      return ! is_positive() && ! is_negative();
+    }
 
     // Returns true if the distance measure is positive. Distance measure
     // algorithm returns positive value if it is located on the left side.
-    bool is_positive() const { return measure > 0.0; }
+    bool is_positive() const { return measure > T(0); }
 
     // Returns true if the distance measure is negative. Distance measure
     // algorithm returns negative value if it is located on the right side.
-    bool is_negative() const { return measure < 0.0; }
+    bool is_negative() const { return measure < T(0); }
 };
-
-template <>
-struct distance_measure<long double>
-    : public distance_measure_floating<long double> {};
-
-template <>
-struct distance_measure<double>
-    : public distance_measure_floating<double> {};
-
-template <>
-struct distance_measure<float>
-    : public distance_measure_floating<float> {};
 
 } // detail
 

--- a/include/boost/geometry/algorithms/detail/sections/section_box_policies.hpp
+++ b/include/boost/geometry/algorithms/detail/sections/section_box_policies.hpp
@@ -14,6 +14,7 @@
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_SECTIONS_SECTION_BOX_POLICIES_HPP
 
 
+#include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/algorithms/detail/disjoint/box_box.hpp>
 #include <boost/geometry/algorithms/expand.hpp>
 
@@ -31,6 +32,7 @@ struct get_section_box
     template <typename Box, typename Section>
     static inline void apply(Box& total, Section const& section)
     {
+        assert_coordinate_type_equal(total, section.bounding_box);
         geometry::expand(total, section.bounding_box,
                          ExpandBoxStrategy());
     }
@@ -42,6 +44,7 @@ struct overlaps_section_box
     template <typename Box, typename Section>
     static inline bool apply(Box const& box, Section const& section)
     {
+        assert_coordinate_type_equal(box, section.bounding_box);
         return ! detail::disjoint::disjoint_box_box(box, section.bounding_box,
                                                     DisjointBoxBoxStrategy());
     }

--- a/include/boost/geometry/algorithms/detail/sections/section_functions.hpp
+++ b/include/boost/geometry/algorithms/detail/sections/section_functions.hpp
@@ -14,9 +14,8 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_SECTIONS_FUNCTIONS_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_SECTIONS_FUNCTIONS_HPP
 
-#include <boost/static_assert.hpp>
-
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/algorithms/detail/recalculate.hpp>
 #include <boost/geometry/policies/robustness/robust_point_type.hpp>
 
@@ -123,41 +122,38 @@ template
 <
     std::size_t Dimension,
     typename Point,
-    typename RobustBox,
+    typename Box,
     typename RobustPolicy
 >
 static inline bool preceding(int dir,
                              Point const& point,
-                             RobustBox const& point_robust_box,
-                             RobustBox const& other_robust_box,
+                             Box const& point_box,
+                             Box const& other_box,
                              RobustPolicy const& robust_policy)
 {
-    typedef typename geometry::robust_point_type<Point, RobustPolicy>::type robust_point_type;
-    BOOST_STATIC_ASSERT((boost::is_same
-                         <
-                             typename geometry::coordinate_type<robust_point_type>::type,
-                             typename geometry::coordinate_type<RobustBox>::type
-                         >::value));
-
-    robust_point_type robust_point;
+    typename geometry::robust_point_type<Point, RobustPolicy>::type robust_point;
+    assert_coordinate_type_equal(robust_point, point_box);
     geometry::recalculate(robust_point, point, robust_policy);
-    return preceding_check<Dimension, Point>::apply(dir, robust_point, point_robust_box, other_robust_box);
+
+    return preceding_check<Dimension, Box>::apply(dir, robust_point,
+                                                    point_box,
+                                                    other_box);
 }
 
 template
 <
     std::size_t Dimension,
     typename Point,
-    typename RobustBox,
+    typename Box,
     typename RobustPolicy
 >
 static inline bool exceeding(int dir,
                              Point const& point,
-                             RobustBox const& point_robust_box,
-                             RobustBox const& other_robust_box,
+                             Box const& point_box,
+                             Box const& other_box,
                              RobustPolicy const& robust_policy)
 {
-    return preceding<Dimension>(-dir, point, point_robust_box, other_robust_box, robust_policy);
+    return preceding<Dimension>(-dir, point, point_box, other_box, robust_policy);
 }
 
 

--- a/include/boost/geometry/core/coordinate_type.hpp
+++ b/include/boost/geometry/core/coordinate_type.hpp
@@ -101,6 +101,19 @@ struct fp_coordinate_type
         >::type type;
 };
 
+/*!
+\brief assert_coordinate_type_equal, a compile-time check for equality of two coordinate types
+\ingroup utility
+*/
+template <typename Geometry1, typename Geometry2>
+constexpr inline void assert_coordinate_type_equal(Geometry1 const& , Geometry2 const& )
+{
+  static_assert(std::is_same
+      <
+          typename coordinate_type<Geometry1>::type,
+          typename coordinate_type<Geometry2>::type
+      >::value, "Coordinate types in geometries should be the same");
+}
 
 }} // namespace boost::geometry
 

--- a/test/robustness/common/common_settings.hpp
+++ b/test/robustness/common/common_settings.hpp
@@ -1,7 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 // Robustness Test
 //
-// Copyright (c) 2009-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2009-2020 Barend Gehrels, Amsterdam, the Netherlands.
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -11,22 +11,15 @@
 
 struct common_settings
 {
-    bool svg;
-    bool wkt;
-    bool also_difference;
-    double tolerance;
+    bool svg{false};
+    bool wkt{false};
+    bool also_difference{false};
+    double tolerance{1.0e-6};
 
-    int field_size;
-    bool triangular;
+    int field_size{10};
+    bool triangular{false};
 
-    common_settings()
-        : svg(false)
-        , wkt(false)
-        , also_difference(false)
-        , tolerance(1.0e-6)
-        , field_size(10)
-        , triangular(false)
-    {}
+    bool check_validity{true};
 };
 
 #endif // BOOST_GEOMETRY_COMMON_SETTINGS_HPP


### PR DESCRIPTION
This reverts the removal of monotonic sections in previous PR, because it is indeed for optimization as Adam mentioned. Difference in performance is around 20%

Instead it fixes the type used for partitioning, and extends the type checking to various places where partitioning is used in buffer (and in assign_parents).

For the type checking I added a file (and it uses `static_assert` and `std::is_same` now :-) )