### PR TITLE
Fix/buffer cluster order

### DIFF
--- a/test/algorithms/buffer/buffer_linestring.cpp
+++ b/test/algorithms/buffer/buffer_linestring.cpp
@@ -430,7 +430,7 @@ int test_main(int, char* [])
 #endif
 
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(2, 2, 9, 1);
+    BoostGeometryWriteExpectedFailures(2, 4, 9, 4);
 #endif
 
     return 0;

--- a/test/algorithms/buffer/buffer_multi_linestring.cpp
+++ b/test/algorithms/buffer/buffer_multi_linestring.cpp
@@ -226,7 +226,7 @@ int test_main(int, char* [])
 #endif
 
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(9, 0, 10, 3);
+    BoostGeometryWriteExpectedFailures(9, 6, 9, 3);
 #endif
     return 0;
 }

--- a/test/algorithms/buffer/buffer_multi_polygon.cpp
+++ b/test/algorithms/buffer/buffer_multi_polygon.cpp
@@ -359,6 +359,10 @@ static std::string const nores_2881b
 
 static std::string const nores_3af0
     = "MULTIPOLYGON(((1 8,0 8,0 9,1 9,1 8)),((1 8,1 7,0 7,1 8)),((2 4,3 5,3 4,2 4)),((2 6,2 7,3 6,2 6)))";
+
+static std::string const nores_5318
+    = "MULTIPOLYGON(((3 8,3 9,4 9,3 8)),((3 4,4 5,4 4,3 4)),((2 7,1 6,1 7,2 7)),((2 7,3 6,2 6,2 7)))";
+
 static std::string const nores_6061
     = "MULTIPOLYGON(((2 8,2 9,3 8,2 8)),((4 3,4 4,5 4,4 3)),((7 2,7 3,8 2,7 2)),((5 3,6 4,6 3,5 3)),((2 6,3 7,3 6,2 6)),((2 3,3 2,3 1,2 1,2 3)),((2 3,3 4,3 3,2 3)))";
 
@@ -567,7 +571,7 @@ void test_all()
 
     test_one<multi_polygon_type, polygon_type>("rt_u7", rt_u7, join_miter, end_flat, 42.6421, 1.0);
     test_one<multi_polygon_type, polygon_type>("rt_u7", rt_u7, join_round, end_flat, 35.6233, 1.0);
-    test_one<multi_polygon_type, polygon_type>("rt_u7_rough", rt_u7, join_round_rough, end_flat, 35.1675, 1.0);
+    test_one<multi_polygon_type, polygon_type>("rt_u7_rough", rt_u7, join_round_rough, end_flat, {35.1675, 35.2290}, 1.0);
 
     test_one<multi_polygon_type, polygon_type>("rt_u8", rt_u8, join_miter, end_flat, 70.9142, 1.0);
     test_one<multi_polygon_type, polygon_type>("rt_u9", rt_u9, join_miter, end_flat, 59.3063, 1.0);
@@ -611,7 +615,7 @@ void test_all()
     test_one<multi_polygon_type, polygon_type>("nores_et_7", nores_et_7, join_round32, end_flat, 105.9577, 1.0);
 
     test_one<multi_polygon_type, polygon_type>("nores_wn_1", nores_wn_1, join_round32, end_flat, 23.7659, 1.0);
-    test_one<multi_polygon_type, polygon_type>("nores_wn_2", nores_wn_2, join_round32, end_flat, 18.2669, 1.0);
+    test_one<multi_polygon_type, polygon_type>("nores_wn_2", nores_wn_2, join_round32, end_flat, {18.2669, 18.2691}, 1.0);
 
     test_one<multi_polygon_type, polygon_type>("nores_wt_1", nores_wt_1, join_round32, end_flat, 80.1609, 1.0);
     test_one<multi_polygon_type, polygon_type>("nores_wt_2", nores_wt_2, join_round32, end_flat, 22.1102, 1.0);
