### PR TITLE
Fix/start turns

### DIFF
--- a/include/boost/geometry/algorithms/detail/buffer/get_piece_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/get_piece_turns.hpp
@@ -266,7 +266,7 @@ class piece_turn_visitor
 
                 typedef detail::overlay::get_turn_info
                     <
-                        detail::overlay::assign_null_policy
+                        detail::overlay::assign_policy_only_start_turns
                     > turn_policy;
 
                 turn_policy::apply(unique_sub_range1, unique_sub_range2,

--- a/include/boost/geometry/algorithms/detail/disjoint/linear_linear.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/linear_linear.hpp
@@ -79,6 +79,7 @@ struct assign_disjoint_policy
     static bool const include_no_turn = true;
     static bool const include_degenerate = true;
     static bool const include_opposite = true;
+    static bool const include_start_turn = false;
 };
 
 

--- a/include/boost/geometry/algorithms/detail/overlay/enrich_intersection_points.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/enrich_intersection_points.hpp
@@ -491,8 +491,8 @@ inline void enrich_intersection_points(Turns& turns,
     {
         detail::overlay::discard_closed_turns
             <
-            OverlayType,
-            target_operation
+                OverlayType,
+                target_operation
             >::apply(turns, clusters, geometry1, geometry2,
                      strategy);
         detail::overlay::discard_open_turns

--- a/include/boost/geometry/algorithms/detail/overlay/handle_colocations.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/handle_colocations.hpp
@@ -507,6 +507,46 @@ inline void discard_interior_exterior_turns(Turns& turns, Clusters& clusters)
     }
 }
 
+template<typename Turns, typename Clusters>
+inline void discard_start_turns(Turns& turns, Clusters& clusters)
+{
+    for (auto& nv : clusters)
+    {
+        cluster_info& cinfo = nv.second;
+        auto& indices = cinfo.turn_indices;
+        std::size_t start_count{0};
+        for (signed_size_type index : indices)
+        {
+            auto const& turn = turns[index];
+            if (turn.method == method_start)
+            {
+               start_count++;
+            }
+        }
+        if (start_count == 0 && start_count == indices.size())
+        {
+            // There are no start turns, or all turns in the cluster are start turns.
+            continue;
+        }
+
+        // Discard the start turns and simultaneously erase them from the indices
+        for (auto it = indices.begin(); it != indices.end();)
+        {
+          auto& turn = turns[*it];
+          if (turn.method == method_start)
+          {
+              turn.discarded = true;
+              turn.cluster_id = -1;
+              it = indices.erase(it);
+          }
+          else
+          {
+              ++it;
+          }
+        }
+    }
+}
+
 template <typename Geometry0, typename Geometry1>
 inline segment_identifier get_preceding_segment_id(segment_identifier const& id,
         Geometry0 const& geometry0, Geometry1 const& geometry1)
