### PR TITLE
Replace MPL_ASSERT with std static_assert.

### DIFF
--- a/include/boost/geometry/algorithms/area.hpp
+++ b/include/boost/geometry/algorithms/area.hpp
@@ -21,8 +21,9 @@
 
 #include <boost/concept_check.hpp>
 #include <boost/core/ignore_unused.hpp>
-#include <boost/range/functions.hpp>
-#include <boost/range/metafunctions.hpp>
+#include <boost/range/begin.hpp>
+#include <boost/range/end.hpp>
+#include <boost/range/value_type.hpp>
 
 #include <boost/variant/apply_visitor.hpp>
 #include <boost/variant/static_visitor.hpp>

--- a/include/boost/geometry/algorithms/assign.hpp
+++ b/include/boost/geometry/algorithms/assign.hpp
@@ -24,7 +24,6 @@
 
 #include <boost/concept/requires.hpp>
 #include <boost/concept_check.hpp>
-#include <boost/mpl/assert.hpp>
 #include <boost/numeric/conversion/bounds.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 
@@ -41,6 +40,7 @@
 #include <boost/geometry/arithmetic/arithmetic.hpp>
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/exterior_ring.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/geometries/concepts/check.hpp>
@@ -236,20 +236,16 @@ struct assign
             
         static bool const same_point_order
             = point_order<Geometry1>::value == point_order<Geometry2>::value;
-        BOOST_MPL_ASSERT_MSG
-        (
-            (same_point_order),
-            ASSIGN_IS_NOT_SUPPORTED_FOR_DIFFERENT_POINT_ORDER,
-            (types<Geometry1, Geometry2>)
-        );
+        BOOST_GEOMETRY_STATIC_ASSERT(
+            same_point_order,
+            "Assign is not supported for different point orders.",
+            Geometry1, Geometry2);
         static bool const same_closure
             = closure<Geometry1>::value == closure<Geometry2>::value;
-        BOOST_MPL_ASSERT_MSG
-        (
-            (same_closure),
-            ASSIGN_IS_NOT_SUPPORTED_FOR_DIFFERENT_CLOSURE,
-            (types<Geometry1, Geometry2>)
-        );
+        BOOST_GEOMETRY_STATIC_ASSERT(
+            same_closure,
+            "Assign is not supported for different closures.",
+            Geometry1, Geometry2);
             
         dispatch::convert<Geometry2, Geometry1>::apply(geometry2, geometry1);
     }

--- a/include/boost/geometry/algorithms/correct.hpp
+++ b/include/boost/geometry/algorithms/correct.hpp
@@ -24,7 +24,6 @@
 #include <cstddef>
 #include <functional>
 
-#include <boost/mpl/assert.hpp>
 #include <boost/range.hpp>
 
 #include <boost/variant/apply_visitor.hpp>

--- a/include/boost/geometry/algorithms/detail/assign_values.hpp
+++ b/include/boost/geometry/algorithms/detail/assign_values.hpp
@@ -22,10 +22,10 @@
 
 
 #include <cstddef>
+#include <type_traits>
 
 #include <boost/concept/requires.hpp>
 #include <boost/concept_check.hpp>
-#include <boost/mpl/assert.hpp>
 #include <boost/numeric/conversion/bounds.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 
@@ -34,10 +34,10 @@
 #include <boost/geometry/algorithms/clear.hpp>
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/exterior_ring.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/geometries/concepts/check.hpp>
-
 
 #include <boost/geometry/util/is_inverse_spheroidal_coordinates.hpp>
 #include <boost/geometry/util/for_each_coordinate.hpp>
@@ -254,11 +254,9 @@ namespace dispatch
 template <typename GeometryTag, typename Geometry, std::size_t DimensionCount>
 struct assign
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_OR_NOT_YET_IMPLEMENTED_FOR_THIS_GEOMETRY_TYPE
-            , (types<Geometry>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not or not yet implemented for this Geometry type.",
+        GeometryTag, Geometry, std::integral_constant<std::size_t, DimensionCount>);
 };
 
 template <typename Point>

--- a/include/boost/geometry/algorithms/detail/calculate_point_order.hpp
+++ b/include/boost/geometry/algorithms/detail/calculate_point_order.hpp
@@ -13,11 +13,10 @@
 
 #include <vector>
 
-#include <boost/mpl/assert.hpp>
-
 #include <boost/geometry/algorithms/area.hpp>
 #include <boost/geometry/core/point_order.hpp>
 #include <boost/geometry/core/radian_access.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/strategies/geographic/point_order.hpp>
 #include <boost/geometry/util/math.hpp>
 #include <boost/geometry/util/range.hpp>
@@ -323,10 +322,9 @@ template
 >
 struct calculate_point_order
 {
-    BOOST_MPL_ASSERT_MSG
-    (
-        false, NOT_IMPLEMENTED_FOR_THIS_TAG, (types<VersionTag>)
-    );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this VersionTag.",
+        VersionTag);
 };
 
 template <typename Strategy>

--- a/include/boost/geometry/algorithms/detail/direction_code.hpp
+++ b/include/boost/geometry/algorithms/detail/direction_code.hpp
@@ -19,13 +19,12 @@
 #include <type_traits>
 
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/arithmetic/infinite_line_functions.hpp>
 #include <boost/geometry/algorithms/detail/make/make.hpp>
 #include <boost/geometry/util/math.hpp>
 #include <boost/geometry/util/select_coordinate_type.hpp>
 #include <boost/geometry/util/normalize_spheroidal_coordinates.hpp>
-
-#include <boost/mpl/assert.hpp>
 
 
 namespace boost { namespace geometry
@@ -39,7 +38,9 @@ namespace detail
 template <typename CSTag>
 struct direction_code_impl
 {
-    BOOST_MPL_ASSERT_MSG((false), NOT_IMPLEMENTED_FOR_THIS_CS, (CSTag));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this coordinate system.",
+        CSTag);
 };
 
 template <>
@@ -93,9 +94,10 @@ struct direction_code_impl<spherical_equatorial_tag>
         typedef typename coordinate_type<Point2>::type coord2_t;
         typedef typename cs_angular_units<Point1>::type units_t;
         typedef typename cs_angular_units<Point2>::type units2_t;
-        BOOST_MPL_ASSERT_MSG((std::is_same<units_t, units2_t>::value),
-                             NOT_IMPLEMENTED_FOR_DIFFERENT_UNITS,
-                             (units_t, units2_t));
+        BOOST_GEOMETRY_STATIC_ASSERT(
+            (std::is_same<units_t, units2_t>::value),
+            "Not implemented for different units.",
+            units_t, units2_t);
 
         typedef typename geometry::select_coordinate_type <Point1, Point2>::type calc_t;
         typedef math::detail::constants_on_spheroid<coord1_t, units_t> constants1;

--- a/include/boost/geometry/algorithms/detail/disjoint/multipoint_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/multipoint_geometry.hpp
@@ -15,8 +15,10 @@
 #include <algorithm>
 #include <vector>
 
-#include <boost/range.hpp>
-#include <boost/mpl/assert.hpp>
+#include <boost/range/begin.hpp>
+#include <boost/range/end.hpp>
+#include <boost/range/size.hpp>
+#include <boost/range/value_type.hpp>
 
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/tag.hpp>

--- a/include/boost/geometry/algorithms/detail/for_each_range.hpp
+++ b/include/boost/geometry/algorithms/detail/for_each_range.hpp
@@ -24,10 +24,10 @@
 
 #include <boost/concept/requires.hpp>
 #include <boost/core/addressof.hpp>
-#include <boost/mpl/assert.hpp>
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tag_cast.hpp>
 #include <boost/geometry/core/tags.hpp>
@@ -138,11 +138,9 @@ template
 >
 struct for_each_range
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_OR_NOT_YET_IMPLEMENTED_FOR_THIS_GEOMETRY_TYPE
-            , (types<Geometry>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not or not yet implemented for this Geometry type.",
+        Geometry, Tag);
 };
 
 

--- a/include/boost/geometry/algorithms/detail/overlay/convert_ring.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/convert_ring.hpp
@@ -2,9 +2,8 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2018.
-// Modifications copyright (c) 2018, Oracle and/or its affiliates.
-
+// This file was modified by Oracle on 2018-2020.
+// Modifications copyright (c) 2018-2020, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -14,15 +13,15 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_CONVERT_RING_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_CONVERT_RING_HPP
 
-#include <boost/mpl/assert.hpp>
 #include <boost/range/algorithm/reverse.hpp>
 
 #include <boost/geometry/algorithms/convert.hpp>
 #include <boost/geometry/algorithms/num_points.hpp>
 
-#include <boost/geometry/core/tags.hpp>
 #include <boost/geometry/core/exterior_ring.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
+#include <boost/geometry/core/static_assert.hpp>
+#include <boost/geometry/core/tags.hpp>
 
 namespace boost { namespace geometry
 {
@@ -36,11 +35,9 @@ namespace detail { namespace overlay
 template<typename Tag>
 struct convert_ring
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_OR_NOT_YET_IMPLEMENTED_FOR_THIS_GEOMETRY_TAG
-            , (types<Tag>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not or not yet implemented for this geometry Tag.",
+        Tag);
 };
 
 template<>

--- a/include/boost/geometry/algorithms/detail/overlay/copy_segment_point.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/copy_segment_point.hpp
@@ -2,6 +2,10 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2020.
+// Modifications copyright (c) 2020, Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -11,19 +15,19 @@
 
 
 #include <boost/array.hpp>
-#include <boost/mpl/assert.hpp>
 #include <boost/range.hpp>
 
-#include <boost/geometry/core/assert.hpp>
-#include <boost/geometry/core/ring_type.hpp>
-#include <boost/geometry/core/exterior_ring.hpp>
-#include <boost/geometry/core/interior_rings.hpp>
-#include <boost/geometry/core/tags.hpp>
 #include <boost/geometry/algorithms/convert.hpp>
 #include <boost/geometry/algorithms/detail/signed_size_type.hpp>
+#include <boost/geometry/core/assert.hpp>
+#include <boost/geometry/core/exterior_ring.hpp>
+#include <boost/geometry/core/interior_rings.hpp>
+#include <boost/geometry/core/ring_type.hpp>
+#include <boost/geometry/core/static_assert.hpp>
+#include <boost/geometry/core/tags.hpp>
 #include <boost/geometry/geometries/concepts/check.hpp>
-#include <boost/geometry/util/range.hpp>
 #include <boost/geometry/iterators/ever_circling_iterator.hpp>
+#include <boost/geometry/util/range.hpp>
 #include <boost/geometry/views/closeable_view.hpp>
 #include <boost/geometry/views/reversible_view.hpp>
 
@@ -165,11 +169,9 @@ template
 >
 struct copy_segment_point
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_OR_NOT_YET_IMPLEMENTED_FOR_THIS_GEOMETRY_TYPE
-            , (types<GeometryIn>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not or not yet implemented for this Geometry type.",
+        Tag, GeometryIn);
 };
 
 

--- a/include/boost/geometry/algorithms/detail/overlay/copy_segments.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/copy_segments.hpp
@@ -4,7 +4,6 @@
 
 // This file was modified by Oracle on 2014-2020.
 // Modifications copyright (c) 2014-2020 Oracle and/or its affiliates.
-
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -20,8 +19,9 @@
 #include <vector>
 
 #include <boost/array.hpp>
-#include <boost/mpl/assert.hpp>
-#include <boost/range.hpp>
+#include <boost/range/begin.hpp>
+#include <boost/range/end.hpp>
+#include <boost/range/size.hpp>
 
 #include <boost/geometry/algorithms/detail/assign_box_corners.hpp>
 #include <boost/geometry/algorithms/detail/signed_size_type.hpp>

--- a/include/boost/geometry/algorithms/detail/overlay/follow.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/follow.hpp
@@ -3,7 +3,7 @@
 // Copyright (c) 2007-2014 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2014, 2017, 2018, 2019, 2020.
+// This file was modified by Oracle on 2014-2020.
 // Modifications copyright (c) 2014-2020 Oracle and/or its affiliates.
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -16,20 +16,19 @@
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_FOLLOW_HPP
 
 #include <cstddef>
+#include <type_traits>
 
 #include <boost/range.hpp>
-#include <boost/mpl/assert.hpp>
-
-#include <boost/geometry/algorithms/detail/point_on_border.hpp>
-#include <boost/geometry/algorithms/detail/overlay/append_no_duplicates.hpp>
-#include <boost/geometry/algorithms/detail/overlay/copy_segments.hpp>
-#include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>
 
 #include <boost/geometry/algorithms/covered_by.hpp>
 #include <boost/geometry/algorithms/clear.hpp>
+#include <boost/geometry/algorithms/detail/overlay/append_no_duplicates.hpp>
+#include <boost/geometry/algorithms/detail/overlay/copy_segments.hpp>
+#include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>
+#include <boost/geometry/algorithms/detail/point_on_border.hpp>
 #include <boost/geometry/algorithms/detail/relate/turns.hpp>
 #include <boost/geometry/algorithms/detail/tupled_output.hpp>
-
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/util/condition.hpp>
 
 namespace boost { namespace geometry
@@ -202,8 +201,9 @@ struct add_isolated_point<PointOut, point_tag>
 template <overlay_type OverlayType, bool RemoveSpikes = true>
 struct action_selector
 {
-    // If you get here the overlay type is not intersection or difference
-    // BOOST_MPL_ASSERT(false);
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "If you get here the overlay type is not intersection or difference.",
+        std::integral_constant<overlay_type, OverlayType>);
 };
 
 // Specialization for intersection, containing the implementation

--- a/include/boost/geometry/algorithms/detail/overlay/intersection_insert.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/intersection_insert.hpp
@@ -17,23 +17,33 @@
 
 
 #include <cstddef>
+#include <deque>
 #include <type_traits>
 
-#include <boost/mpl/assert.hpp>
-#include <boost/range/metafunctions.hpp>
+#include <boost/range/begin.hpp>
+#include <boost/range/end.hpp>
+#include <boost/range/size.hpp>
 
-#include <boost/geometry/core/point_order.hpp>
-#include <boost/geometry/core/reverse_dispatch.hpp>
-#include <boost/geometry/geometries/concepts/check.hpp>
 #include <boost/geometry/algorithms/convert.hpp>
+#include <boost/geometry/algorithms/detail/check_iterator_range.hpp>
 #include <boost/geometry/algorithms/detail/point_on_border.hpp>
 #include <boost/geometry/algorithms/detail/overlay/clip_linestring.hpp>
 #include <boost/geometry/algorithms/detail/overlay/follow.hpp>
 #include <boost/geometry/algorithms/detail/overlay/get_intersection_points.hpp>
+#include <boost/geometry/algorithms/detail/overlay/linear_linear.hpp>
 #include <boost/geometry/algorithms/detail/overlay/overlay.hpp>
 #include <boost/geometry/algorithms/detail/overlay/overlay_type.hpp>
+#include <boost/geometry/algorithms/detail/overlay/pointlike_areal.hpp>
+#include <boost/geometry/algorithms/detail/overlay/pointlike_linear.hpp>
+#include <boost/geometry/algorithms/detail/overlay/pointlike_pointlike.hpp>
 #include <boost/geometry/algorithms/detail/overlay/range_in_geometry.hpp>
 #include <boost/geometry/algorithms/detail/overlay/segment_as_subrange.hpp>
+
+#include <boost/geometry/core/point_order.hpp>
+#include <boost/geometry/core/reverse_dispatch.hpp>
+#include <boost/geometry/core/static_assert.hpp>
+
+#include <boost/geometry/geometries/concepts/check.hpp>
 
 #include <boost/geometry/policies/robustness/rescale_policy_tags.hpp>
 #include <boost/geometry/policies/robustness/segment_ratio_type.hpp>
@@ -41,12 +51,6 @@
 
 #include <boost/geometry/views/segment_view.hpp>
 #include <boost/geometry/views/detail/boundary_view.hpp>
-
-#include <boost/geometry/algorithms/detail/check_iterator_range.hpp>
-#include <boost/geometry/algorithms/detail/overlay/linear_linear.hpp>
-#include <boost/geometry/algorithms/detail/overlay/pointlike_areal.hpp>
-#include <boost/geometry/algorithms/detail/overlay/pointlike_linear.hpp>
-#include <boost/geometry/algorithms/detail/overlay/pointlike_pointlike.hpp>
 
 #if defined(BOOST_GEOMETRY_DEBUG_FOLLOW)
 #include <boost/geometry/algorithms/detail/overlay/debug_turn_info.hpp>
@@ -553,11 +557,10 @@ template
 >
 struct intersection_insert
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_OR_NOT_YET_IMPLEMENTED_FOR_THIS_GEOMETRY_TYPES_OR_ORIENTATIONS
-            , (types<Geometry1, Geometry2, GeometryOut>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not or not yet implemented for these Geometry types or their order.",
+        Geometry1, Geometry2, GeometryOut,
+        std::integral_constant<overlay_type, OverlayType>);
 };
 
 

--- a/include/boost/geometry/algorithms/detail/overlay/overlay.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/overlay.hpp
@@ -3,9 +3,8 @@
 // Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2013-2017 Adam Wulkiewicz, Lodz, Poland
 
-// This file was modified by Oracle on 2015, 2017, 2019.
-// Modifications copyright (c) 2015-2019, Oracle and/or its affiliates.
-
+// This file was modified by Oracle on 2015-2020.
+// Modifications copyright (c) 2015-2020, Oracle and/or its affiliates.
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -20,9 +19,9 @@
 #include <deque>
 #include <map>
 
-#include <boost/range.hpp>
-#include <boost/mpl/assert.hpp>
-
+#include <boost/range/begin.hpp>
+#include <boost/range/end.hpp>
+#include <boost/range/value_type.hpp>
 
 #include <boost/geometry/algorithms/detail/overlay/cluster_info.hpp>
 #include <boost/geometry/algorithms/detail/overlay/enrich_intersection_points.hpp>

--- a/include/boost/geometry/algorithms/detail/recalculate.hpp
+++ b/include/boost/geometry/algorithms/detail/recalculate.hpp
@@ -21,12 +21,10 @@
 
 #include <boost/concept/requires.hpp>
 #include <boost/concept_check.hpp>
-#include <boost/mpl/assert.hpp>
 #include <boost/numeric/conversion/bounds.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
-#include <boost/range/iterator.hpp>
 #include <boost/range/size.hpp>
 
 #include <boost/geometry/arithmetic/arithmetic.hpp>

--- a/include/boost/geometry/algorithms/detail/relate/result.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/result.hpp
@@ -1,4 +1,4 @@
-﻿// Boost.Geometry (aka GGL, Generic Geometry Library)
+// Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
@@ -20,14 +20,13 @@
 #include <cstring>
 #include <type_traits>
 
-#include <boost/mpl/assert.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/throw_exception.hpp>
 #include <boost/tuple/tuple.hpp>
 
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/exception.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/util/condition.hpp>
 #include <boost/geometry/util/sequence.hpp>
 
@@ -666,9 +665,9 @@ struct static_check_characters<std::integer_sequence<char, C, Cs...>>
     typedef std::integer_sequence<char, C, Cs...> type;
     static const bool is_valid = (C >= '0' && C <= '9')
                                || C == 'T' || C == 'F' || C == '*';
-    BOOST_MPL_ASSERT_MSG((is_valid),
-                         INVALID_STATIC_MASK_CHARACTER,
-                         (type));
+    BOOST_GEOMETRY_STATIC_ASSERT((is_valid),
+                                 "Invalid static mask character",
+                                 type);
 };
 
 template <char ...Cs>

--- a/include/boost/geometry/algorithms/detail/sections/range_by_section.hpp
+++ b/include/boost/geometry/algorithms/detail/sections/range_by_section.hpp
@@ -7,20 +7,19 @@
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2013, 2014.
-// Modifications copyright (c) 2013, 2014, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013-2020.
+// Modifications copyright (c) 2013-2020, Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
-
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_SECTIONS_RANGE_BY_SECTION_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_SECTIONS_RANGE_BY_SECTION_HPP
 
-#include <boost/mpl/assert.hpp>
-#include <boost/range.hpp>
+#include <boost/range/size.hpp>
+#include <boost/range/value_type.hpp>
 
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/assert.hpp>
@@ -28,6 +27,7 @@
 #include <boost/geometry/core/exterior_ring.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
 #include <boost/geometry/core/ring_type.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tags.hpp>
 #include <boost/geometry/geometries/concepts/check.hpp>
 #include <boost/geometry/util/range.hpp>
@@ -105,11 +105,9 @@ template
 >
 struct range_by_section
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_OR_NOT_YET_IMPLEMENTED_FOR_THIS_GEOMETRY_TYPE
-            , (types<Geometry>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not or not yet implemented for this Geometry type.",
+        Tag, Geometry, Section);
 };
 
 

--- a/include/boost/geometry/algorithms/detail/sections/sectionalize.hpp
+++ b/include/boost/geometry/algorithms/detail/sections/sectionalize.hpp
@@ -27,9 +27,10 @@
 
 #include <boost/concept/requires.hpp>
 #include <boost/core/ignore_unused.hpp>
-#include <boost/mpl/assert.hpp>
-#include <boost/range.hpp>
-#include <boost/static_assert.hpp>
+#include <boost/range/begin.hpp>
+#include <boost/range/end.hpp>
+#include <boost/range/size.hpp>
+#include <boost/range/value_type.hpp>
 
 #include <boost/geometry/core/config.hpp>
 
@@ -47,6 +48,7 @@
 #include <boost/geometry/core/closure.hpp>
 #include <boost/geometry/core/exterior_ring.hpp>
 #include <boost/geometry/core/point_order.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/geometries/concepts/check.hpp>
@@ -867,11 +869,9 @@ template
 >
 struct sectionalize
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_OR_NOT_YET_IMPLEMENTED_FOR_THIS_GEOMETRY_TYPE
-            , (types<Geometry>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not or not yet implemented for this Geometry type.",
+        Tag, Geometry);
 };
 
 template

--- a/include/boost/geometry/algorithms/detail/tupled_output.hpp
+++ b/include/boost/geometry/algorithms/detail/tupled_output.hpp
@@ -9,8 +9,11 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_TUPLED_OUTPUT_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_TUPLED_OUTPUT_HPP
 
+#include <boost/range/value_type.hpp>
+
 #include <boost/geometry/algorithms/convert.hpp>
 #include <boost/geometry/core/config.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tag_cast.hpp>
 #include <boost/geometry/core/tags.hpp>
@@ -18,8 +21,6 @@
 #include <boost/geometry/util/range.hpp>
 #include <boost/geometry/util/tuples.hpp>
 #include <boost/geometry/util/type_traits.hpp>
