### PR TITLE
fixed risk of undefined behavior when parsing a byte_order byte

### DIFF
--- a/include/boost/geometry/extensions/gis/io/wkb/detail/parser.hpp
+++ b/include/boost/geometry/extensions/gis/io/wkb/detail/parser.hpp
@@ -116,6 +116,8 @@ struct byte_order_parser
             if (byte_order_type::unknown > value)
             {
                 order = byte_order_type::enum_t(value);
+            }else{
+                order = byte_order_type::unknown;
             }
             return true;
         }
@@ -146,7 +148,7 @@ struct parsing_assigner
 {
     template <typename Iterator>
     static void run(Iterator& it, Iterator end, P& point, 
-                byte_order_type::enum_t order)
+                byte_order_type::enum_t order)order
     {
         typedef typename coordinate_type<P>::type coordinate_type;
 

--- a/include/boost/geometry/extensions/gis/io/wkb/detail/parser.hpp
+++ b/include/boost/geometry/extensions/gis/io/wkb/detail/parser.hpp
@@ -148,7 +148,7 @@ struct parsing_assigner
 {
     template <typename Iterator>
     static void run(Iterator& it, Iterator end, P& point, 
-                byte_order_type::enum_t order)order
+                byte_order_type::enum_t order)
     {
         typedef typename coordinate_type<P>::type coordinate_type;
 


### PR DESCRIPTION
tried to parse a spatialite WKB blob with this code but the byte_order byte was replaced by a '69' token :
 parsing this byte is successful but if the value read is not part of the enum, the function returns true but the order parameter is left untouched. 
Calls to that function elsewhere in the code do not initialise the order parameter.
see https://github.com/boostorg/geometry/blob/869e72fc01f2fce5ec3bcdfb91afab65ebd3ec6f/include/boost/geometry/extensions/multi/gis/io/wkb/detail/parser.hpp#L83

another option would be to return false in that case, but it didn't fit my need