### PR TITLE
Fix initializer lists

### DIFF
--- a/include/boost/geometry/strategy/cartesian/side_robust.hpp
+++ b/include/boost/geometry/strategy/cartesian/side_robust.hpp
@@ -5,6 +5,11 @@
 // Contributed and/or modified by Tinko Bartels,
 //   as part of Google Summer of Code 2019 program.
 
+// This file was modified by Oracle on 2021.
+// Modifications copyright (c) 2021, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -49,10 +54,16 @@ public:
     static inline PromotedType side_value(P1 const& p1, P2 const& p2,
         P const& p)
     {
-        typedef ::boost::geometry::detail::precise_math::vec2d<PromotedType> vec2d;
-        vec2d pa { get<0>(p1), get<1>(p1) };
-        vec2d pb { get<0>(p2), get<1>(p2) };
-        vec2d pc { get<0>(p), get<1>(p) };
+        using vec2d = ::boost::geometry::detail::precise_math::vec2d<PromotedType>;
+        vec2d pa;
+        pa.x = get<0>(p1);
+        pa.y = get<1>(p1);
+        vec2d pb;
+        pb.x = get<0>(p2);
+        pb.y = get<1>(p2);
+        vec2d pc;
+        pc.x = get<0>(p);
+        pc.y = get<1>(p);
         return ::boost::geometry::detail::precise_math::orient2d
             <PromotedType, Robustness>(pa, pb, pc);
     }

--- a/test/algorithms/overlay/get_clusters.cpp
+++ b/test/algorithms/overlay/get_clusters.cpp
@@ -3,6 +3,10 @@
 
 // Copyright (c) 2021 Barend Gehrels, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2021.
+// Modifications copyright (c) 2021, Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -63,8 +67,8 @@ void do_test(std::string const& case_id,
                         << " detected: " << clusters.size());
 }
 
-template <typename Point, typename T>
-void test_get_clusters(T eps)
+template <typename Point>
+void test_get_clusters(typename bg::coordinate_type<Point>::type eps)
 {
     do_test<Point>("no", {{1.0, 1.0}, {1.0, 2.0}}, 0);
     do_test<Point>("simplex", {{1.0, 1.0}, {1.0, 1.0}}, 1);
@@ -78,10 +82,10 @@ void test_get_clusters(T eps)
                    8);
 
     // Border cases
-    do_test<Point>("borderx_no", {{1.0, 1.0}, {1.0, 2.0}, {1.0 + eps * 10.0, 1.0}}, 0);
-    do_test<Point>("borderx_yes", {{1.0, 1.0}, {1.0, 2.0}, {1.0 + eps, 1.0}}, 1);
-    do_test<Point>("bordery_no", {{1.0, 1.0}, {2.0, 1.0}, {1.0 + eps * 10.0, 1.0}}, 0);
-    do_test<Point>("bordery_yes", {{1.0, 1.0}, {2.0, 1.0}, {1.0 + eps, 1.0}}, 1);
+    do_test<Point>("borderx_no",  {{1, 1}, {1, 2}, {1 + eps * 10, 1}}, 0);
+    do_test<Point>("borderx_yes", {{1, 1}, {1, 2}, {1 + eps, 1}}, 1);
+    do_test<Point>("bordery_no",  {{1, 1}, {2, 1}, {1 + eps * 10, 1}}, 0);
+    do_test<Point>("bordery_yes", {{1, 1}, {2, 1}, {1 + eps, 1}}, 1);
 }
 
 int test_main(int, char* [])
@@ -89,7 +93,7 @@ int test_main(int, char* [])
     using fp = bg::model::point<float, 2, bg::cs::cartesian>;
     using dp = bg::model::point<double, 2, bg::cs::cartesian>;
     using ep = bg::model::point<long double, 2, bg::cs::cartesian>;
-    test_get_clusters<fp>(1.0e-8);
+    test_get_clusters<fp>(1.0e-8f);
     test_get_clusters<dp>(1.0e-13);
     test_get_clusters<ep>(1.0e-16);
     return 0;


### PR DESCRIPTION
This PR fixes compilation errors caused by narrowing conversions in initializer lists.

Related:
- https://github.com/boostorg/geometry/pull/873
- https://github.com/boostorg/geometry/issues/849