-
-#include <boost/range/value_type.hpp>
 
 namespace boost { namespace geometry
 {
@@ -519,31 +520,28 @@ struct expect_output_assert_base;
 template <typename Geometry1, typename Geometry2, typename TupledOut, bool IsFound>
 struct expect_output_assert_base<Geometry1, Geometry2, TupledOut, IsFound, pointlike_tag>
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            IsFound, POINTLIKE_GEOMETRY_EXPECTED_IN_TUPLED_OUTPUT,
-            (types<Geometry1, Geometry2, TupledOut>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT(
+        IsFound,
+        "PointLike Geometry expected in tupled output.",
+        Geometry1, Geometry2, TupledOut);
 };
 
 template <typename Geometry1, typename Geometry2, typename TupledOut, bool IsFound>
 struct expect_output_assert_base<Geometry1, Geometry2, TupledOut, IsFound, linear_tag>
 {
-    BOOST_MPL_ASSERT_MSG
-    (
-        IsFound, LINEAR_GEOMETRY_EXPECTED_IN_TUPLED_OUTPUT,
-        (types<Geometry1, Geometry2, TupledOut>)
-    );
+    BOOST_GEOMETRY_STATIC_ASSERT(
+        IsFound,
+        "Linear Geometry expected in tupled output.",
+        Geometry1, Geometry2, TupledOut);
 };
 
 template <typename Geometry1, typename Geometry2, typename TupledOut, bool IsFound>
 struct expect_output_assert_base<Geometry1, Geometry2, TupledOut, IsFound, areal_tag>
 {
-    BOOST_MPL_ASSERT_MSG
-    (
-        IsFound, AREAL_GEOMETRY_EXPECTED_IN_TUPLED_OUTPUT,
-        (types<Geometry1, Geometry2, TupledOut>)
-    );
+    BOOST_GEOMETRY_STATIC_ASSERT(
+        IsFound,
+        "Areal Geometry expected in tupled output.",
+        Geometry1, Geometry2, TupledOut);
 };
 
 

--- a/include/boost/geometry/algorithms/detail/within/point_in_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/within/point_in_geometry.hpp
@@ -22,8 +22,10 @@
 
 
 #include <boost/core/ignore_unused.hpp>
-#include <boost/mpl/assert.hpp>
-#include <boost/range.hpp>
+#include <boost/range/begin.hpp>
+#include <boost/range/end.hpp>
+#include <boost/range/size.hpp>
+#include <boost/range/value_type.hpp>
 
 #include <boost/geometry/core/assert.hpp>
 

--- a/include/boost/geometry/algorithms/line_interpolate.hpp
+++ b/include/boost/geometry/algorithms/line_interpolate.hpp
@@ -22,6 +22,7 @@
 
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/closure.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/geometries/concepts/check.hpp>
@@ -174,11 +175,9 @@ template
 >
 struct line_interpolate
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_GEOMETRY_TYPE
-            , (types<Geometry>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Geometry type.",
+        Geometry, Pointlike);
 };
 
 

--- a/include/boost/geometry/algorithms/not_implemented.hpp
+++ b/include/boost/geometry/algorithms/not_implemented.hpp
@@ -22,30 +22,12 @@
 #define BOOST_GEOMETRY_ALGORITHMS_NOT_IMPLEMENTED_HPP
 
 
-#include <boost/mpl/assert.hpp>
-#include <boost/mpl/identity.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tags.hpp>
 
 
 namespace boost { namespace geometry
 {
-
-
-namespace info
-{
-    struct UNRECOGNIZED_GEOMETRY_TYPE {};
-    struct POINT {};
-    struct LINESTRING {};
-    struct POLYGON {};
-    struct RING {};
-    struct BOX {};
-    struct SEGMENT {};
-    struct MULTI_POINT {};
-    struct MULTI_LINESTRING {};
-    struct MULTI_POLYGON {};
-    struct GEOMETRY_COLLECTION {};
-    template <size_t D> struct DIMENSION {};
-}
 
 
 namespace nyi
@@ -54,12 +36,7 @@ namespace nyi
 
 struct not_implemented_tag {};
 
-template
-<
-    typename Term1,
-    typename Term2,
-    typename Term3
->
+template <typename ...Terms>
 struct not_implemented_error
 {
 
@@ -67,62 +44,20 @@ struct not_implemented_error
 # define BOOST_GEOMETRY_IMPLEMENTATION_STATUS_BUILD false
 #endif
 
-    BOOST_MPL_ASSERT_MSG
-        (
-            BOOST_GEOMETRY_IMPLEMENTATION_STATUS_BUILD,
-            THIS_OPERATION_IS_NOT_OR_NOT_YET_IMPLEMENTED,
-            (
-                types<Term1, Term2, Term3>
-            )
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT(
+        BOOST_GEOMETRY_IMPLEMENTATION_STATUS_BUILD,
+        "This operation is not or not yet implemented.",
+        Terms...);
 };
 
-template <typename Tag>
-struct tag_to_term
-{
-    typedef Tag type;
-};
-
-template <> struct tag_to_term<geometry_not_recognized_tag> { typedef info::UNRECOGNIZED_GEOMETRY_TYPE type; };
-template <> struct tag_to_term<point_tag>                   { typedef info::POINT type; };
-template <> struct tag_to_term<linestring_tag>              { typedef info::LINESTRING type; };
-template <> struct tag_to_term<polygon_tag>                 { typedef info::POLYGON type; };
-template <> struct tag_to_term<ring_tag>                    { typedef info::RING type; };
-template <> struct tag_to_term<box_tag>                     { typedef info::BOX type; };
-template <> struct tag_to_term<segment_tag>                 { typedef info::SEGMENT type; };
-template <> struct tag_to_term<multi_point_tag>             { typedef info::MULTI_POINT type; };
-template <> struct tag_to_term<multi_linestring_tag>        { typedef info::MULTI_LINESTRING type; };
-template <> struct tag_to_term<multi_polygon_tag>           { typedef info::MULTI_POLYGON type; };
-template <> struct tag_to_term<geometry_collection_tag>     { typedef info::GEOMETRY_COLLECTION type; };
-template <int D> struct tag_to_term<std::integral_constant<int, D> > { typedef info::DIMENSION<D> type; };
-template <size_t D> struct tag_to_term<std::integral_constant<size_t, D> > { typedef info::DIMENSION<D> type; };
 
 }
 
 
-template
-<
-    typename Term1 = void,
-    typename Term2 = void,
-    typename Term3 = void
->
+template <typename ...Terms>
 struct not_implemented
     : nyi::not_implemented_tag,
-      nyi::not_implemented_error
-      <
-          typename boost::mpl::identity
-              <
-                  typename nyi::tag_to_term<Term1>::type
-              >::type,
-          typename boost::mpl::identity
-              <
-                  typename nyi::tag_to_term<Term2>::type
-              >::type,
-          typename boost::mpl::identity
-              <
-                  typename nyi::tag_to_term<Term3>::type
-              >::type
-      >
+      nyi::not_implemented_error<Terms...>
 {};
 
 

--- a/include/boost/geometry/algorithms/perimeter.hpp
+++ b/include/boost/geometry/algorithms/perimeter.hpp
@@ -4,10 +4,10 @@
 // Copyright (c) 2008-2014 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2014 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2014.
-// Modifications copyright (c) 2014, Oracle and/or its affiliates.
-
+// This file was modified by Oracle on 2014-2020.
+// Modifications copyright (c) 2014-2020, Oracle and/or its affiliates.
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
@@ -19,7 +19,7 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_PERIMETER_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_PERIMETER_HPP
 
-#include <boost/range/metafunctions.hpp>
+#include <boost/range/value_type.hpp>
 
 #include <boost/variant/apply_visitor.hpp>
 #include <boost/variant/static_visitor.hpp>

--- a/include/boost/geometry/algorithms/union.hpp
+++ b/include/boost/geometry/algorithms/union.hpp
@@ -2,7 +2,7 @@
 
 // Copyright (c) 2007-2014 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2014, 2017, 2018, 2019, 2020.
+// This file was modified by Oracle on 2014-2020.
 // Modifications copyright (c) 2014-2020 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
@@ -16,7 +16,7 @@
 #define BOOST_GEOMETRY_ALGORITHMS_UNION_HPP
 
 
-#include <boost/range/metafunctions.hpp>
+#include <boost/range/value_type.hpp>
 
 #include <boost/geometry/core/point_order.hpp>
 #include <boost/geometry/core/reverse_dispatch.hpp>

--- a/include/boost/geometry/arithmetic/cross_product.hpp
+++ b/include/boost/geometry/arithmetic/cross_product.hpp
@@ -19,10 +19,9 @@
 #include <cstddef>
 #include <type_traits>
 
-#include <boost/mpl/assert.hpp>
-
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 
 #include <boost/geometry/geometries/concepts/point_concept.hpp>
 
@@ -41,9 +40,9 @@ struct cross_product
     // In Math, it is also well-defined for 7-dimension.
     // Generalisation of cross product to n-dimension is defined as
     // wedge product but it is not direct analogue to binary cross product.
-    BOOST_MPL_ASSERT_MSG((false),
-                         NOT_IMPLEMENTED_FOR_THIS_DIMENSION,
-                         (std::integral_constant<std::size_t, Dimension>));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Dimension.",
+        std::integral_constant<std::size_t, Dimension>);
 };
 
 template <>

--- a/include/boost/geometry/core/access.hpp
+++ b/include/boost/geometry/core/access.hpp
@@ -21,10 +21,9 @@
 
 #include <cstddef>
 
-#include <boost/mpl/assert.hpp>
-
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/point_type.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/util/type_traits_std.hpp>
 
@@ -55,10 +54,9 @@ namespace traits
 template <typename Geometry, std::size_t Dimension, typename Enable = void>
 struct access
 {
-   BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_POINT_TYPE, (types<Geometry>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Geometry type.",
+        Geometry);
 };
 
 

--- a/include/boost/geometry/core/closure.hpp
+++ b/include/boost/geometry/core/closure.hpp
@@ -19,10 +19,10 @@
 #ifndef BOOST_GEOMETRY_CORE_CLOSURE_HPP
 #define BOOST_GEOMETRY_CORE_CLOSURE_HPP
 
-#include <boost/mpl/assert.hpp>
 #include <boost/range/value_type.hpp>
 
 #include <boost/geometry/core/ring_type.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tags.hpp>
 #include <boost/geometry/util/type_traits_std.hpp>
@@ -118,11 +118,9 @@ namespace core_dispatch
 template <typename Tag, typename Geometry>
 struct closure
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_GEOMETRY_TYPE
-            , (types<Geometry>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Geometry type.",
+        Geometry);
 };
 
 template <typename Box>

--- a/include/boost/geometry/core/coordinate_dimension.hpp
+++ b/include/boost/geometry/core/coordinate_dimension.hpp
@@ -21,10 +21,8 @@
 
 #include <cstddef>
 
-#include <boost/mpl/assert.hpp>
-#include <boost/static_assert.hpp>
-
 #include <boost/geometry/core/point_type.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/util/type_traits_std.hpp>
 
 namespace boost { namespace geometry
@@ -44,10 +42,9 @@ namespace traits
 template <typename Point, typename Enable = void>
 struct dimension
 {
-   BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_POINT_TYPE, (types<Point>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Point type.",
+        Point);
 };
 
 } // namespace traits
@@ -70,10 +67,10 @@ struct dimension<point_tag, P>
             traits::dimension<util::remove_cptrref_t<P>>::value
         >
 {
-    BOOST_MPL_ASSERT_MSG(
+    BOOST_GEOMETRY_STATIC_ASSERT(
         (traits::dimension<util::remove_cptrref_t<P>>::value > 0),
-        INVALID_DIMENSION_VALUE,
-        (traits::dimension<util::remove_cptrref_t<P>>)
+        "Dimension has to be greater than 0.",
+        traits::dimension<util::remove_cptrref_t<P>>
     );
 };
 
@@ -100,26 +97,26 @@ struct dimension
 \brief assert_dimension, enables compile-time checking if coordinate dimensions are as expected
 \ingroup utility
 */
-template <typename Geometry, int Dimensions>
+template <typename Geometry, std::size_t Dimensions>
 constexpr inline void assert_dimension()
 {
-    BOOST_STATIC_ASSERT(( static_cast<int>(dimension<Geometry>::value) == Dimensions ));
+    BOOST_STATIC_ASSERT(( dimension<Geometry>::value == Dimensions ));
 }
 
 /*!
 \brief assert_dimension, enables compile-time checking if coordinate dimensions are as expected
 \ingroup utility
 */
-template <typename Geometry, int Dimensions>
+template <typename Geometry, std::size_t Dimensions>
 constexpr inline void assert_dimension_less_equal()
 {
-    BOOST_STATIC_ASSERT(( static_cast<int>(dimension<Geometry>::value) <= Dimensions ));
+    BOOST_STATIC_ASSERT(( dimension<Geometry>::value <= Dimensions ));
 }
 
-template <typename Geometry, int Dimensions>
+template <typename Geometry, std::size_t Dimensions>
 constexpr inline void assert_dimension_greater_equal()
 {
-    BOOST_STATIC_ASSERT(( static_cast<int>(dimension<Geometry>::value) >= Dimensions ));
+    BOOST_STATIC_ASSERT(( dimension<Geometry>::value >= Dimensions ));
 }
 
 /*!
@@ -129,7 +126,7 @@ constexpr inline void assert_dimension_greater_equal()
 template <typename G1, typename G2>
 constexpr inline void assert_dimension_equal()
 {
-    BOOST_STATIC_ASSERT(( static_cast<size_t>(dimension<G1>::value) == static_cast<size_t>(dimension<G2>::value) ));
+    BOOST_STATIC_ASSERT(( dimension<G1>::value == dimension<G2>::value ));
 }
 
 }} // namespace boost::geometry

--- a/include/boost/geometry/core/coordinate_system.hpp
+++ b/include/boost/geometry/core/coordinate_system.hpp
@@ -19,9 +19,8 @@
 #define BOOST_GEOMETRY_CORE_COORDINATE_SYSTEM_HPP
 
 
-#include <boost/mpl/assert.hpp>
-
 #include <boost/geometry/core/point_type.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/util/type_traits_std.hpp>
 
 
@@ -43,10 +42,9 @@ namespace traits
 template <typename Point, typename Enable = void>
 struct coordinate_system
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_POINT_TYPE, (types<Point>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Point type.",
+        Point);
 };
 
 } // namespace traits

--- a/include/boost/geometry/core/coordinate_type.hpp
+++ b/include/boost/geometry/core/coordinate_type.hpp
@@ -19,9 +19,8 @@
 #define BOOST_GEOMETRY_CORE_COORDINATE_TYPE_HPP
 
 
-#include <boost/mpl/assert.hpp>
-
 #include <boost/geometry/core/point_type.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/util/promote_floating_point.hpp>
 #include <boost/geometry/util/type_traits_std.hpp>
@@ -44,10 +43,9 @@ namespace traits
 template <typename Point, typename Enable = void>
 struct coordinate_type
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_POINT_TYPE, (types<Point>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Point type.",
+        Point);
 };
 
 } // namespace traits

--- a/include/boost/geometry/core/cs.hpp
+++ b/include/boost/geometry/core/cs.hpp
@@ -4,8 +4,8 @@
 // Copyright (c) 2008-2014 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2014 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2014, 2018.
-// Modifications copyright (c) 2014-2018, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014-2020.
+// Modifications copyright (c) 2014-2020, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -20,11 +20,11 @@
 #ifndef BOOST_GEOMETRY_CORE_CS_HPP
 #define BOOST_GEOMETRY_CORE_CS_HPP
 
+
 #include <cstddef>
 
-#include <boost/mpl/assert.hpp>
-
 #include <boost/geometry/core/coordinate_system.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tags.hpp>
 
 
@@ -58,10 +58,9 @@ namespace core_detail
 template <typename DegreeOrRadian>
 struct define_angular_units
 {
-    BOOST_MPL_ASSERT_MSG
-        ((false),
-         COORDINATE_SYSTEM_UNITS_MUST_BE_DEGREES_OR_RADIANS,
-         (types<DegreeOrRadian>));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Coordinate system unit must be degree or radian.",
+        DegreeOrRadian);
 };
 
 template <>
@@ -298,9 +297,9 @@ struct cs_angular_units
 template <typename Units, typename CsTag>
 struct cs_tag_to_coordinate_system
 {
-    BOOST_MPL_ASSERT_MSG((false),
-                         NOT_IMPLEMENTED_FOR_THIS_COORDINATE_SYSTEM,
-                         (types<CsTag>));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this coordinate system.",
+        Units, CsTag);
 };
 
 template <typename Units>

--- a/include/boost/geometry/core/exterior_ring.hpp
+++ b/include/boost/geometry/core/exterior_ring.hpp
@@ -22,9 +22,8 @@
 
 #include <type_traits>
 
-#include <boost/mpl/assert.hpp>
-
 #include <boost/geometry/core/ring_type.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tags.hpp>
 
@@ -50,11 +49,9 @@ namespace traits
 template <typename Polygon>
 struct exterior_ring
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_POLYGON_TYPE
-            , (types<Polygon>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Polygon type.",
+        Polygon);
 };
 
 
@@ -69,11 +66,9 @@ namespace core_dispatch
 template <typename Tag, typename Geometry>
 struct exterior_ring
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_GEOMETRY_TYPE
-            , (types<Geometry>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Geometry type.",
+        Tag, Geometry);
 };
 
 

--- a/include/boost/geometry/core/geometry_id.hpp
+++ b/include/boost/geometry/core/geometry_id.hpp
@@ -22,8 +22,7 @@
 
 #include <type_traits>
 
-#include <boost/mpl/assert.hpp>
-
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tags.hpp>
 
@@ -39,11 +38,9 @@ namespace core_dispatch
 template <typename GeometryTag>
 struct geometry_id
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_GEOMETRY_TYPE
-            , (types<GeometryTag>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Geometry type.",
+        GeometryTag);
 };
 
 

--- a/include/boost/geometry/core/interior_rings.hpp
+++ b/include/boost/geometry/core/interior_rings.hpp
@@ -21,12 +21,12 @@
 #include <cstddef>
 #include <type_traits>
 
-#include <boost/mpl/assert.hpp>
 #include <boost/range/value_type.hpp>
 
+#include <boost/geometry/core/interior_type.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tags.hpp>
-#include <boost/geometry/core/interior_type.hpp>
 
 namespace boost { namespace geometry
 {
@@ -49,11 +49,9 @@ namespace traits
 template <typename Geometry>
 struct interior_rings
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_GEOMETRY_TYPE
-            , (types<Geometry>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Geometry type.",
+        Geometry);
 };
 
 

--- a/include/boost/geometry/core/interior_type.hpp
+++ b/include/boost/geometry/core/interior_type.hpp
@@ -21,8 +21,7 @@
 
 #include <type_traits>
 
-#include <boost/mpl/assert.hpp>
-
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tags.hpp>
 
@@ -46,21 +45,17 @@ namespace traits
 template <typename Geometry>
 struct interior_const_type
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_GEOMETRY_TYPE
-            , (types<Geometry>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Geometry type.",
+        Geometry);
 };
 
 template <typename Geometry>
 struct interior_mutable_type
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_GEOMETRY_TYPE
-            , (types<Geometry>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Geometry type.",
+        Geometry);
 };
 
 
@@ -77,11 +72,9 @@ namespace core_dispatch
 template <typename GeometryTag, typename Geometry>
 struct interior_return_type
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_GEOMETRY_TYPE
-            , (types<Geometry>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Geometry type.",
+        Geometry);
 };
 
 
@@ -104,11 +97,9 @@ struct interior_return_type<polygon_tag, Polygon>
 template <typename GeometryTag, typename Geometry>
 struct interior_type
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_GEOMETRY_TYPE
-            , (types<Geometry>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Geometry type.",
+        Geometry);
 };
 
 

--- a/include/boost/geometry/core/point_order.hpp
+++ b/include/boost/geometry/core/point_order.hpp
@@ -20,10 +20,10 @@
 #define BOOST_GEOMETRY_CORE_POINT_ORDER_HPP
 
 
-#include <boost/mpl/assert.hpp>
 #include <boost/range/value_type.hpp>
 
 #include <boost/geometry/core/ring_type.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tags.hpp>
 #include <boost/geometry/util/type_traits_std.hpp>
@@ -97,11 +97,9 @@ namespace core_dispatch
 template <typename Tag, typename Geometry>
 struct point_order
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_GEOMETRY_TYPE
-            , (types<Geometry>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Geometry type.",
+        Geometry);
 };
 
 template <typename Point>

--- a/include/boost/geometry/core/point_type.hpp
+++ b/include/boost/geometry/core/point_type.hpp
@@ -19,10 +19,10 @@
 #define BOOST_GEOMETRY_CORE_POINT_TYPE_HPP
 
 
-#include <boost/mpl/assert.hpp>
 #include <boost/range/value_type.hpp>
 
 #include <boost/geometry/core/ring_type.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tags.hpp>
 #include <boost/geometry/util/type_traits_std.hpp>
@@ -46,10 +46,9 @@ namespace traits
 template <typename Geometry>
 struct point_type
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_POINT_TYPE, (types<Geometry>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Geometry type.",
+        Geometry);
 };
 
 

--- a/include/boost/geometry/core/ring_type.hpp
+++ b/include/boost/geometry/core/ring_type.hpp
@@ -22,9 +22,9 @@
 
 #include <type_traits>
 
-#include <boost/mpl/assert.hpp>
 #include <boost/range/value_type.hpp>
 
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tags.hpp>
 
@@ -48,21 +48,17 @@ namespace traits
 template <typename Geometry>
 struct ring_const_type
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_GEOMETRY_TYPE
-            , (types<Geometry>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Geometry type.",
+        Geometry);
 };
 
 template <typename Geometry>
 struct ring_mutable_type
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_GEOMETRY_TYPE
-            , (types<Geometry>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Geometry type.",
+        Geometry);
 };
 
 

--- a/include/boost/geometry/core/static_assert.hpp
+++ b/include/boost/geometry/core/static_assert.hpp
@@ -1,0 +1,33 @@
+// Boost.Geometry
+
+// Copyright (c) 2020, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+#ifndef BOOST_GEOMETRY_CORE_STATIC_ASSERT_HPP
+#define BOOST_GEOMETRY_CORE_STATIC_ASSERT_HPP
+
+#include <type_traits>
+
+#include <boost/static_assert.hpp>
+
+namespace boost { namespace geometry { namespace detail
+{
+
+template <bool Check, typename ...Ts>
+struct static_assert_check : std::integral_constant<bool, Check> {};
+
+#define BOOST_GEOMETRY_STATIC_ASSERT(CHECK, MESSAGE, ...) \
+static_assert(boost::geometry::detail::static_assert_check<(CHECK), __VA_ARGS__>::value, MESSAGE)
+
+
+#define BOOST_GEOMETRY_STATIC_ASSERT_FALSE(MESSAGE, ...) \
+static_assert(boost::geometry::detail::static_assert_check<false, __VA_ARGS__>::value, MESSAGE)
+
+
+}}} // namespace boost::geometry::detail
+
+#endif // BOOST_GEOMETRY_CORE_STATIC_ASSERT_HPP

--- a/include/boost/geometry/extensions/algebra/algorithms/assign.hpp
+++ b/include/boost/geometry/extensions/algebra/algorithms/assign.hpp
@@ -43,7 +43,9 @@ struct assign_zero<vector_tag, Vector>
 template <typename GeometryTag, typename Geometry>
 struct assign_identity
 {
-    BOOST_MPL_ASSERT_MSG(false, NOT_IMPLEMENTED_FOR_THIS_GEOMETRY, (GeometryTag, Geometry));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Geometry type.",
+        GeometryTag, Geometry);
 };
 
 template <typename R>

--- a/include/boost/geometry/extensions/algebra/algorithms/rotation.hpp
+++ b/include/boost/geometry/extensions/algebra/algorithms/rotation.hpp
@@ -32,7 +32,9 @@ namespace detail { namespace rotation {
 template <typename V1, typename V2, typename Rotation, typename Tag1, typename Tag2, std::size_t Dimension>
 struct matrix
 {
-    BOOST_MPL_ASSERT_MSG(false, NOT_IMPLEMENTED_FOR_THIS_DIMENSION, (Rotation));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Dimension.",
+        Rotation, std::integral_constant<std::size_t, Dimension>);
 };
 
 template <typename V1, typename V2, typename Rotation>
@@ -42,7 +44,10 @@ struct matrix<V1, V2, Rotation, vector_tag, vector_tag, 3>
         std::is_same<typename traits::coordinate_system<V1>::type, cs::cartesian>::value &&
         std::is_same<typename traits::coordinate_system<V2>::type, cs::cartesian>::value;
 
-    BOOST_MPL_ASSERT_MSG(cs_check, NOT_IMPLEMENTED_FOR_THOSE_SYSTEMS, (V1, V2));
+    BOOST_GEOMETRY_STATIC_ASSERT(
+        cs_check,
+        "Not implemented for coordinate systems of these vectors.",
+        V1, V2);
 
     typedef typename geometry::select_most_precise<
         typename traits::coordinate_type<V1>::type,
@@ -123,7 +128,10 @@ struct matrix<V1, V2, Rotation, vector_tag, vector_tag, 2>
         std::is_same<typename traits::coordinate_system<V1>::type, cs::cartesian>::value &&
         std::is_same<typename traits::coordinate_system<V2>::type, cs::cartesian>::value;
 
-    BOOST_MPL_ASSERT_MSG(cs_check, NOT_IMPLEMENTED_FOR_THOSE_SYSTEMS, (V1, V2));
+    BOOST_GEOMETRY_STATIC_ASSERT(
+        cs_check,
+        "Not implemented for coordinate systems of these vectors.",
+        V1, V2);
 
     typedef typename geometry::select_most_precise<
         typename traits::coordinate_type<V1>::type,
@@ -180,7 +188,9 @@ template <typename V1, typename V2, typename Rotation,
 >
 struct rotation
 {
-    BOOST_MPL_ASSERT_MSG(false, NOT_IMPLEMENTED_FOR_THOSE_TAGS, (Tag1, Tag2, Rotation));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for these Geometries and Rotation.",
+        V1, V2, Rotation);
 };
 
 template <typename V1, typename V2, typename Rotation>
@@ -190,7 +200,10 @@ struct rotation<V1, V2, Rotation, vector_tag, vector_tag, rotation_quaternion_ta
         std::is_same<typename traits::coordinate_system<V1>::type, cs::cartesian>::value &&
         std::is_same<typename traits::coordinate_system<V2>::type, cs::cartesian>::value;
 
-    BOOST_MPL_ASSERT_MSG(cs_check, NOT_IMPLEMENTED_FOR_THOSE_SYSTEMS, (V1, V2));
+    BOOST_GEOMETRY_STATIC_ASSERT(
+        cs_check,
+        "Not implemented for coordinate systems of these vectors.",
+        V1, V2);
 
     typedef typename geometry::select_most_precise<
         typename traits::coordinate_type<V1>::type,

--- a/include/boost/geometry/extensions/algebra/algorithms/transform_geometrically.hpp
+++ b/include/boost/geometry/extensions/algebra/algorithms/transform_geometrically.hpp
@@ -17,6 +17,7 @@
 
 #include <boost/geometry/algorithms/convert.hpp>
 #include <boost/geometry/arithmetic/arithmetic.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/extensions/algebra/algorithms/detail.hpp>
 #include <boost/geometry/extensions/algebra/geometries/concepts/vector_concept.hpp>
 #include <boost/geometry/extensions/algebra/geometries/concepts/rotation_quaternion_concept.hpp>
@@ -30,7 +31,10 @@ namespace detail { namespace transform_geometrically {
 template <typename Box, typename Vector, std::size_t Dimension>
 struct box_vector_cartesian
 {
-    BOOST_MPL_ASSERT_MSG((0 < Dimension), INVALID_DIMENSION, (Box));
+    BOOST_GEOMETRY_STATIC_ASSERT(
+        (Dimension > 0),
+        "Dimension has to be greater than 0.",
+        Box);
 
     static inline void apply(Box & box, Vector const& vector)
     {
@@ -60,7 +64,9 @@ template <typename Geometry, typename Transform,
           typename TTag = typename tag<Transform>::type>
 struct transform_geometrically
 {
-    BOOST_MPL_ASSERT_MSG(false, NOT_IMPLEMENTED_FOR_THOSE_TAGS, (GTag, TTag));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Geometry.",
+        Geometry, Transform);
 };
 
 // Point translation by Vector
@@ -87,8 +93,9 @@ struct transform_geometrically<Point, Vector, point_tag, vector_tag>
 
     static inline void apply(Point & point, Vector const& vector, std::false_type /*is_cartesian*/)
     {
-        typedef typename traits::coordinate_system<Point>::type cs;
-        BOOST_MPL_ASSERT_MSG(false, NOT_IMPLEMENTED_FOR_THIS_CS, (cs));
+        BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+            "Not implemented for this coordinate system.",
+            typename traits::coordinate_system<Point>::type);
     }
 };
 
