### PR TITLE
Catch up examples with addition of robustness policy and others

### DIFF
--- a/example/05_b_overlay_linestring_polygon_example.cpp
+++ b/example/05_b_overlay_linestring_polygon_example.cpp
@@ -67,12 +67,13 @@ int main(void)
 #endif
 
     // Calculate intersection points (turn points)
-    typedef bg::segment_ratio_type<point_2d, bg::detail::no_rescale_policy>::type segment_ratio;
+    typedef bg::detail::segment_ratio_type<point_2d, bg::detail::no_rescale_policy>::type segment_ratio;
     typedef bg::detail::overlay::turn_info<point_2d, segment_ratio> turn_info;
     std::vector<turn_info> turns;
     bg::detail::get_turns::no_interrupt_policy policy;
     bg::detail::no_rescale_policy rescale_policy;
-    bg::get_turns<false, false, bg::detail::overlay::assign_null_policy>(ls, p, rescale_policy, turns, policy);
+    bg::strategy::intersection::services::default_strategy<typename bg::cs_tag<point_2d>::type>::type intersection_strategy;
+    bg::get_turns<false, false, bg::detail::overlay::assign_null_policy>(ls, p, intersection_strategy, rescale_policy, turns, policy);
 
     std::cout << "Intersection of linestring/polygon" << std::endl;
     BOOST_FOREACH(turn_info const& turn, turns)

--- a/example/c05_custom_point_pointer_example.cpp
+++ b/example/c05_custom_point_pointer_example.cpp
@@ -102,10 +102,11 @@ int main()
 
     // This works because outputs to a normal struct point, no point*
     typedef boost::geometry::model::linestring<point_2d> linestring_2d;
+    boost::geometry::detail::no_rescale_policy rescale_policy;
     std::vector<linestring_2d> clipped;
     boost::geometry::strategy::intersection::liang_barsky<box_2d, point_2d> strategy;
     boost::geometry::detail::intersection::clip_range_with_box<linestring_2d>(cb,
-                    myline, std::back_inserter(clipped), strategy);
+                    myline, rescale_policy, std::back_inserter(clipped), strategy);
 
 
     std::cout << boost::geometry::length(clipped.front()) << std::endl;

--- a/example/c08_custom_non_std_example.cpp
+++ b/example/c08_custom_non_std_example.cpp
@@ -281,7 +281,7 @@ int main()
 
     // Create (as an example) a regular polygon
     const int n = 5;
-    const double d = (360 / n) * boost::geometry::math::d2r;
+    const double d = (360 / n) * boost::geometry::math::d2r<double>();
     double a = 0;
     for (int i = 0; i < n + 1; i++, a += d)
     {


### PR DESCRIPTION
The `example/c03_custom_linestring_example.cpp` requires change from PR #786

These changes make all examples compile again.
Fixes #784