### PR TITLE
Conform the countset, replace many #ifdefs with expectation limits

### DIFF
--- a/test/algorithms/buffer/buffer_countries.cpp
+++ b/test/algorithms/buffer/buffer_countries.cpp
@@ -241,7 +241,7 @@ int test_main(int, char* [])
 #endif
 
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(1, BG_NO_FAILURES);
+    BoostGeometryWriteExpectedFailures(1, BG_NO_FAILURES, 2, BG_NO_FAILURES);
 #endif
 
     return 0;

--- a/test/algorithms/buffer/buffer_linestring.cpp
+++ b/test/algorithms/buffer/buffer_linestring.cpp
@@ -113,6 +113,7 @@ void test_all()
 {
     typedef bg::model::linestring<P> linestring;
     typedef bg::model::polygon<P, Clockwise> polygon;
+    typedef typename bg::coordinate_type<P>::type coor_type;
 
     bg::strategy::buffer::join_miter join_miter;
     bg::strategy::buffer::join_round join_round(100);
@@ -138,23 +139,23 @@ void test_all()
     test_one<linestring, polygon>("simplex_vertical32", simplex_vertical, join_round32, end_round32, 5.12145, 1);
     test_one<linestring, polygon>("simplex_horizontal32", simplex_horizontal, join_round32, end_round32, 5.12145, 1);
 
-    test_one<linestring, polygon>("simplex_asym_neg", simplex, join_miter, end_flat, 3.202, +1.5, settings, -1.0);
-    test_one<linestring, polygon>("simplex_asym_pos", simplex, join_miter, end_flat, 3.202, -1.0, settings, +1.5);
+    test_one<linestring, polygon>("simplex_asym_neg", simplex, join_miter, end_flat, 3.2016, +1.5, settings, -1.0);
+    test_one<linestring, polygon>("simplex_asym_pos", simplex, join_miter, end_flat, 3.2016, -1.0, settings, +1.5);
     // Do not work yet:
     //    test_one<linestring, polygon>("simplex_asym_neg", simplex, join_miter, end_round, 3.202, +1.5, settings, -1.0);
     //    test_one<linestring, polygon>("simplex_asym_pos", simplex, join_miter, end_round, 3.202, -1.0, settings, +1.5);
 
     // Generates (initially) a reversed polygon, with a negative area, which is reversed afterwards in assign_parents
-    test_one<linestring, polygon>("simplex_asym_neg_rev", simplex, join_miter, end_flat, 3.202, +1.0, settings, -1.5);
-    test_one<linestring, polygon>("simplex_asym_pos_rev", simplex, join_miter, end_flat, 3.202, -1.5, settings, +1.0);
+    test_one<linestring, polygon>("simplex_asym_neg_rev", simplex, join_miter, end_flat, 3.2016, +1.0, settings, -1.5);
+    test_one<linestring, polygon>("simplex_asym_pos_rev", simplex, join_miter, end_flat, 3.2016, -1.5, settings, +1.0);
 
     test_one<linestring, polygon>("straight", straight, join_round, end_flat, 38.4187, 1.5);
     test_one<linestring, polygon>("straight", straight, join_miter, end_flat, 38.4187, 1.5);
 
     // One bend/two bends (tests join-type)
-    test_one<linestring, polygon>("one_bend", one_bend, join_round, end_flat, 28.488, 1.5);
+    test_one<linestring, polygon>("one_bend", one_bend, join_round, end_flat, 28.496, 1.5);
     test_one<linestring, polygon>("one_bend", one_bend, join_miter, end_flat, 28.696, 1.5);
-    test_one<linestring, polygon>("one_bend", one_bend, join_round_by_divide, end_flat, 28.488, 1.5);
+    test_one<linestring, polygon>("one_bend", one_bend, join_round_by_divide, end_flat, 28.497, 1.5);
 
     test_one<linestring, polygon>("one_bend", one_bend, join_round, end_round, 35.5603, 1.5);
     test_one<linestring, polygon>("one_bend", one_bend, join_miter, end_round, 35.7601, 1.5);
@@ -163,7 +164,7 @@ void test_all()
     test_one<linestring, polygon>("two_bends", two_bends, join_round, end_flat, 39.235, 1.5);
     test_one<linestring, polygon>("two_bends", two_bends, join_round_by_divide, end_flat, 39.235, 1.5);
     test_one<linestring, polygon>("two_bends", two_bends, join_miter, end_flat, 39.513, 1.5);
-    test_one<linestring, polygon>("two_bends_left", two_bends, join_round, end_flat, 20.028, 1.5, settings, 0.0);
+    test_one<linestring, polygon>("two_bends_left", two_bends, join_round, end_flat, 20.025, 1.5, settings, 0.0);
     test_one<linestring, polygon>("two_bends_left", two_bends, join_miter, end_flat, 20.225, 1.5, settings, 0.0);
     test_one<linestring, polygon>("two_bends_right", two_bends, join_round, end_flat, 19.211, 0.0, settings, 1.5);
     test_one<linestring, polygon>("two_bends_right", two_bends, join_miter, end_flat, 19.288, 0.0, settings, 1.5);
@@ -207,8 +208,8 @@ void test_all()
     test_one<linestring, polygon>("chained4", chained4, join_round, end_flat, 22.6274, 2.5, settings, 1.5);
 
     test_one<linestring, polygon>("field_sprayer1", field_sprayer1, join_round, end_flat, 324.3550, 16.5, settings, 6.5);
-    test_one<linestring, polygon>("field_sprayer1", field_sprayer1, join_round, end_round, 718.761877, 16.5, settings, 6.5);
-    test_one<linestring, polygon>("field_sprayer1", field_sprayer1, join_miter, end_round, 718.939628, 16.5, settings, 6.5);
+    test_one<linestring, polygon>("field_sprayer1", field_sprayer1, join_round, end_round, {718.686, 718.762}, 16.5, settings, 6.5);
+    test_one<linestring, polygon>("field_sprayer1", field_sprayer1, join_miter, end_round, {718.845, 718.940}, 16.5, settings, 6.5);
 
     test_one<linestring, polygon>("degenerate0", degenerate0, join_round, end_round, 0.0, 3.0);
     test_one<linestring, polygon>("degenerate1", degenerate1, join_round, end_round, 28.25, 3.0);
@@ -254,8 +255,9 @@ void test_all()
     }
 
     {
-        // Check on validity, with high precision because areas are all very small
-        ut_settings settings(1.0e-10, true);
+        ut_settings settings;
+        settings.tolerance = 0.1;
+        settings.use_ln_area = true;
 
         test_one<linestring, polygon>("aimes120", aimes120, join_miter, end_flat, 1.62669948622351512e-08, 0.000018, settings);
         test_one<linestring, polygon>("aimes120", aimes120, join_round, end_round, 1.72842078427493107e-08, 0.000018, settings);
@@ -299,9 +301,12 @@ void test_all()
             27862.733459829971,
             5.9518403867035365);
 
-    test_one<linestring, polygon>("mysql_report_2015_09_08a", mysql_report_2015_09_08a, join_round32, end_round32, 0.0, 1.0);
-    test_one<linestring, polygon>("mysql_report_2015_09_08b", mysql_report_2015_09_08b, join_round32, end_round32, 0.0, 1099511627778.0);
-    test_one<linestring, polygon>("mysql_report_2015_09_08c", mysql_report_2015_09_08c, join_round32, end_round32, 0.0, 0xbe);
+    if (BOOST_GEOMETRY_CONDITION((boost::is_same<coor_type, double>::value)))
+    {
+        test_one<linestring, polygon>("mysql_report_2015_09_08a", mysql_report_2015_09_08a, join_round32, end_round32, 0.0, 1.0);
+        test_one<linestring, polygon>("mysql_report_2015_09_08b", mysql_report_2015_09_08b, join_round32, end_round32, 0.0, 1099511627778.0);
+        test_one<linestring, polygon>("mysql_report_2015_09_08c", mysql_report_2015_09_08c, join_round32, end_round32, 0.0, 0xbe);
+    }
 
     test_one<linestring, polygon>("mysql_23023665_1", mysql_23023665, join_round32, end_flat, 459.1051, 10);
     test_one<linestring, polygon>("mysql_23023665_2", mysql_23023665, join_round32, end_flat, 6877.7097, 50);
@@ -372,6 +377,11 @@ void test_all()
 template <bool Clockwise, typename P>
 void test_invalid()
 {
+    typedef typename bg::coordinate_type<P>::type coor_type;
+    if (! BOOST_GEOMETRY_CONDITION((boost::is_same<coor_type, double>::value)))
+    {
+        return;
+    }
     typedef bg::model::linestring<P> linestring;
     typedef bg::model::polygon<P, Clockwise> polygon;
 
@@ -408,7 +418,7 @@ int test_main(int, char* [])
 #endif
 
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(2, 2);
+    BoostGeometryWriteExpectedFailures(2, 2, 15, 2);
 #endif
 
     return 0;

--- a/test/algorithms/buffer/buffer_linestring_aimes.cpp
+++ b/test/algorithms/buffer/buffer_linestring_aimes.cpp
@@ -455,10 +455,6 @@ void test_aimes()
         double aimes_width = static_cast<double>(width) / 1000000.0;
         for (int i = 0; i < n; i++)
         {
-#if ! defined(BOOST_GEOMETRY_USE_RESCALING)
-            // Without rescaling, several cases are still reported as invalid
-            settings.set_test_validity(i <= 10);
-#endif
             std::ostringstream name;
             try
             {
@@ -492,8 +488,8 @@ int test_main(int, char* [])
     test_aimes<bg::model::point<default_test_type, 2, bg::cs::cartesian> >();
 
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    // Non-rescaled reports failures, but in validity only
-    BoostGeometryWriteExpectedFailures(BG_NO_FAILURES, 4);
+    // Type float is not supported for these cases
+    BoostGeometryWriteExpectedFailures(BG_NO_FAILURES, BG_NO_FAILURES);
 #endif
 
     return 0;

--- a/test/algorithms/buffer/buffer_multi_linestring.cpp
+++ b/test/algorithms/buffer/buffer_multi_linestring.cpp
@@ -226,7 +226,7 @@ int test_main(int, char* [])
 #endif
 
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(9, BG_NO_FAILURES);
+    BoostGeometryWriteExpectedFailures(9, BG_NO_FAILURES, 12, BG_NO_FAILURES);
 #endif
     return 0;
 }

--- a/test/algorithms/buffer/buffer_multi_polygon.cpp
+++ b/test/algorithms/buffer/buffer_multi_polygon.cpp
@@ -13,7 +13,6 @@
 
 #include "test_buffer.hpp"
 
-
 static std::string const simplex
     = "MULTIPOLYGON(((0 1,2 5,5 3,0 1)),((1 1,5 2,5 0,1 1)))";
 
@@ -338,7 +337,7 @@ void test_all()
 
     test_one<multi_polygon_type, polygon_type>("multi_simplex_01", simplex, join_round, end_flat, 9.7514, -0.1);
     test_one<multi_polygon_type, polygon_type>("multi_simplex_05", simplex, join_round, end_flat, 3.2019, -0.5);
-    test_one<multi_polygon_type, polygon_type>("multi_simplex_10", simplex, join_round, end_flat, 0.2012, -1.0);
+    test_one<multi_polygon_type, polygon_type>("multi_simplex_10", simplex, join_round, end_flat, 0.20116, -1.0);
     test_one<multi_polygon_type, polygon_type>("multi_simplex_12", simplex, join_round, end_flat, 0.0, -1.2);
 
     test_one<multi_polygon_type, polygon_type>("zonethru_05", zonethru, join_round, end_flat, 67.4627, 0.5);
@@ -382,7 +381,7 @@ void test_all()
     test_one<multi_polygon_type, polygon_type>("degenerate1", degenerate1, join_round, end_flat, 5.708, 1.0);
     test_one<multi_polygon_type, polygon_type>("degenerate2", degenerate2, join_round, end_flat, 133.0166, 0.75);
 
-    test_one<multi_polygon_type, polygon_type>("rt_a", rt_a, join_round, end_flat, 34.5381, 1.0);
+    test_one<multi_polygon_type, polygon_type>("rt_a", rt_a, join_round, end_flat, 34.53437, 1.0);
     test_one<multi_polygon_type, polygon_type>("rt_a", rt_a, join_miter, end_flat, 36.0, 1.0);
     test_one<multi_polygon_type, polygon_type>("rt_b", rt_b, join_round, end_flat, 31.4186, 1.0);
     test_one<multi_polygon_type, polygon_type>("rt_b", rt_b, join_miter, end_flat, 34.0, 1.0);
@@ -476,12 +475,11 @@ void test_all()
     test_one<multi_polygon_type, polygon_type>("rt_u8", rt_u8, join_miter, end_flat, 70.9142, 1.0);
     test_one<multi_polygon_type, polygon_type>("rt_u9", rt_u9, join_miter, end_flat, 59.3063, 1.0);
     test_one<multi_polygon_type, polygon_type>("rt_u10", rt_u10, join_miter, end_flat, 144.0858, 1.0);
-    test_one<multi_polygon_type, polygon_type>("rt_u10_51", rt_u10, join_miter, end_flat, 0.1674, -0.51);
+    test_one<multi_polygon_type, polygon_type>("rt_u10_51", rt_u10, join_miter, end_flat, 0.16738, -0.51);
     test_one<multi_polygon_type, polygon_type>("rt_u10_c_51", rt_u10_c, join_miter, end_flat, 0.066952, -0.51);
 
-    test_one<multi_polygon_type, polygon_type>("rt_u10_51", rt_u10, join_miter, end_flat, 0.1674, -0.51);
     // TODO: invalid - making a bow-tie
-    test_one<multi_polygon_type, polygon_type>("rt_u10_50", rt_u10, join_miter, end_flat, 0.2145, -0.50, ut_settings::ignore_validity());
+    test_one<multi_polygon_type, polygon_type>("rt_u10_50", rt_u10, join_miter, end_flat, 0.214466, -0.50, ut_settings::ignore_validity());
     test_one<multi_polygon_type, polygon_type>("rt_u10_45", rt_u10, join_miter, end_flat, 1.3000, -0.45);
     test_one<multi_polygon_type, polygon_type>("rt_u10_25", rt_u10, join_miter, end_flat, 9.6682, -0.25);
 
@@ -489,7 +487,10 @@ void test_all()
     test_one<multi_polygon_type, polygon_type>("rt_u11_50", rt_u11, join_miter, end_flat, 0.04289, -0.50);
     test_one<multi_polygon_type, polygon_type>("rt_u11_25", rt_u11, join_miter, end_flat, 10.1449, -0.25);
 
+#if defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
+    // Failing because of a start turn
     test_one<multi_polygon_type, polygon_type>("rt_u12", rt_u12, join_miter, end_flat, 142.1348, 1.0);
+#endif
     test_one<multi_polygon_type, polygon_type>("rt_u13", rt_u13, join_miter, end_flat, 115.4853, 1.0);
 
     test_one<multi_polygon_type, polygon_type>("rt_v1", rt_v1, join_round32, end_flat, 26.9994, 1.0);
@@ -540,7 +541,7 @@ int test_main(int, char* [])
 #endif
 
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(1, 1);
+    BoostGeometryWriteExpectedFailures(1, 1, 2, 3);
 #endif
 
     return 0;

--- a/test/algorithms/buffer/buffer_polygon.cpp
+++ b/test/algorithms/buffer/buffer_polygon.cpp
@@ -326,14 +326,14 @@ void test_all()
 
     // Indentation - deflated
     test_one<polygon_type, polygon_type>("indentation4", indentation, join_miter, end_flat, 6.991, -0.4);
-    test_one<polygon_type, polygon_type>("indentation4", indentation, join_round, end_flat, 7.255, -0.4);
-    test_one<polygon_type, polygon_type>("indentation8", indentation, join_miter, end_flat, 1.369, -0.8);
-    test_one<polygon_type, polygon_type>("indentation8", indentation, join_round, end_flat, 1.374, -0.8);
+    test_one<polygon_type, polygon_type>("indentation4", indentation, join_round, end_flat, 7.25306, -0.4);
+    test_one<polygon_type, polygon_type>("indentation8", indentation, join_miter, end_flat, 1.36942, -0.8);
+    test_one<polygon_type, polygon_type>("indentation8", indentation, join_round, end_flat, 1.37289, -0.8);
     test_one<polygon_type, polygon_type>("indentation12", indentation, join_miter, end_flat, 0, -1.2);
     test_one<polygon_type, polygon_type>("indentation12", indentation, join_round, end_flat, 0, -1.2);
 
     test_one<polygon_type, polygon_type>("donut_simplex6", donut_simplex, join_miter, end_flat, 53.648, 0.6);
-    test_one<polygon_type, polygon_type>("donut_simplex6", donut_simplex, join_round, end_flat, 52.820, 0.6);
+    test_one<polygon_type, polygon_type>("donut_simplex6", donut_simplex, join_round, end_flat, 52.826, 0.6);
     test_one<polygon_type, polygon_type>("donut_simplex8", donut_simplex, join_miter, end_flat, 61.132, 0.8);
     test_one<polygon_type, polygon_type>("donut_simplex8", donut_simplex, join_round, end_flat, 59.6713, 0.8);
     test_one<polygon_type, polygon_type>("donut_simplex10", donut_simplex, join_miter, end_flat, 68.670, 1.0);
@@ -360,9 +360,9 @@ void test_all()
     test_one<polygon_type, polygon_type>("donut_diamond3", donut_diamond, join_miter, end_flat, 17.7084, -3.0);
 
     test_one<polygon_type, polygon_type>("arrow4", arrow, join_miter, end_flat, 28.265, 0.4);
-    test_one<polygon_type, polygon_type>("arrow4", arrow, join_round, end_flat, 27.039, 0.4);
+    test_one<polygon_type, polygon_type>("arrow4", arrow, join_round, end_flat, 27.043, 0.4);
     test_one<polygon_type, polygon_type>("arrow5", arrow, join_miter, end_flat, 31.500, 0.5);
-    test_one<polygon_type, polygon_type>("arrow5", arrow, join_round, end_flat, 29.621, 0.5);
+    test_one<polygon_type, polygon_type>("arrow5", arrow, join_round, end_flat, 29.628, 0.5);
     test_one<polygon_type, polygon_type>("arrow6", arrow, join_miter, end_flat, 34.903, 0.6);
     test_one<polygon_type, polygon_type>("arrow6", arrow, join_round, end_flat, 32.268, 0.6);
 
@@ -474,38 +474,34 @@ void test_all()
         }
     }
 