@@ -120,8 +127,9 @@ struct transform_geometrically<Box, Vector, box_tag, vector_tag>
 
     static inline void apply(Box & box, Vector const& vector, std::false_type /*is_cartesian*/)
     {
-        typedef typename traits::coordinate_system<point_type>::type cs;
-        BOOST_MPL_ASSERT_MSG(false, NOT_IMPLEMENTED_FOR_THIS_CS, (cs));
+        BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+            "Not implemented for this coordinate system.",
+            typename traits::coordinate_system<point_type>::type);
     }
 };
 

--- a/include/boost/geometry/extensions/algebra/core/coordinate_dimension.hpp
+++ b/include/boost/geometry/extensions/algebra/core/coordinate_dimension.hpp
@@ -19,9 +19,8 @@
 #ifndef BOOST_GEOMETRY_EXTENSIONS_ALGEBRA_CORE_COORDINATE_DIMENSION_HPP
 #define BOOST_GEOMETRY_EXTENSIONS_ALGEBRA_CORE_COORDINATE_DIMENSION_HPP
 
-#include <boost/mpl/assert.hpp>
-
 #include <boost/geometry/core/coordinate_dimension.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 
 #include <boost/geometry/extensions/algebra/core/tags.hpp>
 
@@ -32,9 +31,9 @@ namespace traits {
 template <typename Geometry, std::size_t Index>
 struct indexed_dimension
 {
-     BOOST_MPL_ASSERT_MSG(false,
-                          NOT_IMPLEMENTED_FOR_THIS_GEOMETRY_OR_INDEX,
-                          (Geometry, std::integral_constant<std::size_t, Index>));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Geometry or Index",
+        Geometry, std::integral_constant<std::size_t, Index>);
 };
 
 } // namespace traits
@@ -55,9 +54,9 @@ struct dimension<quaternion_tag, G>
 template <typename T, typename G, std::size_t Index>
 struct indexed_dimension
 {
-    BOOST_MPL_ASSERT_MSG(false,
-                         NOT_IMPLEMENTED_FOR_THIS_GEOMETRY_OR_INDEX,
-                         (G, std::integral_constant<std::size_t, Index>));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Geometry or Index",
+        G, std::integral_constant<std::size_t, Index>);
 };
 
 template <typename G, std::size_t Index>

--- a/include/boost/geometry/extensions/algebra/geometries/concepts/matrix_concept.hpp
+++ b/include/boost/geometry/extensions/algebra/geometries/concepts/matrix_concept.hpp
@@ -23,12 +23,13 @@
 
 #include <boost/concept_check.hpp>
 #include <boost/core/ignore_unused.hpp>
+
 #include <boost/geometry/core/cs.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/extensions/algebra/core/access.hpp>
 #include <boost/geometry/extensions/algebra/core/coordinate_dimension.hpp>
 #include <boost/geometry/extensions/algebra/core/coordinate_system.hpp>
 #include <boost/geometry/extensions/algebra/core/coordinate_type.hpp>
