### PR TITLE
[intersection] fix intersection points outside of the segments

### DIFF
--- a/test/algorithms/set_operations/difference/difference.cpp
+++ b/test/algorithms/set_operations/difference/difference.cpp
@@ -574,12 +574,11 @@ void test_all()
                     optional(), optional_sliver(1.0e-5),
                     count_set(1, 2));
 
-    TEST_DIFFERENCE_WITH(issue_838, 2,
+    TEST_DIFFERENCE(issue_838, 2,
                          BG_IF_RESCALED(2.68771e-05,
-                                        2.68052e-05),
+                                        2.680517e-05),
                          1, 0.674982,
-                         BG_IF_RESCALED(3, 2),
-                         ut_settings(0.001, BG_IF_RESCALED(true, false)));
+                         BG_IF_RESCALED(3, 2));
 
     TEST_DIFFERENCE(mysql_21977775, 2, 160.856568913, 2, 92.3565689126, 4);
     TEST_DIFFERENCE(mysql_21965285, 1, 92.0, 1, 14.0, 1);
@@ -637,7 +636,7 @@ int test_main(int, char* [])
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
     // Not yet fully tested for float and long double.
     // The difference algorithm can generate (additional) slivers
-    BoostGeometryWriteExpectedFailures(10, 11, 24, 15);
+    BoostGeometryWriteExpectedFailures(10, 7, 22, 8);
 #endif
 
     return 0;

--- a/test/algorithms/set_operations/union/union.cpp
+++ b/test/algorithms/set_operations/union/union.cpp
@@ -430,12 +430,8 @@ void test_areal()
     TEST_UNION_REV(issue_566_a, 1, 0, -1, 214.3728);
     TEST_UNION_REV(issue_566_b, 1, 0, -1, 214.3728);
 
-    {
-        // Without rescaling, the result is invalid
-        ut_settings settings;
-        settings.set_test_validity(BG_IF_RESCALED(true, false));
-        TEST_UNION_WITH(issue_838, 1, 0, -1, 1.3333);
-    }
+    TEST_UNION(issue_838, 1, 0, -1, expectation_limits(1.3333, 1.33785));
+    TEST_UNION_REV(issue_838, 1, 0, -1, expectation_limits(1.3333, 1.33785));
 
     {
         // Rescaling produces an invalid result
@@ -601,7 +597,7 @@ int test_main(int, char* [])
 #endif
 
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(3, 2, 3, 0);
+    BoostGeometryWriteExpectedFailures(3, 1, 2, 0);
 #endif
 
     return 0;

--- a/test/algorithms/set_operations/union/union_multi.cpp
+++ b/test/algorithms/set_operations/union/union_multi.cpp
@@ -489,7 +489,7 @@ int test_main(int, char* [])
 #endif
 
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(9, 0, 6, 0);
+    BoostGeometryWriteExpectedFailures(9, 0, 1, 0);
 #endif
 
     return 0;


### PR DESCRIPTION
This fixes bug #838 (the visible artifact was an intersection point far away from both segments)

It also fixes some other errors (probably artifacts)