-    {
-        ut_settings settings;
-        settings.use_ln_area = true;
-        test_one<polygon_type, polygon_type>("county1", county1, join_round, end_flat, 0.00114, 0.01, settings);
-        test_one<polygon_type, polygon_type>("county1", county1, join_miter, end_flat, 0.00133, 0.01, settings);
-        test_one<polygon_type, polygon_type>("county1", county1, join_round, end_flat, 3.94411e-05, -0.003, settings);
-        test_one<polygon_type, polygon_type>("county1", county1, join_miter, end_flat, 3.94301e-05, -0.003, settings);
-    }
+    test_one<polygon_type, polygon_type>("county1", county1, join_round, end_flat, {0.00114, 0.00115}, 0.01);
+    test_one<polygon_type, polygon_type>("county1", county1, join_miter, end_flat, {0.00132, 0.00133}, 0.01);
+    test_one<polygon_type, polygon_type>("county1", county1, join_round, end_flat, {3.944e-05, 3.947e-5}, -0.003);
+    test_one<polygon_type, polygon_type>("county1", county1, join_miter, end_flat, {3.943e-05, 3.946e-5}, -0.003);
 
     test_one<polygon_type, polygon_type>("parcel1_10", parcel1, join_round, end_flat, 7571.405, 10.0);
-    test_one<polygon_type, polygon_type>("parcel1_10", parcel1, join_miter, end_flat, 8207.453, 10.0);
+    test_one<polygon_type, polygon_type>("parcel1_10", parcel1, join_miter, end_flat, {8207, 8217}, 10.0);
     test_one<polygon_type, polygon_type>("parcel1_20", parcel1, join_round, end_flat, 11648.111, 20.0);
-    test_one<polygon_type, polygon_type>("parcel1_20", parcel1, join_miter, end_flat, 14184.022, 20.0);
-    test_one<polygon_type, polygon_type>("parcel1_30", parcel1, join_round, end_flat, 16350.488, 30.0);
-    test_one<polygon_type, polygon_type>("parcel1_30", parcel1, join_miter, end_flat, 22417.799, 30.0);
+    test_one<polygon_type, polygon_type>("parcel1_20", parcel1, join_miter, end_flat, {14184, 14195}, 20.0);
+    test_one<polygon_type, polygon_type>("parcel1_30", parcel1, join_round, end_flat, {16345, 16351}, 30.0);
+    test_one<polygon_type, polygon_type>("parcel1_30", parcel1, join_miter, end_flat, {22072, 22418}, 30.0);
 
-    test_one<polygon_type, polygon_type>("parcel2_10", parcel2, join_round, end_flat, 5000.867, 10.0);
-    test_one<polygon_type, polygon_type>("parcel2_10", parcel2, join_miter, end_flat, 5091.122, 10.0);
-    test_one<polygon_type, polygon_type>("parcel2_20", parcel2, join_round, end_flat, 9049.673, 20.0);
-    test_one<polygon_type, polygon_type>("parcel2_20", parcel2, join_miter, end_flat, 9410.691, 20.0);
-    test_one<polygon_type, polygon_type>("parcel2_30", parcel2, join_round, end_flat, 13726.528, 30.0);
-    test_one<polygon_type, polygon_type>("parcel2_30", parcel2, join_miter, end_flat, 14535.232, 30.0);
+    test_one<polygon_type, polygon_type>("parcel2_10", parcel2, join_round, end_flat, {5000, 5004}, 10.0);
+    test_one<polygon_type, polygon_type>("parcel2_10", parcel2, join_miter, end_flat, {5091, 5094}, 10.0);
+    test_one<polygon_type, polygon_type>("parcel2_20", parcel2, join_round, end_flat, {9049, 9052}, 20.0);
+    test_one<polygon_type, polygon_type>("parcel2_20", parcel2, join_miter, end_flat, {9410, 9415}, 20.0);
+    test_one<polygon_type, polygon_type>("parcel2_30", parcel2, join_round, end_flat, {13726, 13731}, 30.0);
+    test_one<polygon_type, polygon_type>("parcel2_30", parcel2, join_miter, end_flat, {14535, 14543}, 30.0);
 
-    test_one<polygon_type, polygon_type>("parcel3_10", parcel3, join_round, end_flat, 19993.007, 10.0);
-    test_one<polygon_type, polygon_type>("parcel3_10", parcel3, join_miter, end_flat, 20024.558, 10.0, ut_settings(0.05)); // MSVC 14 reports 20024.51456, so we increase the tolerance
-    test_one<polygon_type, polygon_type>("parcel3_20", parcel3, join_round, end_flat, 34505.837, 20.0);
-    test_one<polygon_type, polygon_type>("parcel3_20", parcel3, join_miter, end_flat, 34633.261, 20.0);
+    test_one<polygon_type, polygon_type>("parcel3_10", parcel3, join_round, end_flat, {19993, 19994}, 10.0);
+    test_one<polygon_type, polygon_type>("parcel3_10", parcel3, join_miter, end_flat, {20024, 20025}, 10.0);
+    test_one<polygon_type, polygon_type>("parcel3_20", parcel3, join_round, end_flat, {34505, 34510}, 20.0);
+    test_one<polygon_type, polygon_type>("parcel3_20", parcel3, join_miter, end_flat, {34633, 34653}, 20.0);
     test_one<polygon_type, polygon_type>("parcel3_30", parcel3, join_round, end_flat, 45262.452, 30.0);
-    test_one<polygon_type, polygon_type>("parcel3_30", parcel3, join_miter, end_flat, 45567.388, 30.0);
+    test_one<polygon_type, polygon_type>("parcel3_30", parcel3, join_miter, end_flat, {45567, 45575}, 30.0);
 
-    test_one<polygon_type, polygon_type>("parcel3_bend_5", parcel3_bend, join_round, end_flat, 155.634, 5.0);
-    test_one<polygon_type, polygon_type>("parcel3_bend_10", parcel3_bend, join_round, end_flat, 458.454, 10.0);
+    test_one<polygon_type, polygon_type>("parcel3_bend_5", parcel3_bend, join_round, end_flat, {155.54, 155.64}, 5.0);
+    test_one<polygon_type, polygon_type>("parcel3_bend_10", parcel3_bend, join_round, end_flat, {458.3, 458.5}, 10.0);
 
     // These cases differ a bit based on point order, because piece generation is different in one corner. Tolerance is increased
     test_one<polygon_type, polygon_type>("parcel3_bend_15", parcel3_bend, join_round, end_flat, 918.06, 15.0, ut_settings(0.25));
@@ -514,22 +510,23 @@ void test_all()
     // Parcel - deflated
     test_one<polygon_type, polygon_type>("parcel1_10", parcel1, join_round, end_flat, 1571.9024, -10.0);
     test_one<polygon_type, polygon_type>("parcel1_10", parcel1, join_miter, end_flat, 1473.7325, -10.0);