-#include <boost/mpl/assert.hpp>
 
 namespace boost { namespace geometry { namespace concepts {
 
@@ -81,7 +82,11 @@ public:
     BOOST_CONCEPT_USAGE(Matrix)
     {
         static const bool cs_check = std::is_same<csystem, cs::cartesian>::value;
-        BOOST_MPL_ASSERT_MSG(cs_check, NOT_IMPLEMENTED_FOR_THIS_CS, (csystem));
+        BOOST_GEOMETRY_STATIC_ASSERT(
+            cs_check,
+            "Not implemented for this coordinate system.",
+            csystem
+        );
 
         dimension_checker<Geometry, 0, ccount>::apply();
     }
@@ -139,7 +144,7 @@ public:
     BOOST_CONCEPT_USAGE(ConstMatrix)
     {
         //static const bool cs_check = std::is_same<csystem, cs::cartesian>::value;
-        //BOOST_MPL_ASSERT_MSG(cs_check, NOT_IMPLEMENTED_FOR_THIS_CS, (csystem));
+        //BOOST_GEOMETRY_STATIC_ASSERT(cs_check, "Not implemented for this coordinate system.", csystem);
 
         //dimension_checker<Geometry, 0, ccount>::apply();
     }

--- a/include/boost/geometry/extensions/algebra/geometries/concepts/quaternion_concept.hpp
+++ b/include/boost/geometry/extensions/algebra/geometries/concepts/quaternion_concept.hpp
@@ -23,8 +23,10 @@
 
 #include <boost/concept_check.hpp>
 #include <boost/core/ignore_unused.hpp>
-#include <boost/geometry/core/coordinate_dimension.hpp>
+
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/coordinate_dimension.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 
 namespace boost { namespace geometry { namespace concepts {
 
@@ -60,9 +62,9 @@ public:
     BOOST_CONCEPT_USAGE(Quaternion)
     {
         //static const bool dim_check = dimension<Geometry>::value == 4;
-        //BOOST_MPL_ASSERT_MSG(dim_check, INVALID_DIMENSION, (RotationQuaternion));
+        //BOOST_GEOMETRY_STATIC_ASSERT(dim_check, "INVALID_DIMENSION", RotationQuaternion);
         //static const bool cs_check = std::is_same<csystem, cs::cartesian>::value;
-        //BOOST_MPL_ASSERT_MSG(cs_check, NOT_IMPLEMENTED_FOR_THIS_CS, (csystem));
+        //BOOST_GEOMETRY_STATIC_ASSERT(cs_check, "NOT_IMPLEMENTED_FOR_THIS_CS", csystem);
 
         dimension_checker<Geometry, 0, 4>::apply();
     }
@@ -103,9 +105,9 @@ public:
     BOOST_CONCEPT_USAGE(ConstQuaternion)
     {
         //static const bool dim_check = dimension<Geometry>::value == 4;
-        //BOOST_MPL_ASSERT_MSG(dim_check, INVALID_DIMENSION, (ConstRotationQuaternion));
+        //BOOST_GEOMETRY_STATIC_ASSERT(dim_check, "INVALID_DIMENSION", ConstRotationQuaternion);
         //static const bool cs_check = std::is_same<csystem, cs::cartesian>::value;
-        //BOOST_MPL_ASSERT_MSG(cs_check, NOT_IMPLEMENTED_FOR_THIS_CS, (csystem));
+        //BOOST_GEOMETRY_STATIC_ASSERT(cs_check, "NOT_IMPLEMENTED_FOR_THIS_CS", csystem);
 
         dimension_checker<Geometry, 0, 4>::apply();
     }

--- a/include/boost/geometry/extensions/algebra/geometries/concepts/rotation_matrix_concept.hpp
+++ b/include/boost/geometry/extensions/algebra/geometries/concepts/rotation_matrix_concept.hpp
@@ -23,12 +23,13 @@
 
 #include <boost/concept_check.hpp>
 #include <boost/core/ignore_unused.hpp>
+
 #include <boost/geometry/core/cs.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/extensions/algebra/core/access.hpp>
 #include <boost/geometry/extensions/algebra/core/coordinate_dimension.hpp>
 #include <boost/geometry/extensions/algebra/core/coordinate_system.hpp>
 #include <boost/geometry/extensions/algebra/core/coordinate_type.hpp>
-#include <boost/mpl/assert.hpp>
 
 namespace boost { namespace geometry { namespace concepts {
 
@@ -81,7 +82,9 @@ public:
     BOOST_CONCEPT_USAGE(RotationMatrix)
     {
         static const bool cs_check = std::is_same<csystem, cs::cartesian>::value;
-        BOOST_MPL_ASSERT_MSG(cs_check, NOT_IMPLEMENTED_FOR_THIS_CS, (csystem));
+        BOOST_GEOMETRY_STATIC_ASSERT(cs_check,
+            "Not implemented for this coordinate system.",
+            csystem);
 
         dimension_checker<Geometry, 0, ccount>::apply();
     }
@@ -139,7 +142,9 @@ public:
     BOOST_CONCEPT_USAGE(ConstRotationMatrix)
     {
         static const bool cs_check = std::is_same<csystem, cs::cartesian>::value;
-        BOOST_MPL_ASSERT_MSG(cs_check, NOT_IMPLEMENTED_FOR_THIS_CS, (csystem));
+        BOOST_GEOMETRY_STATIC_ASSERT(cs_check,
+            "Not implemented for this coordinate system.",
+            csystem);
 
         dimension_checker<Geometry, 0, ccount>::apply();
     }

--- a/include/boost/geometry/extensions/algebra/geometries/concepts/rotation_quaternion_concept.hpp
+++ b/include/boost/geometry/extensions/algebra/geometries/concepts/rotation_quaternion_concept.hpp
@@ -23,12 +23,13 @@
 
 #include <boost/concept_check.hpp>
 #include <boost/core/ignore_unused.hpp>
+
 #include <boost/geometry/core/cs.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/extensions/algebra/core/access.hpp>
 #include <boost/geometry/extensions/algebra/core/coordinate_dimension.hpp>
 #include <boost/geometry/extensions/algebra/core/coordinate_system.hpp>
 #include <boost/geometry/extensions/algebra/core/coordinate_type.hpp>
-#include <boost/mpl/assert.hpp>
 
 namespace boost { namespace geometry { namespace concepts {
 
@@ -64,9 +65,13 @@ public:
     BOOST_CONCEPT_USAGE(RotationQuaternion)
     {
         static const bool dim_check = dimension<Geometry>::value == 3;
-        BOOST_MPL_ASSERT_MSG(dim_check, INVALID_DIMENSION, (RotationQuaternion));
+        BOOST_GEOMETRY_STATIC_ASSERT(dim_check,
+            "Invalid dimension.",
+            RotationQuaternion);
         static const bool cs_check = std::is_same<csystem, cs::cartesian>::value;
-        BOOST_MPL_ASSERT_MSG(cs_check, NOT_IMPLEMENTED_FOR_THIS_CS, (csystem));
+        BOOST_GEOMETRY_STATIC_ASSERT(cs_check,
+            "Not implemented for this coordinate system.",
+            csystem);
 
         dimension_checker<Geometry, 0, 4>::apply();
     }
@@ -107,9 +112,13 @@ public:
     BOOST_CONCEPT_USAGE(ConstRotationQuaternion)
     {
         static const bool dim_check = dimension<Geometry>::value == 3;
-        BOOST_MPL_ASSERT_MSG(dim_check, INVALID_DIMENSION, (ConstRotationQuaternion));
+        BOOST_GEOMETRY_STATIC_ASSERT(dim_check,
+            "Invalid dimension.",
+            ConstRotationQuaternion);
         static const bool cs_check = std::is_same<csystem, cs::cartesian>::value;
-        BOOST_MPL_ASSERT_MSG(cs_check, NOT_IMPLEMENTED_FOR_THIS_CS, (csystem));
+        BOOST_GEOMETRY_STATIC_ASSERT(cs_check,
+            "Not implemented for this coordinate system.",
+            csystem);
 
         dimension_checker<Geometry, 0, 4>::apply();
     }

--- a/include/boost/geometry/extensions/algebra/geometries/concepts/vector_concept.hpp
+++ b/include/boost/geometry/extensions/algebra/geometries/concepts/vector_concept.hpp
@@ -6,7 +6,7 @@
 // Copyright (c) 2013 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2018-2020.
-// Modifications copyright (c) 2018 Oracle and/or its affiliates.
+// Modifications copyright (c) 2018-2020 Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
@@ -23,7 +23,9 @@
 
 #include <boost/concept_check.hpp>
 #include <boost/core/ignore_unused.hpp>
+
 #include <boost/geometry/core/cs.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/extensions/algebra/core/access.hpp>
 #include <boost/geometry/extensions/algebra/core/coordinate_dimension.hpp>
 #include <boost/geometry/extensions/algebra/core/coordinate_type.hpp>
@@ -66,7 +68,9 @@ public:
     BOOST_CONCEPT_USAGE(Vector)
     {
         static const bool cs_check = std::is_same<csystem, cs::cartesian>::value;
-        BOOST_MPL_ASSERT_MSG(cs_check, NOT_IMPLEMENTED_FOR_THIS_CS, (csystem));
+        BOOST_GEOMETRY_STATIC_ASSERT(cs_check,
+            "Not implemented for this coordinate system.",
+            csystem);
 
         dimension_checker<Geometry, 0, ccount>::apply();
     }
@@ -109,7 +113,9 @@ public:
     BOOST_CONCEPT_USAGE(ConstVector)
     {
         static const bool cs_check = std::is_same<csystem, cs::cartesian>::value;
-        BOOST_MPL_ASSERT_MSG(cs_check, NOT_IMPLEMENTED_FOR_THIS_CS, (csystem));
+        BOOST_GEOMETRY_STATIC_ASSERT(cs_check,
+            "Not implemented for this coordinate system.",
+            csystem);
 
         dimension_checker<Geometry, 0, ccount>::apply();
     }

--- a/include/boost/geometry/extensions/algorithms/distance_info.hpp
+++ b/include/boost/geometry/extensions/algorithms/distance_info.hpp
@@ -16,8 +16,9 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DISTANCE_INFO_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DISTANCE_INFO_HPP
 
-#include <boost/range/functions.hpp>
-#include <boost/range/metafunctions.hpp>
+#include <boost/range/begin.hpp>
+#include <boost/range/end.hpp>
+#include <boost/range/value_type.hpp>
 #include <boost/static_assert.hpp>
 
 #include <boost/geometry/core/access.hpp>

--- a/include/boost/geometry/extensions/algorithms/offset.hpp
+++ b/include/boost/geometry/extensions/algorithms/offset.hpp
@@ -2,6 +2,10 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2020.
+// Modifications copyright (c) 2020 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -10,8 +14,10 @@
 #define BOOST_GEOMETRY_EXTENSIONS_ALGORITHMS_OFFSET_HPP
 
 #include <boost/config.hpp>
-
-#include <boost/range/functions.hpp>
+#include <boost/range/begin.hpp>
+#include <boost/range/end.hpp>
+#include <boost/range/rbegin.hpp>
+#include <boost/range/rend.hpp>
 
 #include <boost/geometry/core/point_type.hpp>
 #include <boost/geometry/algorithms/detail/buffer/buffer_inserter.hpp>

--- a/include/boost/geometry/extensions/gis/io/shapelib/shp_create_object.hpp
+++ b/include/boost/geometry/extensions/gis/io/shapelib/shp_create_object.hpp
@@ -2,6 +2,10 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2020.
+// Modifications copyright (c) 2020 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -10,13 +14,13 @@
 #define BOOST_GEOMETRY_EXT_GIS_IO_SHAPELIB_SHP_CREATE_OBJECT_HPP
 
 
-#include <boost/mpl/assert.hpp>
 #include <boost/range.hpp>
 #include <boost/scoped_array.hpp>
 
 #include <boost/geometry/core/exterior_ring.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
 #include <boost/geometry/core/ring_type.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/algorithms/num_interior_rings.hpp>
 #include <boost/geometry/algorithms/num_points.hpp>
 #include <boost/geometry/views/box_view.hpp>
@@ -25,7 +29,6 @@
 
 // Should be somewhere in your include path
 #include "shapefil.h"
-
 
 
 namespace boost { namespace geometry
@@ -158,11 +161,9 @@ namespace dispatch
 template <typename Tag, typename Geometry>
 struct shp_create_object
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_OR_NOT_YET_IMPLEMENTED_FOR_THIS_GEOMETRY_TYPE
-            , (Geometry)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Geometry type.",
+        Tag, Geometry);
 };
 
 

--- a/include/boost/geometry/extensions/gis/io/shapelib/shp_read_object.hpp
+++ b/include/boost/geometry/extensions/gis/io/shapelib/shp_read_object.hpp
@@ -2,6 +2,10 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2020.
+// Modifications copyright (c) 2020 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -10,19 +14,18 @@
 #define BOOST_GEOMETRY_EXT_GIS_IO_SHAPELIB_SHP_READ_OBJECT_HPP
 
 
-#include <boost/mpl/assert.hpp>
 #include <boost/range.hpp>
 #include <boost/scoped_array.hpp>
 
 #include <boost/geometry/core/exterior_ring.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
 #include <boost/geometry/core/ring_type.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/algorithms/num_points.hpp>
 
 
 // Should be somewhere in your include path
 #include "shapefil.h"
-
 
 
 namespace boost { namespace geometry
@@ -160,11 +163,9 @@ namespace dispatch
 template <typename Tag, typename Geometry>
 struct shp_read_object
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_OR_NOT_YET_IMPLEMENTED_FOR_THIS_GEOMETRY_TYPE
-            , (Geometry)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Geometry type.",
+        Tag, Geometry);
 };
 
 

--- a/include/boost/geometry/extensions/nsphere/algorithms/disjoint.hpp
+++ b/include/boost/geometry/extensions/nsphere/algorithms/disjoint.hpp
@@ -23,9 +23,8 @@
 
 #include <boost/geometry/algorithms/disjoint.hpp>
 #include <boost/geometry/algorithms/comparable_distance.hpp>
-
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/extensions/nsphere/views/center_view.hpp>
-
 #include <boost/geometry/util/select_most_precise.hpp>
 
 namespace boost { namespace geometry
@@ -105,9 +104,10 @@ struct disjoint<Point, NSphere, DimensionCount, point_tag, nsphere_tag, Reverse>
         typedef typename coordinate_system<NSphere>::type s_cs;
         static const bool check_cs = std::is_same<p_cs, cs::cartesian>::value
                                   && std::is_same<s_cs, cs::cartesian>::value;
-        BOOST_MPL_ASSERT_MSG(check_cs,
-                             NOT_IMPLEMENTED_FOR_THOSE_COORDINATE_SYSTEMS,
-                             (p_cs, s_cs));
+        BOOST_GEOMETRY_STATIC_ASSERT(
+            check_cs,
+            "Not implemented for those coordinate systems.",
+            p_cs, s_cs);
 
         typename radius_type<NSphere>::type const r = get_radius<0>(s);
         center_view<const NSphere> const c(s);
@@ -129,9 +129,10 @@ struct disjoint<NSphere, Box, DimensionCount, nsphere_tag, box_tag, Reverse>
         typedef typename coordinate_system<NSphere>::type s_cs;
         static const bool check_cs = std::is_same<b_cs, cs::cartesian>::value
                                   && std::is_same<s_cs, cs::cartesian>::value;
-        BOOST_MPL_ASSERT_MSG(check_cs,
-                             NOT_IMPLEMENTED_FOR_THOSE_COORDINATE_SYSTEMS,
-                             (b_cs, s_cs));
+        BOOST_GEOMETRY_STATIC_ASSERT(
+            check_cs,
+            "Not implemented for those coordinate systems.",
+            b_cs, s_cs);
 
         typename radius_type<NSphere>::type const r = get_radius<0>(s);
 
@@ -153,9 +154,10 @@ struct disjoint<NSphere1, NSphere2, DimensionCount, nsphere_tag, nsphere_tag, Re
         typedef typename coordinate_system<NSphere2>::type s2_cs;
         static const bool check_cs = std::is_same<s1_cs, cs::cartesian>::value
                                   && std::is_same<s2_cs, cs::cartesian>::value;
-        BOOST_MPL_ASSERT_MSG(check_cs,
-                             NOT_IMPLEMENTED_FOR_THOSE_COORDINATE_SYSTEMS,
-                             (s1_cs, s2_cs));
+        BOOST_GEOMETRY_STATIC_ASSERT(
+            check_cs,
+            "Not implemented for those coordinate systems.",
+            s1_cs, s2_cs);
 
         /*return get_radius<0>(s1) + get_radius<0>(s2)
                <   ::sqrt(geometry::comparable_distance(center_view<NSphere>(s1), center_view<NSphere>(s2)));*/

--- a/include/boost/geometry/formulas/vertex_latitude.hpp
+++ b/include/boost/geometry/formulas/vertex_latitude.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2016-2017 Oracle and/or its affiliates.
+// Copyright (c) 2016-2020 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -13,10 +13,9 @@
 #define BOOST_GEOMETRY_FORMULAS_MAXIMUM_LATITUDE_HPP
 
 
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/formulas/flattening.hpp>
 #include <boost/geometry/formulas/spherical.hpp>
-
-#include <boost/mpl/assert.hpp>
 
 
 namespace boost { namespace geometry { namespace formula
@@ -127,11 +126,9 @@ public:
 template <typename CT, typename CS_Tag>
 struct vertex_latitude
 {
-    BOOST_MPL_ASSERT_MSG
-         (
-             false, NOT_IMPLEMENTED_FOR_THIS_COORDINATE_SYSTEM, (types<CS_Tag>)
-         );
-
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this coordinate system.",
+        CT, CS_Tag);
 };
 
 template <typename CT>

--- a/include/boost/geometry/formulas/vertex_longitude.hpp
+++ b/include/boost/geometry/formulas/vertex_longitude.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2016-2018 Oracle and/or its affiliates.
+// Copyright (c) 2016-2020 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -12,10 +12,10 @@
 #ifndef BOOST_GEOMETRY_FORMULAS_MAXIMUM_LONGITUDE_HPP
 #define BOOST_GEOMETRY_FORMULAS_MAXIMUM_LONGITUDE_HPP
 
+
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/formulas/spherical.hpp>
 #include <boost/geometry/formulas/flattening.hpp>
-
-#include <boost/mpl/assert.hpp>
 
 #include <boost/math/special_functions/hypot.hpp>
 
@@ -224,11 +224,9 @@ public:
 template <typename CT, typename CS_Tag>
 struct compute_vertex_lon
 {
-    BOOST_MPL_ASSERT_MSG
-    (
-        false, NOT_IMPLEMENTED_FOR_THIS_COORDINATE_SYSTEM, (types<CS_Tag>)
-    );
-
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this coordinate system.",
+        CT, CS_Tag);
 };
 
 template <typename CT>

--- a/include/boost/geometry/geometries/concepts/multi_linestring_concept.hpp
+++ b/include/boost/geometry/geometries/concepts/multi_linestring_concept.hpp
@@ -4,6 +4,10 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
+// This file was modified by Oracle on 2020.
+// Modifications copyright (c) 2020 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -18,7 +22,7 @@
 
 #include <boost/concept_check.hpp>
 #include <boost/range/concepts.hpp>
-#include <boost/range/metafunctions.hpp>
+#include <boost/range/value_type.hpp>
 
 
 #include <boost/geometry/geometries/concepts/linestring_concept.hpp>

--- a/include/boost/geometry/geometries/concepts/multi_point_concept.hpp
+++ b/include/boost/geometry/geometries/concepts/multi_point_concept.hpp
@@ -4,6 +4,10 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
+// This file was modified by Oracle on 2020.
+// Modifications copyright (c) 2020 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -18,7 +22,7 @@
 
 #include <boost/concept_check.hpp>
 #include <boost/range/concepts.hpp>
-#include <boost/range/metafunctions.hpp>
+#include <boost/range/value_type.hpp>
 
 #include <boost/geometry/core/mutable_range.hpp>
 

--- a/include/boost/geometry/geometries/concepts/multi_polygon_concept.hpp
+++ b/include/boost/geometry/geometries/concepts/multi_polygon_concept.hpp
@@ -4,6 +4,10 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
+// This file was modified by Oracle on 2020.
+// Modifications copyright (c) 2020 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -18,7 +22,7 @@
 
 #include <boost/concept_check.hpp>
 #include <boost/range/concepts.hpp>
-#include <boost/range/metafunctions.hpp>
+#include <boost/range/value_type.hpp>
 
 #include <boost/geometry/geometries/concepts/polygon_concept.hpp>
 

--- a/include/boost/geometry/geometries/helper_geometry.hpp
+++ b/include/boost/geometry/geometries/helper_geometry.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2015-2017, Oracle and/or its affiliates.
+// Copyright (c) 2015-2020, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -11,7 +11,6 @@
 #ifndef BOOST_GEOMETRY_GEOMETRIES_HELPER_GEOMETRY_HPP
 #define BOOST_GEOMETRY_GEOMETRIES_HELPER_GEOMETRY_HPP
 
-#include <boost/mpl/assert.hpp>
 
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>

--- a/include/boost/geometry/index/adaptors/query.hpp
+++ b/include/boost/geometry/index/adaptors/query.hpp
@@ -4,12 +4,18 @@
 //
 // Copyright (c) 2011-2013 Adam Wulkiewicz, Lodz, Poland.
 //
+// This file was modified by Oracle on 2020.
+// Modifications copyright (c) 2020 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+//
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef BOOST_GEOMETRY_INDEX_ADAPTORS_QUERY_HPP
 #define BOOST_GEOMETRY_INDEX_ADAPTORS_QUERY_HPP
+
+#include <boost/geometry/core/static_assert.hpp>
 
 /*!
 \defgroup adaptors Adaptors (boost::geometry::index::adaptors::)
@@ -24,10 +30,9 @@ namespace detail {
 template <typename Index>
 class query_range
 {
-    BOOST_MPL_ASSERT_MSG(
-        (false),
-        NOT_IMPLEMENTED_FOR_THIS_INDEX,
-        (query_range));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Index type.",
+        Index);
 
     typedef int* iterator;
     typedef const int* const_iterator;

--- a/include/boost/geometry/index/detail/algorithms/content.hpp
+++ b/include/boost/geometry/index/detail/algorithms/content.hpp
@@ -4,12 +4,18 @@
 //
 // Copyright (c) 2011-2014 Adam Wulkiewicz, Lodz, Poland.
 //
+// This file was modified by Oracle on 2020.
+// Modifications copyright (c) 2020 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+//
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_ALGORITHMS_CONTENT_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_ALGORITHMS_CONTENT_HPP
+
+#include <boost/geometry/core/static_assert.hpp>
 
 namespace boost { namespace geometry { namespace index { namespace detail {
 
@@ -49,7 +55,9 @@ struct content_box<Box, 1>
 template <typename Indexable, typename Tag>
 struct content
 {
-    BOOST_MPL_ASSERT_MSG(false, NOT_IMPLEMENTED_FOR_THIS_INDEXABLE_AND_TAG, (Indexable, Tag));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Indexable and Tag.",
+        Indexable, Tag);
 };
 
 template <typename Indexable>

--- a/include/boost/geometry/index/detail/algorithms/is_valid.hpp
+++ b/include/boost/geometry/index/detail/algorithms/is_valid.hpp
@@ -4,6 +4,10 @@
 //
 // Copyright (c) 2011-2014 Adam Wulkiewicz, Lodz, Poland.
 //
+// This file was modified by Oracle on 2020.
+// Modifications copyright (c) 2020 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+//
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -12,7 +16,9 @@
 #define BOOST_GEOMETRY_INDEX_DETAIL_ALGORITHMS_IS_VALID_HPP
 
 #include <cstddef>
+
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 
 namespace boost { namespace geometry { namespace index { namespace detail {
 
@@ -42,10 +48,9 @@ template <typename Indexable,
           typename Tag = typename geometry::tag<Indexable>::type>
 struct is_valid
 {
-    BOOST_MPL_ASSERT_MSG(
-        (false),
-        NOT_IMPLEMENTED_FOR_THIS_INDEXABLE,
-        (is_valid));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Indexable type.",
+        Indexable, Tag);
 };
 
 template <typename Indexable>

--- a/include/boost/geometry/index/detail/algorithms/margin.hpp
+++ b/include/boost/geometry/index/detail/algorithms/margin.hpp
@@ -4,12 +4,18 @@
 //
 // Copyright (c) 2011-2014 Adam Wulkiewicz, Lodz, Poland.
 //
+// This file was modified by Oracle on 2020.
+// Modifications copyright (c) 2020 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+//
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_ALGORITHMS_MARGIN_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_ALGORITHMS_MARGIN_HPP
+
+#include <boost/geometry/core/static_assert.hpp>
 
 // WARNING! comparable_margin() will work only if the same Geometries are compared
 // so it shouldn't be used in the case of Variants!
@@ -124,7 +130,9 @@ namespace dispatch {
 template <typename Geometry, typename Tag>
 struct comparable_margin
 {
-    BOOST_MPL_ASSERT_MSG(false, NOT_IMPLEMENTED_FOR_THIS_GEOMETRY, (Geometry, Tag));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Geometry type.",
+        Geometry, Tag);
 };
 
 template <typename Geometry>

--- a/include/boost/geometry/index/detail/algorithms/minmaxdist.hpp
+++ b/include/boost/geometry/index/detail/algorithms/minmaxdist.hpp
@@ -4,6 +4,10 @@
 //
 // Copyright (c) 2011-2014 Adam Wulkiewicz, Lodz, Poland.
 //
+// This file was modified by Oracle on 2020.
+// Modifications copyright (c) 2020 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+//
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -13,6 +17,8 @@
 
 #include <boost/geometry/algorithms/distance.hpp>
 #include <boost/geometry/algorithms/comparable_distance.hpp>
+
+#include <boost/geometry/core/static_assert.hpp>
 
 #include <boost/geometry/index/detail/algorithms/diff_abs.hpp>
 #include <boost/geometry/index/detail/algorithms/sum_for_indexable.hpp>
@@ -64,10 +70,9 @@ struct smallest_for_indexable_dimension<Point, BoxIndexable, box_tag, minmaxdist
 template <typename Point, typename Indexable, typename IndexableTag>
 struct minmaxdist_impl
 {
-    BOOST_MPL_ASSERT_MSG(
-        (false),
-        NOT_IMPLEMENTED_FOR_THIS_INDEXABLE_TAG_TYPE,
-        (minmaxdist_impl));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Indexable type.",
+        Point, Indexable, IndexableTag);
 };
 
 template <typename Point, typename Indexable>

--- a/include/boost/geometry/index/detail/algorithms/path_intersection.hpp
+++ b/include/boost/geometry/index/detail/algorithms/path_intersection.hpp
@@ -4,6 +4,10 @@
 //
 // Copyright (c) 2011-2017 Adam Wulkiewicz, Lodz, Poland.
 //
+// This file was modified by Oracle on 2020.
+// Modifications copyright (c) 2020 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+//
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -11,6 +15,8 @@
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_ALGORITHMS_PATH_INTERSECTION_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_ALGORITHMS_PATH_INTERSECTION_HPP
 
+
+#include <boost/geometry/core/static_assert.hpp>
 
 #include <boost/geometry/index/detail/algorithms/segment_intersection.hpp>
 
@@ -24,7 +30,9 @@ namespace dispatch {
 template <typename Indexable, typename Geometry, typename IndexableTag, typename GeometryTag>
 struct path_intersection
 {
-    BOOST_MPL_ASSERT_MSG((false), NOT_IMPLEMENTED_FOR_THIS_GEOMETRY_OR_INDEXABLE, (path_intersection));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Geometry or Indexable.",
+        Indexable, Geometry, IndexableTag, GeometryTag);
 };
 
 // TODO: FP type must be used as a relative distance type!

--- a/include/boost/geometry/index/detail/algorithms/segment_intersection.hpp
+++ b/include/boost/geometry/index/detail/algorithms/segment_intersection.hpp
@@ -17,6 +17,8 @@
 
 #include <type_traits>
 
+#include <boost/geometry/core/static_assert.hpp>
+
 namespace boost { namespace geometry { namespace index { namespace detail {
 
 //template <typename Indexable, typename Point>
@@ -31,8 +33,8 @@ namespace boost { namespace geometry { namespace index { namespace detail {
 //    >::type type;
 //
 //
-//    BOOST_MPL_ASSERT_MSG((!std::is_unsigned<type>::value),
-//        THIS_TYPE_SHOULDNT_BE_UNSIGNED, (type));
+//    BOOST_GEOMETRY_STATIC_ASSERT((!std::is_unsigned<type>::value),
+//        "Distance type can not be unsigned.", type);
 //};
 
 namespace dispatch {
@@ -99,13 +101,17 @@ struct box_segment_intersection<Box, Point, 1>
 template <typename Indexable, typename Point, typename Tag>
 struct segment_intersection
 {
-    BOOST_MPL_ASSERT_MSG((false), NOT_IMPLEMENTED_FOR_THIS_GEOMETRY, (segment_intersection));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Indexable type.",
+        Indexable, Point, Tag);
 };
 
 template <typename Indexable, typename Point>
 struct segment_intersection<Indexable, Point, point_tag>
 {
-    BOOST_MPL_ASSERT_MSG((false), SEGMENT_POINT_INTERSECTION_UNAVAILABLE, (segment_intersection));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Segment-Point intersection unavailable.",
+        Indexable, Point);
 };
 
 template <typename Indexable, typename Point>
@@ -120,7 +126,9 @@ struct segment_intersection<Indexable, Point, box_tag>
 // TODO: this ASSERT CHECK is wrong for user-defined CoordinateTypes!
 
         static const bool check = !std::is_integral<RelativeDistance>::value;
-        BOOST_MPL_ASSERT_MSG(check, RELATIVE_DISTANCE_MUST_BE_FLOATING_POINT_TYPE, (RelativeDistance));
+        BOOST_GEOMETRY_STATIC_ASSERT(check,
+            "RelativeDistance must be a floating point type.",
+            RelativeDistance);
 
         RelativeDistance t_near = -(::std::numeric_limits<RelativeDistance>::max)();
         RelativeDistance t_far = (::std::numeric_limits<RelativeDistance>::max)();

--- a/include/boost/geometry/index/detail/algorithms/smallest_for_indexable.hpp
+++ b/include/boost/geometry/index/detail/algorithms/smallest_for_indexable.hpp
@@ -4,12 +4,18 @@
 //
 // Copyright (c) 2011-2013 Adam Wulkiewicz, Lodz, Poland.
 //
+// This file was modified by Oracle on 2020.
+// Modifications copyright (c) 2020 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+//
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_ALGORITHMS_SMALLEST_FOR_INDEXABLE_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_ALGORITHMS_SMALLEST_FOR_INDEXABLE_HPP
+
+#include <boost/geometry/core/static_assert.hpp>
 
 namespace boost { namespace geometry { namespace index { namespace detail {
 
@@ -21,10 +27,9 @@ template <
     size_t DimensionIndex>
 struct smallest_for_indexable_dimension
 {
-    BOOST_MPL_ASSERT_MSG(
-        (false),
-        NOT_IMPLEMENTED_FOR_THIS_INDEXABLE_TAG_TYPE,
-        (smallest_for_indexable_dimension));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Indexable type.",
+        Geometry, Indexable, IndexableTag, AlgoTag);
 };
 
 template <

--- a/include/boost/geometry/index/detail/algorithms/sum_for_indexable.hpp
+++ b/include/boost/geometry/index/detail/algorithms/sum_for_indexable.hpp
@@ -4,12 +4,18 @@
 //
 // Copyright (c) 2011-2013 Adam Wulkiewicz, Lodz, Poland.
 //
+// This file was modified by Oracle on 2020.
+// Modifications copyright (c) 2020 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+//
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_ALGORITHMS_SUM_FOR_INDEXABLE_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_ALGORITHMS_SUM_FOR_INDEXABLE_HPP
+
+#include <boost/geometry/core/static_assert.hpp>
 
 namespace boost { namespace geometry { namespace index { namespace detail {
 
@@ -21,10 +27,9 @@ template <
     size_t DimensionIndex>
 struct sum_for_indexable_dimension
 {
-    BOOST_MPL_ASSERT_MSG(
-        (false),
-        NOT_IMPLEMENTED_FOR_THIS_INDEXABLE_TAG_TYPE,
-        (sum_for_indexable_dimension));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Indexable type.",
+        Geometry, Indexable, IndexableTag, AlgoTag);
 };
 
 template <

--- a/include/boost/geometry/index/detail/bounded_view.hpp
+++ b/include/boost/geometry/index/detail/bounded_view.hpp
@@ -5,8 +5,8 @@
 //
 // Copyright (c) 2014-2015 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2019.
-// Modifications copyright (c) 2019 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2019-2020.
+// Modifications copyright (c) 2019-2020 Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -16,11 +16,11 @@
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_BOUNDED_VIEW_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_BOUNDED_VIEW_HPP
 
-#include <boost/mpl/assert.hpp>
 
 #include <boost/geometry/algorithms/envelope.hpp>
-
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/strategies/index.hpp>
+
 
 namespace boost { namespace geometry {
 
@@ -53,10 +53,9 @@ template
 >
 struct bounded_view_base
 {
-    BOOST_MPL_ASSERT_MSG(
-        (false),
-        NOT_IMPLEMENTED_FOR_THOSE_GEOMETRIES,
-        (types<Tag, BoundingTag, CSTag>));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for these Geometries.",
+        Geometry, BoundingGeometry, Strategy, Tag, BoundingTag, CSTag);
 };
 
 

--- a/include/boost/geometry/index/detail/distance_predicates.hpp
+++ b/include/boost/geometry/index/detail/distance_predicates.hpp
@@ -5,8 +5,8 @@
 //
 // Copyright (c) 2011-2015 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2019.
-// Modifications copyright (c) 2019 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2019-2020.
+// Modifications copyright (c) 2019-2020 Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -15,6 +15,8 @@
 
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_DISTANCE_PREDICATES_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_DISTANCE_PREDICATES_HPP
+
+#include <boost/geometry/core/static_assert.hpp>
 
 #include <boost/geometry/index/detail/algorithms/comparable_distance_near.hpp>
 #include <boost/geometry/index/detail/algorithms/comparable_distance_far.hpp>
@@ -235,7 +237,9 @@ struct comparable_distance_call<G1, G2, default_strategy>
 template <typename Predicate, typename Indexable, typename Strategy, typename Tag>
 struct calculate_distance
 {
-    BOOST_MPL_ASSERT_MSG((false), INVALID_PREDICATE_OR_TAG, (calculate_distance));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Invalid Predicate or Tag.",
+        Predicate, Indexable, Strategy, Tag);
 };
 
 // this handles nearest() with default Point parameter, to_nearest() and bounds

--- a/include/boost/geometry/index/detail/predicates.hpp
+++ b/include/boost/geometry/index/detail/predicates.hpp
@@ -4,8 +4,8 @@
 //
 // Copyright (c) 2011-2015 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2019.
-// Modifications copyright (c) 2019 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2019-2020.
+// Modifications copyright (c) 2019-2020 Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -15,10 +15,12 @@
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_PREDICATES_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_PREDICATES_HPP
 
+#include <type_traits>
 //#include <utility>
 
-#include <boost/mpl/assert.hpp>
 #include <boost/tuple/tuple.hpp>
+
+#include <boost/geometry/core/static_assert.hpp>
 
 #include <boost/geometry/index/detail/tags.hpp>
 
@@ -121,10 +123,9 @@ struct path
 template <typename Predicate, typename Tag>
 struct predicate_check
 {
-    BOOST_MPL_ASSERT_MSG(
-        (false),
-        NOT_IMPLEMENTED_FOR_THIS_PREDICATE_OR_TAG,
-        (predicate_check));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Predicate or Tag.",
+        Predicate, Tag);
 };
 
 // ------------------------------------------------------------------ //
@@ -154,7 +155,9 @@ struct predicate_check<predicates::satisfies<Fun, true>, value_tag>
 template <typename Tag>
 struct spatial_predicate_call
 {
-    BOOST_MPL_ASSERT_MSG(false, NOT_IMPLEMENTED_FOR_THIS_TAG, (Tag));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Tag.",
+        Tag);
 };
 
 template <>
@@ -546,7 +549,10 @@ struct predicates_length< boost::tuples::cons<Head, Tail> >
 template <unsigned I, typename T>
 struct predicates_element
 {
-    BOOST_MPL_ASSERT_MSG((I < 1), INVALID_INDEX, (predicates_element));
+    BOOST_GEOMETRY_STATIC_ASSERT((I < 1),
+        "Invalid I index.",
+        std::integral_constant<unsigned, I>);
+
     typedef T type;
     static type const& get(T const& p) { return p; }
 };
@@ -554,7 +560,7 @@ struct predicates_element
 //template <unsigned I, typename F, typename S>
 //struct predicates_element< I, std::pair<F, S> >
 //{
-//    BOOST_MPL_ASSERT_MSG((I < 2), INVALID_INDEX, (predicates_element));
+//    BOOST_GEOMETRY_STATIC_ASSERT((I < 2), "INVALID_INDEX", std::integral_constant<unsigned, I>, F, S);
 //
 //    typedef F type;
 //    static type const& get(std::pair<F, S> const& p) { return p.first; }
@@ -662,7 +668,9 @@ template <typename Predicate, typename Tag, unsigned First, unsigned Last>
 struct predicates_check_impl
 {
     static const bool check = First < 1 && Last <= 1 && First <= Last;
-    BOOST_MPL_ASSERT_MSG((check), INVALID_INDEXES, (predicates_check_impl));
+    BOOST_GEOMETRY_STATIC_ASSERT((check),
+        "Invalid First or Last index.",
+        std::integer_sequence<unsigned, First, Last>);
 
     template <typename Value, typename Indexable, typename Strategy>
     static inline bool apply(Predicate const& p, Value const& v, Indexable const& i, Strategy const& s)
@@ -674,7 +682,9 @@ struct predicates_check_impl
 //template <typename Predicate1, typename Predicate2, typename Tag, size_t First, size_t Last>
 //struct predicates_check_impl<std::pair<Predicate1, Predicate2>, Tag, First, Last>
 //{
-//    BOOST_MPL_ASSERT_MSG((First < 2 && Last <= 2 && First <= Last), INVALID_INDEXES, (predicates_check_impl));
+//    BOOST_GEOMETRY_STATIC_ASSERT((First < 2 && Last <= 2 && First <= Last),
+//        "INVALID_INDEXES",
+//        std::integer_sequence<unsigned, First, Last>);
 //
 //    template <typename Value, typename Indexable>
 //    static inline bool apply(std::pair<Predicate1, Predicate2> const& p, Value const& v, Indexable const& i)
@@ -697,7 +707,9 @@ struct predicates_check_impl
 //    typedef boost::tuple<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> predicates_type;
 //
 //    static const unsigned pred_len = boost::tuples::length<predicates_type>::value;
-//    BOOST_MPL_ASSERT_MSG((First < pred_len && Last <= pred_len && First <= Last), INVALID_INDEXES, (predicates_check_impl));
+//    BOOST_GEOMETRY_STATIC_ASSERT((First < pred_len && Last <= pred_len && First <= Last),
+//        "INVALID_INDEXES",
+//        std::integer_sequence<unsigned, First, Last>);
 //
 //    template <typename Value, typename Indexable>
 //    static inline bool apply(predicates_type const& p, Value const& v, Indexable const& i)
@@ -719,7 +731,9 @@ struct predicates_check_impl<
 
     static const unsigned pred_len = boost::tuples::length<predicates_type>::value;
     static const bool check = First < pred_len && Last <= pred_len && First <= Last;
-    BOOST_MPL_ASSERT_MSG((check), INVALID_INDEXES, (predicates_check_impl));
+    BOOST_GEOMETRY_STATIC_ASSERT((check),
+        "Invalid First or Last index.",
+        std::integer_sequence<unsigned, First, Last>);
 
     template <typename Value, typename Indexable, typename Strategy>
     static inline bool apply(predicates_type const& p, Value const& v, Indexable const& i, Strategy const& s)

--- a/include/boost/geometry/index/detail/rtree/linear/redistribute_elements.hpp
+++ b/include/boost/geometry/index/detail/rtree/linear/redistribute_elements.hpp
@@ -20,6 +20,8 @@
 
 #include <boost/core/ignore_unused.hpp>
 
+#include <boost/geometry/core/static_assert.hpp>
+
 #include <boost/geometry/index/detail/algorithms/bounds.hpp>
 #include <boost/geometry/index/detail/algorithms/content.hpp>
 #include <boost/geometry/index/detail/bounded_view.hpp>
@@ -49,7 +51,9 @@ inline R difference_dispatch(T const& from, T const& to, std::true_type /*is_uns
 template <typename R, typename T>
 inline R difference(T const& from, T const& to)
 {
-    BOOST_MPL_ASSERT_MSG((! std::is_unsigned<R>::value), RESULT_CANT_BE_UNSIGNED, (R));
+    BOOST_GEOMETRY_STATIC_ASSERT((! std::is_unsigned<R>::value),
+        "Result can not be an unsigned type.",
+        R);
 
     return difference_dispatch<R>(from, to, std::is_unsigned<T>());
 }

--- a/include/boost/geometry/index/detail/rtree/node/concept.hpp
+++ b/include/boost/geometry/index/detail/rtree/node/concept.hpp
@@ -4,12 +4,18 @@
 //
 // Copyright (c) 2011-2013 Adam Wulkiewicz, Lodz, Poland.
 //
+// This file was modified by Oracle on 2020.
+// Modifications copyright (c) 2020 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+//
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_RTREE_NODE_CONCEPT_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_RTREE_NODE_CONCEPT_HPP
+
+#include <boost/geometry/core/static_assert.hpp>
 
 namespace boost { namespace geometry { namespace index {
 
@@ -18,64 +24,57 @@ namespace detail { namespace rtree {
 template <typename Value, typename Parameters, typename Box, typename Allocators, typename Tag>
 struct node
 {
-    BOOST_MPL_ASSERT_MSG(
-        (false),
-        NOT_IMPLEMENTED_FOR_THIS_TAG_TYPE,
-        (node));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Tag type.",
+        Value, Parameters, Box, Allocators, Tag);
 };
 
 template <typename Value, typename Parameters, typename Box, typename Allocators, typename Tag>
 struct internal_node
 {
-    BOOST_MPL_ASSERT_MSG(
-        (false),
-        NOT_IMPLEMENTED_FOR_THIS_TAG_TYPE,
-        (internal_node));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Tag type.",
+        Value, Parameters, Box, Allocators, Tag);
 };
 
 template <typename Value, typename Parameters, typename Box, typename Allocators, typename Tag>
 struct leaf
 {
-    BOOST_MPL_ASSERT_MSG(
-        (false),
-        NOT_IMPLEMENTED_FOR_THIS_TAG_TYPE,
-        (leaf));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Tag type.",
+        Value, Parameters, Box, Allocators, Tag);
 };
 
 template <typename Value, typename Parameters, typename Box, typename Allocators, typename Tag, bool IsVisitableConst>
 struct visitor
 {
-    BOOST_MPL_ASSERT_MSG(
-        (false),
-        NOT_IMPLEMENTED_FOR_THIS_TAG_TYPE,
-        (visitor));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Tag type.",
+        Value, Parameters, Box, Allocators, Tag);
 };
 
 template <typename Allocator, typename Value, typename Parameters, typename Box, typename Tag>
 class allocators
 {
-    BOOST_MPL_ASSERT_MSG(
-        (false),
-        NOT_IMPLEMENTED_FOR_THIS_TAG_TYPE,
-        (allocators));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Tag type.",
+        Allocator, Value, Parameters, Box, Tag);
 };
 
 template <typename Allocators, typename Node>
 struct create_node
 {
-    BOOST_MPL_ASSERT_MSG(
-        (false),
-        NOT_IMPLEMENTED_FOR_THIS_NODE_TYPE,
-        (create_node));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Node type.",
+        Allocators, Node);
 };
 
 template <typename Allocators, typename Node>
 struct destroy_node
 {
-    BOOST_MPL_ASSERT_MSG(
-        (false),
-        NOT_IMPLEMENTED_FOR_THIS_NODE_TYPE,
-        (destroy_node));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Node type.",
+        Allocators, Node);
 };
 
 }} // namespace detail::rtree

--- a/include/boost/geometry/index/detail/rtree/node/node.hpp
+++ b/include/boost/geometry/index/detail/rtree/node/node.hpp
@@ -18,6 +18,9 @@
 #include <type_traits>
 
 #include <boost/container/vector.hpp>
+
+#include <boost/geometry/core/static_assert.hpp>
+
 #include <boost/geometry/index/detail/varray.hpp>
 
 #include <boost/geometry/index/detail/rtree/node/concept.hpp>
@@ -82,9 +85,9 @@ inline Box values_box(FwdIter first, FwdIter last, Translator const& tr,
                       Strategy const& strategy)
 {
     typedef typename std::iterator_traits<FwdIter>::value_type element_type;
-    BOOST_MPL_ASSERT_MSG((is_leaf_element<element_type>::value),
-                         SHOULD_BE_CALLED_ONLY_FOR_LEAF_ELEMENTS,
-                         (element_type));
+    BOOST_GEOMETRY_STATIC_ASSERT((is_leaf_element<element_type>::value),
+        "This function should be called only for elements of leaf nodes.",
+        element_type);
 
     Box result = elements_box<Box>(first, last, tr, strategy);
 

--- a/include/boost/geometry/index/detail/rtree/rstar/redistribute_elements.hpp
+++ b/include/boost/geometry/index/detail/rtree/rstar/redistribute_elements.hpp
@@ -4,8 +4,8 @@
 //
 // Copyright (c) 2011-2017 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2019.
-// Modifications copyright (c) 2019 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2019-2020.
+// Modifications copyright (c) 2019-2020 Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -16,6 +16,8 @@
 #define BOOST_GEOMETRY_INDEX_DETAIL_RTREE_RSTAR_REDISTRIBUTE_ELEMENTS_HPP
 
 #include <boost/core/ignore_unused.hpp>
+
+#include <boost/geometry/core/static_assert.hpp>
 
 #include <boost/geometry/index/detail/algorithms/intersection_content.hpp>
 #include <boost/geometry/index/detail/algorithms/margin.hpp>
@@ -188,7 +190,7 @@ struct choose_split_axis_and_index_for_corner
 //template <typename Box, size_t AxisIndex, typename ElementIndexableTag>
 //struct choose_split_axis_and_index_for_axis
 //{
-//    BOOST_MPL_ASSERT_MSG(false, NOT_IMPLEMENTED_FOR_THIS_TAG, (ElementIndexableTag));
+//    BOOST_GEOMETRY_STATIC_ASSERT_FALSE("Not implemented for this Tag type.", ElementIndexableTag);
 //};
 
 template <typename Box, size_t AxisIndex, typename ElementIndexableTag>

--- a/include/boost/geometry/index/detail/rtree/utilities/gl_draw.hpp
+++ b/include/boost/geometry/index/detail/rtree/utilities/gl_draw.hpp
@@ -4,8 +4,8 @@
 //
 // Copyright (c) 2011-2013 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2019.
-// Modifications copyright (c) 2019 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2019-2020.
+// Modifications copyright (c) 2019-2020 Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -15,7 +15,7 @@
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_RTREE_UTILITIES_GL_DRAW_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_RTREE_UTILITIES_GL_DRAW_HPP
 
-#include <boost/mpl/assert.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 
 namespace boost { namespace geometry { namespace index { namespace detail {
 
@@ -83,7 +83,9 @@ struct gl_draw_segment<Segment, 2>
 template <typename Indexable, typename Tag>
 struct gl_draw_indexable
 {
-    BOOST_MPL_ASSERT_MSG((false), NOT_IMPLEMENTED_FOR_THIS_TAG, (Tag));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Indexable type.",
+        Indexable, Tag);
 };
 
 template <typename Box>

--- a/include/boost/geometry/index/detail/rtree/utilities/print.hpp
+++ b/include/boost/geometry/index/detail/rtree/utilities/print.hpp
@@ -4,8 +4,8 @@
 //
 // Copyright (c) 2011-2013 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2019.
-// Modifications copyright (c) 2019 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2019-2020.
+// Modifications copyright (c) 2019-2020 Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -16,6 +16,8 @@
 #define BOOST_GEOMETRY_INDEX_DETAIL_RTREE_UTILITIES_PRINT_HPP
 
 #include <iostream>
+
+#include <boost/geometry/core/static_assert.hpp>
 
 namespace boost { namespace geometry { namespace index { namespace detail {
     
@@ -70,7 +72,9 @@ struct print_corner<Box, Corner, 1>
 template <typename Indexable, typename Tag>
 struct print_indexable
 {
-    BOOST_MPL_ASSERT_MSG((false), NOT_IMPLEMENTED_FOR_THIS_TAG, (Tag));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Indexable type.",
+        Indexable, Tag);
 };
 
 template <typename Indexable>

--- a/include/boost/geometry/index/detail/rtree/visitors/insert.hpp
+++ b/include/boost/geometry/index/detail/rtree/visitors/insert.hpp
@@ -20,6 +20,7 @@
 #endif
 
 #include <boost/geometry/algorithms/detail/expand_by_epsilon.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/util/condition.hpp>
 
 #include <boost/geometry/index/detail/algorithms/bounds.hpp>
@@ -110,10 +111,9 @@ template
 >
 struct redistribute_elements
 {
-    BOOST_MPL_ASSERT_MSG(
-        (false),
-        NOT_IMPLEMENTED_FOR_THIS_REDISTRIBUTE_TAG_TYPE,
-        (redistribute_elements));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this RedistributeTag type.",
+        MembersHolder, RedistributeTag);
 };
 
 // ----------------------------------------------------------------------- //
@@ -126,10 +126,9 @@ template
 >
 class split
 {
-    BOOST_MPL_ASSERT_MSG(
-        (false),
-        NOT_IMPLEMENTED_FOR_THIS_SPLIT_TAG_TYPE,
-        (split));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this SplitTag type.",
+        MembersHolder, SplitTag);
 };
 
 // Default split algorithm

--- a/include/boost/geometry/index/detail/varray.hpp
+++ b/include/boost/geometry/index/detail/varray.hpp
@@ -22,15 +22,11 @@
 #include <boost/move/detail/fwd_macros.hpp>
 #endif
 
+#include <boost/concept_check.hpp>
 #include <boost/config.hpp>
 #include <boost/core/ignore_unused.hpp>
 #include <boost/swap.hpp>
 #include <boost/integer.hpp>
-
-#include <boost/mpl/assert.hpp>
-
-#include <boost/type_traits/alignment_of.hpp>
-#include <boost/type_traits/aligned_storage.hpp>
 
 // TODO - use std::reverse_iterator and std::iterator_traits
 // instead Boost.Iterator to remove dependency?
@@ -38,12 +34,15 @@
 #include <boost/iterator/reverse_iterator.hpp>
 #include <boost/iterator/iterator_concepts.hpp>
 
+#include <boost/type_traits/alignment_of.hpp>
+#include <boost/type_traits/aligned_storage.hpp>
+
+#include <boost/geometry/core/static_assert.hpp>
+
 #include <boost/geometry/index/detail/assert.hpp>
 #include <boost/geometry/index/detail/exception.hpp>
 
 #include <boost/geometry/index/detail/varray_detail.hpp>
-
-#include <boost/concept_check.hpp>
 
 /*!
 \defgroup varray_non_member varray non-member functions
@@ -158,11 +157,11 @@ class varray
     typedef varray_detail::varray_traits<Value, Capacity> vt;
     typedef varray_detail::checker<varray> errh;
 
-    BOOST_MPL_ASSERT_MSG(
+    BOOST_GEOMETRY_STATIC_ASSERT(
         ( std::is_unsigned<typename vt::size_type>::value &&
           sizeof(typename boost::uint_value_t<Capacity>::least) <= sizeof(typename vt::size_type) ),
-        SIZE_TYPE_IS_TOO_SMALL_FOR_SPECIFIED_CAPACITY,
-        (varray)
+        "Size type is too small for specified capacity.",
+        typename vt::size_type, std::integral_constant<std::size_t, Capacity>
     );
 
     typedef boost::aligned_storage<
@@ -1939,7 +1938,7 @@ public:
     template <typename Iterator>
     void insert(iterator, Iterator first, Iterator last)
     {
-        // TODO - add MPL_ASSERT, check if Iterator is really an iterator
+        // TODO - add BOOST_GEOMETRY_STATIC_ASSERT, check if Iterator is really an iterator
         errh::check_capacity(*this, std::distance(first, last));                    // may throw
     }
 
@@ -1962,7 +1961,7 @@ public:
     template <typename Iterator>
     void assign(Iterator first, Iterator last)
     {
-        // TODO - add MPL_ASSERT, check if Iterator is really an iterator
+        // TODO - add BOOST_GEOMETRY_STATIC_ASSERT, check if Iterator is really an iterator
         errh::check_capacity(*this, std::distance(first, last));                    // may throw
     }
 

--- a/include/boost/geometry/index/indexable.hpp
+++ b/include/boost/geometry/index/indexable.hpp
@@ -13,8 +13,9 @@
 #ifndef BOOST_GEOMETRY_INDEX_INDEXABLE_HPP
 #define BOOST_GEOMETRY_INDEX_INDEXABLE_HPP
 
-#include <boost/mpl/assert.hpp>
 #include <boost/tuple/tuple.hpp>
+
+#include <boost/geometry/core/static_assert.hpp>
 
 #include <boost/geometry/index/detail/is_indexable.hpp>
 
@@ -35,11 +36,7 @@ struct is_referencable
 template <typename Indexable, typename V>
 inline Indexable const& indexable_prevent_any_type(V const& )
 {
-    BOOST_MPL_ASSERT_MSG(
-        (false),
-        UNEXPECTED_TYPE,
-        (V)
-    );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE("Unexpected type.", V);
     return Indexable();
 }
 
@@ -56,11 +53,10 @@ and std::tuple<Indexable, ...>.
 template <typename Value, bool IsIndexable = is_indexable<Value>::value>
 struct indexable
 {
-    BOOST_MPL_ASSERT_MSG(
+    BOOST_GEOMETRY_STATIC_ASSERT(
         (detail::is_indexable<Value>::value),
-        NOT_VALID_INDEXABLE_TYPE,
-        (Value)
-    );
+        "Value has to be an Indexable.",
+        Value);
 
     /*! \brief The type of result returned by function object. */
     typedef Value const& result_type;
@@ -99,11 +95,10 @@ struct indexable<std::pair<Indexable, Second>, false>
 {
     typedef std::pair<Indexable, Second> value_type;
 
-    BOOST_MPL_ASSERT_MSG(
+    BOOST_GEOMETRY_STATIC_ASSERT(
         (detail::is_indexable<Indexable>::value),
-        NOT_VALID_INDEXABLE_TYPE,
-        (Indexable)
-    );
+        "The first type of std::pair has to be an Indexable.",
+        Indexable);
 
     /*! \brief The type of result returned by function object. */
     typedef Indexable const& result_type;
@@ -128,11 +123,10 @@ struct indexable<std::pair<Indexable, Second>, false>
     template <typename I, typename S>
     inline result_type operator()(std::pair<I, S> const& v) const
     {
-        BOOST_MPL_ASSERT_MSG(
+        BOOST_GEOMETRY_STATIC_ASSERT(
             (is_referencable<I, result_type>::value),
-            UNEXPECTED_TYPE,
-            (std::pair<I, S>)
-        );
+            "Unexpected type.",
+            std::pair<I, S>);
         return v.first;
     }
 
@@ -160,11 +154,10 @@ struct indexable_boost_tuple
 {
     typedef Value value_type;
 
-    BOOST_MPL_ASSERT_MSG(
+    BOOST_GEOMETRY_STATIC_ASSERT(
         (detail::is_indexable<Indexable>::value),
-        NOT_VALID_INDEXABLE_TYPE,
-        (Indexable)
-        );
+        "The first type of boost::tuple has to be an Indexable.",
+        Indexable);
 
     /*! \brief The type of result returned by function object. */
     typedef Indexable const& result_type;
@@ -190,11 +183,10 @@ struct indexable_boost_tuple
               typename U5, typename U6, typename U7, typename U8, typename U9>
     inline result_type operator()(boost::tuple<I, U1, U2, U3, U4, U5, U6, U7, U8, U9> const& v) const
     {
-        BOOST_MPL_ASSERT_MSG(
+        BOOST_GEOMETRY_STATIC_ASSERT(
             (is_referencable<I, result_type>::value),
-            UNEXPECTED_TYPE,
-            (boost::tuple<I, U1, U2, U3, U4, U5, U6, U7, U8, U9>)
-        );
+            "Unexpected type.",
+            boost::tuple<I, U1, U2, U3, U4, U5, U6, U7, U8, U9>);
         return boost::get<0>(v);
     }
 
@@ -207,11 +199,10 @@ struct indexable_boost_tuple
     template <typename I, typename T>
     inline result_type operator()(boost::tuples::cons<I, T> const& v) const
     {
-        BOOST_MPL_ASSERT_MSG(
+        BOOST_GEOMETRY_STATIC_ASSERT(
             (is_referencable<I, result_type>::value),
-            UNEXPECTED_TYPE,
-            (boost::tuples::cons<I, T>)
-        );
+            "Unexpected type.",
+            boost::tuples::cons<I, T>);
         return boost::get<0>(v);
     }
 
@@ -279,11 +270,10 @@ struct indexable<std::tuple<Indexable, Args...>, false>
 {
     typedef std::tuple<Indexable, Args...> value_type;
 
-    BOOST_MPL_ASSERT_MSG(
+    BOOST_GEOMETRY_STATIC_ASSERT(
         (detail::is_indexable<Indexable>::value),
-        NOT_VALID_INDEXABLE_TYPE,
-        (Indexable)
-        );
+        "The first type of std::tuple has to be an Indexable.",
+        Indexable);
 
     /*! \brief The type of result returned by function object. */
     typedef Indexable const& result_type;
@@ -308,11 +298,10 @@ struct indexable<std::tuple<Indexable, Args...>, false>
     template <typename I, typename ...A>
     inline result_type operator()(std::tuple<I, A...> const& v) const
     {
-        BOOST_MPL_ASSERT_MSG(
+        BOOST_GEOMETRY_STATIC_ASSERT(
             (is_referencable<I, result_type>::value),
-            UNEXPECTED_TYPE,
-            (std::tuple<I, A...>)
-        );
+            "Unexpected type.",
+            std::tuple<I, A...>);
         return std::get<0>(v);
     }
 

--- a/include/boost/geometry/index/parameters.hpp
+++ b/include/boost/geometry/index/parameters.hpp
@@ -4,8 +4,8 @@
 //
 // Copyright (c) 2011-2017 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2019.
-// Modifications copyright (c) 2019 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2019-2020.
+// Modifications copyright (c) 2019-2020 Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -18,7 +18,7 @@
 
 #include <limits>
 
-#include <boost/mpl/assert.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 
 #include <boost/geometry/index/detail/exception.hpp>
 
@@ -83,8 +83,9 @@ template <size_t MaxElements,
           size_t MinElements = detail::default_min_elements_s<MaxElements>::value>
 struct linear
 {
-    BOOST_MPL_ASSERT_MSG((0 < MinElements && 2*MinElements <= MaxElements+1),
-                         INVALID_STATIC_MIN_MAX_PARAMETERS, (linear));
+    BOOST_GEOMETRY_STATIC_ASSERT((0 < MinElements && 2*MinElements <= MaxElements+1),
+        "Invalid MaxElements or MinElements.",
+        std::integer_sequence<size_t, MaxElements, MinElements>);
 
     static const size_t max_elements = MaxElements;
     static const size_t min_elements = MinElements;
@@ -103,8 +104,9 @@ template <size_t MaxElements,
           size_t MinElements = detail::default_min_elements_s<MaxElements>::value>
 struct quadratic
 {
-    BOOST_MPL_ASSERT_MSG((0 < MinElements && 2*MinElements <= MaxElements+1),
-                         INVALID_STATIC_MIN_MAX_PARAMETERS, (quadratic));
+    BOOST_GEOMETRY_STATIC_ASSERT((0 < MinElements && 2*MinElements <= MaxElements+1),
+        "Invalid MaxElements or MinElements.",
+        std::integer_sequence<size_t, MaxElements, MinElements>);
 
     static const size_t max_elements = MaxElements;
     static const size_t min_elements = MinElements;
@@ -133,8 +135,9 @@ template <size_t MaxElements,
           size_t OverlapCostThreshold = 32>
 struct rstar
 {
-    BOOST_MPL_ASSERT_MSG((0 < MinElements && 2*MinElements <= MaxElements+1),
-                         INVALID_STATIC_MIN_MAX_PARAMETERS, (rstar));
+    BOOST_GEOMETRY_STATIC_ASSERT((0 < MinElements && 2*MinElements <= MaxElements+1),
+        "Invalid MaxElements or MinElements.",
+        std::integer_sequence<size_t, MaxElements, MinElements>);
 
     static const size_t max_elements = MaxElements;
     static const size_t min_elements = MinElements;

--- a/include/boost/geometry/index/rtree.hpp
+++ b/include/boost/geometry/index/rtree.hpp
@@ -27,6 +27,8 @@
 #include <boost/tuple/tuple.hpp>
 
 // Boost.Geometry
+#include <boost/geometry/core/static_assert.hpp>
+
 #include <boost/geometry/algorithms/detail/comparable_distance/interface.hpp>
 #include <boost/geometry/algorithms/detail/covered_by/interface.hpp>
 #include <boost/geometry/algorithms/detail/disjoint/interface.hpp>
@@ -878,6 +880,10 @@ public:
             this->raw_create();
 
         typedef std::is_convertible<ConvertibleOrRange, value_type> is_conv_t;
+        typedef range::detail::is_range<ConvertibleOrRange> is_range_t;
+        BOOST_GEOMETRY_STATIC_ASSERT((is_conv_t::value || is_range_t::value),
+            "The argument has to be convertible to Value type or be a Range.",
+            ConvertibleOrRange);
 
         this->insert_dispatch(conv_or_rng, is_conv_t());
     }
@@ -974,6 +980,10 @@ public:
             return 0;
 
         typedef std::is_convertible<ConvertibleOrRange, value_type> is_conv_t;
+        typedef range::detail::is_range<ConvertibleOrRange> is_range_t;
+        BOOST_GEOMETRY_STATIC_ASSERT((is_conv_t::value || is_range_t::value),
+            "The argument has to be convertible to Value type or be a Range.",
+            ConvertibleOrRange);
 
         return this->remove_dispatch(conv_or_rng, is_conv_t());
     }
@@ -1074,7 +1084,9 @@ public:
 
         static const unsigned distance_predicates_count = detail::predicates_count_distance<Predicates>::value;
         static const bool is_distance_predicate = 0 < distance_predicates_count;
-        BOOST_MPL_ASSERT_MSG((distance_predicates_count <= 1), PASS_ONLY_ONE_DISTANCE_PREDICATE, (Predicates));
+        BOOST_GEOMETRY_STATIC_ASSERT((distance_predicates_count <= 1),
+            "Only one distance predicate can be passed.",
+            Predicates);
 
         return query_dispatch(predicates, out_it,
                               std::integral_constant<bool, is_distance_predicate>());
@@ -1241,7 +1253,9 @@ private:
     qbegin_(Predicates const& predicates) const
     {
         static const unsigned distance_predicates_count = detail::predicates_count_distance<Predicates>::value;
-        BOOST_MPL_ASSERT_MSG((distance_predicates_count <= 1), PASS_ONLY_ONE_DISTANCE_PREDICATE, (Predicates));
+        BOOST_GEOMETRY_STATIC_ASSERT((distance_predicates_count <= 1),
+            "Only one distance predicate can be passed.",
+            Predicates);
 
         typedef std::conditional_t
             <
@@ -1306,7 +1320,9 @@ private:
     qend_(Predicates const& predicates) const
     {
         static const unsigned distance_predicates_count = detail::predicates_count_distance<Predicates>::value;
-        BOOST_MPL_ASSERT_MSG((distance_predicates_count <= 1), PASS_ONLY_ONE_DISTANCE_PREDICATE, (Predicates));
+        BOOST_GEOMETRY_STATIC_ASSERT((distance_predicates_count <= 1),
+            "Only one distance predicate can be passed.",
+            Predicates);
 
         typedef std::conditional_t
             <
@@ -1556,9 +1572,9 @@ public:
             >::type value_or_indexable;
 
         static const bool is_void = std::is_void<value_or_indexable>::value;
-        BOOST_MPL_ASSERT_MSG((! is_void),
-                             PASSED_OBJECT_NOT_CONVERTIBLE_TO_VALUE_NOR_INDEXABLE_TYPE,
-                             (ValueOrIndexable));
+        BOOST_GEOMETRY_STATIC_ASSERT((! is_void),
+            "The argument has to be convertible to Value or Indexable type.",
+            ValueOrIndexable);
 
         // NOTE: If an object of convertible but not the same type is passed
         // into the function, here a temporary will be created.
@@ -1833,10 +1849,6 @@ private:
     inline void insert_dispatch(Range const& rng,
                                 std::false_type /*is_convertible*/)
     {
-        BOOST_MPL_ASSERT_MSG((range::detail::is_range<Range>::value),
-                             PASSED_OBJECT_IS_NOT_CONVERTIBLE_TO_VALUE_NOR_A_RANGE,
-                             (Range));
-
         typedef typename boost::range_const_iterator<Range>::type It;
         for ( It it = boost::const_begin(rng); it != boost::const_end(rng) ; ++it )
             this->raw_insert(*it);
@@ -1869,10 +1881,6 @@ private:
     inline size_type remove_dispatch(Range const& rng,
                                      std::false_type /*is_convertible*/)
     {
-        BOOST_MPL_ASSERT_MSG((range::detail::is_range<Range>::value),
-                             PASSED_OBJECT_IS_NOT_CONVERTIBLE_TO_VALUE_NOR_A_RANGE,
-                             (Range));
-
         size_type result = 0;
         typedef typename boost::range_const_iterator<Range>::type It;
         for ( It it = boost::const_begin(rng); it != boost::const_end(rng) ; ++it )

--- a/include/boost/geometry/io/svg/svg_mapper.hpp
+++ b/include/boost/geometry/io/svg/svg_mapper.hpp
@@ -24,13 +24,12 @@
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/config.hpp>
-#include <boost/mpl/assert.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/scoped_ptr.hpp>
 
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tags.hpp>
 #include <boost/geometry/core/tag_cast.hpp>
-
 #include <boost/geometry/algorithms/envelope.hpp>
 #include <boost/geometry/algorithms/expand.hpp>
 #include <boost/geometry/algorithms/is_empty.hpp>
@@ -56,11 +55,9 @@ namespace dispatch
 template <typename GeometryTag, typename Geometry, typename SvgPoint>
 struct svg_map
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_OR_NOT_YET_IMPLEMENTED_FOR_THIS_GEOMETRY_TYPE
-            , (Geometry)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not or not yet implemented for this Geometry type.",
+        GeometryTag, Geometry);
 };
 
 

--- a/include/boost/geometry/io/svg/write.hpp
+++ b/include/boost/geometry/io/svg/write.hpp
@@ -3,8 +3,8 @@
 // Copyright (c) 2009-2012 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2014 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2016.
-// Modifications copyright (c) 2016, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2016-2020.
+// Modifications copyright (c) 2016-2020, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -22,9 +22,9 @@
 #include <string>
 
 #include <boost/config.hpp>
-#include <boost/mpl/assert.hpp>
-#include <boost/range.hpp>
-
+#include <boost/range/begin.hpp>
+#include <boost/range/end.hpp>
+#include <boost/range/value_type.hpp>
 #include <boost/variant/apply_visitor.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/variant_fwd.hpp>
@@ -34,6 +34,7 @@
 #include <boost/geometry/core/exterior_ring.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
 #include <boost/geometry/core/ring_type.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 
 #include <boost/geometry/geometries/concepts/check.hpp>
 
@@ -240,11 +241,9 @@ static inline void apply(std::basic_ostream<Char, Traits>& os, G const& geometry
 template <typename Geometry, typename Tag = typename tag<Geometry>::type>
 struct svg
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_OR_NOT_YET_IMPLEMENTED_FOR_THIS_GEOMETRY_TYPE
-            , (Geometry)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not or not yet implemented for this Geometry type.",
+        Geometry, Tag);
 };
 
 template <typename Point>

--- a/include/boost/geometry/iterators/concatenate_iterator.hpp
+++ b/include/boost/geometry/iterators/concatenate_iterator.hpp
@@ -13,9 +13,10 @@
 
 #include <type_traits>
 
-#include <boost/mpl/assert.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/iterator/iterator_categories.hpp>
+
+#include <boost/geometry/core/static_assert.hpp>
 
 
 namespace boost { namespace geometry
@@ -84,9 +85,9 @@ public:
             = std::is_convertible<OtherIt1, Iterator1>::value
            && std::is_convertible<OtherIt2, Iterator2>::value;
 
-        BOOST_MPL_ASSERT_MSG((are_conv),
-                             NOT_CONVERTIBLE,
-                             (types<OtherIt1, OtherIt2>));
+        BOOST_GEOMETRY_STATIC_ASSERT((are_conv),
+            "Other iterators have to be convertible to member iterators.",
+            OtherIt1, OtherIt2);
     }
 
 private:

--- a/include/boost/geometry/iterators/detail/segment_iterator/range_segment_iterator.hpp
+++ b/include/boost/geometry/iterators/detail/segment_iterator/range_segment_iterator.hpp
@@ -13,12 +13,14 @@
 
 #include <type_traits>
 
-#include <boost/mpl/assert.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/iterator/iterator_categories.hpp>
-#include <boost/range.hpp>
+#include <boost/range/begin.hpp>
+#include <boost/range/end.hpp>
+#include <boost/range/size.hpp>
 
 #include <boost/geometry/core/closure.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/iterators/closing_iterator.hpp>
 
 
@@ -154,7 +156,9 @@ public:
         static const bool are_conv
             = std::is_convertible<other_iterator_type, iterator_type>::value;
 
-        BOOST_MPL_ASSERT_MSG((are_conv), NOT_CONVERTIBLE, (types<OtherRange>));
+        BOOST_GEOMETRY_STATIC_ASSERT((are_conv),
+            "Other iterator has to be convertible to member iterator.",
+            OtherRange);
     }
 
 private:

--- a/include/boost/geometry/iterators/flatten_iterator.hpp
+++ b/include/boost/geometry/iterators/flatten_iterator.hpp
@@ -12,11 +12,11 @@
 
 #include <type_traits>
 
-#include <boost/mpl/assert.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/iterator/iterator_categories.hpp>
 
 #include <boost/geometry/core/assert.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 
 namespace boost { namespace geometry
 {
@@ -102,9 +102,9 @@ public:
                     OtherInnerIterator, InnerIterator
                 >::value;
 
-        BOOST_MPL_ASSERT_MSG((are_conv),
-                             NOT_CONVERTIBLE,
-                             (types<OtherOuterIterator, OtherInnerIterator>));
+        BOOST_GEOMETRY_STATIC_ASSERT((are_conv),
+            "Other iterators have to be convertible to member iterators.",
+            OtherOuterIterator, OtherInnerIterator);
     }
 
     flatten_iterator& operator=(flatten_iterator const& other)

--- a/include/boost/geometry/iterators/point_iterator.hpp
+++ b/include/boost/geometry/iterators/point_iterator.hpp
@@ -14,11 +14,12 @@
 #include <type_traits>
 
 #include <boost/iterator/iterator_adaptor.hpp>
-#include <boost/mpl/assert.hpp>
-#include <boost/range.hpp>
+#include <boost/range/begin.hpp>
+#include <boost/range/end.hpp>
 
 #include <boost/geometry/core/exterior_ring.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/iterators/dispatch/point_iterator.hpp>
@@ -280,9 +281,9 @@ public:
                     >::type
             >::value;
 
-        BOOST_MPL_ASSERT_MSG((is_conv),
-                             NOT_CONVERTIBLE,
-                             (point_iterator<OtherGeometry>));
+        BOOST_GEOMETRY_STATIC_ASSERT((is_conv),
+            "Other iterator has to be convertible to member iterator.",
+            point_iterator<OtherGeometry>);
     }
 };
 

--- a/include/boost/geometry/iterators/point_reverse_iterator.hpp
+++ b/include/boost/geometry/iterators/point_reverse_iterator.hpp
@@ -13,8 +13,7 @@
 #include <iterator>
 #include <type_traits>
 
-#include <boost/mpl/assert.hpp>
-
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/iterators/point_iterator.hpp>
 
 namespace boost { namespace geometry
@@ -53,9 +52,9 @@ public:
                 std::reverse_iterator<point_iterator<OtherGeometry> >
             >::value;
 
-        BOOST_MPL_ASSERT_MSG((is_conv),
-                             NOT_CONVERTIBLE,
-                             (point_reverse_iterator<OtherGeometry>));
+        BOOST_GEOMETRY_STATIC_ASSERT((is_conv),
+            "Other iterator has to be convertible to member iterator.",
+            point_reverse_iterator<OtherGeometry>);
     }
 };
 

--- a/include/boost/geometry/iterators/segment_iterator.hpp
+++ b/include/boost/geometry/iterators/segment_iterator.hpp
@@ -13,11 +13,12 @@
 
 #include <type_traits>
 
-#include <boost/mpl/assert.hpp>
-#include <boost/range.hpp>
+#include <boost/range/begin.hpp>
+#include <boost/range/end.hpp>
 
 #include <boost/geometry/core/exterior_ring.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/iterators/detail/point_iterator/inner_range_type.hpp>
@@ -299,9 +300,9 @@ public:
                 typename detail::segment_iterator::iterator_type<Geometry>::type
             >::value;
 
-        BOOST_MPL_ASSERT_MSG((is_conv),
-                             NOT_CONVERTIBLE,
-                             (segment_iterator<OtherGeometry>));
+        BOOST_GEOMETRY_STATIC_ASSERT((is_conv),
+            "Other iterator has to be convertible to member iterator.",
+            segment_iterator<OtherGeometry>);
     }
 
     inline segment_iterator& operator++() // prefix

--- a/include/boost/geometry/policies/robustness/get_rescale_policy.hpp
+++ b/include/boost/geometry/policies/robustness/get_rescale_policy.hpp
@@ -21,8 +21,6 @@
 
 #include <cstddef>
 
-#include <boost/mpl/assert.hpp>
-
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/config.hpp>
 #include <boost/geometry/core/tag_cast.hpp>
@@ -32,17 +30,14 @@
 #include <boost/geometry/algorithms/is_empty.hpp>
 #include <boost/geometry/algorithms/detail/recalculate.hpp>
 #include <boost/geometry/algorithms/detail/get_max_size.hpp>
-#include <boost/geometry/policies/robustness/robust_type.hpp>
-
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/geometries/point.hpp>
 #include <boost/geometry/geometries/box.hpp>
-
 #include <boost/geometry/policies/robustness/no_rescale_policy.hpp>
 #include <boost/geometry/policies/robustness/rescale_policy.hpp>
-
+#include <boost/geometry/policies/robustness/robust_type.hpp>
 #include <boost/geometry/util/promote_floating_point.hpp>
 #include <boost/geometry/util/type_traits.hpp>
-
 
 // TEMP
 #include <boost/geometry/strategies/envelope/cartesian.hpp>
@@ -305,9 +300,10 @@ struct rescale_policy_type
 #endif
     >
 {
-    BOOST_MPL_ASSERT_MSG((util::is_point<Point>::value),
-                         INVALID_INPUT_GEOMETRY,
-                         (typename geometry::tag<Point>::type));
+    BOOST_GEOMETRY_STATIC_ASSERT(
+        (util::is_point<Point>::value),
+        "Point type expected.",
+        Point);
 };
 
 

--- a/include/boost/geometry/srs/projection.hpp
+++ b/include/boost/geometry/srs/projection.hpp
@@ -17,10 +17,14 @@
 #include <string>
 #include <type_traits>
 
+#include <boost/smart_ptr/shared_ptr.hpp>
+#include <boost/throw_exception.hpp>
+
 #include <boost/geometry/algorithms/convert.hpp>
 #include <boost/geometry/algorithms/detail/convert_point_to_point.hpp>
 
 #include <boost/geometry/core/coordinate_dimension.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 
 #include <boost/geometry/srs/projections/dpar.hpp>
 #include <boost/geometry/srs/projections/exception.hpp>
@@ -33,10 +37,6 @@
 #include <boost/geometry/srs/projections/spar.hpp>
 
 #include <boost/geometry/views/detail/indexed_point_view.hpp>
-
-#include <boost/mpl/assert.hpp>
-#include <boost/smart_ptr/shared_ptr.hpp>
-#include <boost/throw_exception.hpp>
 
 
 namespace boost { namespace geometry
@@ -75,9 +75,9 @@ inline void copy_higher_dimensions(Point1 const& point1, Point2 & point2)
     static const std::size_t dim1 = geometry::dimension<Point1>::value;
     static const std::size_t dim2 = geometry::dimension<Point2>::value;
     static const std::size_t lesser_dim = dim1 < dim2 ? dim1 : dim2;
-    BOOST_MPL_ASSERT_MSG((lesser_dim >= MinDim),
-                         THE_DIMENSION_OF_POINTS_IS_TOO_SMALL,
-                         (Point1, Point2));
+    BOOST_GEOMETRY_STATIC_ASSERT((lesser_dim >= MinDim),
+        "The dimension of Point1 or Point2 is too small.",
+        Point1, Point2);
 
     geometry::detail::conversion::point_to_point
         <
@@ -322,9 +322,9 @@ struct dynamic_parameters<srs::dpar::parameters<T> >
 template <typename Proj, typename CT>
 class proj_wrapper
 {
-    BOOST_MPL_ASSERT_MSG((false),
-                         UNKNOWN_PROJECTION_DEFINITION,
-                         (Proj));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Unknown projection definition.",
+        Proj);
 };
 
 template <typename CT>
@@ -459,9 +459,10 @@ public:
     template <typename LL, typename XY>
     inline bool forward(LL const& ll, XY& xy) const
     {
-        BOOST_MPL_ASSERT_MSG((projections::detail::same_tags<LL, XY>::value),
-                             NOT_SUPPORTED_COMBINATION_OF_GEOMETRIES,
-                             (LL, XY));
+        BOOST_GEOMETRY_STATIC_ASSERT(
+            (projections::detail::same_tags<LL, XY>::value),
+            "Not supported combination of Geometries.",
+            LL, XY);
 
         concepts::check_concepts_and_equal_dimensions<LL const, XY>();
 
@@ -476,9 +477,10 @@ public:
     template <typename XY, typename LL>
     inline bool inverse(XY const& xy, LL& ll) const
     {
-        BOOST_MPL_ASSERT_MSG((projections::detail::same_tags<XY, LL>::value),
-                             NOT_SUPPORTED_COMBINATION_OF_GEOMETRIES,
-                             (XY, LL));
+        BOOST_GEOMETRY_STATIC_ASSERT(
+            (projections::detail::same_tags<XY, LL>::value),
+            "Not supported combination of Geometries.",
+            XY, LL);
 
         concepts::check_concepts_and_equal_dimensions<XY const, LL>();
 

--- a/include/boost/geometry/srs/projections/dpar.hpp
+++ b/include/boost/geometry/srs/projections/dpar.hpp
@@ -26,7 +26,6 @@
 
 #include <boost/geometry/util/range.hpp>
 
-#include <boost/mpl/assert.hpp>
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 #include <boost/range/size.hpp>

--- a/include/boost/geometry/srs/projections/factory.hpp
+++ b/include/boost/geometry/srs/projections/factory.hpp
@@ -2,8 +2,8 @@
 
 // Copyright (c) 2008-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017, 2019.
-// Modifications copyright (c) 2017, 2019, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017-2020.
+// Modifications copyright (c) 2017-2020, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -17,6 +17,8 @@
 #include <string>
 
 #include <boost/shared_ptr.hpp>
+
+#include <boost/geometry/core/static_assert.hpp>
 
 #include <boost/geometry/srs/projections/dpar.hpp>
 #include <boost/geometry/srs/projections/proj4.hpp>
@@ -129,7 +131,9 @@ namespace detail
 template <typename Params>
 struct factory_key
 {
-    BOOST_MPL_ASSERT_MSG((false), INVALID_PARAMETERS_TYPE, (Params));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Invalid parameters type.",
+        Params);
 };
 
 template <>

--- a/include/boost/geometry/srs/projections/impl/base_dynamic.hpp
+++ b/include/boost/geometry/srs/projections/impl/base_dynamic.hpp
@@ -2,8 +2,8 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017, 2018, 2019.
-// Modifications copyright (c) 2017-2019, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017-2020.
+// Modifications copyright (c) 2017-2020, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,

--- a/include/boost/geometry/srs/projections/impl/base_static.hpp
+++ b/include/boost/geometry/srs/projections/impl/base_static.hpp
@@ -2,8 +2,8 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017, 2018, 2019.
-// Modifications copyright (c) 2017-2019, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017-2020.
+// Modifications copyright (c) 2017-2020, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -22,12 +22,11 @@
 #include <string>
 
 #include <boost/geometry/core/assert.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/srs/projections/impl/pj_fwd.hpp>
 #include <boost/geometry/srs/projections/impl/pj_inv.hpp>
-
-#include <boost/mpl/assert.hpp>
 
 
 namespace boost { namespace geometry { namespace projections
@@ -41,9 +40,9 @@ namespace detail
 template <typename Prj, typename CSTag, typename SP, typename CT, typename P>
 struct static_projection_type
 {
-    BOOST_MPL_ASSERT_MSG((false),
-        NOT_IMPLEMENTED_FOR_THIS_PROJECTION_OR_CSTAG,
-        (Prj, CSTag));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this projection or coordinate system.",
+        Prj, CSTag, SP, CT, P);
 };
 
 #define BOOST_GEOMETRY_PROJECTIONS_DETAIL_STATIC_PROJECTION_F(PROJ, P_SPHXXX) \
@@ -129,9 +128,9 @@ public:
     template <typename XY, typename LL>
     inline bool inverse(XY const&, LL&) const
     {
-        BOOST_MPL_ASSERT_MSG((false),
-            PROJECTION_IS_NOT_INVERTABLE,
-            (Prj));
+        BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+            "This projection is not invertable.",
+            Prj);
         return false;
     }
 };

--- a/include/boost/geometry/srs/projections/impl/pj_datum_set.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_datum_set.hpp
@@ -3,8 +3,8 @@
 
 // Copyright (c) 2008-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017, 2018, 2019.
-// Modifications copyright (c) 2017-2019, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017-2020.
+// Modifications copyright (c) 2017-2020, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -146,7 +146,7 @@ struct pj_datum_find_datum_static
         }
         else
         {
-            // TODO: Implemnt as MPL_ASSERT instead
+            // TODO: Implemnt as BOOST_GEOMETRY_STATIC_ASSERT instead
             BOOST_THROW_EXCEPTION( projection_exception(error_unknown_ellp_param) );
         }
     }

--- a/include/boost/geometry/srs/projections/impl/pj_ell_set.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_ell_set.hpp
@@ -45,6 +45,7 @@
 #include <type_traits>
 #include <vector>
 
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/formulas/eccentricity_sqr.hpp>
 #include <boost/geometry/util/math.hpp>
 
@@ -516,7 +517,9 @@ struct static_srs_tag<Params, void, void, void>
         > type;
 
     static const bool is_found = ! std::is_void<type>::value;
-    BOOST_MPL_ASSERT_MSG((is_found), UNKNOWN_ELLP_PARAM, (Params));
+    BOOST_GEOMETRY_STATIC_ASSERT((is_found),
+        "Expected ellipsoid or sphere definition.",
+        Params);
 };
 
 

--- a/include/boost/geometry/srs/projections/impl/pj_init.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_init.hpp
@@ -45,10 +45,9 @@
 #include <vector>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/range.hpp>
+#include <boost/tuple/tuple.hpp>
 
-#include <boost/geometry/util/math.hpp>
-#include <boost/geometry/util/condition.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 
 #include <boost/geometry/srs/projections/dpar.hpp>
 #include <boost/geometry/srs/projections/impl/dms_parser.hpp>
@@ -60,6 +59,9 @@
 #include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/proj4.hpp>
 #include <boost/geometry/srs/projections/spar.hpp>
+
+#include <boost/geometry/util/math.hpp>
+#include <boost/geometry/util/condition.hpp>
 
 
 namespace boost { namespace geometry { namespace projections
@@ -104,7 +106,7 @@ inline void pj_init_proj(srs::spar::parameters<BOOST_GEOMETRY_PROJECTIONS_DETAIL
 
     static const bool is_found = geometry::tuples::is_found<proj_type>::value;
 
-    BOOST_MPL_ASSERT_MSG((is_found), PROJECTION_NOT_NAMED, (params_type));
+    BOOST_GEOMETRY_STATIC_ASSERT((is_found), "Projection not named.", params_type);
 
     par.id = srs::spar::detail::proj_traits<proj_type>::id;
 }
@@ -261,7 +263,7 @@ struct pj_init_units_static<Params, Vertical, UnitsI, N, N>
                     >::id;
     static const bool is_valid = i >= 0 && i < n;
 
-    BOOST_MPL_ASSERT_MSG((is_valid), UNKNOWN_UNIT_ID, (Params));
+    BOOST_GEOMETRY_STATIC_ASSERT((is_valid), "Unknown unit ID.", Params);
 
     template <typename T>
     static void apply(Params const& ,

--- a/include/boost/geometry/srs/projections/impl/pj_param.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_param.hpp
@@ -45,7 +45,7 @@
 #include <type_traits>
 #include <vector>
 
-#include <boost/mpl/assert.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 
 #include <boost/geometry/srs/projections/exception.hpp>
 
@@ -191,7 +191,7 @@ inline void check_name(Name const&)
                            || std::is_same<Name, srs::dpar::name_i>::value
                            || std::is_same<Name, srs::dpar::name_f>::value
                            || std::is_same<Name, srs::dpar::name_r>::value;
-    BOOST_MPL_ASSERT_MSG((is_ok), INVALID_ARGUMENT, (Name));
+    BOOST_GEOMETRY_STATIC_ASSERT((is_ok), "Invalid argument.", Name);
 }
 
 

--- a/include/boost/geometry/srs/projections/proj/ob_tran.hpp
+++ b/include/boost/geometry/srs/projections/proj/ob_tran.hpp
@@ -45,6 +45,8 @@
 #include <boost/geometry/util/math.hpp>
 #include <boost/shared_ptr.hpp>
 
+#include <boost/geometry/core/static_assert.hpp>
+
 #include <boost/geometry/srs/projections/impl/aasincos.hpp>
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
@@ -145,17 +147,23 @@ namespace projections
                     >::type o_proj_type;
 
                 static const bool is_found = geometry::tuples::is_found<o_proj_type>::value;
-                BOOST_MPL_ASSERT_MSG((is_found), NO_ROTATION_PROJ, (params_type));
+                BOOST_GEOMETRY_STATIC_ASSERT((is_found),
+                    "Rotation projection not specified.",
+                    params_type);
 
                 typedef typename o_proj_type::type proj_type;
                 static const bool is_specialized = srs::spar::detail::proj_traits<proj_type>::is_specialized;
-                BOOST_MPL_ASSERT_MSG((is_specialized), NO_ROTATION_PROJ, (params_type));
+                BOOST_GEOMETRY_STATIC_ASSERT((is_specialized),
+                    "Rotation projection not specified.",
+                    params_type);
 
                 pj.id = srs::spar::detail::proj_traits<proj_type>::id;
 
                 /* avoid endless recursion */
                 static const bool is_non_resursive = ! std::is_same<proj_type, srs::spar::proj_ob_tran>::value;
-                BOOST_MPL_ASSERT_MSG((is_non_resursive), INVALID_O_PROJ_PARAMETER, (params_type));
+                BOOST_GEOMETRY_STATIC_ASSERT((is_non_resursive),
+                    "o_proj parameter can not be set to ob_tran projection.",
+                    params_type);
 
                 // Commented out for consistency with Proj4 >= 5.0.0
                 /* force spherical earth */
@@ -207,7 +215,9 @@ namespace projections
 
                 /* avoid endless recursion */
                 static const bool is_o_proj_not_ob_tran = ! std::is_same<o_proj_tag, srs::spar::proj_ob_tran>::value;
-                BOOST_MPL_ASSERT_MSG((is_o_proj_not_ob_tran), INVALID_O_PROJ_PARAMETER, (StaticParameters));
+                BOOST_GEOMETRY_STATIC_ASSERT((is_o_proj_not_ob_tran),
+                    "o_proj parameter can not be set to ob_tran projection.",
+                    StaticParameters);
 
                 typedef typename projections::detail::static_projection_type
                     <

--- a/include/boost/geometry/srs/projections/spar.hpp
+++ b/include/boost/geometry/srs/projections/spar.hpp
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include <boost/geometry/core/radius.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tags.hpp>
 
@@ -28,7 +29,6 @@
 
 #include <boost/geometry/util/tuples.hpp>
 
-#include <boost/mpl/assert.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/variant/variant.hpp>
 
@@ -203,7 +203,9 @@ namespace detail
 template <typename Parameters, typename Parameter>
 struct add_parameter
 {
-    BOOST_MPL_ASSERT_MSG((false), INVALID_ARGUMENT, (Parameters));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Invalid Parameters argument.",
+        Parameters);
 };
 
 // NOTE: parameters has to be convertible to tuples::cons
@@ -1068,7 +1070,7 @@ struct pick_proj_tag
 
     static const bool is_found = geometry::tuples::is_found<proj_type>::value;
 
-    BOOST_MPL_ASSERT_MSG((is_found), PROJECTION_NOT_NAMED, (Tuple));
+    BOOST_GEOMETRY_STATIC_ASSERT((is_found), "Projection not named.", Tuple);
 
     typedef proj_traits<proj_type> traits_type;
     typedef typename traits_type::type type;
@@ -1085,7 +1087,7 @@ struct pick_o_proj_tag
 
     static const bool is_found = geometry::tuples::is_found<o_proj_type>::value;
 
-    BOOST_MPL_ASSERT_MSG((is_found), NO_O_PROJ_PARAMETER, (Tuple));
+    BOOST_GEOMETRY_STATIC_ASSERT((is_found), "Expected o_proj parameter.", Tuple);
 
     typedef proj_traits<typename o_proj_type::type> traits_type;
     typedef typename traits_type::type type;

--- a/include/boost/geometry/srs/transformation.hpp
+++ b/include/boost/geometry/srs/transformation.hpp
@@ -14,9 +14,12 @@
 #include <string>
 #include <type_traits>
 
+#include <boost/throw_exception.hpp>
+
 #include <boost/geometry/algorithms/convert.hpp>
 
 #include <boost/geometry/core/coordinate_dimension.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 
 #include <boost/geometry/geometries/point.hpp>
 #include <boost/geometry/geometries/multi_point.hpp>
@@ -29,10 +32,6 @@
 #include <boost/geometry/srs/projections/impl/pj_transform.hpp>
 
 #include <boost/geometry/views/detail/indexed_point_view.hpp>
-
-#include <boost/mpl/assert.hpp>
-#include <boost/smart_ptr/shared_ptr.hpp>
-#include <boost/throw_exception.hpp>
 
 
 namespace boost { namespace geometry
@@ -677,9 +676,10 @@ public:
     bool forward(GeometryIn const& in, GeometryOut & out,
                  transformation_grids<GridsStorage> const& grids) const
     {
-        BOOST_MPL_ASSERT_MSG((projections::detail::same_tags<GeometryIn, GeometryOut>::value),
-                             NOT_SUPPORTED_COMBINATION_OF_GEOMETRIES,
-                             (GeometryIn, GeometryOut));
+        BOOST_GEOMETRY_STATIC_ASSERT(
+            (projections::detail::same_tags<GeometryIn, GeometryOut>::value),
+            "Not supported combination of Geometries.",
+            GeometryIn, GeometryOut);
 
         return projections::detail::transform
                 <
@@ -696,9 +696,10 @@ public:
     bool inverse(GeometryIn const& in, GeometryOut & out,
                  transformation_grids<GridsStorage> const& grids) const
     {
-        BOOST_MPL_ASSERT_MSG((projections::detail::same_tags<GeometryIn, GeometryOut>::value),
-                             NOT_SUPPORTED_COMBINATION_OF_GEOMETRIES,
-                             (GeometryIn, GeometryOut));
+        BOOST_GEOMETRY_STATIC_ASSERT(
+            (projections::detail::same_tags<GeometryIn, GeometryOut>::value),
+            "Not supported combination of Geometries.",
+            GeometryIn, GeometryOut);
 
         return projections::detail::transform
                 <

--- a/include/boost/geometry/strategies/agnostic/point_in_poly_winding.hpp
+++ b/include/boost/geometry/strategies/agnostic/point_in_poly_winding.hpp
@@ -3,8 +3,8 @@
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2013 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2013, 2014, 2016, 2017, 2019.
-// Modifications copyright (c) 2013-2019 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013-2020.
+// Modifications copyright (c) 2013-2020 Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
@@ -18,9 +18,8 @@
 #define BOOST_GEOMETRY_STRATEGY_AGNOSTIC_POINT_IN_POLY_WINDING_HPP
 
 
-#include <boost/mpl/assert.hpp>
-
 #include <boost/geometry/core/cs.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tag_cast.hpp>
 #include <boost/geometry/core/tags.hpp>
 
@@ -54,9 +53,9 @@ template
 >
 struct winding_base_type
 {
-    BOOST_MPL_ASSERT_MSG(false,
-                         NOT_IMPLEMENTED_FOR_THIS_COORDINATE_SYSTEM,
-                         (CSTag));
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this coordinate system.",
+        Point, PointOfSegment, CSTag);
 };
 
 template <typename Point, typename PointOfSegment, typename CalculationType>

--- a/include/boost/geometry/strategies/area/services.hpp
+++ b/include/boost/geometry/strategies/area/services.hpp
@@ -12,8 +12,7 @@
 
 
 #include <boost/geometry/core/cs.hpp>
-
-#include <boost/mpl/assert.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 
 
 namespace boost { namespace geometry
@@ -32,21 +31,17 @@ template
 >
 struct default_strategy
 {
-    BOOST_MPL_ASSERT_MSG
-    (
-        false, NOT_IMPLEMENTED_FOR_THIS_COORDINATE_SYSTEM
-        , (types<Geometry, CSTag>)
-    );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Geometry's coordinate system.",
+        Geometry, CSTag);
 };
 
 template <typename Strategy>
 struct strategy_converter
 {
-    BOOST_MPL_ASSERT_MSG
-    (
-        false, NOT_IMPLEMENTED_FOR_THIS_STRATEGY
-        , (Strategy)
-    );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Strategy.",
+        Strategy);
 };
 
 

--- a/include/boost/geometry/strategies/azimuth.hpp
+++ b/include/boost/geometry/strategies/azimuth.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2016-2017 Oracle and/or its affiliates.
+// Copyright (c) 2016-2020 Oracle and/or its affiliates.
 // Contributed and/or modified by Vissarion Fisikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -11,7 +11,7 @@
 #ifndef BOOST_GEOMETRY_STRATEGIES_AZIMUTH_HPP
 #define BOOST_GEOMETRY_STRATEGIES_AZIMUTH_HPP
 
-#include <boost/mpl/assert.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 
 namespace boost { namespace geometry
 {
@@ -29,11 +29,9 @@ namespace strategy { namespace azimuth { namespace services
 template <typename CSTag, typename CalculationType = void>
 struct default_strategy
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_TYPE
-            , (types<CSTag>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this type.",
+        CSTag);
 };
 
 }}} // namespace strategy::azimuth::services

--- a/include/boost/geometry/strategies/centroid.hpp
+++ b/include/boost/geometry/strategies/centroid.hpp
@@ -4,6 +4,10 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
+// This file was modified by Oracle on 2020.
+// Modifications copyright (c) 2020, Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -16,8 +20,6 @@
 
 
 #include <cstddef>
-
-#include <boost/mpl/assert.hpp>
 
 #include <boost/geometry/core/tags.hpp>
 #include <boost/geometry/strategies/tags.hpp>

--- a/include/boost/geometry/strategies/compare.hpp
+++ b/include/boost/geometry/strategies/compare.hpp
@@ -24,12 +24,11 @@
 #include <cstddef>
 #include <functional>
 
-#include <boost/mpl/assert.hpp>
-
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 
 #include <boost/geometry/util/math.hpp>
 
@@ -194,12 +193,9 @@ template
 >
 struct default_strategy
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false,
-            NOT_IMPLEMENTED_FOR_THESE_TYPES,
-            (types<CSTag1, CSTag2>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for these types.",
+        CSTag1, CSTag2);
 };
 
 

--- a/include/boost/geometry/strategies/concepts/distance_concept.hpp
+++ b/include/boost/geometry/strategies/concepts/distance_concept.hpp
@@ -26,9 +26,8 @@
 
 #include <boost/concept_check.hpp>
 #include <boost/core/ignore_unused.hpp>
-#include <boost/mpl/assert.hpp>
 
-#include <boost/geometry/util/parameter_type_of.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 
 #include <boost/geometry/geometries/concepts/point_concept.hpp>
 #include <boost/geometry/geometries/segment.hpp>
@@ -36,6 +35,8 @@
 
 #include <boost/geometry/strategies/distance.hpp>
 #include <boost/geometry/strategies/tags.hpp>
+
+#include <boost/geometry/util/parameter_type_of.hpp>
 
 
 namespace boost { namespace geometry { namespace concepts
@@ -91,10 +92,10 @@ private :
                 || std::is_same<tag, strategy_tag_distance_point_box>::value
                 || std::is_same<tag, strategy_tag_distance_box_box>::value;
 
-            BOOST_MPL_ASSERT_MSG
-                ((is_correct_strategy_tag),
-                 INCORRECT_STRATEGY_TAG,
-                 (types<tag>));
+            BOOST_GEOMETRY_STATIC_ASSERT(
+                 is_correct_strategy_tag,
+                 "Incorrect Strategy tag.",
+                 Strategy, tag);
 
             // 5) must implement apply with arguments
             Strategy* str = 0;
@@ -161,13 +162,13 @@ private :
             // 2) must define meta-function "tag"
             typedef typename services::tag<Strategy>::type tag;
 
-            BOOST_MPL_ASSERT_MSG
-                ((std::is_same
-                      <
-                          tag, strategy_tag_distance_point_segment
-                      >::value),
-                 INCORRECT_STRATEGY_TAG,
-                 (types<tag>));
+            BOOST_GEOMETRY_STATIC_ASSERT(
+                (std::is_same
+                    <
+                        tag, strategy_tag_distance_point_segment
+                    >::value),
+                "Incorrect Strategy tag.",
+                Strategy, tag);
 
             // 3) must define meta-function "return_type"
             typedef typename services::return_type

--- a/include/boost/geometry/strategies/concepts/within_concept.hpp
+++ b/include/boost/geometry/strategies/concepts/within_concept.hpp
@@ -25,6 +25,7 @@
 #include <boost/core/ignore_unused.hpp>
 #include <boost/function_types/result_type.hpp>
 
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tag_cast.hpp>
 #include <boost/geometry/core/tags.hpp>
@@ -79,23 +80,23 @@ class WithinStrategyPolygonal
                 );
 
             // CHECK: return types (result: int, apply: bool)
-            BOOST_MPL_ASSERT_MSG
+            BOOST_GEOMETRY_STATIC_ASSERT
                 (
                     (std::is_same
                         <
                             bool, typename boost::function_types::result_type<ApplyMethod>::type
                         >::value),
-                    WRONG_RETURN_TYPE_OF_APPLY
-                    , (bool)
+                    "Wrong return type of apply().",
+                    bool, ApplyMethod
                 );
-            BOOST_MPL_ASSERT_MSG
+            BOOST_GEOMETRY_STATIC_ASSERT
                 (
                     (std::is_same
                         <
                             int, typename boost::function_types::result_type<ResultMethod>::type
                         >::value),
-                    WRONG_RETURN_TYPE_OF_RESULT
-                    , (int)
+                    "Wrong return type of result().",
+                    int, ResultMethod
                 );
 
 
@@ -153,15 +154,15 @@ class WithinStrategyPointBox
                 );
 
             // CHECK: return types (apply: bool)
-            BOOST_MPL_ASSERT_MSG
+            BOOST_GEOMETRY_STATIC_ASSERT
                 (
                     (std::is_same
                         <
                             bool,
                             typename boost::function_types::result_type<ApplyMethod>::type
                         >::value),
-                    WRONG_RETURN_TYPE
-                    , (bool)
+                    "Wrong return type of apply().",
+                    bool, ApplyMethod
                 );
 
 
@@ -216,15 +217,15 @@ class WithinStrategyBoxBox
                 );
 
             // CHECK: return types (apply: bool)
-            BOOST_MPL_ASSERT_MSG
+            BOOST_GEOMETRY_STATIC_ASSERT
                 (
                     (std::is_same
                         <
                             bool,
                             typename boost::function_types::result_type<ApplyMethod>::type
                         >::value),
-                    WRONG_RETURN_TYPE
-                    , (bool)
+                    "Wrong return type of apply().",
+                    bool, ApplyMethod
                 );
 
 

--- a/include/boost/geometry/strategies/covered_by.hpp
+++ b/include/boost/geometry/strategies/covered_by.hpp
@@ -4,9 +4,8 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
-
+// This file was modified by Oracle on 2017-2020.
+// Modifications copyright (c) 2017-2020, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
@@ -19,10 +18,10 @@
 #ifndef BOOST_GEOMETRY_STRATEGIES_COVERED_BY_HPP
 #define BOOST_GEOMETRY_STRATEGIES_COVERED_BY_HPP
 
-#include <boost/mpl/assert.hpp>
 
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/point_type.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tags.hpp>
 #include <boost/geometry/core/tag_cast.hpp>
@@ -78,11 +77,9 @@ template
 >
 struct default_strategy
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THESE_TYPES
-            , (types<GeometryContained, GeometryContaining>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for these types.",
+        GeometryContained, GeometryContaining);
 };
 
 

--- a/include/boost/geometry/strategies/densify.hpp
+++ b/include/boost/geometry/strategies/densify.hpp
@@ -1,7 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2017, Oracle and/or its affiliates.
-
+// Copyright (c) 2017-2020, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Licensed under the Boost Software License version 1.0.
@@ -11,7 +10,7 @@
 #define BOOST_GEOMETRY_STRATEGIES_DENSIFY_HPP
 
 
-#include <boost/mpl/assert.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 
 
 namespace boost { namespace geometry
@@ -26,11 +25,9 @@ namespace services
 template <typename CSTag>
 struct default_strategy
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_CS
-            , (types<CSTag>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this coordinate system.",
+        CSTag);
 };
 
 } // namespace services

--- a/include/boost/geometry/strategies/disjoint.hpp
+++ b/include/boost/geometry/strategies/disjoint.hpp
@@ -12,8 +12,6 @@
 #define BOOST_GEOMETRY_STRATEGIES_DISJOINT_HPP
 
 
-#include <boost/mpl/assert.hpp>
-
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/point_type.hpp>
 #include <boost/geometry/core/topological_dimension.hpp>

--- a/include/boost/geometry/strategies/distance.hpp
+++ b/include/boost/geometry/strategies/distance.hpp
@@ -4,10 +4,10 @@
 // Copyright (c) 2008-2014 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2014 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2014.
-// Modifications copyright (c) 2014, Oracle and/or its affiliates.
-
+// This file was modified by Oracle on 2014-2020.
+// Modifications copyright (c) 2014-2020, Oracle and/or its affiliates.
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
@@ -20,9 +20,8 @@
 #define BOOST_GEOMETRY_STRATEGIES_DISTANCE_HPP
 
 
-#include <boost/mpl/assert.hpp>
-
 #include <boost/geometry/core/cs.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/strategies/tags.hpp>
 
 
@@ -39,31 +38,33 @@ template <typename Strategy> struct tag {};
 template <typename Strategy, typename P1, typename P2>
 struct return_type
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_STRATEGY, (types<Strategy, P1, P2>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Strategy.",
+        Strategy, P1, P2);
 };
 
 
 template <typename Strategy> struct comparable_type
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_STRATEGY, (types<Strategy>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Strategy.",
+        Strategy);
 };
 
 template <typename Strategy> struct get_comparable
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_STRATEGY, (types<Strategy>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Strategy.",
+        Strategy);
 };
 
 template <typename Strategy, typename P1, typename P2>
-struct result_from_distance {};
+struct result_from_distance
+{
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Strategy.",
+        Strategy, P1, P2);
+};
 
 
 
@@ -94,11 +95,9 @@ template
 >
 struct default_strategy
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_POINT_TYPE_COMBINATION
-            , (types<Point1, Point2, CsTag1, CsTag2>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Point type combination.",
+        Point1, Point2, CsTag1, CsTag2);
 };
 
 

--- a/include/boost/geometry/strategies/envelope/services.hpp
+++ b/include/boost/geometry/strategies/envelope/services.hpp
@@ -12,8 +12,7 @@
 
 
 #include <boost/geometry/core/cs.hpp>
-
-#include <boost/mpl/assert.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 
 
 namespace boost { namespace geometry
@@ -30,21 +29,17 @@ template
 >
 struct default_strategy
 {
-    BOOST_MPL_ASSERT_MSG
-    (
-        false, NOT_IMPLEMENTED_FOR_THIS_COORDINATE_SYSTEM
-        , (types<Geometry, Box, CSTag>)
-    );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this coordinate system.",
+        Geometry, Box, CSTag);
 };
 
 template <typename Strategy>
 struct strategy_converter
 {
-    BOOST_MPL_ASSERT_MSG
-    (
-        false, NOT_IMPLEMENTED_FOR_THIS_STRATEGY
-        , (Strategy)
-    );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Strategy.",
+        Strategy);
 };
 
 

--- a/include/boost/geometry/strategies/expand/services.hpp
+++ b/include/boost/geometry/strategies/expand/services.hpp
@@ -10,9 +10,9 @@
 #ifndef BOOST_GEOMETRY_STRATEGIES_EXPAND_SERVICES_HPP
 #define BOOST_GEOMETRY_STRATEGIES_EXPAND_SERVICES_HPP
 
-#include <boost/geometry/core/cs.hpp>
 
-#include <boost/mpl/assert.hpp>
+#include <boost/geometry/core/cs.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 
 
 namespace boost { namespace geometry
@@ -29,21 +29,17 @@ template
 >
 struct default_strategy
 {
-    BOOST_MPL_ASSERT_MSG
-    (
-        false, NOT_IMPLEMENTED_FOR_THIS_COORDINATE_SYSTEM
-        , (types<Box, Geometry, CSTag>)
-    );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this coordinate system.",
+        Geometry, Box, CSTag);
 };
 
 template <typename Strategy>
 struct strategy_converter
 {
-    BOOST_MPL_ASSERT_MSG
-    (
-        false, NOT_IMPLEMENTED_FOR_THIS_STRATEGY
-        , (Strategy)
-    );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this Strategy.",
+        Strategy);
 };
 
 