@@ -624,14 +628,13 @@ void test_all()
     test_one<multi_polygon_type, polygon_type>("nores_1ea1", nores_1ea1, join_round32, end_flat, 28.9755, 1.0);
     test_one<multi_polygon_type, polygon_type>("nores_804e", nores_804e, join_round32, end_flat, 26.4503, 1.0);
     test_one<multi_polygon_type, polygon_type>("nores_51c6", nores_51c6, join_round32, end_flat, 20.2419, 1.0);
-    test_one<multi_polygon_type, polygon_type>("nores_e5f3", nores_e5f3, join_round32, end_flat, 14.5512, 1.0);
-#if defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
-    // Cases not yet solved without rescaling
-    test_one<multi_polygon_type, polygon_type>("nores_3af0", nores_3af0, join_round32, end_flat, 22.1008, 1.0);
+    test_one<multi_polygon_type, polygon_type>("nores_e5f3", nores_e5f3, join_round32, end_flat, 14.5503, 1.0);
+
+    test_one<multi_polygon_type, polygon_type>("nores_3af0", nores_3af0, join_round32, end_flat, {22.0991, 22.1008}, 1.0);
     test_one<multi_polygon_type, polygon_type>("nores_2881b", nores_2881b, join_round32, end_flat, 24.6731, 1.0);
-#endif
+    test_one<multi_polygon_type, polygon_type>("nores_5318", nores_5318, join_round32, end_flat, 22.7311, 1.0);
     test_one<multi_polygon_type, polygon_type>("nores_495d", nores_495d, join_round32, end_flat, 23.4376, 1.0);
-    test_one<multi_polygon_type, polygon_type>("nores_e402", nores_e402, join_round32, end_flat, 9.9888, 1.0);
+    test_one<multi_polygon_type, polygon_type>("nores_e402", nores_e402, join_round32, end_flat, {9.9888, 9.9898}, 1.0);
 
 #if ! defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
     // Erroneous cases with rescaling (out of 8)
@@ -683,7 +686,7 @@ int test_main(int, char* [])
 #endif
 
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(5, 4, 4, 9);
+    BoostGeometryWriteExpectedFailures(5, 1, 3, 4);
 #endif
 
     return 0;

--- a/test/algorithms/set_operations/difference/difference_multi.cpp
+++ b/test/algorithms/set_operations/difference/difference_multi.cpp
@@ -517,7 +517,7 @@ int test_main(int, char* [])
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
     // Not yet fully tested for float.
     // The difference algorithm can generate (additional) slivers
-    BoostGeometryWriteExpectedFailures(22, 7, 21, 9);
+    BoostGeometryWriteExpectedFailures(22, 12, 16, 7);
 #endif
 
     return 0;

--- a/test/algorithms/set_operations/intersection/intersection.cpp
+++ b/test/algorithms/set_operations/intersection/intersection.cpp
@@ -305,7 +305,7 @@ void test_areal()
     TEST_INTERSECTION(issue_566_a, 1, -1, 70.7107);
     TEST_INTERSECTION(issue_566_b, 1, -1, 70.7107);
 
-    TEST_INTERSECTION(issue_838, 1, -1, 0.65829087);
+    TEST_INTERSECTION(issue_838, 1, -1, (expectation_limits{0.6582, 0.6650}));
 
     test_one<Polygon, Polygon, Polygon>("buffer_mp1", buffer_mp1[0], buffer_mp1[1],
                 1, 31, 2.271707796);