-    test_one<polygon_type, polygon_type>("parcel1_20", parcel1, join_round, end_flat, 209.3579, -20.0);
+    test_one<polygon_type, polygon_type>("parcel1_20", parcel1, join_round, end_flat, {209.35, 209.97}, -20.0);
     test_one<polygon_type, polygon_type>("parcel1_20", parcel1, join_miter, end_flat, 188.4224, -20.0);
 
     test_one<polygon_type, polygon_type>("nl_part1_2", nl_part1,
-        join_round, end_flat,  BG_IF_RESCALED(1848737356.991, 1848737292.653), -0.2 * 1000.0);
+        join_round, end_flat,  {1848737292, 1848737357}, -0.2 * 1000.0);
     test_one<polygon_type, polygon_type>("nl_part1_5", nl_part1,
-        join_round, end_flat,  BG_IF_RESCALED(1775953811.679, 1775953824.799), -0.5 * 1000.0);
+        join_round, end_flat,  {1775953811, 1775953825}, -0.5 * 1000.0);
 
     test_one<polygon_type, polygon_type>("italy_part1_30", italy_part1,
-        join_round, end_flat,  BG_IF_RESCALED(5015638814.956, 5015638827.704), 30.0 * 1000.0);
+        join_round, end_flat,  {5015638814, 5015638828}, 30.0 * 1000.0);
     test_one<polygon_type, polygon_type>("italy_part1_50", italy_part1,
-        join_round, end_flat, BG_IF_RESCALED(11363180044.822, 11363180033.564), 50.0 * 1000.0);
-    test_one<polygon_type, polygon_type>("italy_part1_60", italy_part1, join_round, end_flat, 15479097108.720, 60.0 * 1000.0);
+        join_round, end_flat, {11363180033, 11363180045}, 50.0 * 1000.0);
+    test_one<polygon_type, polygon_type>("italy_part1_60", italy_part1,
+        join_round, end_flat, 15479097108.720, 60.0 * 1000.0);
 
     test_one<polygon_type, polygon_type>("italy_part2_5", italy_part2,
-        join_round, end_flat, BG_IF_RESCALED(12496082123.6245, 12496082120.9337444), 5 * 1000.0);
+        join_round, end_flat, {12496082120, 12496082124}, 5 * 1000.0);
 
     if (! BOOST_GEOMETRY_CONDITION((boost::is_same<coor_type, float>::value)))
     {
@@ -539,12 +536,9 @@ void test_all()
         // Tickets
         test_one<polygon_type, polygon_type>("ticket_10398_1_5", ticket_10398_1, join_miter, end_flat, 494.7192, 0.5, settings);
         test_one<polygon_type, polygon_type>("ticket_10398_1_25", ticket_10398_1, join_miter, end_flat, 697.7798, 2.5, settings);
-        {
-            // qcc-arm reports 1470.79863681712281
-            ut_settings specific = settings;
-            specific.tolerance = 0.02;
-            test_one<polygon_type, polygon_type>("ticket_10398_1_84", ticket_10398_1, join_miter, end_flat, 1470.8096, 8.4, specific);
-        }
+
+        // qcc-arm reports 1470.79863681712281
+        test_one<polygon_type, polygon_type>("ticket_10398_1_84", ticket_10398_1, join_miter, end_flat, {1470.79, 1470.81}, 8.4, settings);
 
         test_one<polygon_type, polygon_type>("ticket_10398_2_45", ticket_10398_2, join_miter, end_flat, 535.4780, 4.5, settings);
         test_one<polygon_type, polygon_type>("ticket_10398_2_62", ticket_10398_2, join_miter, end_flat, 705.2046, 6.2, settings);
@@ -865,7 +859,7 @@ int test_main(int, char* [])
 #endif
 
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(2, 1);
+    BoostGeometryWriteExpectedFailures(2, 1, 10, 1);
 #endif
 
     return 0;

--- a/test/algorithms/buffer/test_buffer.hpp
+++ b/test/algorithms/buffer/test_buffer.hpp
@@ -25,7 +25,8 @@
 #include <iomanip>
 
 #include <boost/foreach.hpp>
-#include "geometry_test_common.hpp"
+#include <geometry_test_common.hpp>
+#include <expectation_limits.hpp>
 
 #include <boost/geometry/algorithms/envelope.hpp>
 #include <boost/geometry/algorithms/area.hpp>
@@ -150,7 +151,7 @@ void test_buffer(std::string const& caseid,
             AreaStrategy const& area_strategy,
             int expected_count,
             int expected_holes_count,
-            double expected_area,
+            expectation_limits const& expected_area,
             ut_settings const& settings)
 {
     namespace bg = boost::geometry;
@@ -267,7 +268,7 @@ void test_buffer(std::string const& caseid,
     //std::cout << complete.str() << "," << std::fixed << std::setprecision(0) << area << std::endl;
     //return;
 
-    if (bg::is_empty(buffered) && bg::math::equals(expected_area, 0.0))
+    if (bg::is_empty(buffered) && expected_area.is_zero())
     {
         // As expected - don't get rescale policy for output (will be invalid)
         return;
@@ -317,36 +318,14 @@ void test_buffer(std::string const& caseid,
 
     if (settings.test_area)
     {
-        // Because areas vary hugely in buffer, the Boost.Test methods are not convenient.
-        // Use just the abs - but if the areas are really small that is not convenient either.
-        // Therefore there is a logarithmic option too.
-        typedef typename bg::default_area_result<GeometryOut>::type area_type;
-        area_type const area = bg::area(buffered, area_strategy);
-        area_type const difference = settings.use_ln_area
-                ? log(area) - std::log(expected_area)
-                : area  - expected_area;
-        BOOST_CHECK_MESSAGE
-            (
-                bg::math::abs(difference) < settings.tolerance,
-                complete.str() << " not as expected. " 
-                << std::setprecision(18)
-                << " Expected: " << expected_area
-                << " Detected: " << area
-                << " Diff: " << difference
-                << " Tol: " << settings.tolerance
-                << std::setprecision(3)
-                << " , " << 100.0 * (difference / expected_area) << "%"
-            );
-//        if (settings.use_ln_area)
-//        {
-//            std::cout << complete.str()
-//                      << std::setprecision(6)
-//                      << " ln(detected)=" << std::log(area)
-//                      << " ln(expected)=" << std::log(expected_area)
-//                      << " diff=" << difference
-//                      << " detected=" << area
-//                      << std::endl;
-//        }
+        typename bg::default_area_result<GeometryOut>::type area
+          = bg::area(buffered, area_strategy);
+        BOOST_CHECK_MESSAGE(expected_area.contains(area, settings.tolerance, settings.use_ln_area),
+              "difference: " << caseid << std::setprecision(20)
+              << " #area expected: " << expected_area
+              << " detected: " << area
+              << " type: " << (type_for_assert_message<Geometry, GeometryOut>())
+              );
     }
 
     if (settings.test_validity() && ! bg::is_valid(buffered))
@@ -394,7 +373,7 @@ void test_buffer(std::string const& caseid, bg::model::multi_polygon<GeometryOut
             DistanceStrategy const& distance_strategy,
             SideStrategy const& side_strategy,
             PointStrategy const& point_strategy,
-            double expected_area,
+            expectation_limits const& expected_area,
             ut_settings const& settings = ut_settings())
 {
     typename bg::strategy::area::services::default_strategy
@@ -421,7 +400,7 @@ template
 >
 void test_one(std::string const& caseid, std::string const& wkt,
         JoinStrategy const& join_strategy, EndStrategy const& end_strategy,
-        int expected_count, int expected_holes_count, double expected_area,
+        int expected_count, int expected_holes_count, expectation_limits const& expected_area,
         double distance_left, ut_settings const& settings = ut_settings(),
         double distance_right = same_distance)
 {
@@ -501,7 +480,7 @@ template
 >
 void test_one(std::string const& caseid, std::string const& wkt,
         JoinStrategy const& join_strategy, EndStrategy const& end_strategy,
-        double expected_area,
+        expectation_limits const& expected_area,
         double distance_left, ut_settings const& settings = ut_settings(),
         double distance_right = same_distance)
 {
@@ -527,7 +506,7 @@ void test_with_custom_strategies(std::string const& caseid,
         DistanceStrategy const& distance_strategy,
         SideStrategy const& side_strategy,
         PointStrategy const& point_strategy,
-        double expected_area,
+        expectation_limits const& expected_area,
         ut_settings const& settings = ut_settings())
 {
     namespace bg = boost::geometry;

--- a/test/algorithms/set_operations/difference/difference.cpp
+++ b/test/algorithms/set_operations/difference/difference.cpp
@@ -36,7 +36,7 @@
     ( #caseid, caseid[0], caseid[1], clips1, -1, area1, clips2, -1, area2, \
                 clips3, -1, area1 + area2)
 
-#define TEST_DIFFERENCE_WITH(caseid, clips1, area1, clips2, area2, clips3) \
+#define TEST_DIFFERENCE_WITH(caseid, clips1, area1, clips2, area2, clips3, settings) \
     (test_one<polygon, polygon, polygon>) \
     ( #caseid, caseid[0], caseid[1], clips1, -1, area1, clips2, -1, area2, \
                 clips3, -1, area1 + area2, settings)
@@ -233,35 +233,39 @@ void test_all()
     TEST_DIFFERENCE(case_106, 1, 17.5, 2, 32.5, 3);
     TEST_DIFFERENCE(case_107, 2, 18.0, 2, 29.0, 4);
 
-    TEST_DIFFERENCE(case_precision_1, 1, 14.0, 1, BG_IF_KRAMER(8.00001, 8.0), 1);
+    TEST_DIFFERENCE_WITH(case_precision_1, 1, 14, 1, 8, 1, ut_settings(0.001));
     TEST_DIFFERENCE(case_precision_2, 1, 14.0, 1, 8.0, 1);
     TEST_DIFFERENCE(case_precision_3, 1, 14.0, 1, 8.0, 1);
     TEST_DIFFERENCE(case_precision_4, 1, 14.0, 1, 8.0, 1);
     TEST_DIFFERENCE(case_precision_5, 1, 14.0, 1, 8.0, count_set(1, 2));
     // Small optional sliver allowed, here and below
-    TEST_DIFFERENCE(case_precision_6, optional(), 0.0, 1, 57.0, count_set(1, 2));
+    TEST_DIFFERENCE_WITH(case_precision_6, optional(), optional_sliver(), 1, 57.0,
+                         count_set(1, 2), ut_settings(0.001));
     TEST_DIFFERENCE(case_precision_7, 1, 14.0, 1, 8.0, 1);
     TEST_DIFFERENCE(case_precision_8, 0, 0.0, 1, 59.0, 1);
-    TEST_DIFFERENCE(case_precision_9, optional(), 0.0, 1, 59.0, count_set(1, 2));
-    TEST_DIFFERENCE(case_precision_10, optional(), 0.0, 1, 59.0, count_set(1, 2));
+    TEST_DIFFERENCE(case_precision_9, optional(), optional_sliver(), 1, 59.0, count_set(1, 2));
+    TEST_DIFFERENCE_WITH(case_precision_10, optional(), optional_sliver(), 1, 59, count_set(1, 2), ut_settings(0.001));
+
 #if ! defined(BOOST_GEOMETRY_USE_KRAMER_RULE) || defined(BOOST_GEOMETRY_TEST_FAILURES)
-    TEST_DIFFERENCE(case_precision_11, optional(), 0.0, 1, 59.0, 1);
+    TEST_DIFFERENCE(case_precision_11, optional(), optional_sliver(), 1, 59.0, count_set(1, 2));
 #endif
+
     TEST_DIFFERENCE(case_precision_12, 1, 12.0, 0, 0.0, 1);
-    TEST_DIFFERENCE(case_precision_13, 1, BG_IF_KRAMER(12.00002, 12.0), 0, 0.0, 1);
+    TEST_DIFFERENCE_WITH(case_precision_13, 1, 12, 0, 0.0, 1, ut_settings(0.001));
     TEST_DIFFERENCE(case_precision_14, 1, 14.0, 1, 8.0, 1);
     TEST_DIFFERENCE(case_precision_15, 0, 0.0, 1, 59.0, 1);
-    TEST_DIFFERENCE(case_precision_16, optional(), 0.0, 1, 59.0, 1);
+    TEST_DIFFERENCE(case_precision_16, optional(), optional_sliver(), 1, 59.0, 1);
     TEST_DIFFERENCE(case_precision_17, 0, 0.0, 1, 59.0, 1);
     TEST_DIFFERENCE(case_precision_18, 0, 0.0, 1, 59.0, 1);
-    TEST_DIFFERENCE(case_precision_19, 1, 0.0, 1, 59.0, 2);
+    TEST_DIFFERENCE(case_precision_19, 1, expectation_limits(1.2e-6, 1.35e-5), 1, 59.0, 2);
     TEST_DIFFERENCE(case_precision_20, 1, 14.0, 1, 8.0, 1);
     TEST_DIFFERENCE(case_precision_21, 1, 14.0, 1, 7.99999, 1);
-    TEST_DIFFERENCE(case_precision_22, optional(), 0.0, 1, 59.0, count_set(1, 2));
-    TEST_DIFFERENCE(case_precision_23, optional(), 0.0, 1, 59.0, count_set(1, 2));
+    TEST_DIFFERENCE_WITH(case_precision_22, optional(), optional_sliver(), 1, 59.0,
+                         count_set(1, 2), ut_settings(0.001));
+    TEST_DIFFERENCE(case_precision_23, optional(), optional_sliver(), 1, 59.0, count_set(1, 2));
     TEST_DIFFERENCE(case_precision_24, 1, 14.0, 1, 8.0, 1);
     TEST_DIFFERENCE(case_precision_25, 1, 14.0, 1, 7.99999, 1);
-    TEST_DIFFERENCE(case_precision_26, optional(), 0.0, 1, 59.0, count_set(1, 2));
+    TEST_DIFFERENCE(case_precision_26, optional(), optional_sliver(), 1, 59.0, count_set(1, 2));
 
     test_one<polygon, polygon, polygon>("winded",
         winded[0], winded[1],
@@ -290,7 +294,7 @@ void test_all()
             buffer_mp2[0], buffer_mp2[1],
             1, 91, 12.09857,
             1, 155, 24.19714,
-            BG_IF_RESCALED(2, 1), -1, 12.09857 + 24.19714);
+            {1, 2}, -1, 12.09857 + 24.19714);
     }
 
     /*** TODO: self-tangencies for difference
@@ -326,34 +330,26 @@ void test_all()
     }
 
 #if ! defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
-    {
-        ut_settings settings;
-        settings.percentage = 0.1;
-        settings.set_test_validity(false);
-
-        // SQL Server gives: 0.28937764436705 and 0.000786406897532288 with 44/35 rings
-        // PostGIS gives:    0.30859375       and 0.033203125 with 35/35 rings
-        TEST_DIFFERENCE_WITH(geos_1,
-            ignore_count(), BG_IF_KRAMER(0.29171, 0.20705),
-            ignore_count(), BG_IF_KRAMER(0.00076855, 0.00060440758),
-            ignore_count());
-    }
+      // SQL Server gives: 0.28937764436705 and 0.000786406897532288 with 44/35 rings
+      // PostGIS gives:    0.30859375       and 0.033203125 with 35/35 rings
+      TEST_DIFFERENCE_WITH(geos_1,
+          ignore_count(), expectation_limits(0.20705, 0.29172),
+          ignore_count(), expectation_limits(0.00060440758, 0.00076856),
+          ignore_count(), ut_settings(0.1, false));
 #endif
 
     {
+        //geos_2_a #area expected: 138.69238279999999008 detected: 138.53125 type: f
+        //geos_2_b #area expected: 211.859375 detected: 210.53125 type: f
+
         // MSVC 14 expects 138.69214 and 211.85913: increase percentage
-
-        ut_settings settings = sym_settings;
-        settings.percentage = 0.01;
-        settings.set_test_validity(false);
-
         // Output polygons for sym difference might be combined
         test_one<polygon, polygon, polygon>("geos_2",
             geos_2[0], geos_2[1],
             1, -1, 138.6923828,
             1, -1, 211.859375,
-            BG_IF_RESCALED(2, 1), -1, 138.6923828 + 211.859375,
-            settings);
+            {1, 2}, -1, 138.6923828 + 211.859375,
+            ut_settings(0.1, false, false));
     }
 
     // Output polygons for sym difference might be combined
@@ -361,7 +357,7 @@ void test_all()
         geos_3[0], geos_3[1],
         1, -1, 16211128.5,
         1, -1, 13180420.0,
-        BG_IF_RESCALED(1, 2), -1, 16211128.5 + 13180420.0,
+        {1, 2}, -1, 16211128.5 + 13180420.0,
         sym_settings);
 
     test_one<polygon, polygon, polygon>("geos_4",
@@ -378,32 +374,24 @@ void test_all()
 
     test_one<polygon, polygon, polygon>("ggl_list_20110307_javier",
         ggl_list_20110307_javier[0], ggl_list_20110307_javier[1],
-        1, if_typed<ct, float>(14, 13), 16815.6,
-        1, 4, 3200.4,
+        1, -1, 16815.6,
+        1, -1, 3200.4,
         tolerance(0.01));
 
-    if ( BOOST_GEOMETRY_CONDITION((! boost::is_same<ct, float>::value)) )
-    {
-        TEST_DIFFERENCE(ggl_list_20110716_enrico,
-            3, 35723.8506317139, // TODO FOR GENERIC, misses one of three outputs
-            1, 58456.4964294434,
-            1);
-    }
+    TEST_DIFFERENCE(ggl_list_20110716_enrico,
+        3, 35723.8506317139,
+        1, 58456.4964294434,
+        1);
 
 #if defined(BOOST_GEOMETRY_USE_RESCALING) \
     || ! defined(BOOST_GEOMETRY_USE_KRAMER_RULE) \
     || defined(BOOST_GEOMETRY_TEST_FAILURES)
-    {
-        // Symmetric difference should output one polygon
-        // Using rescaling, it currently outputs two.
-        ut_settings settings;
-        settings.set_test_validity(false);
-
-        TEST_DIFFERENCE_WITH(ggl_list_20110820_christophe,
-            1, 2.8570121719168924,
-            1, 64.498061986388564,
-            BG_IF_RESCALED(2, 1));
-    }
+      // Symmetric difference should output one polygon
+      // Using rescaling, it currently outputs two.
+      TEST_DIFFERENCE_WITH(ggl_list_20110820_christophe,
+          1, 2.8570121719168924,
+          1, 64.498061986388564,
+          count_set(1, 2), ut_settings(0.0001, false));
 #endif
 
     test_one<polygon, polygon, polygon>("ggl_list_20120717_volker",
@@ -422,9 +410,9 @@ void test_all()
     // Without rescaling there is no output, like PostGIS
     test_one<polygon, polygon, polygon>("ggl_list_20110627_phillip",
         ggl_list_20110627_phillip[0], ggl_list_20110627_phillip[1],
-        BG_IF_RESCALED(1, 0), -1,
-        BG_IF_RESCALED(0.000125137888971949, 0),
-        1, -1, 3577.40960816756,
+        optional(), -1,
+        optional_sliver(0.00013),
+        1, -1, expectation_limits(3577.4096, 3577.415),
         tolerance(0.01)
         );
 
@@ -435,8 +423,8 @@ void test_all()
         TEST_DIFFERENCE_WITH(ggl_list_20190307_matthieu_1,
                 count_set(1, 2), 0.18461532,
                 count_set(1, 2), 0.617978,
-                count_set(3, 4));
-        TEST_DIFFERENCE_WITH(ggl_list_20190307_matthieu_2, 2, 12.357152, 0, 0.0, 2);
+                count_set(3, 4), settings);
+        TEST_DIFFERENCE_WITH(ggl_list_20190307_matthieu_2, 2, 12.357152, 0, 0.0, 2, settings);
     }
 
     // Ticket 8310, one should be completely subtracted from the other.
@@ -455,13 +443,15 @@ void test_all()
 
     test_one<polygon, polygon, polygon>("ticket_9081_15",
             ticket_9081_15[0], ticket_9081_15[1],
-            2, -1, 0.0334529710902111,
-            BG_IF_RESCALED(1, 0), -1, BG_IF_RESCALED(5.3469555172380723e-010, 0));
+            2, -1, {0.033452, 0.033454},
+            optional(), -1,
+            optional_sliver(1.0e-5));
 
     test_one<polygon, polygon, polygon>("ticket_9081_314",
             ticket_9081_314[0], ticket_9081_314[1],
-            2, 12, 0.0451236449624935,
-            0, 0, 0);
+            2, -1, 0.0451236449624935,
+            count_set(0, 2), -1, 0,
+            count_set(2, 3), -1, 0.0451236449624935);
 
     {
         ut_settings settings;
@@ -474,23 +464,23 @@ void test_all()
         TEST_DIFFERENCE_WITH(ticket_9563,
                 0, 0,
                 expected_count, 20.096189,
-                expected_count);
+                expected_count, settings);
     }
 
 #if defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
     // Without rescaling the "b" case produces no output.
     test_one<polygon, polygon, polygon>("ticket_10108_a",
             ticket_10108_a[0], ticket_10108_a[1],
-            1, 4,  0.0145037,
+            1, 4,  {0.0145036, 0.0145037},
             1, 4,  0.029019232,
             sym_settings);
 #endif
 
     test_one<polygon, polygon, polygon>("ticket_10108_b",
             ticket_10108_b[0], ticket_10108_b[1],
-            1, -1, 1081.68697,
+            1, -1, {1081.6858, 1081.6870},
             1, -1, 1342.65795,
-            BG_IF_RESCALED(2, 1), -1, 1081.68697 + 1342.65795);
+            count_set(1, 2), -1, 1081.68697 + 1342.65795);
 
     test_one<polygon, polygon, polygon>("ticket_11725",
         ticket_11725[0], ticket_11725[1],
@@ -571,18 +561,12 @@ void test_all()
 #endif
 
     // Rescaling generates a very small false polygon
-    {
-        ut_settings settings;
-#if defined(BOOST_GEOMETRY_USE_KRAMER_RULE)
-        settings.set_test_validity(BG_IF_RESCALED(true, false));
-#endif
-        TEST_DIFFERENCE_WITH(issue_566_a, 1, 143.662, BG_IF_RESCALED(1, 0),
-                             BG_IF_RESCALED(1.605078e-6, 0.0),
-                             BG_IF_RESCALED(2, 1));
-    }
-    TEST_DIFFERENCE(issue_566_b, 1, 143.662, BG_IF_RESCALED(1, 0),
-                    BG_IF_RESCALED(1.605078e-6, 0.0),
-                    BG_IF_RESCALED(2, 1));
+    TEST_DIFFERENCE(issue_566_a, 1, expectation_limits(143.662),
+                         optional(), optional_sliver(1.0e-5),
+                         count_set(1, 2));
+    TEST_DIFFERENCE(issue_566_b, 1, expectation_limits(143.662),
+                    optional(), optional_sliver(1.0e-5),
+                    count_set(1, 2));
 
     TEST_DIFFERENCE(mysql_21977775, 2, 160.856568913, 2, 92.3565689126, 4);
     TEST_DIFFERENCE(mysql_21965285, 1, 92.0, 1, 14.0, 1);
@@ -638,7 +622,9 @@ int test_main(int, char* [])
 #endif
 
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(12, 11);
+    // Not yet fully tested for float and long double.
+    // The difference algorithm can generate (additional) slivers
+    BoostGeometryWriteExpectedFailures(10, 11, 24, 14);
 #endif
 
     return 0;

--- a/test/algorithms/set_operations/difference/difference_multi.cpp
+++ b/test/algorithms/set_operations/difference/difference_multi.cpp
@@ -165,7 +165,10 @@ void test_areal()
 #else
         // Very small sliver for B, and sym difference is not considered valid
         settings.set_test_validity(false);
-        TEST_DIFFERENCE_WITH(0, 1, bug_21155501, 1, 3.758937, 1, 1.7763568394002505e-15, 2);
+        TEST_DIFFERENCE_WITH(0, 1, bug_21155501,
+                             (count_set(1, 4)), expectation_limits(3.75893, 3.75894),
+                             (count_set(1, 4)), (expectation_limits(1.776357e-15, 7.661281e-15)),
+                             (count_set(2, 5)));
 #endif
     }
 
@@ -174,12 +177,11 @@ void test_areal()
         // With rescaling, it is complete but invalid
         // Without rescaling, one ring is missing (for a and s)
         ut_settings settings;
-        settings.percentage = 0.001;
         settings.set_test_validity(BG_IF_RESCALED(false, true));
         TEST_DIFFERENCE_WITH(0, 1, ticket_9081,
                              2, 0.0907392476356186,
                              4, 0.126018011439877,
-                             BG_IF_RESCALED(4, 3));
+                             count_set(3, 4));
     }
 #endif
 
@@ -191,7 +193,7 @@ void test_areal()
         settings.percentage = 0.001;
 
 #if ! defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
-        TEST_DIFFERENCE_WITH(0, 1, issue_630_a, 0, 0.0, 1, BG_IF_KRAMER(2.023326, 2.200326), 1);
+        TEST_DIFFERENCE_WITH(0, 1, issue_630_a, 0, expectation_limits(0.0), 1, (expectation_limits(2.023, 2.2004)), 1);
 #endif
         TEST_DIFFERENCE_WITH(0, 1, issue_630_b, 1, 0.0056089, 2, 1.498976, 3);
 #if ! defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
@@ -201,7 +203,7 @@ void test_areal()
         TEST_DIFFERENCE_WITH(0, 1, issue_630_c, 0, 0, 1, 1.493367, 1);
 #endif
 
-        TEST_DIFFERENCE_WITH(0, 1, issue_643, 1, 76.5385, BG_IF_KRAMER(1, 0), BG_IF_KRAMER(2.8634e-09, 0.0), 1);
+        TEST_DIFFERENCE_WITH(0, 1, issue_643, 1, expectation_limits(76.5385), optional(), optional_sliver(1.0e-6), 1);
 #endif
     }
 
@@ -367,8 +369,8 @@ void test_areal()
     TEST_DIFFERENCE(case_recursive_boxes_79, 2, 1.25, 6, 4.5, 8);
 
     // one polygon is divided into two, for same reason as union creates a small
-    // interior ring there
-    TEST_DIFFERENCE(case_recursive_boxes_80, 1, 0.5, 2, 0.75, BG_IF_RESCALED(3, 2));
+    // interior ring there, which is acceptable
+    TEST_DIFFERENCE(case_recursive_boxes_80, 1, 0.5, 2, 0.75, count_set(2, 3));
 
     TEST_DIFFERENCE(case_recursive_boxes_81, 3, 5.0, 6, 6.75, 6);
     TEST_DIFFERENCE(case_recursive_boxes_82, 5, 7.25, 7, 4.5, 8);
@@ -383,7 +385,7 @@ void test_areal()
     TEST_DIFFERENCE(case_recursive_boxes_88, 3, 4.75, 5, 6.75, 4);
 
     // Output of A can be 0 or 1 polygons (with a very small area)
-    TEST_DIFFERENCE(case_precision_m1, optional(), 0.0, 1, 57.0, count_set(1, 2));
+    TEST_DIFFERENCE(case_precision_m1, optional(), expectation_limits(0.0, 5.0e-7), 1, 57.0, count_set(1, 2));
     // Output of A can be 1 or 2 polygons (one with a very small area)
     TEST_DIFFERENCE(case_precision_m2, count_set(1, 2), 1.0, 1, 57.75, count_set(2, 3));
 
@@ -401,8 +403,8 @@ void test_areal()
     }
 
     TEST_DIFFERENCE(mysql_regression_1_65_2017_08_31,
-                    optional(), BG_IF_RESCALED(4.30697514e-7, 0),
-                    3, 152.0642, count_set(3, 4));
+                    optional(), optional_sliver(1e-6),
+                    3, 152.064185, count_set(3, 4));
 }
 
 
@@ -427,10 +429,10 @@ void test_specific_areal()
         settings.set_test_validity(false);
 
         TEST_DIFFERENCE_WITH(0, 1, ticket_11674,
-                             BG_IF_KRAMER(3, 4),
-                             BG_IF_KRAMER(9105781.5, 9105473.5),
+                             count_set(3, 4),
+                             expectation_limits(9105473, 9105782),
                              5,
-                             BG_IF_KRAMER(119059.5, 119423), ignore_count());
+                             expectation_limits(119059, 119424), ignore_count());
     }
 
     {
@@ -441,8 +443,8 @@ void test_specific_areal()
         settings.remove_spikes = true;
 
         TEST_DIFFERENCE_WITH(0, 1, ticket_12751, 1,
-                             BG_IF_KRAMER(2781965.0, 2782114), 1,
-                             BG_IF_KRAMER(597.0, 598.0), 2);
+                             expectation_limits(2781964, 2782115), 1,
+                             expectation_limits(597.0, 598.0), 2);
 
 #if ! defined(BOOST_GEOMETRY_USE_KRAMER)
         // Fails with general line form intersection, symmetric version misses one outcut
@@ -452,8 +454,8 @@ void test_specific_areal()
 #endif
 
         TEST_DIFFERENCE_WITH(2, 3, ticket_12751,
-                             2, BG_IF_KRAMER(2537992.5, 2538305),
-                             2, BG_IF_KRAMER(294963.5, 294737),
+                             2, expectation_limits(2537992, 2538306),
+                             2, expectation_limits(294736, 294964),
                              3);
     }
 
@@ -464,8 +466,8 @@ void test_specific_areal()
         settings.remove_spikes = true;
         settings.sym_difference = false;
         TEST_DIFFERENCE_WITH(0, 1, ticket_12752,
-                             BG_IF_KRAMER(3, 2), BG_IF_KRAMER(2776692.0, 2776657),
-                             3, BG_IF_KRAMER(7893.0, 7710.5),
+                             count_set(2, 3), expectation_limits(2776656, 2776693),
+                             3, expectation_limits(7710, 7894),
                              2);
     }
 
@@ -480,7 +482,7 @@ void test_specific_areal()
         test_one<Polygon, MultiPolygon, MultiPolygon>("ticket_10661_2",
             a_min_b, ticket_10661[2],
             1, 8, 825192.0,
-            1, 10, BG_IF_KRAMER(27226370.5, 27842811),
+            1, 10, expectation_limits(27226370, 27842812),
             1, -1, 825192.0 + 27226370.5);
 #endif
     }
@@ -490,15 +492,12 @@ void test_specific_areal()
         settings.sym_difference = false;
 
 #if defined(BOOST_GEOMETRY_USE_KRAMER) || defined(BOOST_GEOMETRY_TEST_FAILURES)
-        // Fails with general line form intersection
-        // Misses one clip
-        // TODO GENERAL FORM
-        TEST_DIFFERENCE_WITH(0, 1, ticket_9942, 4, 7427727.5, 4,
-                             BG_IF_KRAMER(131506, 130083.5), 4);
+        TEST_DIFFERENCE_WITH(0, 1, ticket_9942, 4, expectation_limits(7427727.5), 4,
+                             expectation_limits(130083, 131507), 4);
 #endif
         TEST_DIFFERENCE_WITH(0, 1, ticket_9942a, 2,
-                             BG_IF_KRAMER(412676.5, 413183.5), 2,
-                             BG_IF_KRAMER(76779.5, 76924), 4);
+                             expectation_limits(412676, 413184), 2,
+                             expectation_limits(76779, 76925), 4);
     }
 }
 
@@ -523,7 +522,9 @@ int test_main(int, char* [])
 #endif
 
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(23, 13);
+    // Not yet fully tested for float.
+    // The difference algorithm can generate (additional) slivers
+    BoostGeometryWriteExpectedFailures(22, 13, 19, 7);
 #endif
 
     return 0;

--- a/test/algorithms/set_operations/difference/test_difference.hpp
+++ b/test/algorithms/set_operations/difference/test_difference.hpp
@@ -20,6 +20,7 @@
 
 #include <geometry_test_common.hpp>
 #include <count_set.hpp>
+#include <expectation_limits.hpp>
 #include <algorithms/check_validity.hpp>
 #include "../setop_output_type.hpp"
 
@@ -65,9 +66,10 @@ struct ut_settings : ut_base_settings
     bool sym_difference;
     bool remove_spikes;
 
-    ut_settings()
-        : percentage(0.0001)
-        , sym_difference(true)
+    explicit ut_settings(double p = 0.0001, bool tv = true, bool sd = true)
+        : ut_base_settings(tv)
+        , percentage(p)
+        , sym_difference(sd)
         , remove_spikes(false)
     {}
 
@@ -134,7 +136,7 @@ template <typename OutputType, typename G1, typename G2>
 std::string test_difference(std::string const& caseid, G1 const& g1, G2 const& g2,
         const count_set& expected_count,
         int expected_rings_count, int expected_point_count,
-        double expected_area,
+        expectation_limits const& expected_area,
         bool sym,
         ut_settings const& settings)
 {
@@ -247,11 +249,11 @@ std::string test_difference(std::string const& caseid, G1 const& g1, G2 const& g
     if (! expected_count.empty())
     {
         BOOST_CHECK_MESSAGE(expected_count.has(boost::size(result)),
-                "difference: " << caseid
-                << " #outputs expected: " << expected_count
-                << " detected: " << result.size()
-                << " type: " << (type_for_assert_message<G1, G2>())
-                );
+                            "difference: " << caseid
+                            << " #outputs expected: " << expected_count
+                            << " detected: " << result.size()
+                            << " type: " << (type_for_assert_message<G1, G2>())
+                            );
     }
 
     if (expected_rings_count >= 0)
@@ -265,15 +267,12 @@ std::string test_difference(std::string const& caseid, G1 const& g1, G2 const& g
                 );
     }
 
-    if (expected_area > 0)
-    {
-        BOOST_CHECK_CLOSE(area, expected_area, settings.percentage);
-    }
-    else
-    {
-        // Compare 0 with 0 or a very small detected area
-        BOOST_CHECK_LE(area, settings.percentage);
-    }
+    BOOST_CHECK_MESSAGE(expected_area.contains(area, settings.percentage),
+            "difference: " << caseid << std::setprecision(20)
+            << " #area expected: " << expected_area
+            << " detected: " << area
+            << " type: " << (type_for_assert_message<G1, G2>())
+            );
 #endif
 
     return return_string.str();
@@ -282,7 +281,7 @@ std::string test_difference(std::string const& caseid, G1 const& g1, G2 const& g
 template <typename OutputType, typename G1, typename G2>
 std::string test_difference(std::string const& caseid, G1 const& g1, G2 const& g2,
         const count_set&  expected_count, int expected_point_count,
-        double expected_area,
+        expectation_limits const& expected_area,
         bool sym,
         ut_settings const& settings)
 {
@@ -302,15 +301,15 @@ std::string test_one(std::string const& caseid,
         const count_set& expected_count1,
         int expected_rings_count1,
         int expected_point_count1,
-        double expected_area1,
+        expectation_limits const& expected_area1,
         const count_set& expected_count2,
         int expected_rings_count2,
         int expected_point_count2,
-        double expected_area2,
+        expectation_limits const& expected_area2,
         const count_set&  expected_count_s,
         int expected_rings_count_s,
         int expected_point_count_s,
-        double expected_area_s,
+        expectation_limits const& expected_area_s,
         ut_settings const& settings = ut_settings())
 {
     G1 g1;
@@ -354,11 +353,11 @@ std::string test_one(std::string const& caseid,
         const count_set&  expected_count1,
         int expected_rings_count1,
         int expected_point_count1,
-        double expected_area1,
+        expectation_limits const& expected_area1,
         const count_set&  expected_count2,
         int expected_rings_count2,
         int expected_point_count2,
-        double expected_area2,
+        expectation_limits const& expected_area2,
         ut_settings const& settings = ut_settings())
 {
     return test_one<OutputType, G1, G2>(caseid, wkt1, wkt2,
@@ -377,13 +376,13 @@ std::string test_one(std::string const& caseid,
         std::string const& wkt1, std::string const& wkt2,
         const count_set&  expected_count1,
         int expected_point_count1,
-        double expected_area1,
+        expectation_limits const& expected_area1,
         const count_set&  expected_count2,
         int expected_point_count2,
-        double expected_area2,
+        expectation_limits const& expected_area2,
         const count_set&  expected_count_s,
         int expected_point_count_s,
-        double expected_area_s,
+        expectation_limits const& expected_area_s,
         ut_settings const& settings = ut_settings())
 {
     return test_one<OutputType, G1, G2>(caseid, wkt1, wkt2,
@@ -398,10 +397,10 @@ std::string test_one(std::string const& caseid,
         std::string const& wkt1, std::string const& wkt2,
         const count_set&  expected_count1,
         int expected_point_count1,
-        double expected_area1,
+        expectation_limits const& expected_area1,
         const count_set&  expected_count2,
         int expected_point_count2,
-        double expected_area2,
+        expectation_limits const& expected_area2,
         ut_settings const& settings = ut_settings())
 {
     return test_one<OutputType, G1, G2>(caseid, wkt1, wkt2,

--- a/test/algorithms/set_operations/intersection/intersection.cpp
+++ b/test/algorithms/set_operations/intersection/intersection.cpp
@@ -50,6 +50,11 @@ BOOST_GEOMETRY_REGISTER_LINESTRING_TEMPLATED(std::vector)
     (test_one<Polygon, Polygon, Polygon>) \
     ( #caseid "_rev", caseid[1], caseid[0], clips, points, area)
 
+#define TEST_INTERSECTION_IGNORE(caseid, clips, points, area) \
+    { ut_settings ignore_validity; ignore_validity.set_test_validity(false); \
+    (test_one<Polygon, Polygon, Polygon>) \
+    ( #caseid, caseid[0], caseid[1], clips, points, area, ignore_validity); }
+
 #define TEST_INTERSECTION_WITH(caseid, index1, index2, \
      clips, points, area, settings) \
     (test_one<Polygon, Polygon, Polygon>) \
@@ -59,10 +64,6 @@ BOOST_GEOMETRY_REGISTER_LINESTRING_TEMPLATED(std::vector)
 template <typename Polygon>
 void test_areal()
 {
-    typedef typename bg::coordinate_type<Polygon>::type ct;
-    bool const ccw = bg::point_order<Polygon>::value == bg::counterclockwise;
-    bool const open = bg::closure<Polygon>::value == bg::open;
-
     test_one<Polygon, Polygon, Polygon>("simplex_with_empty_1",
         simplex_normal[0], polygon_empty,
         0, 0, 0.0);
@@ -151,7 +152,7 @@ void test_areal()
 
     test_one<Polygon, Polygon, Polygon>("distance_zero",
         distance_zero[0], distance_zero[1],
-        1, 0 /* f: 4, other: 5 */, 0.29516139, ut_settings(0.01));
+        1, 0, 0.29516139);
 
     test_one<Polygon, Polygon, Polygon>("equal_holes_disjoint",
         equal_holes_disjoint[0], equal_holes_disjoint[1],
@@ -176,53 +177,19 @@ void test_areal()
         pie_2_3_23_0[0], pie_2_3_23_0[1],
         1, 4, 163292.679042133, ut_settings(0.1));
 
-    {
-        ut_settings settings(0.1);
-        settings.set_test_validity(BG_IF_RESCALED(true, false));
+    TEST_INTERSECTION(isovist, 1, 19, expectation_limits(88.19202, 88.19206));
 
-        // SQL Server gives: 88.1920416352664
-        // PostGIS gives:    88.19203677911
-        test_one<Polygon, Polygon, Polygon>("isovist",
-            isovist1[0], isovist1[1],
-            1, 19, 88.192037,
-            settings);
-    }
+    TEST_INTERSECTION_IGNORE(geos_1, 1, -1, expectation_limits(3455, 3462));
 
-    if (! BOOST_GEOMETRY_CONDITION((boost::is_same<ct, float>::value)) )
-    {
-        test_one<Polygon, Polygon, Polygon>("geos_1",
-            geos_1[0], geos_1[1],
-                1, -1, BG_IF_RESCALED(3461.12321694, BG_IF_KRAMER(3461.02336, 3461.105448)), // MSVC 14 reports 3461.025390625
-                ut_settings(0.01, false));
-    }
-
-    // Expectations:
-    // In most cases: 0 (no intersection)
+    // Can, in some cases, create small slivers
     // In some cases: 1.430511474609375e-05 (clang/gcc on Xubuntu using b2)
     // In some cases: 5.6022983000000002e-05 (powerpc64le-gcc-6-0)
-    test_one<Polygon, Polygon, Polygon>("geos_2", geos_2[0], geos_2[1],
-            0, 0, 6.0e-5, ut_settings(-1.0)); // -1 denotes: compare with <=
+    TEST_INTERSECTION(geos_2, count_set(0, 1, 2), 0, optional_sliver(6.0e-5));
 
-    test_one<Polygon, Polygon, Polygon>("geos_3",
-        geos_3[0], geos_3[1],
-            0, 0, 0.0);
-    test_one<Polygon, Polygon, Polygon>("geos_4",
-        geos_4[0], geos_4[1],
-            1, -1, 0.08368849, ut_settings(0.01));
+    TEST_INTERSECTION(geos_3, optional(), 0, optional_sliver(3.0e-7));
+    TEST_INTERSECTION(geos_4, 1, -1, expectation_limits(0.08368, 0.08370));
 
-
-    if ( BOOST_GEOMETRY_CONDITION(! ccw && open) )
-    {
-        // Pointcount for double (5) or float (4)
-        // double returns 5 (since method append_no_dups_or_spikes)
-        // but not for ccw/open. Those cases has to be adapted once, anyway,
-        // because for open always one point too much is generated...
-        test_one<Polygon, Polygon, Polygon>("ggl_list_20110306_javier",
-            ggl_list_20110306_javier[0], ggl_list_20110306_javier[1],
-            1, if_typed<ct, float>(4, 5),
-            0.6649875,
-            ut_settings(if_typed<ct, float>(1.0, 0.01)));
-    }
+    TEST_INTERSECTION(ggl_list_20110306_javier, 1, -1, expectation_limits(0.6649, 0.6670));
 
     // SQL Server reports: 0.400390625
     // PostGIS reports 0.4
@@ -230,11 +197,11 @@ void test_areal()
     // when selecting other IP closer at endpoint or if segment B is smaller than A
     test_one<Polygon, Polygon, Polygon>("ggl_list_20110307_javier",
         ggl_list_20110307_javier[0], ggl_list_20110307_javier[1],
-        1, 4, BG_IF_RESCALED(0.397162651, 0.40), ut_settings(0.01));
+        1, 4, {0.397162651, 0.40});
 
     test_one<Polygon, Polygon, Polygon>("ggl_list_20110627_phillip",
         ggl_list_20110627_phillip[0], ggl_list_20110627_phillip[1],
-        1, 5, 11151.6618);
+        1, -1, 11151.6618);
 
     test_one<Polygon, Polygon, Polygon>("ggl_list_20110716_enrico",
         ggl_list_20110716_enrico[0], ggl_list_20110716_enrico[1],
@@ -242,31 +209,31 @@ void test_areal()
 
     test_one<Polygon, Polygon, Polygon>("ggl_list_20131119_james",
         ggl_list_20131119_james[0], ggl_list_20131119_james[1],
-        1, 4, 6.6125873045, ut_settings(0.1));
+        1, 4, 6.6125873045);
 
     test_one<Polygon, Polygon, Polygon>("ggl_list_20140223_shalabuda",
         ggl_list_20140223_shalabuda[0], ggl_list_20140223_shalabuda[1],
-        1, 4, 3.77106, ut_settings(0.001));
+        1, 4, {3.771058, 3.771066});
 
     // Mailed to the Boost.Geometry list on 2014/03/21 by 7415963@gmail.com
     test_one<Polygon, Polygon, Polygon>("ggl_list_20140321_7415963",
         ggl_list_20140321_7415963[0], ggl_list_20140321_7415963[1],
-        0, 0, 0, ut_settings(0.1));
+        0, 0, 0);
 
     TEST_INTERSECTION(ggl_list_20190307_matthieu_1, 2, -1, 0.035136);
     TEST_INTERSECTION(ggl_list_20190307_matthieu_2, 1, -1, 3.64285);
 
 #if defined(BOOST_GEOMETRY_USE_RESCALING) || ! defined(BOOST_GEOMETRY_USE_KRAMER_RULE) || defined(BOOST_GEOMETRY_TEST_FAILURES)
     test_one<Polygon, Polygon, Polygon>("buffer_rt_f", buffer_rt_f[0], buffer_rt_f[1],
-                1, 4,  0.00029437899183903937, ut_settings(0.01));
+                1, 4, expectation_limits(0.00029437, 0.000294380));
 #endif
     test_one<Polygon, Polygon, Polygon>("buffer_rt_g", buffer_rt_g[0], buffer_rt_g[1],
                 1, 0, 2.914213562373);
 
     test_one<Polygon, Polygon, Polygon>("ticket_8254", ticket_8254[0], ticket_8254[1],
-                if_typed<ct, float>(0, 1), -1, if_typed<ct, float>(0.0, 3.635930e-08), ut_settings(0.01));
+                optional(), -1, optional_sliver(1e-07));
     test_one<Polygon, Polygon, Polygon>("ticket_6958", ticket_6958[0], ticket_6958[1],
-                if_typed<ct, float>(0, 1), -1, if_typed<ct, float>(0.0, 4.34355e-05), ut_settings(0.01));
+                optional(), -1, optional_sliver());
     test_one<Polygon, Polygon, Polygon>("ticket_8652", ticket_8652[0], ticket_8652[1],
                 1, 4, 0.0003);
 