--- a/include/boost/geometry/strategies/geographic/parameters.hpp
+++ b/include/boost/geometry/strategies/geographic/parameters.hpp
@@ -12,6 +12,7 @@
 
 #include <type_traits>
 
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/formulas/andoyer_inverse.hpp>
 #include <boost/geometry/formulas/thomas_direct.hpp>
 #include <boost/geometry/formulas/thomas_inverse.hpp>
@@ -19,8 +20,6 @@
 #include <boost/geometry/formulas/vincenty_inverse.hpp>
 //#include <boost/geometry/formulas/karney_direct.hpp>
 //#include <boost/geometry/formulas/karney_inverse.hpp>
-
-#include <boost/mpl/assert.hpp>
 
 
 namespace boost { namespace geometry { namespace strategy
@@ -183,11 +182,9 @@ struct karney
 template <typename FormulaPolicy>
 struct default_order
 {
-    BOOST_MPL_ASSERT_MSG
-    (
-        false, NOT_IMPLEMENTED_FOR_THIS_TYPE
-        , (types<FormulaPolicy>)
-    );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this type.",
+        FormulaPolicy);
 };
 
 template<>

--- a/include/boost/geometry/strategies/index.hpp
+++ b/include/boost/geometry/strategies/index.hpp
@@ -2,7 +2,7 @@
 //
 // R-tree strategies
 //
-// Copyright (c) 2019, Oracle and/or its affiliates.
+// Copyright (c) 2019-2020, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -14,7 +14,7 @@
 
 
 #include <boost/geometry/core/cs.hpp>
-
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/strategies/default_strategy.hpp>
 
 
@@ -31,11 +31,9 @@ template
 >
 struct default_strategy
 {
-    /*BOOST_MPL_ASSERT_MSG
-    (
-        false, NOT_IMPLEMENTED_FOR_THESE_TYPES
-        , (types<Geometry>)
-    );*/
+    /*BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this type.",
+        Geometry);*/
 
     typedef geometry::default_strategy type;
 };
@@ -48,11 +46,9 @@ struct default_strategy
 template <typename Strategy>
 struct from_strategy
 {
-    /*BOOST_MPL_ASSERT_MSG
-    (
-        false, NOT_IMPLEMENTED_FOR_THESE_TYPES
-        , (types<Strategy>)
-    );*/
+    /*BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this type.",
+        Strategy);*/
 
     typedef geometry::default_strategy type;
 

--- a/include/boost/geometry/strategies/intersection.hpp
+++ b/include/boost/geometry/strategies/intersection.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2016-2017, Oracle and/or its affiliates.
+// Copyright (c) 2016-2020, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -11,10 +11,8 @@
 #define BOOST_GEOMETRY_STRATEGIES_SEGMENT_INTERSECTION_HPP
 
 
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/strategies/tags.hpp>
-
-
-#include <boost/mpl/assert.hpp>
 
 
 namespace boost { namespace geometry
@@ -35,11 +33,9 @@ namespace services
 template <typename CSTag, typename CalculationType = void>
 struct default_strategy
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_TYPE
-            , (types<CSTag>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this type.",
+        CSTag);
 };
 
 } // namespace services

--- a/include/boost/geometry/strategies/io.hpp
+++ b/include/boost/geometry/strategies/io.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2019, Oracle and/or its affiliates.
+// Copyright (c) 2019-2020, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -11,7 +11,7 @@
 #define BOOST_GEOMETRY_EXTENSIONS_STRATEGIES_IO_HPP
 
 
-#include <boost/mpl/assert.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 
 
 namespace boost { namespace geometry
@@ -26,11 +26,9 @@ namespace services
 template <typename CSTag>
 struct default_strategy
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_CS
-            , (types<CSTag>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this coordinate system.",
+        CSTag);
 };
 
 } // namespace services

