### PR TITLE
Fixed Writing 3D WKT:Z prefix

### DIFF
--- a/example/01_point_example.cpp
+++ b/example/01_point_example.cpp
@@ -129,7 +129,7 @@ int main()
     assign_values(d3a, 1, 2, 3);
     assign_values(d3b, 4, 5, 6);
     d3 = distance(d3a, d3b);
-
+    std::cout << wkt(d3a) << std::endl;
 
 
     // Other examples show other types of points, geometries and more algorithms

--- a/include/boost/geometry/io/wkt/detail/prefix.hpp
+++ b/include/boost/geometry/io/wkt/detail/prefix.hpp
@@ -32,6 +32,11 @@ struct prefix_point
     static inline const char* apply() { return "POINT"; }
 };
 
+struct prefix_point_z
+{
+    static inline const char* apply() { return "POINT Z"; }
+};
+
 struct prefix_polygon
 {
     static inline const char* apply() { return "POLYGON"; }

--- a/include/boost/geometry/io/wkt/write.hpp
+++ b/include/boost/geometry/io/wkt/write.hpp
@@ -113,13 +113,14 @@ struct double_closing_parenthesis
 /*!
 \brief Stream points as \ref WKT
 */
-template <typename Point, typename Policy>
+template <typename Point, typename Policy1, typename Policy2>
 struct wkt_point
 {
     template <typename Char, typename Traits>
     static inline void apply(std::basic_ostream<Char, Traits>& os, Point const& p, bool)
     {
-        os << Policy::apply() << "(";
+        if(dimension<Point>::type::value == 3) os << Policy2::apply() << "(";
+        else os << Policy1::apply() << "(";
         stream_coordinate<Point, 0, dimension<Point>::type::value>::apply(os, p);
         os << ")";
     }
@@ -350,7 +351,8 @@ struct wkt<Point, point_tag>
     : detail::wkt::wkt_point
         <
             Point,
-            detail::wkt::prefix_point
+            detail::wkt::prefix_point,
+            detail::wkt::prefix_point_z
         >
 {};
 
@@ -417,6 +419,7 @@ struct wkt<Multi, multi_point_tag>
             detail::wkt::wkt_point
                 <
                     typename boost::range_value<Multi>::type,
+                    detail::wkt::prefix_null,
                     detail::wkt::prefix_null
                 >,
             detail::wkt::prefix_multipoint


### PR DESCRIPTION
Changed the `wkt_point` struct to take 3 parameters rather than 2, for one for 2d and one for 3d, added the `prefix_z` function in `prefix.hpp,` and also added a line of code to print 3d points in `01_point_example.cpp` .