--- a/test/geometry_test_common.hpp
+++ b/test/geometry_test_common.hpp
@@ -198,6 +198,12 @@ inline T1 const& bg_if_mp(T1 const& value_mp, T2 const& value)
 inline void BoostGeometryWriteTestConfiguration()
 {
     std::cout << std::endl << "Test configuration:" << std::endl;
+#if defined(BOOST_GEOMETRY_COMPILER_MODE_RELEASE)
+    std::cout << "  - Release mode" << std::endl;
+#endif
+#if defined(BOOST_GEOMETRY_COMPILER_MODE_DEBUG)
+    std::cout << "  - Debug mode" << std::endl;
+#endif
 #if defined(BOOST_GEOMETRY_USE_RESCALING)
     std::cout << "  - Using rescaling" << std::endl;
 #endif

--- a/test/geometry_to_crc.hpp
+++ b/test/geometry_to_crc.hpp
@@ -1,0 +1,37 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2021 Barend Gehrels, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef GEOMETRY_TEST_GEOMETRY_TO_CRC_HPP
+#define GEOMETRY_TEST_GEOMETRY_TO_CRC_HPP
+
+#include <boost/geometry/io/wkt/wkt.hpp>
+
+#include <boost/crc.hpp>
+
+#include <iomanip>
+#include <string>
+
+// Convenience function for tests, it generates a 4 character CRC of a geometry
+// which can be used in filenames and/or testcases such as 'nores_37f6'
+template <typename Geometry>
+inline std::string geometry_to_crc(Geometry const& geometry)
+{
+  std::ostringstream out1;
+  out1 << bg::wkt(geometry);
+
+  const std::string str = out1.str();
+
+  boost::crc_ccitt_type result;
+  result.process_bytes(str.data(), str.length());
+
+  std::ostringstream out2;
+  out2 << std::setw(4) << std::setfill('0') << std::hex << result.checksum();
+  return out2.str();
+}
+
+#endif // GEOMETRY_TEST_GEOMETRY_TO_CRC_HPP


### PR DESCRIPTION
This fixes the last 88 errors from the `recursive_polygons_buffer` test. Result is now:
`geometries: 310000 errors: 0 type: d time: 33.439`

There were  `2286` errors when I started to work on this part (many of them had of course the same cause) so I'm glad it's now better than the rescaled version (8 errors).

With this, the version without rescaling is behaving as good, or better, as the rescaling version. See this grep below, where the first value are the detected errors using rescaling. The last 3 values are without rescaling (double, float, long double). There is only one test better now using rescaling, then with double.

So I propose that we change the default to not-rescale this release, and we can deprecate and remove rescaling in one of the coming releases. But I've still to check the tests other than set_operations (area) / buffer. However they should be less influenced.

What are your opinions?

```
set_operations/union/union_multi.cpp:    BoostGeometryWriteExpectedFailures(9, 0, 1, 0);
set_operations/union/union.cpp:    BoostGeometryWriteExpectedFailures(3, 1, 2, 0);
set_operations/difference/difference.cpp:    BoostGeometryWriteExpectedFailures(12, 5, 11, 6);
set_operations/difference/difference_multi.cpp:    BoostGeometryWriteExpectedFailures(22, 12, 16, 7);
set_operations/intersection/intersection.cpp:    BoostGeometryWriteExpectedFailures(5, 2, 6, 1);
set_operations/intersection/intersection_multi.cpp:    BoostGeometryWriteExpectedFailures(9, 1, 2, 1);
buffer/buffer_point.cpp:    BoostGeometryWriteExpectedFailures(0);
buffer/buffer_countries.cpp:    BoostGeometryWriteExpectedFailures(1, 0, 2, 0);
buffer/buffer_multi_polygon.cpp:    BoostGeometryWriteExpectedFailures(5, 1, 3, 4);
buffer/buffer_linestring.cpp:    BoostGeometryWriteExpectedFailures(2, 4, 9, 4); **
buffer/buffer_linestring_aimes.cpp:    BoostGeometryWriteExpectedFailures(0);
buffer/buffer_multi_point.cpp:    BoostGeometryWriteExpectedFailures(0);
buffer/buffer_polygon.cpp:    BoostGeometryWriteExpectedFailures(2, 1, 9, 1);
buffer/buffer_multi_linestring.cpp:    BoostGeometryWriteExpectedFailures(9, 6, 9, 3);
```