--- a/include/boost/geometry/strategies/line_interpolate.hpp
+++ b/include/boost/geometry/strategies/line_interpolate.hpp
@@ -1,8 +1,9 @@
 // Boost.Geometry
 
-// Copyright (c) 2018, Oracle and/or its affiliates.
+// Copyright (c) 2018-2020, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Licensed under the Boost Software License version 1.0.
 // http://www.boost.org/users/license.html
@@ -11,7 +12,7 @@
 #define BOOST_GEOMETRY_STRATEGIES_LINE_INTERPOLATE_HPP
 
 
-#include <boost/mpl/assert.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 
 
 namespace boost { namespace geometry
@@ -26,11 +27,9 @@ namespace services
 template <typename CSTag>
 struct default_strategy
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_CS
-            , (types<CSTag>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this coordinate system.",
+        CSTag);
 };
 
 } // namespace services

--- a/include/boost/geometry/strategies/point_order.hpp
+++ b/include/boost/geometry/strategies/point_order.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2019, Oracle and/or its affiliates.
+// Copyright (c) 2019-2020, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -11,7 +11,7 @@
 #define BOOST_GEOMETRY_STRATEGIES_POINT_ORDER_HPP
 
 
-#include <boost/mpl/assert.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 
 
 namespace boost { namespace geometry
@@ -29,11 +29,9 @@ namespace services
 template <typename CSTag>
 struct default_strategy
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_CS
-            , (types<CSTag>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this coordinate system.",
+        CSTag);
 };
 
 } // namespace services

