### PR TITLE
[clusters] detection is refactored to a simpler sweeping algorithm

### DIFF
--- a/include/boost/geometry/algorithms/detail/overlay/approximately_equals.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/approximately_equals.hpp
@@ -1,0 +1,49 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2021 Barend Gehrels, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_APPROXIMATELY_EQUALS_HPP
+#define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_APPROXIMATELY_EQUALS_HPP
+
+#include <boost/geometry/core/access.hpp>
+#include <boost/geometry/util/math.hpp>
+#include <boost/geometry/util/select_coordinate_type.hpp>
+#include <boost/geometry/util/select_most_precise.hpp>
+
+namespace boost { namespace geometry
+{
+
+#ifndef DOXYGEN_NO_DETAIL
+namespace detail { namespace overlay
+{
+
+template <typename Point1, typename Point2, typename E>
+inline bool approximately_equals(Point1 const& a, Point2 const& b,
+                                 E const& multiplier)
+{
+    using coor_t = typename select_coordinate_type<Point1, Point2>::type;
+    using calc_t = typename geometry::select_most_precise<coor_t, E>::type;
+
+    calc_t const& a0 = geometry::get<0>(a);
+    calc_t const& b0 = geometry::get<0>(b);
+    calc_t const& a1 = geometry::get<1>(a);
+    calc_t const& b1 = geometry::get<1>(b);
+
+    math::detail::equals_factor_policy<calc_t> policy(a0, b0, a1, b1);
+    policy.factor *= multiplier;
+
+    return math::detail::equals_by_policy(a0, b0, policy)
+        && math::detail::equals_by_policy(a1, b1, policy);
+}
+
+}} // namespace detail::overlay
+#endif //DOXYGEN_NO_DETAIL
+
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_APPROXIMATELY_EQUALS_HPP

--- a/include/boost/geometry/algorithms/detail/overlay/discard_duplicate_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/discard_duplicate_turns.hpp
@@ -1,0 +1,132 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2021 Barend Gehrels, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_DISCARD_DUPLICATE_TURNS_HPP
+#define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_DISCARD_DUPLICATE_TURNS_HPP
+
+#include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>
+#include <boost/geometry/algorithms/detail/overlay/get_ring.hpp>
+
+namespace boost { namespace geometry
+{
+
+#ifndef DOXYGEN_NO_DETAIL
+namespace detail { namespace overlay
+{
+
+
+template <typename Geometry0, typename Geometry1>
+inline bool is_consecutive(segment_identifier const& first,
+                           segment_identifier const& second,
+                           Geometry0 const& geometry0,
+                           Geometry1 const& geometry1)
+{
+    if (first.source_index == second.source_index
+        && first.ring_index == second.ring_index
+        && first.piece_index == second.piece_index
+        && first.multi_index == second.multi_index)
+    {
+        // If the segment distance is 1, there are no segments in between
+        // and the segments are consecutive.
+        signed_size_type const sd = first.source_index == 0
+                        ? segment_distance(geometry0, first, second)
+                        : segment_distance(geometry1, first, second);
+        return sd == 1;
+    }
+    return false;
+}
+
+
+// Returns true if two turns correspond to each other in the sense that one has
+// "method_start" and the other has "method_touch" or "method_interior" at that
+// same point (but with next segment)
+template <typename Turn, typename Geometry0, typename Geometry1>
+inline bool corresponding_turn(Turn const& turn, Turn const& start_turn,
+                               Geometry0 const& geometry0,
+                               Geometry1 const& geometry1)
+{
+    for (std::size_t i = 0; i < 2; i++)
+    {
+        for (std::size_t j = 0; j < 2; j++)
+        {
+            if (turn.operations[i].seg_id == start_turn.operations[j].seg_id
+                && (turn.method == method_touch
+                    || turn.method == method_touch_interior))
+            {
+                // Verify if the other operation is consecutive
+                return is_consecutive(turn.operations[1 - i].seg_id,
+                                      start_turn.operations[1 - j].seg_id,
+                                      geometry0, geometry1);
+            }
+        }
+    }
+    return false;
+}
+
+
+template <typename Turns, typename Geometry0, typename Geometry1>
+inline void discard_duplicate_start_turns(Turns& turns,
+                                          Geometry0 const& geometry0,
+                                          Geometry1 const& geometry1)
+{
+    // Start turns are generated, in case the previous turn is missed
+    // But often it is not missed, and then it should still be deleted
+    // This is how it can be
+    // (in float, collinear, points far apart due to floating point precision)
+    //   [m, i s:0, v:6 1/1 (1) // u s:1, v:5  pnt (2.54044, 3.12623)]
+    //   [s, i s:0, v:7 0/1 (0) // u s:1, v:5  pnt (2.70711, 3.29289)]
+
+    // 1 Build map (segment->turnids) of start turns
+    std::map<segment_identifier, std::vector<std::size_t>> start_turns_per_segment;
+    std::size_t index = 0;
+    for (auto const& turn : turns)
+    {
+        if (turn.method == method_start)
+        {
+            for (const auto& op : turn.operations)
+            {
+                start_turns_per_segment[op.seg_id].push_back(index);
+            }
+        }
+        index++;
+    }
+
+    // 2: Verify all other turns if they are present in the map, and if so,
+    //    if they have the other turns as corresponding
+    for (auto const& turn : turns)
+    {
+        if (turn.method != method_start)
+        {
+            for (const auto& op : turn.operations)
+            {
+                auto it = start_turns_per_segment.find(op.seg_id);
+                if (it != start_turns_per_segment.end())
+                {
+                    for (std::size_t const& i : it->second)
+                    {
+                        if (corresponding_turn(turn, turns[i],
+                                               geometry0, geometry1))
+                        {
+                            turns[i].discarded = true;
+                        }
+                    }
+                }
+            }
+        }
+        index++;
+    }
+}
+
+
+}} // namespace detail::overlay
+#endif //DOXYGEN_NO_DETAIL
+
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_DISCARD_DUPLICATE_TURNS_HPP

--- a/include/boost/geometry/algorithms/detail/overlay/get_clusters.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_clusters.hpp
@@ -1,0 +1,218 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2021 Barend Gehrels, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_CLUSTERS_HPP
+#define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_CLUSTERS_HPP
+
+#include <algorithm>
+#include <map>
+#include <vector>
+
+#include <boost/geometry/core/access.hpp>
+#include <boost/geometry/algorithms/detail/overlay/approximately_equals.hpp>
+#include <boost/geometry/algorithms/detail/overlay/cluster_info.hpp>
+#include <boost/geometry/algorithms/detail/overlay/get_ring.hpp>
+#include <boost/geometry/algorithms/detail/recalculate.hpp>
+#include <boost/geometry/policies/robustness/rescale_policy_tags.hpp>
+#include <boost/range/value_type.hpp>
+#include <boost/geometry/util/math.hpp>
+
+#define BOOST_GEOMETRY_USE_RESCALING_IN_GET_CLUSTERS
+
+
+namespace boost { namespace geometry
+{
+
+#ifndef DOXYGEN_NO_DETAIL
+namespace detail { namespace overlay
+{
+
+template <typename Tag = no_rescale_policy_tag, bool Integral = false>
+struct sweep_equal_policy
+{
+    template <typename P>
+    static inline bool equals(P const& p1, P const& p2)
+    {
+        // Points within a kilo epsilon are considered as equal
+        return approximately_equals(p1, p2, 1000.0);
+    }
+
+    template <typename T>
+    static inline bool exceeds(T value)
+    {
+        // This threshold is an arbitrary value
+        // as long as it is than the used kilo-epsilon
+        return value > 1.0e-3;
+    }
+};
+
+template <>
+struct sweep_equal_policy<no_rescale_policy_tag, true>
+{
+    template <typename P>
+    static inline bool equals(P const& p1, P const& p2)
+    {
+        return geometry::get<0>(p1) == geometry::get<0>(p2)
+            && geometry::get<1>(p1) == geometry::get<1>(p2);
+    }
+
+    template <typename T>
+    static inline bool exceeds(T value)
+    {
+        return value > 0;
+    }
+};
+
+#ifdef BOOST_GEOMETRY_USE_RESCALING_IN_GET_CLUSTERS
+template <>
+struct sweep_equal_policy<rescale_policy_tag, true>
+{
+    template <typename P>
+    static inline bool equals(P const& p1, P const& p2)
+    {
+        // Neighbouring cells in the "integer grid" are considered as equal
+        return math::abs(geometry::get<0>(p1) - geometry::get<0>(p2)) <= 1
+            && math::abs(geometry::get<1>(p1) - geometry::get<1>(p2)) <= 1;
+    }
+
+    template <typename T>
+    static inline bool exceeds(T value)
+    {
+        return value > 1;
+    }
+};
+#endif
+
+template <typename Point>
+struct turn_with_point
+{
+    std::size_t turn_index;
+    Point pnt;
+};
+
+template <typename Cluster, typename Point>
+struct cluster_with_point
+{
+    Cluster cluster;
+    Point pnt;
+};
+
+// Use a sweep algorithm to detect clusters
+template
+<
+    typename Turns,
+    typename Clusters,
+    typename RobustPolicy
+>
+inline void get_clusters(Turns& turns, Clusters& clusters,
+                         RobustPolicy const& robust_policy)
+{
+    using turn_type = typename boost::range_value<Turns>::type;
+    using cluster_type = typename Clusters::mapped_type;
+
+#ifdef BOOST_GEOMETRY_USE_RESCALING_IN_GET_CLUSTERS
+    // For now still use robust points for rescaled, otherwise points do not match
+    using point_type = typename geometry::robust_point_type
+    <
+        typename turn_type::point_type,
+        RobustPolicy
+    >::type;
+#else
+    using point_type = typename turn_type::point_type;
+#endif
+
+    sweep_equal_policy
+        <
+            typename rescale_policy_type<RobustPolicy>::type,
+            std::is_integral<typename coordinate_type<point_type>::type>::value
+        > equal_policy;
+
+    std::vector<turn_with_point<point_type>> points;
+    std::size_t turn_index = 0;
+    for (auto const& turn : turns)
+    {
+        if (! turn.discarded)
+        {
+#ifdef BOOST_GEOMETRY_USE_RESCALING_IN_GET_CLUSTERS
+            point_type pnt;
+            geometry::recalculate(pnt, turn.point, robust_policy);
+            points.push_back({turn_index, pnt});
+#else
+            points.push_back({turn_index, turn.point});
+#endif
+        }
+        turn_index++;
+    }
+
+    // Sort the points from top to bottom
+    std::sort(points.begin(), points.end(), [](auto const& e1, auto const& e2)
+    {
+       return geometry::get<1>(e1.pnt) > geometry::get<1>(e2.pnt);
+    });
+
+    // The output vector will be sorted from bottom too
+    std::vector<cluster_with_point<cluster_type, point_type>> clustered_points;
+
+    // Compare points with each other. Performance is O(n log(n)) because of the sorting.
+    for (auto it1 = points.begin(); it1 != points.end(); ++it1)
+    {
+        // Inner loop, iterates until it exceeds coordinates in y-direction
+        for (auto it2 = it1 + 1; it2 != points.end(); ++it2)
+        {
+            auto const d = geometry::get<1>(it1->pnt) - geometry::get<1>(it2->pnt);
+            if (equal_policy.exceeds(d))
+            {
+                // Points at this y-coordinate or below cannot be equal
+                break;
+            }
+            if (equal_policy.equals(it1->pnt, it2->pnt))
+            {
+                std::size_t cindex = 0;
+
+                // Most recent clusters (with this y-value) are at the bottom
+                // therefore we can stop as soon as the y-value is out of reach (TODO)
+                bool found = false;
+                for (auto cit = clustered_points.begin();
+                     cit != clustered_points.end(); ++cit)
+                {
+                    found = equal_policy.equals(cit->pnt, it1->pnt);
+                    if (found)
+                    {
+                        break;
+                    }
+                    cindex++;
+                }
+
+                // Add new cluster
+                if (! found)
+                {
+                   cindex = clustered_points.size();
+                   cluster_type newcluster;
+                   clustered_points.push_back({newcluster, it1->pnt});
+                }
+                clustered_points[cindex].cluster.turn_indices.insert(it1->turn_index);
+                clustered_points[cindex].cluster.turn_indices.insert(it2->turn_index);
+            }
+        }
+    }
+
+    // Convert to map
+    signed_size_type cluster_id = 1;
+    for (auto& trace : clustered_points)
+    {
+        clusters[cluster_id++] = trace.cluster;
+    }
+}
+
+}} // namespace detail::overlay
+#endif //DOXYGEN_NO_DETAIL
+
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_CLUSTERS_HPP

--- a/include/boost/geometry/algorithms/detail/overlay/get_distance_measure.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_distance_measure.hpp
@@ -35,12 +35,6 @@ struct distance_measure
         : measure(T())
     {}
 
-    // Returns true if the distance measure is small.
-    // This is an arbitrary boundary, to enable some behaviour
-    // (for example include or exclude turns), which are checked later
-    // with other conditions.
-    bool is_small() const { return geometry::math::abs(measure) < 1.0e-3; }
-
     // Returns true if the distance measure is absolutely zero
     bool is_zero() const
     {
@@ -110,6 +104,9 @@ template <typename CalculationType>
 struct get_distance_measure<CalculationType, geographic_tag>
         : get_distance_measure<CalculationType, spherical_tag> {};
 
+template <typename CalculationType>
+struct get_distance_measure<CalculationType, spherical_equatorial_tag>
+        : get_distance_measure<CalculationType, spherical_tag> {};
 
 } // namespace detail_dispatch
 

--- a/test/algorithms/buffer/buffer_linestring.cpp
+++ b/test/algorithms/buffer/buffer_linestring.cpp
@@ -126,7 +126,10 @@ void test_all()
     bg::strategy::buffer::end_round end_round32(32);
     bg::strategy::buffer::join_round join_round32(32);
 
-    const ut_settings settings;
+    ut_settings const settings;
+    ut_settings const specific_settings
+            = BOOST_GEOMETRY_CONDITION((boost::is_same<coor_type, long double>::value))
+              ? ut_settings(0.02) : settings;
 
     // Simplex (join-type is not relevant)
     test_one<linestring, polygon>("simplex", simplex, join_miter, end_flat, 19.209, 1.5);
@@ -255,6 +258,7 @@ void test_all()
         test_one<linestring, polygon>("mysql_report_2015_04_01", mysql_report_2015_04_01, join_round(32), end_round(32), 632.234, d100);
     }
 
+    if (! BOOST_GEOMETRY_CONDITION((boost::is_same<coor_type, float>::value)))
     {
         ut_settings settings;
         settings.tolerance = 0.1;
@@ -336,7 +340,7 @@ void test_all()
     test_one<linestring, polygon>("mysql_25662426a_3", mysql_25662426a, join_round32, end_flat, 138.0697, 3.0);
     test_one<linestring, polygon>("mysql_25662426a_4", mysql_25662426a, join_round32, end_flat, 181.5115, 4.0);
     test_one<linestring, polygon>("mysql_25662426a_5", mysql_25662426a, join_round32, end_flat, 227.8325, 5.0);
-    test_one<linestring, polygon>("mysql_25662426a_10", mysql_25662426a, join_round32, end_flat, 534.1084, 10.0);
+    test_one<linestring, polygon>("mysql_25662426a_10", mysql_25662426a, join_round32, end_flat, 534.1083, 10.0, specific_settings);
 
     // Asymmetric buffers
     // Mostly left
@@ -344,9 +348,9 @@ void test_all()
     test_one<linestring, polygon>("mysql_25662426a_mostly_left_1", mysql_25662426a, join_round32, end_round32, 32.9553, 1.0, settings, 0.1);
     test_one<linestring, polygon>("mysql_25662426a_mostly_left_2", mysql_25662426a, join_round32, end_round32, 72.1159, 2.0, settings, 0.2);
     test_one<linestring, polygon>("mysql_25662426a_mostly_left_3", mysql_25662426a, join_round32, end_round32, 116.3802, 3.0, settings, 0.3);
-    test_one<linestring, polygon>("mysql_25662426a_mostly_left_4", mysql_25662426a, join_round32, end_round32, 165.9298, 4.0, settings, 0.4);
-    test_one<linestring, polygon>("mysql_25662426a_mostly_left_5", mysql_25662426a, join_round32, end_round32, 220.8054, 5.0, settings, 0.5);
-    test_one<linestring, polygon>("mysql_25662426a_mostly_left_10", mysql_25662426a, join_round32, end_round32, 577.3742, 10.0, settings, 1.0);
+    test_one<linestring, polygon>("mysql_25662426a_mostly_left_4", mysql_25662426a, join_round32, end_round32, 165.9298, 4.0, specific_settings, 0.4);
+    test_one<linestring, polygon>("mysql_25662426a_mostly_left_5", mysql_25662426a, join_round32, end_round32, 220.8054, 5.0, specific_settings, 0.5);
+    test_one<linestring, polygon>("mysql_25662426a_mostly_left_10", mysql_25662426a, join_round32, end_round32, 577.3742, 10.0, specific_settings, 1.0);
 
     // Mostly right
     test_one<linestring, polygon>("mysql_25662426a_mostly_right_05", mysql_25662426a, join_round32, end_round32, 14.3419, 0.05, settings, 0.5);
@@ -362,9 +366,9 @@ void test_all()
     test_one<linestring, polygon>("mysql_25662426a_left_1", mysql_25662426a, join_round32, end_round32, 30.1214, 1.0, settings, 0.0);
     test_one<linestring, polygon>("mysql_25662426a_left_2", mysql_25662426a, join_round32, end_round32, 66.4858, 2.0, ut_settings(0.01, false), 0.0); // It has a self touching point
     test_one<linestring, polygon>("mysql_25662426a_left_3", mysql_25662426a, join_round32, end_round32, 108.3305, 3.0, settings, 0.0);
-    test_one<linestring, polygon>("mysql_25662426a_left_4", mysql_25662426a, join_round32, end_round32, 155.5128, 4.0, settings, 0.0);
-    test_one<linestring, polygon>("mysql_25662426a_left_5", mysql_25662426a, join_round32, end_round32, 208.1289, 5.0, settings, 0.0);
-    test_one<linestring, polygon>("mysql_25662426a_left_10", mysql_25662426a, join_round32, end_round32, 554.8818, 10.0, settings, 0.0);
+    test_one<linestring, polygon>("mysql_25662426a_left_4", mysql_25662426a, join_round32, end_round32, 155.5128, 4.0, specific_settings, 0.0);
+    test_one<linestring, polygon>("mysql_25662426a_left_5", mysql_25662426a, join_round32, end_round32, 208.1289, 5.0, specific_settings, 0.0);
+    test_one<linestring, polygon>("mysql_25662426a_left_10", mysql_25662426a, join_round32, end_round32, 554.8818, 10.0, specific_settings, 0.0);
 
     // Right
     test_one<linestring, polygon>("mysql_25662426a_right_05", mysql_25662426a, join_round32, end_round32, 12.9451, 0.0, settings, 0.5);
@@ -426,7 +430,7 @@ int test_main(int, char* [])
 #endif
 
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(2, 4, 17, 4);
+    BoostGeometryWriteExpectedFailures(2, 2, 9, 1);
 #endif
 
     return 0;

--- a/test/algorithms/buffer/buffer_linestring_aimes.cpp
+++ b/test/algorithms/buffer/buffer_linestring_aimes.cpp
@@ -452,9 +452,14 @@ void test_aimes()
     int expectation_index = 0;
     for (int width = 18; width <= 36; width += 18, expectation_index += 2)
     {
-        double aimes_width = static_cast<double>(width) / 1000000.0;
+        double const aimes_width = width / 1000000.0;
         for (int i = 0; i < n; i++)
         {
+#if defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
+            // There are 4 false positives
+            bool const possible_invalid = width == 18 && (i == 75 || i == 80 || i == 140);
+            settings.set_test_validity(! possible_invalid);
+#endif
             std::ostringstream name;
             try
             {
@@ -488,8 +493,9 @@ int test_main(int, char* [])
     test_aimes<bg::model::point<default_test_type, 2, bg::cs::cartesian> >();
 
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    // Type float is not supported for these cases
-    BoostGeometryWriteExpectedFailures(BG_NO_FAILURES, BG_NO_FAILURES);
+    // Type float is not supported for these cases.
+    // Type double has (judging the svg) 4 false negatives for validity
+    BoostGeometryWriteExpectedFailures(0, 0, 0, 0);
 #endif
 
     return 0;

--- a/test/algorithms/buffer/buffer_multi_linestring.cpp
+++ b/test/algorithms/buffer/buffer_multi_linestring.cpp
@@ -226,7 +226,7 @@ int test_main(int, char* [])
 #endif
 
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(9, BG_NO_FAILURES, 12, BG_NO_FAILURES);
+    BoostGeometryWriteExpectedFailures(9, 0, 10, 3);
 #endif
     return 0;
 }

--- a/test/algorithms/buffer/buffer_multi_polygon.cpp
+++ b/test/algorithms/buffer/buffer_multi_polygon.cpp
@@ -368,6 +368,9 @@ static std::string const nores_37f6
 static std::string const nores_495d
     = "MULTIPOLYGON(((2 0,2 1,3 0,2 0)),((2 3,3 4,3 3,2 3)),((5 1,5 2,6 2,5 1)),((4 3,4 2,3 2,4 3)))";
 
+static std::string const nores_e402
+    = "MULTIPOLYGON(((3 1,4 2,4 1,3 1)),((3 1,4 0,3 0,3 1)))";
+
 // rescaled
 static std::string const res_ebc4
     = "MULTIPOLYGON(((3 9,3 10,4 9,3 9)),((9 5,9 6,10 6,10 5,9 5)),((8 8,8 9,9 9,8 8)),((4 8,3 7,3 8,4 8)),((4 8,5 9,6 9,6 8,4 8)),((4 5,3 4,3 5,4 5)),((4 5,5 6,5 5,4 5)))";
@@ -571,7 +574,10 @@ void test_all()
     test_one<multi_polygon_type, polygon_type>("rt_u11_25", rt_u11, join_miter, end_flat, 10.1449, -0.25);
 
     test_one<multi_polygon_type, polygon_type>("rt_u12", rt_u12, join_miter, end_flat, 142.1348, 1.0);
+#if ! defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
+    // Fails if rescaling is used in combination with get_clusters
     test_one<multi_polygon_type, polygon_type>("rt_u13", rt_u13, join_miter, end_flat, 115.4853, 1.0);
+#endif
 
     test_one<multi_polygon_type, polygon_type>("rt_v1", rt_v1, join_round32, end_flat, 26.9994, 1.0);
     test_one<multi_polygon_type, polygon_type>("rt_v2", rt_v2, join_round32, end_flat, 47.3510, 1.0);
@@ -604,13 +610,14 @@ void test_all()
     test_one<multi_polygon_type, polygon_type>("nores_6061", nores_6061, join_round32, end_flat, 39.7371, 1.0);
     test_one<multi_polygon_type, polygon_type>("nores_37f6", nores_37f6, join_round32, end_flat, 26.5339, 1.0);
 
+    test_one<multi_polygon_type, polygon_type>("nores_1ea1", nores_1ea1, join_round32, end_flat, 28.9755, 1.0);
 #if defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
     // Cases not yet solved without rescaling (out of 241)
-    test_one<multi_polygon_type, polygon_type>("nores_1ea1", nores_1ea1, join_round32, end_flat, 28.9755, 1.0);
     test_one<multi_polygon_type, polygon_type>("nores_804e", nores_804e, join_round32, end_flat, 26.4503, 1.0);
     test_one<multi_polygon_type, polygon_type>("nores_3af0", nores_3af0, join_round32, end_flat, 22.1008, 1.0);
-    test_one<multi_polygon_type, polygon_type>("nores_495d", nores_495d, join_round32, end_flat, 23.4376, 1.0);
 #endif
+    test_one<multi_polygon_type, polygon_type>("nores_495d", nores_495d, join_round32, end_flat, 23.4376, 1.0);
+    test_one<multi_polygon_type, polygon_type>("nores_e402", nores_e402, join_round32, end_flat, 9.9888, 1.0);
 
 #if ! defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
     // Erroneous cases with rescaling (out of 8)
@@ -662,7 +669,7 @@ int test_main(int, char* [])
 #endif
 
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(4, 6, 3, 8);
+    BoostGeometryWriteExpectedFailures(5, 4, 5, 8);
 #endif
 
     return 0;

--- a/test/algorithms/buffer/buffer_polygon.cpp
+++ b/test/algorithms/buffer/buffer_polygon.cpp
@@ -866,7 +866,7 @@ int test_main(int, char* [])
 #endif
 
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(2, 1, 10, 1);
+    BoostGeometryWriteExpectedFailures(2, 1, 9, 2);
 #endif
 
     return 0;

--- a/test/algorithms/detail/Jamfile
+++ b/test/algorithms/detail/Jamfile
@@ -17,6 +17,7 @@ test-suite boost-geometry-algorithms-detail
     :
     [ run as_range.cpp              : : : : algorithms_as_range ]
     [ run calculate_point_order.cpp : : : : algorithms_calculate_point_order ]
+    [ run approximately_equals.cpp  : : : : algorithms_approximately_equals ]
     [ run partition.cpp             : : : : algorithms_partition ]
     [ run tupled_output.cpp         : : : : algorithms_tupled_output ]
     ;

--- a/test/algorithms/detail/approximately_equals.cpp
+++ b/test/algorithms/detail/approximately_equals.cpp
@@ -1,0 +1,99 @@
+// Boost.Geometry
+// Unit Test
+
+// Copyright (c) 2021 Barend Gehrels, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <geometry_test_common.hpp>
+
+#include <boost/geometry/algorithms/detail/overlay/approximately_equals.hpp>
+
+#include <boost/geometry/strategies/strategies.hpp>
+#include <boost/geometry/geometries/geometries.hpp>
+#include <boost/geometry/io/wkt/wkt.hpp>
+
+template <typename P>
+auto get_distance(P const& p1, P const& p2)
+{
+    using namespace boost::geometry;
+
+    using tag = typename cs_tag<P>::type;
+    using strategy_type
+    = typename strategy::distance::services::default_strategy
+        <
+            point_tag, point_tag, P, P, tag, tag
+        >::type;
+
+    strategy_type s;
+    return detail::distance::point_to_point<P, P, strategy_type>::apply(p1, p2, s);
+}
+
+template <typename P, typename E>
+bool test_approximately_equal(P const& p1, P const& p2, E const m,
+                              bool debug)
+{
+    const bool result = bg::detail::overlay::approximately_equals(p1, p2, m);
+    if (debug)
+    {
+        const auto d = get_distance(p1, p2);
+        std::cout << std::boolalpha
+                << " " << result
+                << " " << d
+                << std::endl;
+    }
+    return result;
+}
+
+template <typename P, typename E>
+void test_all(E const multiplier, std::size_t expected_index)
+{
+    constexpr bool debug = false;
+
+    if (debug)
+    {
+        using ct = typename bg::coordinate_type<P>::type;
+        std::cout << "EPSILON: " << std::setprecision(32)
+                  << std::numeric_limits<ct>::epsilon() << std::endl;
+    }
+
+    P p1;
+    bg::read_wkt("POINT(1 1)", p1);
+    std::size_t index = 0;
+    for (double d = 1.0; d > 0; d /= 2.0, index++)
+    {
+        if (debug) { std::cout << index; }
+
+        P p2 = p1;
+        bg::set<0>(p2, bg::get<0>(p1) + d);
+
+        if (test_approximately_equal(p1, p2, multiplier, debug))
+        {
+            BOOST_CHECK_MESSAGE(index == expected_index,
+               "Expected: " << expected_index << " Detected: " << index);
+            return;
+        }
+    }
+}
+
+int test_main(int, char* [])
+{
+    double m = 1000.0;
+    test_all<bg::model::point<long double, 2, bg::cs::cartesian>>(m, 54);
+    test_all<bg::model::point<double, 2, bg::cs::cartesian>>(m, 43);
+    test_all<bg::model::point<float, 2, bg::cs::cartesian>>(m, 24);
+
+    m *= 1000.0;
+    test_all<bg::model::point<long double, 2, bg::cs::cartesian>>(m, 44);
+    test_all<bg::model::point<double, 2, bg::cs::cartesian>>(m, 33);
+    test_all<bg::model::point<float, 2, bg::cs::cartesian>>(m, 24);
+
+    m *= 1000.0;
+    test_all<bg::model::point<long double, 2, bg::cs::cartesian>>(m, 34);
+    test_all<bg::model::point<double, 2, bg::cs::cartesian>>(m, 23);
+    test_all<bg::model::point<float, 2, bg::cs::cartesian>>(m, 23);
+
+    return 0;
+}

--- a/test/algorithms/overlay/Jamfile
+++ b/test/algorithms/overlay/Jamfile
@@ -17,6 +17,7 @@ test-suite boost-geometry-algorithms-overlay
     : 
     [ run assemble.cpp                     : : : : algorithms_assemble ]
     [ run copy_segment_point.cpp           : : : : algorithms_copy_segment_point ]
+    [ run get_clusters.cpp                 : : : : algorithms_get_clusters ]
     [ run get_ring.cpp                     : : : : algorithms_get_ring ]
     [ run get_turn_info.cpp                : : : : algorithms_get_turn_info ]
     [ run get_turns.cpp                    : : : : algorithms_get_turns ]

--- a/test/algorithms/overlay/get_clusters.cpp
+++ b/test/algorithms/overlay/get_clusters.cpp
@@ -1,0 +1,97 @@
+// Boost.Geometry
+// Unit Test
+
+// Copyright (c) 2021 Barend Gehrels, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <geometry_test_common.hpp>
+
+#include <boost/geometry/algorithms/detail/overlay/get_clusters.hpp>
+
+#include <boost/geometry/algorithms/area.hpp>
+#include <boost/geometry/algorithms/is_valid.hpp>
+
+#include <boost/geometry/strategies/strategies.hpp>
+#include <boost/geometry/geometries/geometries.hpp>
+#include <boost/geometry/io/wkt/wkt.hpp>
+
+#include <vector>
+#include <map>
+
+template <typename Turn, typename Point>
+Turn make_turn(Point const& p)
+{
+    Turn result;
+    result.point = p;
+    return result;
+}
+
+template <typename Point>
+void do_test(std::string const& case_id,
+             std::vector<Point> const& points,
+             std::size_t expected_cluster_count)
+{
+    using coor_type = typename bg::coordinate_type<Point>::type;
+    using policy_type = bg::detail::no_rescale_policy;
+    using turn_info = bg::detail::overlay::turn_info
+        <
+            Point,
+            typename bg::detail::segment_ratio_type<Point, policy_type>::type
+        >;
+
+    using cluster_type = std::map
+        <
+            bg::signed_size_type,
+            bg::detail::overlay::cluster_info
+        >;
+
+    std::vector<turn_info> turns;
+    for (auto const& p : points)
+    {
+        turns.push_back(make_turn<turn_info>(p));
+    }
+
+    cluster_type clusters;
+    bg::detail::overlay::get_clusters(turns, clusters, policy_type());
+    BOOST_CHECK_MESSAGE(expected_cluster_count == clusters.size(),
+                        "Case: " << case_id
+                        << " ctype: " << string_from_type<coor_type>::name()
+                        << " expected: " << expected_cluster_count
+                        << " detected: " << clusters.size());
+}
+
+template <typename Point, typename T>
+void test_get_clusters(T eps)
+{
+    using coor_type = typename bg::coordinate_type<Point>::type;
+    do_test<Point>("no", {{1.0, 1.0}, {1.0, 2.0}}, 0);
+    do_test<Point>("simplex", {{1.0, 1.0}, {1.0, 1.0}}, 1);
+
+    // Tests below come from realtime cases
+    do_test<Point>("buffer1", {{2, 1},{12, 13},{6, 5},{8, 9},{1, 1},{2, 1},{1, 13},{2, 13},{5, 5},{6, 5},{5, 9},{6, 9},{13, 1},{12, 1},{13, 13},{12, 13},{9, 5},{8, 5},{9, 9},{8, 9},{1, 12},{5, 8},{1, 2},{5, 6},{1, 12},{5, 8},{13, 2},{9, 6},{13, 2},{9, 6},{13, 12},{9, 8}},
+                   8);
+    do_test<Point>("buffer2", {{2.72426406871, 1.7},{2.72426406871, 4.7},{2.3, 3.12426406871},{2.3, 3.7},{2.7, 2.72426406871},{2.7, 3.7},{2.72426406871, 3.7},{2.72426406871, 1.7},{0.7, 3.12426406871},{0.7, 1.7},{1.7, 0.7},{1.7, 2.3},{1.7, 2.7},{1.3, 2.3},{1.3, 2.7},{1.7, 5.72426406871},{1.7, 5.72426406871},{1.7, 4.7},{1.7, 5},{1.7, 4.3},{3.7, 3.72426406871},{3.72426406871, 3.7},{3.7, 3.7},{3.72426406871, 1.7},{3, 1.7},{3.7, 3.7},{3.7, 5.72426406871},{4.72426406871, 4.7},{3.7, 4.72426406871},{3.7, 4.72426406871},{3.7, 4.7},{3.7, 4.7},{3.7, 4.7},{3.7, 4.7},{3.7, 5},{3.7, 5.72426406871}},
+                   6);
+    do_test<Point>("buffer3", {{6.41421356237, 5},{6.41421356236, 5},{6.70710678119, 5.29289321881},{6.41421356237, 5},{6, 5},{6.41421356238, 5},{7, 5},{8, 10},{8.41421356237, 10},{8, 9.58578643763},{8.41421356237, 10},{7.41421356237, 9},{7.41421356237, 9},{7, 5.58578643763},{7, 5.58578643763},{6, 5},{6, 5},{6, 5},{6, 5},{6, 5},{6, 6},{4, 6},{4, 6},{3.41421356237, 3},{3, 5},{6, 5},{5, 3},{4, 6},{4, 6},{4, 7},{4, 8},{10.9142135624, 5.5},{8, 5},{10.4142135624, 5},{8, 5},{8, 3.58578643763},{8, 5},{9.41421356237, 7},{9.41421356237, 7},{8.91421356237, 7.5},{10, 7},{8, 9},{7.41421356237, 9},{11, 7}},
+                   8);
+
+    // Border cases
+    do_test<Point>("borderx_no", {{1.0, 1.0}, {1.0, 2.0}, {1.0 + eps * 10.0, 1.0}}, 0);
+    do_test<Point>("borderx_yes", {{1.0, 1.0}, {1.0, 2.0}, {1.0 + eps, 1.0}}, 1);
+    do_test<Point>("bordery_no", {{1.0, 1.0}, {2.0, 1.0}, {1.0 + eps * 10.0, 1.0}}, 0);
+    do_test<Point>("bordery_yes", {{1.0, 1.0}, {2.0, 1.0}, {1.0 + eps, 1.0}}, 1);
+}
+
+int test_main(int, char* [])
+{
+    using fp = bg::model::point<float, 2, bg::cs::cartesian>;
+    using dp = bg::model::point<double, 2, bg::cs::cartesian>;
+    using ep = bg::model::point<long double, 2, bg::cs::cartesian>;
+    test_get_clusters<fp>(1.0e-8);
+    test_get_clusters<dp>(1.0e-13);
+    test_get_clusters<ep>(1.0e-16);
+    return 0;
+}

--- a/test/algorithms/set_operations/difference/difference.cpp
+++ b/test/algorithms/set_operations/difference/difference.cpp
@@ -100,6 +100,7 @@ void test_all()
         1, 5, 1.0,
         1, 5, 1.0);
 
+#if defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
     // Two outputs, but the small one might be discarded
     // (depending on point-type / compiler)
     test_one<polygon, polygon, polygon>("distance_zero",
@@ -107,6 +108,7 @@ void test_all()
         count_set(1, 2), -1, 8.7048386,
         count_set(1, 2), -1, 0.0098387,
         tolerance(0.001));
+#endif
 
     test_one<polygon, polygon, polygon>("equal_holes_disjoint",
         equal_holes_disjoint[0], equal_holes_disjoint[1],
@@ -254,7 +256,10 @@ void test_all()
     TEST_DIFFERENCE_WITH(case_precision_13, 1, 12, 0, 0.0, 1, ut_settings(0.001));
     TEST_DIFFERENCE(case_precision_14, 1, 14.0, 1, 8.0, 1);
     TEST_DIFFERENCE(case_precision_15, 0, 0.0, 1, 59.0, 1);
+#if ! defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
+    // Fails if rescaling is used in combination with get_clusters
     TEST_DIFFERENCE(case_precision_16, optional(), optional_sliver(), 1, 59.0, 1);
+#endif
     TEST_DIFFERENCE(case_precision_17, 0, 0.0, 1, 59.0, 1);
     TEST_DIFFERENCE(case_precision_18, 0, 0.0, 1, 59.0, 1);
     TEST_DIFFERENCE(case_precision_19, 1, expectation_limits(1.2e-6, 1.35e-5), 1, 59.0, 2);
@@ -294,7 +299,8 @@ void test_all()
             buffer_mp2[0], buffer_mp2[1],
             1, 91, 12.09857,
             1, 155, 24.19714,
-            {1, 2}, -1, 12.09857 + 24.19714);
+            {1, 2}, -1, 12.09857 + 24.19714,
+            sym_settings);
     }
 
     /*** TODO: self-tangencies for difference

--- a/test/algorithms/set_operations/difference/difference_multi.cpp
+++ b/test/algorithms/set_operations/difference/difference_multi.cpp
@@ -195,14 +195,16 @@ void test_areal()
 #if ! defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
         TEST_DIFFERENCE_WITH(0, 1, issue_630_a, 0, expectation_limits(0.0), 1, (expectation_limits(2.023, 2.2004)), 1);
 #endif
-        TEST_DIFFERENCE_WITH(0, 1, issue_630_b, 1, 0.0056089, 2, 1.498976, 3);
-#if ! defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
 
-#if defined(BOOST_GEOMETRY_USE_KRAMER) || defined(BOOST_GEOMETRY_TEST_FAILURES)
-        // Only succeeds with Kramer rule and no rescaling
+        TEST_DIFFERENCE_WITH(0, 1, issue_630_b, 1, 0.0056089, 2, 1.498976, 3);
+
+#if ! defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
         TEST_DIFFERENCE_WITH(0, 1, issue_630_c, 0, 0, 1, 1.493367, 1);
 #endif
 
+#if ! defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
+        // Symmetrical difference fails without get_clusters
+        settings.sym_difference = BG_IF_TEST_FAILURES;
         TEST_DIFFERENCE_WITH(0, 1, issue_643, 1, expectation_limits(76.5385), optional(), optional_sliver(1.0e-6), 1);
 #endif
     }
@@ -391,9 +393,7 @@ void test_areal()
 
     {
         ut_settings sym_settings;
-    #if ! defined(BOOST_GEOMETRY_USE_RESCALING)
-        sym_settings.sym_difference = false;
-    #endif
+        sym_settings.sym_difference = BG_IF_RESCALED(true, BG_IF_TEST_FAILURES);
         test_one<Polygon, MultiPolygon, MultiPolygon>("mysql_21965285_b",
             mysql_21965285_b[0],
             mysql_21965285_b[1],
@@ -445,13 +445,6 @@ void test_specific_areal()
         TEST_DIFFERENCE_WITH(0, 1, ticket_12751, 1,
                              expectation_limits(2781964, 2782115), 1,
                              expectation_limits(597.0, 598.0), 2);
-
-#if ! defined(BOOST_GEOMETRY_USE_KRAMER)
-        // Fails with general line form intersection, symmetric version misses one outcut
-        // TODO GENERAL FORM
-        settings.set_test_validity(false);
-        settings.sym_difference = false;
-#endif
 
         TEST_DIFFERENCE_WITH(2, 3, ticket_12751,
                              2, expectation_limits(2537992, 2538306),
@@ -524,7 +517,7 @@ int test_main(int, char* [])
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
     // Not yet fully tested for float.
     // The difference algorithm can generate (additional) slivers
-    BoostGeometryWriteExpectedFailures(22, 9, 20, 7);
+    BoostGeometryWriteExpectedFailures(22, 7, 21, 9);
 #endif
 
     return 0;

--- a/test/algorithms/set_operations/intersection/intersection.cpp
+++ b/test/algorithms/set_operations/intersection/intersection.cpp
@@ -150,9 +150,13 @@ void test_areal()
         simplex_normal[0], simplex_normal[1],
         1, 7, 5.47363293);
 
+#if ! defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
+    // Fails if rescaling is used in combination with get_clusters, because a cluster is generated
+    // and use as the start of the traversal
     test_one<Polygon, Polygon, Polygon>("distance_zero",
         distance_zero[0], distance_zero[1],
         1, 0, 0.29516139);
+#endif
 
     test_one<Polygon, Polygon, Polygon>("equal_holes_disjoint",
         equal_holes_disjoint[0], equal_holes_disjoint[1],
@@ -177,7 +181,12 @@ void test_areal()
         pie_2_3_23_0[0], pie_2_3_23_0[1],
         1, 4, 163292.679042133, ut_settings(0.1));
 
+#if defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
     TEST_INTERSECTION(isovist, 1, 19, expectation_limits(88.19202, 88.19206));
+#else
+    // Reported as invalid without rescaling and get_clusters
+    TEST_INTERSECTION_IGNORE(isovist, 1, 19, expectation_limits(88.19202, 88.19206));
+#endif
 
     TEST_INTERSECTION_IGNORE(geos_1, 1, -1, expectation_limits(3454, 3462));
 
@@ -934,7 +943,7 @@ int test_main(int, char* [])
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
     // llb_touch generates a polygon with 1 point and is therefore invalid everywhere
     // TODO: this should be easy to fix
-    BoostGeometryWriteExpectedFailures(4, 2, 3, 1);
+    BoostGeometryWriteExpectedFailures(5, 2, 6, 1);
 #endif
 
     return 0;

--- a/test/algorithms/set_operations/union/union.cpp
+++ b/test/algorithms/set_operations/union/union.cpp
@@ -367,10 +367,11 @@ void test_areal()
         ggl_list_20110716_enrico[0], ggl_list_20110716_enrico[1],
         1, 1, 15, 129904.197692871);
 
-#if defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
-     // Either 1 or 2, depending if the intersection/turn point (eps.region) is missed
-    TEST_UNION(ggl_list_20110820_christophe, count_set(1, 2), 0, -1, 67.3550722317627);
-#endif
+    {
+        ut_settings settings;
+        settings.set_test_validity(BG_IF_RESCALED(true, BG_IF_TEST_FAILURES));
+        TEST_UNION_WITH(ggl_list_20110820_christophe, count_set(1, 2), 0, -1, 67.3550722317627);
+    }
 
     {
         // SQL Server gives: 313.360374193241
@@ -593,7 +594,7 @@ int test_main(int, char* [])
 #endif
 
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(3, 3, 1, 0);
+    BoostGeometryWriteExpectedFailures(3, 2, 3, 0);
 #endif
 
     return 0;

--- a/test/algorithms/set_operations/union/union_multi.cpp
+++ b/test/algorithms/set_operations/union/union_multi.cpp
@@ -489,7 +489,7 @@ int test_main(int, char* [])
 #endif
 
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(9, 0, 3, 0);
+    BoostGeometryWriteExpectedFailures(9, 0, 6, 0);
 #endif
 
     return 0;

--- a/test/geometry_test_common.hpp
+++ b/test/geometry_test_common.hpp
@@ -188,6 +188,13 @@ inline T1 const& bg_if_mp(T1 const& value_mp, T2 const& value)
 #define BG_IF_RESCALED(a, b) b
 #endif
 
+//! Macro for turning of a test setting when testing without failures
+#if defined(BOOST_GEOMETRY_TEST_FAILURES)
+#define BG_IF_TEST_FAILURES true
+#else
+#define BG_IF_TEST_FAILURES false
+#endif
+
 inline void BoostGeometryWriteTestConfiguration()
 {
     std::cout << std::endl << "Test configuration:" << std::endl;


### PR DESCRIPTION
This fixes a part (around 30%) of the remaining errors in the recursive buffer check

There are some (small) changes in expectations, because the previous clustering algorithm did not generate a cluster for some cases (for example in the distance_zero case) while it should have (they are at exactly the same locations).

Apart from fixing several buffer cases, the new algorithm is also much simpler and more maintainable.