### PR TITLE
Add constexpr and boost::variant workarounds for vs2015.

### DIFF
--- a/include/boost/geometry/arithmetic/cross_product.hpp
+++ b/include/boost/geometry/arithmetic/cross_product.hpp
@@ -147,7 +147,11 @@ template
             int
         > = 0
 >
-constexpr inline ResultP cross_product(P1 const& p1, P2 const& p2)
+// workaround for VS2015
+#if (_MSC_VER >= 1910)
+constexpr
+#endif
+inline ResultP cross_product(P1 const& p1, P2 const& p2)
 {
     BOOST_CONCEPT_ASSERT((concepts::Point<ResultP>));
     BOOST_CONCEPT_ASSERT((concepts::ConstPoint<P1>));
@@ -210,7 +214,11 @@ template
             int
         > = 0
 >
-constexpr inline P cross_product(P const& p1, P const& p2)
+// workaround for VS2015
+#if (_MSC_VER >= 1910)
+constexpr
+#endif
+inline P cross_product(P const& p1, P const& p2)
 {
     BOOST_CONCEPT_ASSERT((concepts::Point<P>));
     BOOST_CONCEPT_ASSERT((concepts::ConstPoint<P>));

--- a/include/boost/geometry/arithmetic/dot_product.hpp
+++ b/include/boost/geometry/arithmetic/dot_product.hpp
@@ -74,7 +74,11 @@ struct dot_product_maker<P1, P2, DimensionCount, DimensionCount>
 
  */
 template <typename Point1, typename Point2>
-constexpr inline typename select_coordinate_type<Point1, Point2>::type dot_product(
+// workaround for VS2015
+#if (_MSC_VER >= 1910)
+constexpr
+#endif
+inline typename select_coordinate_type<Point1, Point2>::type dot_product(
         Point1 const& p1, Point2 const& p2)
 {
     BOOST_CONCEPT_ASSERT( (concepts::ConstPoint<Point1>) );

--- a/include/boost/geometry/geometries/point.hpp
+++ b/include/boost/geometry/geometries/point.hpp
@@ -90,7 +90,13 @@ public:
 
 #if !defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
     /// \constructor_default_no_init
-    constexpr point() = default;
+    constexpr point()
+// Workaround for VS2015
+#if (_MSC_VER < 1910)
+        : m_values{} {}
+#else
+        = default;
+#endif
 #else // defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
     point()
     {

--- a/include/boost/geometry/strategies/comparable_distance_result.hpp
+++ b/include/boost/geometry/strategies/comparable_distance_result.hpp
@@ -20,6 +20,7 @@
 #include <boost/geometry/strategies/distance.hpp>
 #include <boost/geometry/util/select_most_precise.hpp>
 #include <boost/geometry/util/sequence.hpp>
+#include <boost/geometry/util/type_traits.hpp>
 
 
 namespace boost { namespace geometry
@@ -27,8 +28,13 @@ namespace boost { namespace geometry
 
 namespace resolve_strategy
 {
-
-template <typename Geometry1, typename Geometry2, typename Strategy>
+    
+template
+<
+    typename Geometry1, typename Geometry2, typename Strategy,
+    bool AreGeometries = (util::is_geometry<Geometry1>::value
+                       && util::is_geometry<Geometry2>::value)
+>
 struct comparable_distance_result
     : strategy::distance::services::return_type
         <
@@ -41,8 +47,8 @@ struct comparable_distance_result
         >
 {};
 
-template <typename Geometry1, typename Geometry2>
-struct comparable_distance_result<Geometry1, Geometry2, default_strategy>
+template <typename Geometry1, typename Geometry2, bool AreGeometries>
+struct comparable_distance_result<Geometry1, Geometry2, default_strategy, AreGeometries>
     : comparable_distance_result
         <
             Geometry1,
@@ -53,6 +59,21 @@ struct comparable_distance_result<Geometry1, Geometry2, default_strategy>
                 >::type
         >
 {};
+
+// Workaround for VS2015
+#if (_MSC_VER < 1910)
+template <typename Geometry1, typename Geometry2, typename Strategy>
+struct comparable_distance_result<Geometry1, Geometry2, Strategy, false>
+{
+    typedef int type;
+};
+template <typename Geometry1, typename Geometry2>
+struct comparable_distance_result<Geometry1, Geometry2, default_strategy, false>
+{
+    typedef int type;
+};
+#endif
+
 
 } // namespace resolve_strategy
 

--- a/include/boost/geometry/strategies/default_length_result.hpp
+++ b/include/boost/geometry/strategies/default_length_result.hpp
@@ -24,6 +24,7 @@
 
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/util/select_most_precise.hpp>
+#include <boost/geometry/util/type_traits.hpp>
 
 
 namespace boost { namespace geometry
@@ -39,6 +40,23 @@ namespace resolve_strategy
 // It would probably be enough to use distance_result and
 //   default_distance_result here.
 
+
+// Workaround for VS2015
+#if (_MSC_VER < 1910)
+template
+<
+    typename Geometry,
+    bool IsGeometry = util::is_geometry<Geometry>::value
+>
+struct coordinate_type
+    : geometry::coordinate_type<Geometry>
+{};
+template <typename Geometry>
+struct coordinate_type<Geometry, false>
+{
+    typedef long double type;
+};
+#endif
 
 template <typename ...Geometries>
 struct default_length_result

--- a/include/boost/geometry/strategies/distance_result.hpp
+++ b/include/boost/geometry/strategies/distance_result.hpp
@@ -30,6 +30,7 @@
 #include <boost/geometry/strategies/distance.hpp>
 #include <boost/geometry/util/select_most_precise.hpp>
 #include <boost/geometry/util/sequence.hpp>
+#include <boost/geometry/util/type_traits.hpp>
 
 namespace boost { namespace geometry
 {
@@ -38,7 +39,12 @@ namespace boost { namespace geometry
 namespace resolve_strategy
 {
 
-template <typename Geometry1, typename Geometry2, typename Strategy>
+template
+<
+    typename Geometry1, typename Geometry2, typename Strategy,
+    bool AreGeometries = (util::is_geometry<Geometry1>::value
+                       && util::is_geometry<Geometry2>::value)
+>
 struct distance_result
     : strategy::distance::services::return_type
         <
@@ -48,8 +54,8 @@ struct distance_result
         >
 {};
 
-template <typename Geometry1, typename Geometry2>
-struct distance_result<Geometry1, Geometry2, default_strategy>
+template <typename Geometry1, typename Geometry2, bool AreGeometries>
+struct distance_result<Geometry1, Geometry2, default_strategy, AreGeometries>
     : distance_result
         <
             Geometry1,
@@ -60,6 +66,22 @@ struct distance_result<Geometry1, Geometry2, default_strategy>
                 >::type
         >
 {};
+
+
+// Workaround for VS2015
+#if (_MSC_VER < 1910)
+template <typename Geometry1, typename Geometry2, typename Strategy>
+struct distance_result<Geometry1, Geometry2, Strategy, false>
+{
+    typedef int type;
+};
+template <typename Geometry1, typename Geometry2>
+struct distance_result<Geometry1, Geometry2, default_strategy, false>
+{
+    typedef int type;
+};
+#endif
+
 
 } // namespace resolve_strategy
 


### PR DESCRIPTION
If you see our regression tests it looks like the majority of them compiles with VS2015:
https://www.boost.org/development/tests/develop/developer/geometry.html

Therefore I checked how much effort would it take to make all of them to compile. It seems that it was not much. VS2015 doesn't have full `constexpr` support and `boost::variant`'s is implemented using dummy template parameters instead of parameter pack.

For `constexpr` it was sufficient to disable it in some places and add explicitly initialize class member in other.

In order to analyze types of `boost::variant` I decided to not use Boost.MPL as it was before but instead to check raw template parameters, i.e. to check if they are geometries or not. This works for both dummy parameters and types that are not geometries. And while currently non-geometries are not supported in other places of the library we could consider supporting them. An example would be something like:
```
boost::variant<point, polygon, std::string> v = polygon{{{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0, 0}}};
auto a = area(v);
```
Right now this code would not compile. At least I think it would not. But I don't see a semantic reason why it shouldn't. So in the future we could consider expanding the change done in this PR to the whole library.

What do you think about these workarounds?
Does it make sense to support vs2015?