### PR TITLE
[strategies] [test] Fix spherical cross track and convex hull tests

### DIFF
--- a/include/boost/geometry/strategies/spherical/side_by_cross_track.hpp
+++ b/include/boost/geometry/strategies/spherical/side_by_cross_track.hpp
@@ -15,11 +15,15 @@
 #ifndef BOOST_GEOMETRY_STRATEGIES_SPHERICAL_SIDE_BY_CROSS_TRACK_HPP
 #define BOOST_GEOMETRY_STRATEGIES_SPHERICAL_SIDE_BY_CROSS_TRACK_HPP
 
+#include <boost/geometry/algorithms/equals.hpp>
+
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/radian_access.hpp>
 
 #include <boost/geometry/formulas/spherical.hpp>
+
+#include <boost/geometry/strategies/spherical/point_in_point.hpp>
 
 #include <boost/geometry/util/math.hpp>
 #include <boost/geometry/util/promote_floating_point.hpp>

--- a/test/algorithms/Jamfile
+++ b/test/algorithms/Jamfile
@@ -25,8 +25,6 @@ test-suite boost-geometry-algorithms
     [ run comparable_distance.cpp      : : : : algorithms_comparable_distance ]
     [ run convert.cpp                  : : : : algorithms_convert ]
     [ run convert_multi.cpp            : : : : algorithms_convert_multi ]
-    [ run convex_hull.cpp              : : : : algorithms_convex_hull ]
-    [ run convex_hull_multi.cpp        : : : : algorithms_convex_hull_multi ]
     [ run correct.cpp                  : : : : algorithms_correct ]
     [ run correct_multi.cpp            : : : : algorithms_correct_multi ]
     [ run correct_closure.cpp          : : : : algorithms_correct_closure ]


### PR DESCRIPTION
This PR fixes some tests that fail after merging https://github.com/boostorg/geometry/pull/756
See also https://app.circleci.com/pipelines/github/vissarion/geometry/58/workflows/44e84067-89f7-4938-947f-006156956840