@@ -289,7 +256,7 @@ void test_areal()
     // mingw 5.6022954e-5
     test_one<Polygon, Polygon, Polygon>("ticket_10108_b",
                 ticket_10108_b[0], ticket_10108_b[1],
-            0, 0, 5.6022983e-5, ut_settings(-1.0));
+            optional(), 0, optional_sliver(1.0e-4));
 
     test_one<Polygon, Polygon, Polygon>("ticket_10747_a",
                 ticket_10747_a[0], ticket_10747_a[1],
@@ -307,11 +274,11 @@ void test_areal()
     // Delivers very small triangle < 1.0e-13, or zero
     test_one<Polygon, Polygon, Polygon>("ticket_10747_e",
                 ticket_10747_e[0], ticket_10747_e[1],
-                BG_IF_RESCALED(1, 0), -1, 1.0e-13, ut_settings(-1.0));
+                optional(), -1, optional_sliver(1.0e-13));
 
     test_one<Polygon, Polygon, Polygon>("ticket_11576",
                 ticket_11576[0], ticket_11576[1],
-                if_typed<ct, float>(0, 1), -1, if_typed<ct, float>(0.0, 5.585617332907136e-07));
+                1, -1, expectation_limits(5.5856173e-07, 5.5856175e-07));
 
     {
         // Not yet valid when rescaling is turned off
@@ -323,7 +290,7 @@ void test_areal()
 
 #if ! defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
     // With rescaling the output is empty
-    TEST_INTERSECTION(issue_548, 1, -1, 1958824415.2151);
+    TEST_INTERSECTION(issue_548, 1, -1, expectation_limits(1958821942, 1958824416));
 #endif
 
     TEST_INTERSECTION(issue_566_a, 1, -1, 70.7107);
@@ -340,18 +307,18 @@ void test_areal()
 
     test_one<Polygon, Polygon, Polygon>("case_80",
         case_80[0], case_80[1],
-        0, -1, 0.0);
+        0, 0, 0.0);
 
     test_one<Polygon, Polygon, Polygon>("case_81",
         case_81[0], case_81[1],
-        0, -1, 0.0);
+        0, 0, 0.0);
 
     test_one<Polygon, Polygon, Polygon>("case_101",
         case_101[0], case_101[1],
-        0, -1, 6.25);
+        1, -1, 6.25);
     test_one<Polygon, Polygon, Polygon>("case_102",
         case_102[0], case_102[1],
-        0, -1, 3.1875);
+        count_set(1, 2), -1, 3.1875);
 
     test_one<Polygon, Polygon, Polygon>("case_103",
         case_103[0], case_103[1],
@@ -364,11 +331,11 @@ void test_areal()
     TEST_INTERSECTION(case_106, 2, -1, 3.5);
     TEST_INTERSECTION(case_107, 3, -1, 3.0);
 
-    TEST_INTERSECTION(case_precision_1, 0, 0, 0.0);
-    TEST_INTERSECTION(case_precision_2, 0, 0, 0.0);
-    TEST_INTERSECTION(case_precision_3, 0, 0, 0.0);
+    TEST_INTERSECTION(case_precision_1, optional(), 0, optional_sliver(1.0e-4));
+    TEST_INTERSECTION(case_precision_2, optional(), 0, optional_sliver(1.0e-5));
+    TEST_INTERSECTION(case_precision_3, optional(), 0, optional_sliver(1.0e-7));
     TEST_INTERSECTION(case_precision_4, 0, 0, 0.0);
-    TEST_INTERSECTION(case_precision_5, 0, 0, 0.0);
+    TEST_INTERSECTION(case_precision_5, optional(), 0, optional_sliver(1.0e-6));
     TEST_INTERSECTION(case_precision_6, 1, -1, 14.0);
     TEST_INTERSECTION(case_precision_7, 0, -1, 0.0);
     TEST_INTERSECTION(case_precision_8, 1, -1, 14.0);
@@ -391,11 +358,11 @@ void test_areal()
     TEST_INTERSECTION(case_precision_25, 0, 0, 0.0);
     TEST_INTERSECTION(case_precision_26, 1, -1, 14.0);
 
-    TEST_INTERSECTION_REV(case_precision_1, 0, 0, 0.0);
-    TEST_INTERSECTION_REV(case_precision_2, 0, 0, 0.0);
-    TEST_INTERSECTION_REV(case_precision_3, 0, 0, 0.0);
+    TEST_INTERSECTION_REV(case_precision_1, optional(), 0, optional_sliver(1.0e-4));
+    TEST_INTERSECTION_REV(case_precision_2, optional(), 0, optional_sliver(1.0e-5));
+    TEST_INTERSECTION_REV(case_precision_3, optional(), 0, optional_sliver(1.0e-7));
     TEST_INTERSECTION_REV(case_precision_4, 0, 0, 0.0);
-    TEST_INTERSECTION_REV(case_precision_5, 0, 0, 0.0);
+    TEST_INTERSECTION_REV(case_precision_5, optional(), 0, optional_sliver(1.0e-6));
     TEST_INTERSECTION_REV(case_precision_6, 1, -1, 14.0);
     TEST_INTERSECTION_REV(case_precision_7, 0, -1, 0.0);
     TEST_INTERSECTION_REV(case_precision_8, 1, -1, 14.0);
@@ -433,13 +400,15 @@ void test_areal()
 
     TEST_INTERSECTION(mysql_23023665_6, 2, 0, 11.812440191387557);
 
+    // Formation of an interior ring is optional
     test_one<Polygon, Polygon, Polygon>("mysql_23023665_10",
         mysql_23023665_10[0], mysql_23023665_10[1],
-        1, 0, -1, 54.701340543162523);
+        1, optional(), -1, 54.701340543162523);
 