@@ -700,6 +740,8 @@ inline bool handle_colocations(Turns& turns, Clusters& clusters,
     // on turns which are discarded afterwards
     set_colocation<OverlayType>(turns, clusters);
 
+    discard_start_turns(turns, clusters);
+
     if (BOOST_GEOMETRY_CONDITION(target_operation == operation_intersection))
     {
         discard_interior_exterior_turns
@@ -783,7 +825,7 @@ inline bool fill_sbs(Sbs& sbs, Point& turn_point,
     {
         signed_size_type turn_index = *sit;
         turn_type const& turn = turns[turn_index];
-        if (first )
+        if (first)
         {
             turn_point = turn.point;
         }

--- a/include/boost/geometry/algorithms/detail/overlay/linear_linear.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/linear_linear.hpp
@@ -138,6 +138,7 @@ protected:
         static bool const include_no_turn = false;
         static bool const include_degenerate = EnableDegenerateTurns;
         static bool const include_opposite = false;
+        static bool const include_start_turn = false;
     };
 
 

--- a/include/boost/geometry/algorithms/detail/overlay/overlay.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/overlay.hpp
@@ -306,7 +306,7 @@ std::cout << "get turns" << std::endl;
         geometry::get_turns
             <
                 Reverse1, Reverse2,
-                detail::overlay::assign_null_policy
+                assign_policy_only_start_turns
             >(geometry1, geometry2, strategy, robust_policy, turns, policy);
 
         visitor.visit_turns(1, turns);
@@ -318,12 +318,12 @@ std::cout << "get turns" << std::endl;
             // and if necessary (e.g.: multi-geometry, polygon with interior rings)
             if (needs_self_turns<Geometry1>::apply(geometry1))
             {
-                self_get_turn_points::self_turns<Reverse1, assign_null_policy>(geometry1,
+                self_get_turn_points::self_turns<Reverse1, assign_policy_only_start_turns>(geometry1,
                     strategy, robust_policy, turns, policy, 0);
             }
             if (needs_self_turns<Geometry2>::apply(geometry2))
             {
-                self_get_turn_points::self_turns<Reverse2, assign_null_policy>(geometry2,
+                self_get_turn_points::self_turns<Reverse2, assign_policy_only_start_turns>(geometry2,
                     strategy, robust_policy, turns, policy, 1);
             }
         }

--- a/include/boost/geometry/algorithms/detail/overlay/turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/turn_info.hpp
@@ -34,6 +34,7 @@ enum method_type
     method_touch_interior,
     method_collinear,
     method_equal,
+    method_start,
     method_error
 };
 

--- a/include/boost/geometry/algorithms/detail/touches/implementation.hpp
+++ b/include/boost/geometry/algorithms/detail/touches/implementation.hpp
@@ -181,6 +181,7 @@ struct areal_interrupt_policy
                         return true;
                     }
                     break;
+                case overlay::method_start :
                 case overlay::method_none :
                 case overlay::method_disjoint :
                 case overlay::method_error :

--- a/test/algorithms/buffer/buffer_multi_polygon.cpp
+++ b/test/algorithms/buffer/buffer_multi_polygon.cpp
@@ -292,6 +292,52 @@ static std::string const rt_v3
 static std::string const rt_v4
     = "MULTIPOLYGON(((5 4,5 5,6 5,6 4,5 4)),((7 1,6 1,7 2,7 1)),((7 1,8 1,8 0,7 0,7 1)),((6 1,5 1,5 2,6 1)))";
 
+// From 2020 runs of robustness test recursive_polygons_buffer, without rescaling
+// For the same problem there can be multiple cases, but details differ
+
+// Cases missing a turn, or needing a start turn
+static std::string const nores_mt_1
+    = "MULTIPOLYGON(((4 8,4 9,5 9,4 8)),((3 6,3 7,4 6,3 6)))";
+
+static std::string const nores_mt_2
+    = "MULTIPOLYGON(((5 3,6 4,6 3,5 3)),((4 4,3 4,4 5,5 5,4 4)),((4 5,3 5,3 6,4 5)))";
+
+static std::string const nores_mt_3
+    = "MULTIPOLYGON(((7 4,7 5,8 5,8 4,7 4)),((2 6,2 7,3 6,2 6)),((3 10,4 10,4 9,4 8,3 8,3 10)))";
+
+static std::string const nores_mt_4
+    = "MULTIPOLYGON(((6 8,6 9,7 9,6 8)),((1 5,1 6,2 6,1 5)),((7 7,8 8,8 7,7 7)),((0 3,0 4,1 3,0 3)))";
+
+static std::string const nores_mt_5
+    = "MULTIPOLYGON(((4 3,4 4,5 4,5 3,4 3)),((3 1,3 2,4 1,3 1)),((1 6,2 7,2 6,1 6)),((3 6,4 5,3 4,3 6)))";
+
+static std::string const nores_mt_6
+    = "MULTIPOLYGON(((5 7,5 6,4 6,4 5,4 4,3 4,3 6,3 7,5 7)))";
+
+// Cases generating an extra turn, and/or a cluster not yet handled correctly
+static std::string const nores_et_1
+    = "MULTIPOLYGON(((5 7,5 8,6 8,5 7)),((5 4,5 5,6 4,5 4)),((3 6,4 7,4 6,3 6)))";
+
+static std::string const nores_et_2
+    = "MULTIPOLYGON(((4 2,5 3,5 2,4 2)),((6 3,6 4,7 4,7 3,6 3)),((7 2,8 3,8 2,7 2)),((4 4,4 5,5 5,5 4,4 4)))";
+
+static std::string const nores_et_3
+    = "MULTIPOLYGON(((3 1,3 2,4 2,4 1,3 1)),((5 4,5 3,4 3,5 4)),((5 3,6 2,5 2,5 3)),((8 1,7 1,6 1,7 2,7 3,7.5 2.5,8 3,8 1)))";
+
+static std::string const nores_et_4
+    = "MULTIPOLYGON(((4 7,4 8,5 8,5 7,4 7)),((3 5,3 6,4 5,3 5)),((1 6,2 7,2 6,1 6)))";
+
+static std::string const nores_et_5
+    = "MULTIPOLYGON(((3 2,3 3,4 3,4 2,3 2)),((0 3,0 4,1 3,0 3)),((2 2,2 1,1 1,2 2)))";
+
+
+// Cases having wrong next turn information, somehow, taking the "i" (intersection),
+// which is wrong for buffer (it should take the "u" like union)
+static std::string const nores_wn_1
+    = "MULTIPOLYGON(((8 3,8 4,9 4,9 3,8 3)),((9 5,9 6,10 5,9 5)),((8 8,9 9,9 8,8 8)),((8 8,8 7,7 7,8 8)))";
+static std::string const nores_wn_2
+    = "MULTIPOLYGON(((9 5,9 6,10 5,9 5)),((8 8,8 7,7 7,7 8,8 8)),((8 8,9 9,9 8,8 8)))";
+
 
 static std::string const neighbouring
     = "MULTIPOLYGON(((0 0,0 10,10 10,10 0,0 0)),((10 10,10 20,20 20,20 10,10 10)))";
@@ -498,6 +544,23 @@ void test_all()
     test_one<multi_polygon_type, polygon_type>("rt_v3", rt_v3, join_round32, end_flat, 22.9158, 1.0);
     test_one<multi_polygon_type, polygon_type>("rt_v4", rt_v4, join_round32, end_flat, 23.4146, 1.0);
 
+    test_one<multi_polygon_type, polygon_type>("nores_mt_1", nores_mt_1, join_round32, end_flat, 13.4113, 1.0);
+    test_one<multi_polygon_type, polygon_type>("nores_mt_2", nores_mt_2, join_round32, end_flat, 17.5265, 1.0);
+    test_one<multi_polygon_type, polygon_type>("nores_mt_3", nores_mt_3, join_round32, end_flat, 25.6091, 1.0);
+    test_one<multi_polygon_type, polygon_type>("nores_mt_4", nores_mt_4, join_round32, end_flat, 26.0946, 1.0);
+    test_one<multi_polygon_type, polygon_type>("nores_mt_5", nores_mt_5, join_round32, end_flat, 26.4375, 1.0);
+    test_one<multi_polygon_type, polygon_type>("nores_mt_6", nores_mt_6, join_round32, end_flat, 16.9018, 1.0);
+
+#if defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
+    test_one<multi_polygon_type, polygon_type>("nores_et_1", nores_et_1, join_round32, end_flat, 18.9866, 1.0);
+    test_one<multi_polygon_type, polygon_type>("nores_et_2", nores_et_2, join_round32, end_flat, 23.8389, 1.0);
+    test_one<multi_polygon_type, polygon_type>("nores_et_3", nores_et_3, join_round32, end_flat, 26.9030, 1.0);
+    test_one<multi_polygon_type, polygon_type>("nores_et_4", nores_et_4, join_round32, end_flat, 19.9626, 1.0);
+    test_one<multi_polygon_type, polygon_type>("nores_et_5", nores_et_5, join_round32, end_flat, 19.9615, 1.0);
+    test_one<multi_polygon_type, polygon_type>("nores_wn_1", nores_wn_1, join_round32, end_flat, 23.7659, 1.0);
+    test_one<multi_polygon_type, polygon_type>("nores_wn_2", nores_wn_2, join_round32, end_flat, 18.2669, 1.0);
+#endif
+
     test_one<multi_polygon_type, polygon_type>("neighbouring_small",
         neighbouring,
         join_round32, end_round32, 128.0, -1.0);
@@ -541,7 +604,7 @@ int test_main(int, char* [])
 #endif
 
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(1, 1, 2, 3);
+    BoostGeometryWriteExpectedFailures(1, 14, 2, 11);
 #endif
 
     return 0;

--- a/test/algorithms/set_operations/check_turn_less.hpp
+++ b/test/algorithms/set_operations/check_turn_less.hpp
@@ -55,6 +55,7 @@ struct check_turn_less
         static bool const include_no_turn = false;
         static bool const include_degenerate = EnableDegenerateTurns;
         static bool const include_opposite = false;
+        static bool const include_start_turn = false;
 
         template
         <

--- a/test/algorithms/set_operations/test_get_turns_ll_invariance.hpp
+++ b/test/algorithms/set_operations/test_get_turns_ll_invariance.hpp
@@ -45,6 +45,7 @@ private:
         static bool const include_no_turn = false;
         static bool const include_degenerate = EnableDegenerateTurns;
         static bool const include_opposite = false;
+        static bool const include_start_turn = false;
 
         template
         <


### PR DESCRIPTION
This commit adds start turns (if specified in assign policy, and not for rescaling).
They are necessary in cases where the corresponding arrival turn is missed by accuracy.

Testcases (added) are found by `recursive_polygons_buffer`

Performance: with start turns:
```
$ recursive_polygons_buffer --count 10000 --level 4 --form triangle --validity 0
Test configuration:
  - Using Start Turns
  - Default test type: d
geometries: 300797 errors: 1501 type: d time: 26.026

Test configuration:
  - Default test type: d
geometries: 291375 errors: 2286 type: d time: 24.516
```

Note, with rescaling there are 0 errors, so I'm still concentrating on buffer. Next round I will look in some of the other added cases in more detail, but they're not related to missing turns but to clusters.