--- a/include/boost/geometry/strategies/relate.hpp
+++ b/include/boost/geometry/strategies/relate.hpp
@@ -13,10 +13,9 @@
 
 #include <type_traits>
 
-#include <boost/mpl/assert.hpp>
-
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/point_type.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/topological_dimension.hpp>
 
 #include <boost/geometry/strategies/covered_by.hpp>
@@ -60,9 +59,9 @@ struct default_strategy
         >::type covered_by_strategy_type;
 
     static const bool same_strategies = std::is_same<within_strategy_type, covered_by_strategy_type>::value;
-    BOOST_MPL_ASSERT_MSG((same_strategies),
-                         DEFAULT_WITHIN_AND_COVERED_BY_STRATEGIES_NOT_COMPATIBLE,
-                         (within_strategy_type, covered_by_strategy_type));
+    BOOST_GEOMETRY_STATIC_ASSERT(same_strategies,
+        "Default within and covered_by strategies not compatible.",
+        within_strategy_type, covered_by_strategy_type);
 };
 
 template<typename Point, typename Geometry>
@@ -122,11 +121,9 @@ template
 >
 struct default_strategy
 {
-    BOOST_MPL_ASSERT_MSG
-    (
-        false, NOT_IMPLEMENTED_FOR_THESE_TYPES
-        , (types<Geometry1, Geometry2>)
-    );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for these types.",
+        Geometry1, Geometry2);
 };
 
 template <typename PointLike1, typename PointLike2>