+    // Formation of an interior ring is optional
     test_one<Polygon, Polygon, Polygon>("mysql_23023665_11",
         mysql_23023665_11[0], mysql_23023665_11[1],
-        1, 0, -1, 35.933385462482065);
+        1, optional(), -1, 35.933385462482065);
 
 //    test_one<Polygon, Polygon, Polygon>(
 //        "polygon_pseudo_line",
@@ -719,9 +688,6 @@ void test_all()
     typedef bg::model::polygon<P, false, false> polygon_ccw_open;
     boost::ignore_unused<polygon_ccw, polygon_open, polygon_ccw_open>();
 
-    ut_settings ignore_validity;
-    ignore_validity.set_test_validity(false);
-
     std::string clip = "box(2 2,8 8)";
 
     test_areal_linear<polygon, linestring>();
@@ -774,7 +740,8 @@ void test_all()
     test_one<linestring, linestring, box>("llbo", "LINESTRING(9 9,10 10)", clip, 0, 0, 0.0);
 
     // Touching with point (-> output linestring with ONE point)
-    test_one<linestring, linestring, box>("llb_touch", "LINESTRING(8 8,10 10)", clip, 1, 1, 0.0, ignore_validity);
+    test_one<linestring, linestring, box>("llb_touch", "LINESTRING(8 8,10 10)", clip, 1, 1, 0.0,
+                                          ut_settings(0.0001, false));
 
     // Along border
     test_one<linestring, linestring, box>("llb_along", "LINESTRING(2 2,2 8)", clip, 1, 2, 6.0);
