### PR TITLE
Fixes/workarounds for clang 3.5-3.9

### DIFF
--- a/include/boost/geometry/algorithms/area_result.hpp
+++ b/include/boost/geometry/algorithms/area_result.hpp
@@ -143,14 +143,14 @@ struct area_result
     : detail::area::area_result<Geometry, Strategy>
 {};
 
-template <typename ...Ts, typename Strategy>
-struct area_result<boost::variant<Ts...>, Strategy>
+template <BOOST_VARIANT_ENUM_PARAMS(typename T), typename Strategy>
+struct area_result<boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>, Strategy>
     : geometry::area_result
         <
             typename util::select_pack_element
                 <
                     detail::area::more_precise_coordinate_type,
-                    Ts...
+                    BOOST_VARIANT_ENUM_PARAMS(T)
                 >::type,
             Strategy
         >
@@ -161,14 +161,14 @@ struct area_result<Geometry, default_strategy>
     : detail::area::default_area_result<Geometry>
 {};
 
-template <typename ...Ts>
-struct area_result<boost::variant<Ts...>, default_strategy>
+template <BOOST_VARIANT_ENUM_PARAMS(typename T)>
+struct area_result<boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>, default_strategy>
     : detail::area::default_area_result
         <
             typename util::select_pack_element
                 <
                     detail::area::more_precise_default_area_result,
-                    Ts...
+                    BOOST_VARIANT_ENUM_PARAMS(T)
                 >::type
         >
 {};

--- a/include/boost/geometry/geometries/point.hpp
+++ b/include/boost/geometry/geometries/point.hpp
@@ -82,6 +82,11 @@ class point
     // passed for non-Cartesian coordinate systems.
     enum { cs_check = sizeof(CoordinateSystem) };
 
+    template <typename DT, bool Condition, typename T = void>
+    struct enable_ctor_if
+        : std::enable_if<Condition, T>
+    {};
+
 public:
 
     // TODO: constexpr requires LiteralType and until C++20
@@ -124,6 +129,11 @@ public:
     }
 
     /// @brief Constructor to set two values
+    template
+    <
+        typename T = CoordinateType,
+        typename enable_ctor_if<T, (DimensionCount >= 2), int>::type = 0
+    >
 #if ! defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
     constexpr
 #endif
@@ -137,6 +147,11 @@ public:
     }
 
     /// @brief Constructor to set three values
+    template
+    <
+        typename T = CoordinateType,
+        typename enable_ctor_if<T, (DimensionCount >= 3), int>::type = 0
+    >
 #if ! defined(BOOST_GEOMETRY_ENABLE_ACCESS_DEBUGGING)
     constexpr
 #endif