--- a/include/boost/geometry/strategies/side.hpp
+++ b/include/boost/geometry/strategies/side.hpp
@@ -4,8 +4,8 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2018.
-// Modifications copyright (c) 2018, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2018-2020.
+// Modifications copyright (c) 2018-2020, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -20,7 +20,7 @@
 #define BOOST_GEOMETRY_STRATEGIES_SIDE_HPP
 
 
-#include <boost/mpl/assert.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 
 #include <boost/geometry/strategies/tags.hpp>
 
@@ -43,11 +43,9 @@ namespace services
 template <typename CSTag, typename CalculationType = void>
 struct default_strategy
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_TYPE
-            , (types<CSTag>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this type.",
+        CSTag);
 };
 
 

--- a/include/boost/geometry/strategies/transform.hpp
+++ b/include/boost/geometry/strategies/transform.hpp
@@ -4,6 +4,10 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
+// This file was modified by Oracle on 2020.
+// Modifications copyright (c) 2020, Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -16,7 +20,7 @@
 
 #include <cstddef>
 
-#include <boost/mpl/assert.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 
 #include <boost/geometry/strategies/tags.hpp>
 
@@ -48,11 +52,9 @@ template
 >
 struct default_strategy
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_POINT_TYPES
-            , (types<Point1, Point2>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for these Point types.",
+        Point1, Point2);
 };
 
 }}} // namespace strategy::transform::services

--- a/include/boost/geometry/strategies/within.hpp
+++ b/include/boost/geometry/strategies/within.hpp
@@ -4,8 +4,8 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2017.
-// Modifications copyright (c) 2017, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017-2020.
+// Modifications copyright (c) 2017-2020, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -19,10 +19,10 @@
 #ifndef BOOST_GEOMETRY_STRATEGIES_WITHIN_HPP
 #define BOOST_GEOMETRY_STRATEGIES_WITHIN_HPP
 
-#include <boost/mpl/assert.hpp>
 
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/point_type.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tags.hpp>
 #include <boost/geometry/core/tag_cast.hpp>
@@ -77,11 +77,9 @@ template
 >
 struct default_strategy
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THESE_TYPES
-            , (types<GeometryContained, GeometryContaining>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for these types.",
+        GeometryContained, GeometryContaining);
 };
 
 

--- a/include/boost/geometry/strategy/area.hpp
+++ b/include/boost/geometry/strategy/area.hpp
@@ -21,10 +21,9 @@
 
 
 #include <boost/geometry/core/coordinate_type.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 
 #include <boost/geometry/util/select_most_precise.hpp>
-
-#include <boost/mpl/assert.hpp>
 
 
 namespace boost { namespace geometry
@@ -79,11 +78,9 @@ namespace services
 template <typename Tag>
 struct default_strategy
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_COORDINATE_SYSTEM
-            , (types<Tag>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this coordinate system.",
+        Tag);
 };
 
 

--- a/include/boost/geometry/strategy/envelope.hpp
+++ b/include/boost/geometry/strategy/envelope.hpp
@@ -11,7 +11,7 @@
 #ifndef BOOST_GEOMETRY_STRATEGY_ENVELOPE_HPP
 #define BOOST_GEOMETRY_STRATEGY_ENVELOPE_HPP
 
-#include <boost/mpl/assert.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 
 namespace boost { namespace geometry
 {
@@ -30,11 +30,9 @@ namespace strategy { namespace envelope { namespace services
 template <typename Tag, typename CSTag, typename CalculationType = void>
 struct default_strategy
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_TYPE
-            , (types<Tag, CSTag>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this type.",
+        Tag, CSTag);
 };
 
 }}} // namespace strategy::envelope::services

--- a/include/boost/geometry/strategy/expand.hpp
+++ b/include/boost/geometry/strategy/expand.hpp
@@ -10,7 +10,7 @@
 #ifndef BOOST_GEOMETRY_STRATEGY_EXPAND_HPP
 #define BOOST_GEOMETRY_STRATEGY_EXPAND_HPP
 
-#include <boost/mpl/assert.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 
 namespace boost { namespace geometry
 {
@@ -29,11 +29,9 @@ namespace strategy { namespace expand { namespace services
 template <typename Tag, typename CSTag, typename CalculationType = void>
 struct default_strategy
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_IMPLEMENTED_FOR_THIS_TYPE
-            , (types<Tag, CSTag>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented for this type.",
+        Tag, CSTag);
 };
 
 }}} // namespace strategy::expand::services

--- a/include/boost/geometry/strategy/spherical/expand_point.hpp
+++ b/include/boost/geometry/strategy/spherical/expand_point.hpp
@@ -27,8 +27,6 @@
 #include <functional>
 #include <type_traits>
 
-#include <boost/mpl/assert.hpp>
-
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/coordinate_system.hpp>

--- a/include/boost/geometry/views/detail/boundary_view/implementation.hpp
+++ b/include/boost/geometry/views/detail/boundary_view/implementation.hpp
@@ -23,23 +23,19 @@
 #include <boost/core/addressof.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/iterator/iterator_categories.hpp>
-#include <boost/mpl/assert.hpp>
 
+#include <boost/geometry/algorithms/num_interior_rings.hpp>
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/closure.hpp>
 #include <boost/geometry/core/exterior_ring.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
 #include <boost/geometry/core/ring_type.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tags.hpp>
-
 #include <boost/geometry/iterators/flatten_iterator.hpp>
-
 #include <boost/geometry/util/range.hpp>
-
 #include <boost/geometry/views/closeable_view.hpp>
 #include <boost/geometry/views/detail/boundary_view/interface.hpp>
-
-#include <boost/geometry/algorithms/num_interior_rings.hpp>
 
 
 namespace boost { namespace geometry
@@ -121,9 +117,9 @@ public:
         static const bool is_convertible
             = std::is_convertible<OtherPolygon, Polygon>::value;
 
-        BOOST_MPL_ASSERT_MSG((is_convertible),
-                             NOT_CONVERTIBLE,
-                             (types<OtherPolygon>));
+        BOOST_GEOMETRY_STATIC_ASSERT((is_convertible),
+            "OtherPolygon has to be convertible to Polygon.",
+            OtherPolygon, Polygon);
     }
 
 private:

--- a/include/boost/geometry/views/detail/range_type.hpp
+++ b/include/boost/geometry/views/detail/range_type.hpp
@@ -15,10 +15,10 @@
 #define BOOST_GEOMETRY_VIEWS_DETAIL_RANGE_TYPE_HPP
 
 
-#include <boost/mpl/assert.hpp>
 #include <boost/range/value_type.hpp>
 
 #include <boost/geometry/core/ring_type.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tags.hpp>
 
@@ -37,11 +37,9 @@ template <typename Geometry,
           typename Tag = typename tag<Geometry>::type>
 struct range_type
 {
-    BOOST_MPL_ASSERT_MSG
-        (
-            false, NOT_OR_NOT_YET_IMPLEMENTED_FOR_THIS_GEOMETRY_TYPE
-            , (types<Geometry>)
-        );
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not or not yet implemented for this Geometry type.",
+        Geometry, Tag);
 };
 
 

--- a/include/boost/geometry/views/detail/two_dimensional_view.hpp
+++ b/include/boost/geometry/views/detail/two_dimensional_view.hpp
@@ -13,14 +13,12 @@
 
 #include <cstddef>
 
-#include <boost/mpl/assert.hpp>
-#include <boost/mpl/int.hpp>
-
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/coordinate_system.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/point_type.hpp>
+#include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tags.hpp>
 
@@ -51,15 +49,15 @@ struct two_dimensional_view
 template <typename Point, std::size_t Dimension1, std::size_t Dimension2>
 struct two_dimensional_view<Point, Dimension1, Dimension2, point_tag>
 {
-    BOOST_MPL_ASSERT_MSG(
-        (Dimension1 < static_cast<std::size_t>(dimension<Point>::value)),
-        COORDINATE_DIMENSION1_IS_LARGER_THAN_POINT_DIMENSION,
-        (std::integral_constant<std::size_t, Dimension1>));
+    BOOST_GEOMETRY_STATIC_ASSERT(
+        (Dimension1 < dimension<Point>::value),
+        "Coordinate Dimension1 is larger than Point's dimension.",
+        std::integral_constant<std::size_t, Dimension1>);
 
-    BOOST_MPL_ASSERT_MSG(
-        (Dimension2 < static_cast<std::size_t>(dimension<Point>::value)),
-        COORDINATE_DIMENSION2_IS_LARGER_THAN_POINT_DIMENSION,
-        (std::integral_constant<std::size_t, Dimension2>));
+    BOOST_GEOMETRY_STATIC_ASSERT(
+        (Dimension2 < dimension<Point>::value),
+        "Coordinate Dimension2 is larger than Point's dimension.",
+        std::integral_constant<std::size_t, Dimension2>);
 
     two_dimensional_view(Point& point)
         : m_point(point)


### PR DESCRIPTION
This PR replaces `MPL_ASSERT` and `MPL_ASSERT_MSG` with `BOOST_GEOMETRY_STATIC_ASSERT` or `BOOST_GEOMETRY_STATIC_ASSERT_FALSE` expanded to `static_assert`.

`not_implemented` now takes parameter pack so can take arbitrary number of types.

It also removes `bg::info::XXX` from `not_implemented` because IMO this does not really enhance the output.

Below are examples showing how the compiler output is changed by this PR:

MSVC (`MPL_ASSERT` and `bg::info::XXX`):
```
1>  d:\lib\modular-boost\libs\geometry\include\boost\geometry\algorithms\not_implemented.hpp(70): error C2664: 'int boost::mpl::assertion_failed<false>(boost::mpl::assert<false>::type)': cannot convert argument 1 from 'boost::mpl::failed ************(__cdecl boost::geometry::nyi::not_implemented_error<boost::geometry::info::LINESTRING,boost::geometry::info::MULTI_POLYGON,boost::geometry::info::POLYGON>::THIS_OPERATION_IS_NOT_OR_NOT_YET_IMPLEMENTED::* ***********)(boost::mpl::assert_::types<Term1,Term2,Term3,boost::mpl::na>)' to 'boost::mpl::assert<false>::type'
1>          with
1>          [
1>              Term1=boost::geometry::info::LINESTRING,
1>              Term2=boost::geometry::info::MULTI_POLYGON,
1>              Term3=boost::geometry::info::POLYGON
1>          ]
1>  d:\lib\modular-boost\libs\geometry\include\boost\geometry\algorithms\not_implemented.hpp(77): note: No constructor could take the source type, or constructor overload resolution was ambiguous
1>  d:\lib\modular-boost\libs\geometry\include\boost\geometry\algorithms\not_implemented.hpp(126): note: see reference to class template instantiation 'boost::geometry::nyi::not_implemented_error<boost::geometry::info::LINESTRING,boost::geometry::info::MULTI_POLYGON,boost::geometry::info::POLYGON>' being compiled
1>  d:\lib\modular-boost\libs\geometry\include\boost\geometry\algorithms\union.hpp(55): note: see reference to class template instantiation 'boost::geometry::not_implemented<TagIn1,TagIn2,TagOut>' being compiled
1>          with
1>          [
1>              TagIn1=boost::geometry::linestring_tag,
1>              TagIn2=boost::geometry::multi_polygon_tag,
1>              TagOut=boost::geometry::polygon_tag
1>          ]

(...)
```

MSVC (`static_assert`):
```
1>  d:\lib\modular-boost\libs\geometry\include\boost\geometry\algorithms\not_implemented.hpp(64): error C2338: This operation is not or not yet implemented
1>  d:\lib\modular-boost\libs\geometry\include\boost\geometry\algorithms\not_implemented.hpp(98): note: see reference to class template instantiation 'boost::geometry::nyi::not_implemented_error<TagIn1,TagIn2,TagOut>' being compiled
1>          with
1>          [
1>              TagIn1=boost::geometry::linestring_tag,
1>              TagIn2=boost::geometry::multi_polygon_tag,
1>              TagOut=boost::geometry::polygon_tag
1>          ]
1>  d:\lib\modular-boost\libs\geometry\include\boost\geometry\algorithms\union.hpp(55): note: see reference to class template instantiation 'boost::geometry::not_implemented<TagIn1,TagIn2,TagOut>' being compiled
1>          with
1>          [
1>              TagIn1=boost::geometry::linestring_tag,
1>              TagIn2=boost::geometry::multi_polygon_tag,
1>              TagOut=boost::geometry::polygon_tag
1>          ]

(...)
```

GCC (`MPL_ASSERT` and `bg::info::XXX`):
```
..\../boost/geometry/algorithms/not_implemented.hpp: In instantiation of 'struct boost::geometry::nyi::not_implemented_error<boost::geometry::info::LINESTRING, boost::geometry::info::MULTI_POLYGON, boost::geometry::info::POLYGON>':
..\../boost/geometry/algorithms/not_implemented.hpp:109:8:   required from 'struct boost::geometry::not_implemented<boost::geometry::linestring_tag, boost::geometry::multi_polygon_tag, boost::geometry::polygon_tag>'

(...)

..\../boost/mpl/assert.hpp:440:42: error: no matching function for call to 'assertion_failed<false>(mpl_::failed************ (boost::geometry::nyi::not_implemented_error<boost::geometry::info::LINESTRING, boost::geometry::info::MULTI_POLYGON, boost::geometry::info::POLYGON>::THIS_OPERATION_IS_NOT_OR_NOT_YET_IMPLEMENTED::************)(mpl_::assert_::types<boost::geometry::info::LINESTRING, boost::geometry::info::MULTI_POLYGON, boost::geometry::info::POLYGON, mpl_::na>))'
     , BOOST_PP_CAT(mpl_assertion_in_line_,counter) = sizeof( \
                                                            ~~~
         boost::mpl::assertion_failed<(c)>( BOOST_PP_CAT(mpl_assert_arg,counter)::assert_arg() ) \
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         ) \
         ~
..\../boost/mpl/assert.hpp:60:58: note: in definition of macro 'BOOST_MPL_AUX_ASSERT_CONSTANT'
 #   define BOOST_MPL_AUX_ASSERT_CONSTANT(T, expr) enum { expr }
                                                          ^~~~
..\../boost/mpl/assert.hpp:455:1: note: in expansion of macro 'BOOST_MPL_ASSERT_MSG_IMPL'
 BOOST_MPL_ASSERT_MSG_IMPL( BOOST_MPL_AUX_PP_COUNTER(), c, msg, types_ ) \
 ^~~~~~~~~~~~~~~~~~~~~~~~~
..\../boost/geometry/algorithms/not_implemented.hpp:70:5: note: in expansion of macro 'BOOST_MPL_ASSERT_MSG'
     BOOST_MPL_ASSERT_MSG
     ^~~~~~~~~~~~~~~~~~~~
..\../boost/mpl/assert.hpp:83:5: note: candidate: 'template<bool C> int mpl_::assertion_failed(typename mpl_::assert<C>::type)'
 int assertion_failed( typename assert<C>::type );
     ^~~~~~~~~~~~~~~~
..\../boost/mpl/assert.hpp:83:5: note:   template argument deduction/substitution failed:
..\../boost/mpl/assert.hpp:440:92: note:   cannot convert 'boost::geometry::nyi::not_implemented_error<boost::geometry::info::LINESTRING, boost::geometry::info::MULTI_POLYGON, boost::geometry::info::POLYGON>::THIS_OPERATION_IS_NOT_OR_NOT_YET_IMPLEMENTED77::assert_arg()' (type 'mpl_::failed************ (boost::geometry::nyi::not_implemented_error<boost::geometry::info::LINESTRING, boost::geometry::info::MULTI_POLYGON, boost::geometry::info::POLYGON>::THIS_OPERATION_IS_NOT_OR_NOT_YET_IMPLEMENTED::************)(mpl_::assert_::types<boost::geometry::info::LINESTRING, boost::geometry::info::MULTI_POLYGON, boost::geometry::info::POLYGON, mpl_::na>)') to type 'mpl_::assert<false>::type' {aka 'mpl_::assert<false>'}
         boost::mpl::assertion_failed<(c)>( BOOST_PP_CAT(mpl_assert_arg,counter)::assert_arg() ) \
                                                                                            ^
..\../boost/mpl/assert.hpp:60:58: note: in definition of macro 'BOOST_MPL_AUX_ASSERT_CONSTANT'
 #   define BOOST_MPL_AUX_ASSERT_CONSTANT(T, expr) enum { expr }
                                                          ^~~~
..\../boost/mpl/assert.hpp:455:1: note: in expansion of macro 'BOOST_MPL_ASSERT_MSG_IMPL'
 BOOST_MPL_ASSERT_MSG_IMPL( BOOST_MPL_AUX_PP_COUNTER(), c, msg, types_ ) \
 ^~~~~~~~~~~~~~~~~~~~~~~~~
..\../boost/geometry/algorithms/not_implemented.hpp:70:5: note: in expansion of macro 'BOOST_MPL_ASSERT_MSG'
     BOOST_MPL_ASSERT_MSG
     ^~~~~~~~~~~~~~~~~~~~
```

GCC (`static_assert`):
```
..\../boost/geometry/algorithms/not_implemented.hpp: In instantiation of 'struct boost::geometry::nyi::not_implemented_error<boost::geometry::linestring_tag, boost::geometry::multi_polygon_tag, boost::geometry::polygon_tag>':
..\../boost/geometry/algorithms/not_implemented.hpp:94:8:   required from 'struct boost::geometry::not_implemented<boost::geometry::linestring_tag, boost::geometry::multi_polygon_tag, boost::geometry::polygon_tag>'

(...)

..\../boost/geometry/core/static_assert.hpp:25:15: error: static assertion failed: This operation is not or not yet implemented
 static_assert(::boost::geometry::detail::static_assert_check<(CHECK), __VA_ARGS__>::value, MESSAGE)
               ^~
..\../boost/geometry/core/static_assert.hpp:25:15: note: in definition of macro 'BOOST_GEOMETRY_STATIC_ASSERT'
 static_assert(::boost::geometry::detail::static_assert_check<(CHECK), __VA_ARGS__>::value, MESSAGE)
```