@@ -967,7 +934,7 @@ int test_main(int, char* [])
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
     // llb_touch generates a polygon with 1 point and is therefore invalid everywhere
     // TODO: this should be easy to fix
-    BoostGeometryWriteExpectedFailures(4, 3);
+    BoostGeometryWriteExpectedFailures(4, 3, 3, 1);
 #endif
 
     return 0;

--- a/test/algorithms/set_operations/intersection/intersection_multi.cpp
+++ b/test/algorithms/set_operations/intersection/intersection_multi.cpp
@@ -350,21 +350,16 @@ void test_areal()
 
     test_one<Polygon, MultiPolygon, MultiPolygon>("ticket_9081",
         ticket_9081[0], ticket_9081[1],
-        2, 10, 0.0019812556);
+        count_set(2, 4), 10, 0.0019812556);
 
     // Should generate output, even for <float>
+    // For long double two small extra slivers are generated
     test_one<Polygon, MultiPolygon, MultiPolygon>("mail_2019_01_21_johan",
         mail_2019_01_21_johan[2], mail_2019_01_21_johan[3],
-        2, -1, 0.0005889587);
+        count_set(2, 4), -1, 0.0005889587);
 
-    // Very small slice is generated.
-    // qcc-arm reports 1.7791215549400884e-14
-    // With rescaling, generates very small triangle
-    test_one<Polygon, MultiPolygon, MultiPolygon>("ticket_11018",
-        ticket_11018[0], ticket_11018[1],
-        BG_IF_RESCALED(1, 0), 0,
-        1.0e-8, ut_settings(-1)
-    );
+    // Might generate a very small triangle, which is acceptable
+    TEST_INTERSECTION(ticket_11018, count_set(0, 1), 0, expectation_limits(0.0, 4.0e-7));
 
     TEST_INTERSECTION(ticket_12503, 2, 13, 17.375);
 
@@ -374,7 +369,7 @@ void test_areal()
 #endif
 #if ! defined(BOOST_GEOMETRY_USE_KRAMER_RULE) || defined(BOOST_GEOMETRY_TEST_FAILURES)
     // Two cases produce either too large, or no output if Kramer rule is used
-    TEST_INTERSECTION(issue_630_b, 1, -1, BG_IF_KRAMER(0.1714, 0.1713911));
+    TEST_INTERSECTION(issue_630_b, 1, -1, expectation_limits(0.1713911, 0.1714));
     TEST_INTERSECTION(issue_630_c, 1, -1, 0.1770);
 #endif
 
@@ -491,8 +486,6 @@ void test_all()
 #endif
 
     test_point_output<P>();
-    // linear
-
 }
 
 
@@ -506,7 +499,7 @@ int test_main(int, char* [])
 #endif
 
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(10, 4);
+    BoostGeometryWriteExpectedFailures(9, 3, 2, 1);
 #endif
 
     return 0;

--- a/test/algorithms/set_operations/intersection/test_intersection.hpp
+++ b/test/algorithms/set_operations/intersection/test_intersection.hpp
@@ -40,6 +40,8 @@
 #endif
 
 #include <geometry_test_common.hpp>
+#include <count_set.hpp>
+#include <expectation_limits.hpp>
 #include <algorithms/check_validity.hpp>
 #include "../setop_output_type.hpp"
 