--- a/include/boost/geometry/geometries/variant.hpp
+++ b/include/boost/geometry/geometries/variant.hpp
@@ -27,10 +27,30 @@
 namespace boost { namespace geometry
 {
 
+namespace detail
+{
 
-template <typename T, typename ...Ts>
-struct point_type<boost::variant<T, Ts...> >
-    : point_type<T>
+template <typename ...>
+struct parameter_pack_first_type {};
+
+template <typename T, typename ... Ts>
+struct parameter_pack_first_type<T, Ts...>
+{
+    typedef T type;
+};
+
+} // namespace detail
+
+
+template <BOOST_VARIANT_ENUM_PARAMS(typename T)>
+struct point_type<boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)> >
+    : point_type
+        <
+            typename detail::parameter_pack_first_type
+                <
+                    BOOST_VARIANT_ENUM_PARAMS(T)
+                >::type
+        >
 {};
 
 

--- a/include/boost/geometry/srs/projections/dpar.hpp
+++ b/include/boost/geometry/srs/projections/dpar.hpp
@@ -65,9 +65,9 @@ template <typename Variant, typename T>
 struct find_type_index
 {};
 
-template <typename ...Types, typename T>
-struct find_type_index<boost::variant<Types...>, T>
-    : find_type_index_impl<T, 0, Types...>
+template <BOOST_VARIANT_ENUM_PARAMS(typename T), typename T>
+struct find_type_index<boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>, T>
+    : find_type_index_impl<T, 0, BOOST_VARIANT_ENUM_PARAMS(T)>
 {};
 
 

--- a/include/boost/geometry/strategies/comparable_distance_result.hpp
+++ b/include/boost/geometry/strategies/comparable_distance_result.hpp
@@ -132,8 +132,16 @@ struct comparable_distance_result
 {};
 
 
-template <typename Geometry1, typename ...Ts, typename Strategy>
-struct comparable_distance_result<Geometry1, boost::variant<Ts...>, Strategy>
+template
+<
+    typename Geometry1,
+    BOOST_VARIANT_ENUM_PARAMS(typename T),
+    typename Strategy
+>
+struct comparable_distance_result
+    <
+        Geometry1, boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>, Strategy
+    >
 {
     // Select the most precise distance strategy result type
     //   for all variant type combinations.
@@ -142,7 +150,7 @@ struct comparable_distance_result<Geometry1, boost::variant<Ts...>, Strategy>
     typedef typename util::select_combination_element
         <
             util::type_sequence<Geometry1>,
-            util::type_sequence<Ts...>,
+            util::type_sequence<BOOST_VARIANT_ENUM_PARAMS(T)>,
             detail::distance::more_precise_comparable_distance_result
                 <
                     Strategy
@@ -159,19 +167,34 @@ struct comparable_distance_result<Geometry1, boost::variant<Ts...>, Strategy>
 
 
 // Distance arguments are commutative
-template <typename ...Ts, typename Geometry2, typename Strategy>
-struct comparable_distance_result<boost::variant<Ts...>, Geometry2, Strategy>
+template
+<
+    BOOST_VARIANT_ENUM_PARAMS(typename T),
+    typename Geometry2,
+    typename Strategy
+>
+struct comparable_distance_result
+    <
+        boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>, Geometry2, Strategy
+    >
     : public comparable_distance_result
         <
-            Geometry2, boost::variant<Ts...>, Strategy
+            Geometry2, boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>, Strategy
         >
 {};
 
 
-template <typename ...Ts, typename ...Us, typename Strategy>
+template
+<
+    BOOST_VARIANT_ENUM_PARAMS(typename T),
+    BOOST_VARIANT_ENUM_PARAMS(typename U),
+    typename Strategy
+>
 struct comparable_distance_result
     <
-        boost::variant<Ts...>, boost::variant<Us...>, Strategy
+        boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>,
+        boost::variant<BOOST_VARIANT_ENUM_PARAMS(U)>,
+        Strategy
     >
 {
     // Select the most precise distance strategy result type
@@ -180,8 +203,8 @@ struct comparable_distance_result
     //   but is_implemented is not ready for prime time.
     typedef typename util::select_combination_element
         <
-            util::type_sequence<Ts...>,
-            util::type_sequence<Us...>,
+            util::type_sequence<BOOST_VARIANT_ENUM_PARAMS(T)>,
+            util::type_sequence<BOOST_VARIANT_ENUM_PARAMS(U)>,
             detail::distance::more_precise_comparable_distance_result
                 <
                     Strategy

--- a/include/boost/geometry/strategies/default_length_result.hpp
+++ b/include/boost/geometry/strategies/default_length_result.hpp
@@ -79,9 +79,9 @@ struct default_length_result
     : resolve_strategy::default_length_result<Geometry>
 {};
 
-template <typename ...Ts>
-struct default_length_result<boost::variant<Ts...> >
-    : resolve_strategy::default_length_result<Ts...>
+template <BOOST_VARIANT_ENUM_PARAMS(typename T)>
+struct default_length_result<boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)> >
+    : resolve_strategy::default_length_result<BOOST_VARIANT_ENUM_PARAMS(T)>
 {};
 
 } // namespace resolve_variant

--- a/include/boost/geometry/strategies/distance_result.hpp
+++ b/include/boost/geometry/strategies/distance_result.hpp
@@ -140,8 +140,16 @@ struct distance_result
 {};
 
 
-template <typename Geometry1, typename ...Ts, typename Strategy>
-struct distance_result<Geometry1, boost::variant<Ts...>, Strategy>
+template
+<
+    typename Geometry1,
+    BOOST_VARIANT_ENUM_PARAMS(typename T),
+    typename Strategy
+>
+struct distance_result
+    <
+        Geometry1, boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>, Strategy
+    >
 {
     // Select the most precise distance strategy result type
     //   for all variant type combinations.
@@ -150,7 +158,7 @@ struct distance_result<Geometry1, boost::variant<Ts...>, Strategy>
     typedef typename util::select_combination_element
         <
             util::type_sequence<Geometry1>,
-            util::type_sequence<Ts...>,
+            util::type_sequence<BOOST_VARIANT_ENUM_PARAMS(T)>,
             detail::distance::more_precise_distance_result<Strategy>::template predicate
         >::type elements;
 
@@ -164,14 +172,35 @@ struct distance_result<Geometry1, boost::variant<Ts...>, Strategy>
 
 
 // Distance arguments are commutative
-template <typename ...Ts, typename Geometry2, typename Strategy>
-struct distance_result<boost::variant<Ts...>, Geometry2, Strategy>
-    : public distance_result<Geometry2, boost::variant<Ts...>, Strategy>
+template
+<
+    BOOST_VARIANT_ENUM_PARAMS(typename T),
+    typename Geometry2,
+    typename Strategy
+>
+struct distance_result
+    <
+        boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>, Geometry2, Strategy
+    >
+    : public distance_result
+        <
+            Geometry2, boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>, Strategy
+        >
 {};
 
 
-template <typename ...Ts, typename ...Us, typename Strategy>
-struct distance_result<boost::variant<Ts...>, boost::variant<Us...>, Strategy>
+template
+<
+    BOOST_VARIANT_ENUM_PARAMS(typename T),
+    BOOST_VARIANT_ENUM_PARAMS(typename U),
+    typename Strategy
+>
+struct distance_result
+    <
+        boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>,
+        boost::variant<BOOST_VARIANT_ENUM_PARAMS(U)>,
+        Strategy
+    >
 {
     // Select the most precise distance strategy result type
     //   for all variant type combinations.
@@ -179,8 +208,8 @@ struct distance_result<boost::variant<Ts...>, boost::variant<Us...>, Strategy>
     //   but is_implemented is not ready for prime time.
     typedef typename util::select_combination_element
         <
-            util::type_sequence<Ts...>,
-            util::type_sequence<Us...>,
+            util::type_sequence<BOOST_VARIANT_ENUM_PARAMS(T)>,
+            util::type_sequence<BOOST_VARIANT_ENUM_PARAMS(U)>,
             detail::distance::more_precise_distance_result<Strategy>::template predicate
         >::type elements;
 


### PR DESCRIPTION
This PR adds fixes/workarounds for two problems that cause compilation failures with clang 3.5-3.9:
1. 3.5 - Class template partial specialization cannot be deduced for `boost::variant` and parameter pack. The solution to that is to use `BOOST_VARIANT_ENUM_PARAMS` in specializations. The list of types can be analyzed with variadic templates afterwards.
2. 3.5-3.9 - The instantiation of `std::is_constructible` for 2d `model::point` and 3 parameters causes the compilation error related to the initialization of 2-element array with too many elements. The solution to that is to enable the constructor only if the number of arguments is lesser or equal to `Dimension`. 

See the [regression matrix](https://www.boost.org/development/tests/develop/developer/geometry.html) for details.

Note that the error 2 was caused partially by this change to `cross_product`: https://github.com/boostorg/geometry/pull/745
in particular by specific `std::is_constructible` checks for 3 parameters. I think they are incorrect themselves and should be changed. There is a PR for that already: https://github.com/boostorg/geometry/pull/747