@@ -60,8 +62,8 @@ template<typename IntersectionOutput, typename G1, typename G2>
 void check_result(IntersectionOutput const& intersection_output,
     std::string const& caseid,
     G1 const& g1, G2 const& g2,
-    std::size_t expected_count, std::size_t expected_holes_count,
-    int expected_point_count, double expected_length_or_area,
+    const count_set& expected_count, const count_set& expected_hole_count,
+    int expected_point_count, expectation_limits const& expected_length_or_area,
     ut_settings const& settings)
 {
     typedef typename boost::range_value<IntersectionOutput>::type OutputType;
@@ -74,14 +76,14 @@ void check_result(IntersectionOutput const& intersection_output,
             it != intersection_output.end();
             ++it)
     {
-        if (expected_point_count > 0)
+      if (! expected_count.empty())
         {
             // here n should rather be of type std::size_t, but expected_point_count
             // is set to -1 in some test cases so type int was left for now
             n += static_cast<int>(bg::num_points(*it, true));
         }
 
-        if (expected_holes_count > 0)
+        if (! expected_hole_count.empty())
         {
             nholes += bg::num_interior_rings(*it);
         }
@@ -122,46 +124,31 @@ void check_result(IntersectionOutput const& intersection_output,
     }
 #endif
 
-    if (expected_count > 0)
+    if (! expected_count.empty())
     {
-        BOOST_CHECK_MESSAGE(intersection_output.size() == expected_count,
-                "intersection: " << caseid
-                << " #outputs expected: " << expected_count
-                << " detected: " << intersection_output.size()
-                << " type: " << (type_for_assert_message<G1, G2>())
-                );
+        BOOST_CHECK_MESSAGE(expected_count.has(intersection_output.size()),
+                            "intersection: " << caseid
+                            << " #outputs expected: " << expected_count
+                            << " detected: " << intersection_output.size()
+                            << " type: " << (type_for_assert_message<G1, G2>())
+                            );
     }
 
-    if (expected_holes_count > 0)
+    if (! expected_hole_count.empty())
     {
-
-        BOOST_CHECK_MESSAGE(nholes == expected_holes_count,
+        BOOST_CHECK_MESSAGE(expected_hole_count.has(nholes),
             "intersection: " << caseid
-            << " #holes expected: " << expected_holes_count
+            << " #holes expected: " << expected_hole_count
             << " detected: " << nholes
             << " type: " << (type_for_assert_message<G1, G2>())
         );
     }
 
-    double const detected_length_or_area = boost::numeric_cast<double>(length_or_area);
-    if (settings.percentage > 0.0)
-    {
-        if (expected_length_or_area > 0)
-        {
-            BOOST_CHECK_CLOSE(detected_length_or_area, expected_length_or_area, settings.percentage);
-        }
-        else
-        {
-            // Compare 0 with 0 or a very small detected area
-            BOOST_CHECK_LE(detected_length_or_area, settings.percentage);
-        }
-    }
-    else
-    {
-        // In some cases (geos_2) the intersection is either 0, or a tiny rectangle,
-        // depending on compiler/settings. That cannot be tested by CLOSE
-        BOOST_CHECK_LE(detected_length_or_area, expected_length_or_area);
-    }
+    BOOST_CHECK_MESSAGE(expected_length_or_area.contains(length_or_area, settings.percentage),
+            "intersection: " << caseid << std::setprecision(20)
+            << " #area expected: " << expected_length_or_area
+            << " detected: " << length_or_area
+            << " type: " << (type_for_assert_message<G1, G2>()));
 #endif
 
 }
@@ -170,8 +157,9 @@ void check_result(IntersectionOutput const& intersection_output,
 template <typename OutputType, typename CalculationType, typename G1, typename G2>
 typename bg::default_area_result<G1>::type test_intersection(std::string const& caseid,
         G1 const& g1, G2 const& g2,
-        std::size_t expected_count = 0, std::size_t expected_holes_count = 0,
-        int expected_point_count = 0, double expected_length_or_area = 0,
+        const count_set& expected_count = count_set(),
+        const count_set& expected_hole_count = count_set(),
+        int expected_point_count = 0, expectation_limits const& expected_length_or_area = 0,
         ut_settings const& settings = ut_settings())
 {
     if (settings.debug)
@@ -204,7 +192,7 @@ typename bg::default_area_result<G1>::type test_intersection(std::string const& 
     bg::intersection(g1, g2, intersection_output);
 
     check_result(intersection_output, caseid, g1, g2, expected_count,
-        expected_holes_count, expected_point_count, expected_length_or_area,
+        expected_hole_count, expected_point_count, expected_length_or_area,
         settings);
 
 #if ! defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE)
@@ -213,21 +201,21 @@ typename bg::default_area_result<G1>::type test_intersection(std::string const& 
     bg::intersection(boost::variant<G1>(g1), g2, intersection_output);
 
     check_result(intersection_output, caseid, g1, g2, expected_count,
-        expected_holes_count, expected_point_count, expected_length_or_area,
+        expected_hole_count, expected_point_count, expected_length_or_area,
         settings);
 
     intersection_output.clear();
     bg::intersection(g1, boost::variant<G2>(g2), intersection_output);
 
     check_result(intersection_output, caseid, g1, g2, expected_count,
-        expected_holes_count, expected_point_count, expected_length_or_area,
+        expected_hole_count, expected_point_count, expected_length_or_area,
         settings);
 
     intersection_output.clear();
     bg::intersection(boost::variant<G1>(g1), boost::variant<G2>(g2), intersection_output);
 
     check_result(intersection_output, caseid, g1, g2, expected_count,
-        expected_holes_count, expected_point_count, expected_length_or_area,
+        expected_hole_count, expected_point_count, expected_length_or_area,
         settings);
 #endif
 
@@ -290,21 +278,24 @@ typename bg::default_area_result<G1>::type test_intersection(std::string const& 
 template <typename OutputType, typename CalculationType, typename G1, typename G2>
 typename bg::default_area_result<G1>::type test_intersection(std::string const& caseid,
         G1 const& g1, G2 const& g2,
-        std::size_t expected_count = 0, int expected_point_count = 0,
-        double expected_length_or_area = 0,
+        const count_set& expected_count = count_set(), int expected_point_count = 0,
+        expectation_limits const& expected_length_or_area = 0,
         ut_settings const& settings = ut_settings())
 {
     return test_intersection<OutputType, CalculationType>(
-        caseid, g1, g2, expected_count, 0, expected_point_count,
+        caseid, g1, g2, expected_count, count_set(), expected_point_count,
         expected_length_or_area, settings
     );
 }
 
+// Version with expected hole count
 template <typename OutputType, typename G1, typename G2>
 typename bg::default_area_result<G1>::type test_one(std::string const& caseid,
         std::string const& wkt1, std::string const& wkt2,
-        std::size_t expected_count = 0, std::size_t expected_holes_count = 0,
-        int expected_point_count = 0, double expected_length_or_area = 0,
+        const count_set& expected_count,
+        const count_set& expected_hole_count,
+        int expected_point_count,
+        expectation_limits const& expected_length_or_area,
         ut_settings const& settings = ut_settings())
 {
     G1 g1;
@@ -318,19 +309,21 @@ typename bg::default_area_result<G1>::type test_one(std::string const& caseid,
     bg::correct(g2);
 
     return test_intersection<OutputType, void>(caseid, g1, g2,
-        expected_count, expected_holes_count, expected_point_count,
+        expected_count, expected_hole_count, expected_point_count,
         expected_length_or_area, settings);
 }
 
+// Version without expected hole count
 template <typename OutputType, typename G1, typename G2>
 typename bg::default_area_result<G1>::type test_one(std::string const& caseid,
     std::string const& wkt1, std::string const& wkt2,
-    std::size_t expected_count = 0, int expected_point_count = 0,
-    double expected_length_or_area = 0,
+    const count_set& expected_count,
+    int expected_point_count,
+    expectation_limits const& expected_length_or_area,
     ut_settings const& settings = ut_settings())
 {
     return test_one<OutputType, G1, G2>(caseid, wkt1, wkt2,
-        expected_count, 0, expected_point_count,
+        expected_count, count_set(), expected_point_count,
         expected_length_or_area,
         settings);
 }
@@ -338,8 +331,8 @@ typename bg::default_area_result<G1>::type test_one(std::string const& caseid,
 template <typename OutputType, typename Areal, typename Linear>
 void test_one_lp(std::string const& caseid,
         std::string const& wkt_areal, std::string const& wkt_linear,
-        std::size_t expected_count = 0, int expected_point_count = 0,
-        double expected_length = 0,
+        const count_set& expected_count = count_set(), int expected_point_count = 0,
+        expectation_limits const& expected_length = 0,
         ut_settings const& settings = ut_settings())
 {
 #ifdef BOOST_GEOMETRY_TEST_DEBUG

--- a/test/algorithms/set_operations/union/union.cpp
+++ b/test/algorithms/set_operations/union/union.cpp
@@ -30,22 +30,25 @@
     (test_one<Polygon, Polygon, Polygon>) \
     ( #caseid, caseid[0], caseid[1], clips, holes, points, area)
 
+#define TEST_UNION_WITH(caseid, clips, holes, points, area) \
+    (test_one<Polygon, Polygon, Polygon>) \
+    ( #caseid, caseid[0], caseid[1], clips, holes, points, area, settings)
+
 #define TEST_UNION_REV(caseid, clips, holes, points, area) \
     (test_one<Polygon, Polygon, Polygon>) \
     ( #caseid "_rev", caseid[1], caseid[0], clips, holes, points, area)
-
-#if ! defined(BOOST_GEOMETRY_USE_RESCALING) \
-    && defined(BOOST_GEOMETRY_USE_KRAMER_RULE) \
-    && ! defined(BOOST_GEOMETRY_TEST_FAILURES)
-// These testcases are failing for non-rescaled Kramer rule
-#define BOOST_GEOMETRY_EXCLUDE
-#endif
 
 
 template <typename Ring, typename Polygon>
 void test_areal()
 {
     typedef typename bg::coordinate_type<Polygon>::type ct;
+
+    ut_settings ignore_validity_for_float;
+    if (BOOST_GEOMETRY_CONDITION((boost::is_same<ct, float>::value)) )
+    {
+        ignore_validity_for_float.set_test_validity(false);
+    }
 
     test_one<Polygon, Polygon, Polygon>("simplex_normal",
         simplex_normal[0], simplex_normal[1],
@@ -63,8 +66,7 @@ void test_areal()
 
     // This sample was selected because of the border case.
     test_one<Polygon, Polygon, Polygon>("star_poly", example_star, example_polygon,
-        1, 1,
-        27, 5.647949);
+        1, 1, -1, 5.647949);
 
     // Pseudo-box as Polygon
     // (note, internally, the intersection points is different, so yes,
@@ -365,29 +367,18 @@ void test_areal()
         ggl_list_20110716_enrico[0], ggl_list_20110716_enrico[1],
         1, 1, 15, 129904.197692871);
 
-#if ! defined(BOOST_GEOMETRY_EXCLUDE)
-    test_one<Polygon, Polygon, Polygon>("ggl_list_20110820_christophe",
-        ggl_list_20110820_christophe[0], ggl_list_20110820_christophe[1],
-        -1, // Either 1 or 2, depending if the intersection/turn point (eps.region) is missed
-        0,
-        8,
-        67.3550722317627);
+#if defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
+     // Either 1 or 2, depending if the intersection/turn point (eps.region) is missed
+    TEST_UNION(ggl_list_20110820_christophe, count_set(1, 2), 0, -1, 67.3550722317627);
 #endif
 
     {
-        ut_settings settings;
-        settings.percentage = 0.1;
-        settings.set_test_validity(BG_IF_RESCALED(true, false));
-
-        test_one<Polygon, Polygon, Polygon>("isovist",
-            isovist1[0], isovist1[1],
-            1,
-            0,
-            -1,
-            313.36036462, settings);
-
         // SQL Server gives: 313.360374193241
         // PostGIS gives:    313.360364623393
+        // Without rescaling, it is creates an invalidity for double
+        ut_settings settings;
+        settings.set_test_validity(BG_IF_RESCALED(true, false));
+        TEST_UNION_WITH(isovist, 1, 0, -1, 313.36036462);
     }
 
     TEST_UNION(ggl_list_20190307_matthieu_1, 1, 1, -1, 0.83773);
@@ -405,50 +396,31 @@ void test_areal()
     // It is in two points 0.37 off (logical for an int).
     // Because of the width of the polygon (400000 meter)
     // this causes a substantial difference.
+    TEST_UNION(ticket_5103, 1, 0, 25, 2515271327070.5);
 
-    test_one<Polygon, Polygon, Polygon>("ticket_5103",
-                ticket_5103[0], ticket_5103[1],
-                1, 0, 25, 2515271327070.5);
+    TEST_UNION(ticket_8310a, 1, 0, -1, 10.5000019595);
+    TEST_UNION(ticket_8310b, 1, 0, -1, 10.5000019595);
+    TEST_UNION(ticket_8310c, 1, 0, -1, 10.5000019595);
+    TEST_UNION_REV(ticket_8310a, 1, 0, -1, 10.5000019595);
+    TEST_UNION_REV(ticket_8310b, 1, 0, -1, 10.5000019595);
+    TEST_UNION_REV(ticket_8310c, 1, 0, -1, 10.5000019595);
 
-    TEST_UNION(ticket_8310a, 1, 0, 5, 10.5000019595);
-    TEST_UNION(ticket_8310b, 1, 0, 5, 10.5000019595);
-    TEST_UNION(ticket_8310c, 1, 0, 5, 10.5000019595);
-    TEST_UNION_REV(ticket_8310a, 1, 0, 5, 10.5000019595);
-    TEST_UNION_REV(ticket_8310b, 1, 0, 5, 10.5000019595);
-    TEST_UNION_REV(ticket_8310c, 1, 0, 5, 10.5000019595);
+    TEST_UNION(ticket_9081_15, 1, 0, -1, 0.0403425433);
 
-    test_one<Polygon, Polygon, Polygon>("ticket_9081_15",
-            ticket_9081_15[0], ticket_9081_15[1],
-            1, 0, -1, 0.0403425433);
+    TEST_UNION(ticket_9563, 1, 0, -1, 150.0);
 
-    {
-        ut_settings settings;
-        settings.set_test_validity(BG_IF_RESCALED(true, false));
-        test_one<Polygon, Polygon, Polygon>("ticket_9563", ticket_9563[0], ticket_9563[1],
-                1, 0, 13, 150.0, settings);
-    }
-
-    // Float result is OK but a bit larger
-    test_one<Polygon, Polygon, Polygon>("ticket_9756", ticket_9756[0], ticket_9756[1],
-            1, 0, 10, if_typed<ct, float>(1291.5469, 1289.08374));
+    TEST_UNION(ticket_9756, 1, 0, 10, expectation_limits(1289.0835, 1290.40625));
 
     // Can generate one polygon, or two splitted, both is OK
-#if ! defined(BOOST_GEOMETRY_USE_KRAMER_RULE)
-    TEST_UNION(ticket_10108_a, 2, 0, 8, 0.0435229);
-    TEST_UNION(ticket_10108_b, 1, 0, 10, 2424.3449);
-#else
-    TEST_UNION(ticket_10108_a,  BG_IF_RESCALED(2, 1), 0, 8, 0.0435229);
-    TEST_UNION(ticket_10108_b,  BG_IF_RESCALED(1, 2), 0, 10, 2424.3449);
-#endif
+    TEST_UNION(ticket_10108_a, count_set(1, 2), 0, 8, 0.0435229);
+    TEST_UNION(ticket_10108_b, count_set(1, 2), 0, 10, 2424.3449);
 
-    test_one<Polygon, Polygon, Polygon>("ticket_10866", ticket_10866[0], ticket_10866[1],
-            1, 0, 14, if_typed<ct, float>(332752493.0, 332760303.5));
+    TEST_UNION(ticket_10866, 1, 0, 14, 332760303.5);
 
-    test_one<Polygon, Polygon, Polygon>("ticket_11725", ticket_11725[0], ticket_11725[1],
-            1, 1, 10, 7.5);
+    TEST_UNION(ticket_11725, 1, 1, 10, 7.5);
 
 #if ! defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
-    // With rescaling an extra overlapping polygon is generated
+    // With rescaling an extra overlapping polygon is generated, which is wrong
     TEST_UNION(issue_548, 1, 0, -1, 617382720000);
 #endif
 
@@ -457,21 +429,15 @@ void test_areal()
     TEST_UNION_REV(issue_566_a, 1, 0, -1, 214.3728);
     TEST_UNION_REV(issue_566_b, 1, 0, -1, 214.3728);
 
-    if (! BOOST_GEOMETRY_CONDITION((boost::is_same<ct, float>::value)) )
     {
-        ut_settings ignore_validity;
-        ignore_validity.set_test_validity(false);
-        ignore_validity.percentage = 0.01;
-        test_one<Polygon, Polygon, Polygon>("geos_1", geos_1[0], geos_1[1],
-                1, 0, -1, 3461.3203125,
-                ignore_validity);
+        // Rescaling produces an invalid result
+        ut_settings settings;
+        settings.set_test_validity(BG_IF_RESCALED(false, true));
+        TEST_UNION_WITH(geos_1, 1, 0, -1, expectation_limits(3458.0, 3461.3203125));
     }
-    test_one<Polygon, Polygon, Polygon>("geos_2", geos_2[0], geos_2[1],
-            1, 0, -1, 350.55102539);
-    test_one<Polygon, Polygon, Polygon>("geos_3", geos_3[0], geos_3[1],
-            1, 0, -1, 29391548.4998779);
-    test_one<Polygon, Polygon, Polygon>("geos_4", geos_4[0], geos_4[1],
-            1, 0, -1, 2304.4163115);
+    TEST_UNION(geos_2, 1, 0, -1, expectation_limits(349.0625, 350.55102539));
+    TEST_UNION(geos_3, 1, 0, -1, 29391548.4998779);
+    TEST_UNION(geos_4, 1, 0, -1, 2304.4163115);
 
     // Robustness issues, followed out buffer-robustness-tests, test them also reverse
     {
@@ -528,10 +494,10 @@ void test_areal()
     test_one<Polygon, Polygon, Polygon>("buffer_rt_t", buffer_rt_t[0], buffer_rt_t[1],
                 1, 0, -1, 15.6569);
     test_one<Polygon, Polygon, Polygon>("buffer_rt_t_rev", buffer_rt_t[1], buffer_rt_t[0],
-                1, 0, -1, 15.6569);
+                1, 0, -1, 15.6569, ignore_validity_for_float);
 
     test_one<Polygon, Polygon, Polygon>("buffer_mp1", buffer_mp1[0], buffer_mp1[1],
-                1, 0, 91, 22.815);
+                1, 0, -1, 22.815);
 
     test_one<Polygon, Polygon, Polygon>("buffer_mp2", buffer_mp2[0], buffer_mp2[1],
                 1, -1, 217, 36.752837);
@@ -627,7 +593,7 @@ int test_main(int, char* [])
 #endif
 
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(3, 4);
+    BoostGeometryWriteExpectedFailures(3, 5, 1, 0);
 #endif
 
     return 0;

--- a/test/algorithms/set_operations/union/union_multi.cpp
+++ b/test/algorithms/set_operations/union/union_multi.cpp
@@ -424,7 +424,7 @@ void test_areal()
 #endif
     TEST_UNION(issue_630_b, 1, 0, -1, 1.675976);
 #if ! defined(BOOST_GEOMETRY_USE_KRAMER_RULE) || defined(BOOST_GEOMETRY_TEST_FAILURES)
-    // Failure with Kramer rule
+    // Failure with Kramer rule, it doesn't generate any output
     TEST_UNION(issue_630_c, 1, 0, -1, 1.670367);
 #endif
 
@@ -489,7 +489,7 @@ int test_main(int, char* [])
 #endif
 
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(9, 2);
+    BoostGeometryWriteExpectedFailures(9, 2, 5, 0);
 #endif
 
     return 0;

--- a/test/count_set.hpp
+++ b/test/count_set.hpp
@@ -41,6 +41,13 @@ struct count_set
         m_values.insert(value2);
     }
 
+    count_set(std::size_t value1, std::size_t value2, std::size_t value3)
+    {
+        m_values.insert(value1);
+        m_values.insert(value2);
+        m_values.insert(value3);
+    }
+
     bool empty() const { return m_values.empty(); }
 
     bool has(std::size_t value) const

--- a/test/expectation_limits.hpp
+++ b/test/expectation_limits.hpp
@@ -1,0 +1,100 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2020 Barend Gehrels, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef GEOMETRY_TEST_EXPECTATION_LIMITS_HPP
+#define GEOMETRY_TEST_EXPECTATION_LIMITS_HPP
+
+#include <boost/geometry/util/math.hpp>
+
+#include <ostream>
+
+// Structure to manage expectations: there might be small variations in area, for different
+// types or options, which are all acceptable. With tolerance this is inconvenient.
+// The values are stored as doubles, but the member functions accept any type,
+// also for example Boost.MultiPrecision types
+struct expectation_limits
+{
+    expectation_limits(double expectation)
+        : m_lower_limit(expectation)
+        , m_upper_limit(expectation)
+    {
+    }
+
+    expectation_limits(double lower_limit, double upper_limit)
+        : m_lower_limit(lower_limit)
+        , m_upper_limit(upper_limit)
+    {
+    }
+
+    double get() const { return m_lower_limit; }
+
+    bool is_zero() const { return m_lower_limit < 1.0e-8; }
+
+    bool has_two_limits() const { return m_lower_limit < m_upper_limit; }
+
+    template<typename T>
+    bool contains_logarithmic(const T& value, double tolerance) const
+    {
+      return abs(log(value) - std::log(m_lower_limit)) < tolerance;
+    }
+
+    template<typename T>
+    bool contains(const T& value, double percentage, bool logarithmic = false) const
+    {
+        if (m_upper_limit < 1.0e-8)
+        {
+            return value < 1.0e-8;
+        }
+        if (logarithmic)
+        {
+            return contains_logarithmic(value, percentage);
+        }
+
+        // Note the > and <= and percentages, this is to make it exactly equivalent to
+        // BOOST_CHECK_CLOSE(m_lower_limit, value, percentage) (if lower == upper)
+        // But for two limits and optional slivers, >= is needed (for 0.00)
+        double const fraction = percentage / 100.0;
+        double const lower_limit = m_lower_limit * (1.0 - fraction);
+        double const upper_limit = m_upper_limit * (1.0 + fraction);
+        return has_two_limits()
+                ? value >= lower_limit && value <= upper_limit
+                : value > lower_limit && value <= upper_limit;
+    }
+
+    expectation_limits operator+(const expectation_limits& a) const
+    {
+        return this->has_two_limits() || a.has_two_limits()
+                ? expectation_limits(this->m_lower_limit + a.m_lower_limit,
+                                     this->m_upper_limit + a.m_upper_limit)
+                : expectation_limits(this->m_lower_limit + a.m_lower_limit);
+    }
+
+    friend std::ostream &operator<<(std::ostream &os, const expectation_limits& lim)
+    {
+        if (lim.has_two_limits())
+        {
+            os << "[" << lim.m_lower_limit << " .. " << lim.m_upper_limit << "]";
+        }
+        else
+        {
+            os << lim.m_lower_limit;
+        }
+        return os;
+    }
+
+private :
+    double const m_lower_limit;
+    double const m_upper_limit;
+};
+
+inline expectation_limits optional_sliver(double upper_limit = 1.0e-4)
+{
+    return expectation_limits(0, upper_limit);
+}
+
+#endif // GEOMETRY_TEST_EXPECTATION_LIMITS_HPP

--- a/test/geometry_test_common.hpp
+++ b/test/geometry_test_common.hpp
@@ -94,12 +94,6 @@
 namespace bg = boost::geometry;
 
 
-template <typename CoordinateType, typename Specified, typename T>
-inline T if_typed(T value_typed, T value)
-{
-    return boost::is_same<CoordinateType, Specified>::value ? value_typed : value;
-}
-
 template <typename Geometry1, typename Geometry2>
 inline std::string type_for_assert_message()
 {
@@ -162,27 +156,36 @@ private :
     bool m_test_validity;
 };
 
+//! Type used for tests using high precision numbers
+using mp_test_type = boost::multiprecision::cpp_bin_float_100;
 
-typedef boost::multiprecision::cpp_bin_float_100 mp_test_type;
-typedef double default_test_type;
+//! Default type for tests, can optionally be specified on the command line
+//! e.g. float, "long double", mp_test_type
+#if defined(BOOST_GEOMETRY_DEFAULT_TEST_TYPE)
+using default_test_type = BOOST_GEOMETRY_DEFAULT_TEST_TYPE;
+#else
+using default_test_type = double;
+#endif
 
+//! Compile time function for expectations depending on type
+template <typename CoordinateType, typename Specified, typename T>
+inline T if_typed(T value_typed, T value)
+{
+    return boost::is_same<CoordinateType, Specified>::value ? value_typed : value;
+}
+
+//! Compile time function for expectations depending on high precision
 template <typename CoordinateType, typename T1, typename T2>
 inline T1 const& bg_if_mp(T1 const& value_mp, T2 const& value)
 {
     return boost::is_same<CoordinateType, mp_test_type>::type::value ? value_mp : value;
 }
 
-
+//! Macro for expectations depending on rescaling
 #if defined(BOOST_GEOMETRY_USE_RESCALING)
 #define BG_IF_RESCALED(a, b) a
 #else
 #define BG_IF_RESCALED(a, b) b
-#endif
-
-#if defined(BOOST_GEOMETRY_USE_KRAMER_RULE)
-#define BG_IF_KRAMER(a, b) a
-#else
-#define BG_IF_KRAMER(a, b) b
 #endif
 
 inline void BoostGeometryWriteTestConfiguration()
@@ -212,19 +215,35 @@ inline void BoostGeometryWriteTestConfiguration()
 #ifdef BOOST_GEOMETRY_TEST_FAILURES
 #define BG_NO_FAILURES 0
 inline void BoostGeometryWriteExpectedFailures(std::size_t for_rescaling,
-                std::size_t for_no_rescaling = BG_NO_FAILURES)
+                                               std::size_t for_no_rescaling_double,
+                                               std::size_t for_no_rescaling_float,
+                                               std::size_t for_no_rescaling_extended)
 {
-    boost::ignore_unused(for_rescaling, for_no_rescaling);
+    std::size_t const for_no_rescaling
+        = if_typed<default_test_type, double>(for_no_rescaling_double,
+              if_typed<default_test_type, float>(for_no_rescaling_float,
+                  for_no_rescaling_extended));
 
-#if defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE) && defined(BOOST_GEOMETRY_TEST_ONLY_ONE_ORDER)
-    std::cout << std::endl;
+    boost::ignore_unused(for_rescaling, for_no_rescaling, for_no_rescaling_double,
+                         for_no_rescaling_float, for_no_rescaling_extended);
+
+
 #if defined(BOOST_GEOMETRY_USE_RESCALING)
     std::cout << "RESCALED - Expected: " << for_rescaling << " error(s)" << std::endl;
-#else
+#elif defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE) && defined(BOOST_GEOMETRY_TEST_ONLY_ONE_ORDER)
     std::cout << "NOT RESCALED - Expected: " << for_no_rescaling << " error(s)" << std::endl;
-#endif
+#else
+    std::cout << std::endl;
 #endif
 }
+
+inline void BoostGeometryWriteExpectedFailures(std::size_t for_rescaling,
+                                               std::size_t for_no_rescaling_double = BG_NO_FAILURES)
+{
+    BoostGeometryWriteExpectedFailures(for_rescaling, for_no_rescaling_double,
+                                       for_no_rescaling_double, for_no_rescaling_double);
+}
+
 #endif
 
 #endif // GEOMETRY_TEST_GEOMETRY_TEST_COMMON_HPP


### PR DESCRIPTION
I was already busy with this before the rework on buffer.

This is preparing a next commit and avoiding many ifdefs for situations which are OK (just for float a bit more slack, or for more precise types a different amount of output rings or small slivers.

Also you can see the state - often without rescaling tests perform better than with. But I still have to verify all robustness tests too, and there is a PR in preparation to include start turns, which can be necessary in some cases (if rescaling if removed)