### PR TITLE
Fix traversing of the rtree during incremental knn query.

### DIFF
--- a/include/boost/geometry/index/detail/predicates.hpp
+++ b/include/boost/geometry/index/detail/predicates.hpp
@@ -4,8 +4,8 @@
 //
 // Copyright (c) 2011-2015 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2019-2020.
-// Modifications copyright (c) 2019-2020 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2019-2021.
+// Modifications copyright (c) 2019-2021 Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -91,12 +91,12 @@ struct nearest
     nearest()
 //        : count(0)
     {}
-    nearest(PointOrRelation const& por, unsigned k)
+    nearest(PointOrRelation const& por, std::size_t k)
         : point_or_relation(por)
         , count(k)
     {}
     PointOrRelation point_or_relation;
-    unsigned count;
+    std::size_t count;
 };
 
 template <typename SegmentOrLinestring>
@@ -105,12 +105,12 @@ struct path
     path()
 //        : count(0)
     {}
-    path(SegmentOrLinestring const& g, unsigned k)
+    path(SegmentOrLinestring const& g, std::size_t k)
         : geometry(g)
         , count(k)
     {}
     SegmentOrLinestring geometry;
-    unsigned count;
+    std::size_t count;
 };
 
 } // namespace predicates
@@ -520,31 +520,31 @@ struct predicate_check<predicates::path<Linestring>, bounds_tag>
 template <typename T>
 struct predicates_length
 {
-    static const unsigned value = 1;
+    static const std::size_t value = 1;
 };
 
 template <typename ...Ts>
 struct predicates_length<std::tuple<Ts...>>
 {
-    static const unsigned value = std::tuple_size<std::tuple<Ts...>>::value;
+    static const std::size_t value = std::tuple_size<std::tuple<Ts...>>::value;
 };
 
 // ------------------------------------------------------------------ //
 // predicates_element
 // ------------------------------------------------------------------ //
 
-template <unsigned I, typename T>
+template <std::size_t I, typename T>
 struct predicates_element
 {
     BOOST_GEOMETRY_STATIC_ASSERT((I < 1),
         "Invalid I index.",
-        std::integral_constant<unsigned, I>);
+        std::integral_constant<std::size_t, I>);
 
     typedef T type;
     static type const& get(T const& p) { return p; }
 };
 
-template <unsigned I, typename ...Ts>
+template <std::size_t I, typename ...Ts>
 struct predicates_element<I, std::tuple<Ts...>>
 {
     typedef std::tuple<Ts...> predicate_type;
@@ -557,7 +557,7 @@ struct predicates_element<I, std::tuple<Ts...>>
 // predicates_check
 // ------------------------------------------------------------------ //
 
-template <typename TuplePredicates, typename Tag, unsigned First, unsigned Last>
+template <typename TuplePredicates, typename Tag, std::size_t First, std::size_t Last>
 struct predicates_check_tuple
 {
     template <typename Value, typename Indexable, typename Strategy>
@@ -572,7 +572,7 @@ struct predicates_check_tuple
     }
 };
 
-template <typename TuplePredicates, typename Tag, unsigned First>
+template <typename TuplePredicates, typename Tag, std::size_t First>
 struct predicates_check_tuple<TuplePredicates, Tag, First, First>
 {
     template <typename Value, typename Indexable, typename Strategy>
@@ -582,13 +582,13 @@ struct predicates_check_tuple<TuplePredicates, Tag, First, First>
     }
 };
 
-template <typename Predicate, typename Tag, unsigned First, unsigned Last>
+template <typename Predicate, typename Tag, std::size_t First, std::size_t Last>
 struct predicates_check_impl
 {
     static const bool check = First < 1 && Last <= 1 && First <= Last;
     BOOST_GEOMETRY_STATIC_ASSERT((check),
         "Invalid First or Last index.",
-        std::integer_sequence<unsigned, First, Last>);
+        std::integer_sequence<std::size_t, First, Last>);
 
     template <typename Value, typename Indexable, typename Strategy>
     static inline bool apply(Predicate const& p, Value const& v, Indexable const& i, Strategy const& s)
@@ -597,16 +597,16 @@ struct predicates_check_impl
     }
 };
 
-template <typename ...Ts, typename Tag, unsigned First, unsigned Last>
+template <typename ...Ts, typename Tag, std::size_t First, std::size_t Last>
 struct predicates_check_impl<std::tuple<Ts...>, Tag, First, Last>
 {
     typedef std::tuple<Ts...> predicates_type;
 
-    static const unsigned pred_len = std::tuple_size<predicates_type>::value;
+    static const std::size_t pred_len = std::tuple_size<predicates_type>::value;
     static const bool check = First < pred_len && Last <= pred_len && First <= Last;
     BOOST_GEOMETRY_STATIC_ASSERT((check),
         "Invalid First or Last index.",
-        std::integer_sequence<unsigned, First, Last>);
+        std::integer_sequence<std::size_t, First, Last>);
 
     template <typename Value, typename Indexable, typename Strategy>
     static inline bool apply(predicates_type const& p, Value const& v, Indexable const& i, Strategy const& s)
@@ -619,7 +619,7 @@ struct predicates_check_impl<std::tuple<Ts...>, Tag, First, Last>
     }
 };
 
-template <typename Tag, unsigned First, unsigned Last, typename Predicates, typename Value, typename Indexable, typename Strategy>
+template <typename Tag, std::size_t First, std::size_t Last, typename Predicates, typename Value, typename Indexable, typename Strategy>
 inline bool predicates_check(Predicates const& p, Value const& v, Indexable const& i, Strategy const& s)
 {
     return detail::predicates_check_impl<Predicates, Tag, First, Last>
@@ -635,19 +635,19 @@ inline bool predicates_check(Predicates const& p, Value const& v, Indexable cons
 template <typename P>
 struct predicates_is_distance
 {
-    static const unsigned value = 0;
+    static const std::size_t value = 0;
 };
 
 template <typename DistancePredicates>
 struct predicates_is_distance< predicates::nearest<DistancePredicates> >
 {
-    static const unsigned value = 1;
+    static const std::size_t value = 1;
 };
 
 template <typename Linestring>
 struct predicates_is_distance< predicates::path<Linestring> >
 {
-    static const unsigned value = 1;
+    static const std::size_t value = 1;
 };
 
 // predicates_count_nearest
@@ -655,13 +655,13 @@ struct predicates_is_distance< predicates::path<Linestring> >
 template <typename T>
 struct predicates_count_distance
 {
-    static const unsigned value = predicates_is_distance<T>::value;
+    static const std::size_t value = predicates_is_distance<T>::value;
 };
 
-template <typename Tuple, unsigned N>
+template <typename Tuple, std::size_t N>
 struct predicates_count_distance_tuple
 {
-    static const unsigned value =
+    static const std::size_t value =
         predicates_is_distance<typename std::tuple_element<N-1, Tuple>::type>::value
         + predicates_count_distance_tuple<Tuple, N-1>::value;
 };
@@ -669,14 +669,14 @@ struct predicates_count_distance_tuple
 template <typename Tuple>
 struct predicates_count_distance_tuple<Tuple, 1>
 {
-    static const unsigned value =
+    static const std::size_t value =
         predicates_is_distance<typename std::tuple_element<0, Tuple>::type>::value;
 };
 
 template <typename ...Ts>
 struct predicates_count_distance<std::tuple<Ts...>>
 {
-    static const unsigned value = predicates_count_distance_tuple<
+    static const std::size_t value = predicates_count_distance_tuple<
         std::tuple<Ts...>,
         std::tuple_size<std::tuple<Ts...>>::value
     >::value;
@@ -687,16 +687,16 @@ struct predicates_count_distance<std::tuple<Ts...>>
 template <typename T>
 struct predicates_find_distance
 {
-    static const unsigned value = predicates_is_distance<T>::value ? 0 : 1;
+    static const std::size_t value = predicates_is_distance<T>::value ? 0 : 1;
 };
 
-template <typename Tuple, unsigned N>
+template <typename Tuple, std::size_t N>
 struct predicates_find_distance_tuple
 {
     static const bool is_found = predicates_find_distance_tuple<Tuple, N-1>::is_found
                                 || predicates_is_distance<typename std::tuple_element<N-1, Tuple>::type>::value;
 
-    static const unsigned value = predicates_find_distance_tuple<Tuple, N-1>::is_found ?
+    static const std::size_t value = predicates_find_distance_tuple<Tuple, N-1>::is_found ?
         predicates_find_distance_tuple<Tuple, N-1>::value :
         (predicates_is_distance<typename std::tuple_element<N-1, Tuple>::type>::value ?
             N-1 : std::tuple_size<Tuple>::value);
@@ -706,13 +706,13 @@ template <typename Tuple>
 struct predicates_find_distance_tuple<Tuple, 1>
 {
     static const bool is_found = predicates_is_distance<typename std::tuple_element<0, Tuple>::type>::value;
-    static const unsigned value = is_found ? 0 : std::tuple_size<Tuple>::value;
+    static const std::size_t value = is_found ? 0 : std::tuple_size<Tuple>::value;
 };
 
 template <typename ...Ts>
 struct predicates_find_distance<std::tuple<Ts...>>
 {
-    static const unsigned value = predicates_find_distance_tuple<
+    static const std::size_t value = predicates_find_distance_tuple<
         std::tuple<Ts...>,
         std::tuple_size<std::tuple<Ts...>>::value
     >::value;

--- a/include/boost/geometry/index/detail/rtree/visitors/distance_query.hpp
+++ b/include/boost/geometry/index/detail/rtree/visitors/distance_query.hpp
@@ -4,8 +4,8 @@
 //
 // Copyright (c) 2011-2014 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2019.
-// Modifications copyright (c) 2019 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2019-2021.
+// Modifications copyright (c) 2019-2021 Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -97,7 +97,7 @@ template
 <
     typename MembersHolder,
     typename Predicates,
-    unsigned DistancePredicateIndex,
+    std::size_t DistancePredicateIndex,
     typename OutIter
 >
 class distance_query
@@ -125,7 +125,7 @@ public:
     typedef typename calculate_value_distance::result_type value_distance_type;
     typedef typename calculate_node_distance::result_type node_distance_type;
 
-    static const unsigned predicates_len = index::detail::predicates_length<Predicates>::value;
+    static const std::size_t predicates_len = index::detail::predicates_length<Predicates>::value;
 
     inline distance_query(parameters_type const& parameters, translator_type const& translator, Predicates const& pred, OutIter out_it)
         : m_parameters(parameters), m_translator(translator)
@@ -299,7 +299,7 @@ private:
 template <
     typename MembersHolder,
     typename Predicates,
-    unsigned DistancePredicateIndex
+    std::size_t DistancePredicateIndex
 >
 class distance_query_incremental
     : public MembersHolder::visitor_const
@@ -330,7 +330,7 @@ public:
     typedef typename allocators_type::const_reference const_reference;
     typedef typename allocators_type::node_pointer node_pointer;
 
-    static const unsigned predicates_len = index::detail::predicates_length<Predicates>::value;
+    static const std::size_t predicates_len = index::detail::predicates_length<Predicates>::value;
 
     typedef typename rtree::elements_type<internal_node>::type internal_elements;
     typedef typename internal_elements::const_iterator internal_iterator;
@@ -590,7 +590,7 @@ private:
         return greatest_dist <= d;
     }
 
-    inline unsigned max_count() const
+    inline std::size_t max_count() const
     {
         return nearest_predicate_access::get(m_pred).count;
     }

--- a/include/boost/geometry/index/detail/rtree/visitors/distance_query.hpp
+++ b/include/boost/geometry/index/detail/rtree/visitors/distance_query.hpp
@@ -519,7 +519,7 @@ public:
         //   participate in sorting anymore.
 
         // sort array
-        size_type sort_first = current_neighbor == (std::numeric_limits<size_type>::max)() ? 0 : current_neighbor;
+        size_type sort_first = current_neighbor == (std::numeric_limits<size_type>::max)() ? 0 : current_neighbor + 1;
         std::sort(neighbors.begin() + sort_first, neighbors.end(), pair_first_less());
         // remove furthest values
         if ( max_count() < neighbors.size() )

--- a/include/boost/geometry/index/detail/rtree/visitors/distance_query.hpp
+++ b/include/boost/geometry/index/detail/rtree/visitors/distance_query.hpp
@@ -393,16 +393,15 @@ public:
 
                 // if there are no nodes which can have closer values, set new value
                 if ( new_neighbor < neighbors.size() &&
-                     // here must be < because otherwise neighbours may be sorted in different order
-                     // if there is another value with equal distance
-                     neighbors[new_neighbor].first < closest_distance)
+                     // NOTE: In order to use <= current neighbor can't be sorted again
+                     neighbors[new_neighbor].first <= closest_distance )
                 {
                     current_neighbor = new_neighbor;
                     return;
                 }
 
-                // if node is further than the furthest neighbour, following nodes also will be further
-                BOOST_GEOMETRY_INDEX_ASSERT(neighbors.size() <= max_count(), "unexpected neighbours count");
+                // if node is further than the furthest neighbor, following nodes will also be further
+                BOOST_GEOMETRY_INDEX_ASSERT(neighbors.size() <= max_count(), "unexpected neighbors count");
                 if ( max_count() <= neighbors.size() &&
                      neighbors.back().first <= closest_distance )
                 {
@@ -516,6 +515,8 @@ public:
         // TODO: sort is probably suboptimal.
         //   An alternative would be std::set, but it'd probably add constant cost.
         //   Ideally replace this with double-ended priority queue, e.g. min-max heap.
+        // NOTE: A condition in increment() relies on the fact that current neighbor doesn't
+        //   participate in sorting anymore.
 
         // sort array
         size_type sort_first = current_neighbor == (std::numeric_limits<size_type>::max)() ? 0 : current_neighbor;

--- a/include/boost/geometry/index/detail/rtree/visitors/distance_query.hpp
+++ b/include/boost/geometry/index/detail/rtree/visitors/distance_query.hpp
@@ -513,8 +513,13 @@ public:
             }
         }
 
+        // TODO: sort is probably suboptimal.
+        //   An alternative would be std::set, but it'd probably add constant cost.
+        //   Ideally replace this with double-ended priority queue, e.g. min-max heap.
+
         // sort array
-        std::sort(neighbors.begin(), neighbors.end(), pair_first_less());
+        size_type sort_first = current_neighbor == (std::numeric_limits<size_type>::max)() ? 0 : current_neighbor;
+        std::sort(neighbors.begin() + sort_first, neighbors.end(), pair_first_less());
         // remove furthest values
         if ( max_count() < neighbors.size() )
             neighbors.resize(max_count());

--- a/include/boost/geometry/index/detail/rtree/visitors/distance_query.hpp
+++ b/include/boost/geometry/index/detail/rtree/visitors/distance_query.hpp
@@ -19,6 +19,28 @@ namespace boost { namespace geometry { namespace index {
 
 namespace detail { namespace rtree { namespace visitors {
 
+
+struct pair_first_less
+{
+    template <typename First, typename Second>
+    inline bool operator()(std::pair<First, Second> const& p1,
+                           std::pair<First, Second> const& p2) const
+    {
+        return p1.first < p2.first;
+    }
+};
+
+struct pair_first_greater
+{
+    template <typename First, typename Second>
+    inline bool operator()(std::pair<First, Second> const& p1,
+                           std::pair<First, Second> const& p2) const
+    {
+        return p1.first > p2.first;
+    }
+};
+
+
 template <typename Value, typename Translator, typename DistanceType, typename OutIt>
 class distance_query_result
 {
@@ -40,16 +62,16 @@ public:
             m_neighbors.push_back(std::make_pair(curr_comp_dist, val));
 
             if ( m_neighbors.size() == m_count )
-                std::make_heap(m_neighbors.begin(), m_neighbors.end(), neighbors_less);
+                std::make_heap(m_neighbors.begin(), m_neighbors.end(), pair_first_less());
         }
         else
         {
             if ( curr_comp_dist < m_neighbors.front().first )
             {
-                std::pop_heap(m_neighbors.begin(), m_neighbors.end(), neighbors_less);
+                std::pop_heap(m_neighbors.begin(), m_neighbors.end(), pair_first_less());
                 m_neighbors.back().first = curr_comp_dist;
                 m_neighbors.back().second = val;
-                std::push_heap(m_neighbors.begin(), m_neighbors.end(), neighbors_less);
+                std::push_heap(m_neighbors.begin(), m_neighbors.end(), pair_first_less());
             }
         }
     }
@@ -80,13 +102,6 @@ public:
     }
 
 private:
-    inline static bool neighbors_less(
-        std::pair<distance_type, Value> const& p1,
-        std::pair<distance_type, Value> const& p2)
-    {
-        return p1.first < p2.first;
-    }
-
     size_t m_count;
     OutIt m_out_it;
 
@@ -186,7 +201,7 @@ public:
             return;
         
         // sort array
-        std::sort(active_branch_list.begin(), active_branch_list.end(), abl_less);
+        std::sort(active_branch_list.begin(), active_branch_list.end(), pair_first_less());
 
         // recursively visit nodes
         for ( typename active_branch_list_type::const_iterator it = active_branch_list.begin();
@@ -209,7 +224,7 @@ public:
         //           from the copying of the whole containers on resize of the ABLs container
 
         //// make a heap
-        //std::make_heap(active_branch_list.begin(), active_branch_list.end(), abl_greater);
+        //std::make_heap(active_branch_list.begin(), active_branch_list.end(), pair_first_greater());
 
         //// recursively visit nodes
         //while ( !active_branch_list.empty() )
@@ -223,7 +238,7 @@ public:
 
         //    rtree::apply_visitor(*this, *(active_branch_list.front().second));
 
-        //    std::pop_heap(active_branch_list.begin(), active_branch_list.end(), abl_greater);
+        //    std::pop_heap(active_branch_list.begin(), active_branch_list.end(), pair_first_greater());
         //    active_branch_list.pop_back();
         //}
     }
@@ -262,20 +277,6 @@ public:
     }
 
 private:
-    static inline bool abl_less(
-        std::pair<node_distance_type, typename allocators_type::node_pointer> const& p1,
-        std::pair<node_distance_type, typename allocators_type::node_pointer> const& p2)
-    {
-        return p1.first < p2.first;
-    }
-
-    //static inline bool abl_greater(
-    //    std::pair<node_distance_type, typename allocators_type::node_pointer> const& p1,
-    //    std::pair<node_distance_type, typename allocators_type::node_pointer> const& p2)
-    //{
-    //    return p1.first > p2.first;
-    //}
-
     template <typename Distance>
     static inline bool is_node_prunable(Distance const& greatest_dist, node_distance_type const& d)
     {
@@ -337,31 +338,12 @@ public:
     typedef typename rtree::elements_type<leaf>::type leaf_elements;
 
     typedef std::pair<node_distance_type, node_pointer> branch_data;
-    typedef typename index::detail::rtree::container_from_elements_type<
-        internal_elements, branch_data
-    >::type active_branch_list_type;
-    struct internal_stack_element
-    {
-        internal_stack_element() : current_branch(0) {}
-#ifdef BOOST_NO_CXX11_RVALUE_REFERENCES
-        // Required in c++03 for containers using Boost.Move
-        internal_stack_element & operator=(internal_stack_element const& o)
-        {
-            branches = o.branches;
-            current_branch = o.current_branch;
-            return *this;
-        }
-#endif
-        active_branch_list_type branches;
-        typename active_branch_list_type::size_type current_branch;
-    };
-    typedef std::vector<internal_stack_element> internal_stack_type;
+    typedef std::vector<branch_data> internal_heap_type;
 
     inline distance_query_incremental()
         : m_translator(NULL)
 //        , m_pred()
         , current_neighbor((std::numeric_limits<size_type>::max)())
-//        , next_closest_node_distance((std::numeric_limits<node_distance_type>::max)())
 //        , m_strategy_type()
     {}
 
@@ -369,7 +351,6 @@ public:
         : m_translator(::boost::addressof(translator))
         , m_pred(pred)
         , current_neighbor((std::numeric_limits<size_type>::max)())
-        , next_closest_node_distance((std::numeric_limits<node_distance_type>::max)())
         , m_strategy(index::detail::get_strategy(params))
     {
         BOOST_GEOMETRY_INDEX_ASSERT(0 < max_count(), "k must be greather than 0");
@@ -392,7 +373,7 @@ public:
         {
             size_type new_neighbor = current_neighbor == (std::numeric_limits<size_type>::max)() ? 0 : current_neighbor + 1;
 
-            if ( internal_stack.empty() )
+            if ( internal_heap.empty() )
             {
                 if ( new_neighbor < neighbors.size() )
                     current_neighbor = new_neighbor;
@@ -407,20 +388,14 @@ public:
             }
             else
             {
-                active_branch_list_type & branches = internal_stack.back().branches;
-                typename active_branch_list_type::size_type & current_branch = internal_stack.back().current_branch;
-
-                if ( branches.size() <= current_branch )
-                {
-                    internal_stack.pop_back();
-                    continue;
-                }
+                branch_data const& closest_branch = internal_heap.front();
+                node_distance_type const& closest_distance = closest_branch.first;
 
                 // if there are no nodes which can have closer values, set new value
                 if ( new_neighbor < neighbors.size() &&
                      // here must be < because otherwise neighbours may be sorted in different order
                      // if there is another value with equal distance
-                     neighbors[new_neighbor].first < next_closest_node_distance )
+                     neighbors[new_neighbor].first < closest_distance)
                 {
                     current_neighbor = new_neighbor;
                     return;
@@ -429,19 +404,18 @@ public:
                 // if node is further than the furthest neighbour, following nodes also will be further
                 BOOST_GEOMETRY_INDEX_ASSERT(neighbors.size() <= max_count(), "unexpected neighbours count");
                 if ( max_count() <= neighbors.size() &&
-                     is_node_prunable(neighbors.back().first, branches[current_branch].first) )
+                     neighbors.back().first <= closest_distance )
                 {
-                    // stop traversing current level
-                    internal_stack.pop_back();
+                    internal_heap.clear();
                     continue;
                 }
                 else
                 {
-                    // new level - must increment current_branch before traversing of another level (mem reallocation)
-                    ++current_branch;
-                    rtree::apply_visitor(*this, *(branches[current_branch - 1].second));
+                    node_pointer ptr = closest_branch.second;
+                    std::pop_heap(internal_heap.begin(), internal_heap.end(), pair_first_greater());
+                    internal_heap.pop_back();
 
-                    next_closest_node_distance = calc_closest_node_distance(internal_stack.begin(), internal_stack.end());
+                    rtree::apply_visitor(*this, *ptr);
                 }
             }
         }
@@ -470,9 +444,6 @@ public:
         typedef typename rtree::elements_type<internal_node>::type elements_type;
         elements_type const& elements = rtree::elements(n);
 
-        // add new element
-        internal_stack.resize(internal_stack.size()+1);
-
         // fill active branch list array of nodes meeting predicates
         for ( typename elements_type::const_iterator it = elements.begin() ; it != elements.end() ; ++it )
         {
@@ -494,21 +465,16 @@ public:
 
                 // if current node is further than found neighbors - don't analyze it
                 if ( max_count() <= neighbors.size() &&
-                     is_node_prunable(neighbors.back().first, node_distance) )
+                     neighbors.back().first <= node_distance )
                 {
                     continue;
                 }
 
-                // add current node's data into the list
-                internal_stack.back().branches.push_back( std::make_pair(node_distance, it->second) );
+                // add current node's data into the queue
+                internal_heap.push_back(std::make_pair(node_distance, it->second));
+                std::push_heap(internal_heap.begin(), internal_heap.end(), pair_first_greater());
             }
         }
-
-        if ( internal_stack.back().branches.empty() )
-            internal_stack.pop_back();
-        else
-            // sort array
-            std::sort(internal_stack.back().branches.begin(), internal_stack.back().branches.end(), abl_less);
     }
 
     // Put values into the list of neighbours if those values meets predicates
@@ -548,48 +514,13 @@ public:
         }
 
         // sort array
-        std::sort(neighbors.begin(), neighbors.end(), neighbors_less);
+        std::sort(neighbors.begin(), neighbors.end(), pair_first_less());
         // remove furthest values
         if ( max_count() < neighbors.size() )
             neighbors.resize(max_count());
     }
 
 private:
-    static inline bool abl_less(std::pair<node_distance_type, node_pointer> const& p1,
-                                std::pair<node_distance_type, node_pointer> const& p2)
-    {
-        return p1.first < p2.first;
-    }
-
-    static inline bool neighbors_less(std::pair<value_distance_type, const value_type *> const& p1,
-                                      std::pair<value_distance_type, const value_type *> const& p2)
-    {
-        return p1.first < p2.first;
-    }
-
-    node_distance_type
-    calc_closest_node_distance(typename internal_stack_type::const_iterator first,
-                               typename internal_stack_type::const_iterator last)
-    {
-        node_distance_type result = (std::numeric_limits<node_distance_type>::max)();
-        for ( ; first != last ; ++first )
-        {
-            if ( first->branches.size() <= first->current_branch )
-                continue;
-
-            node_distance_type curr_dist = first->branches[first->current_branch].first;
-            if ( curr_dist < result )
-                result = curr_dist;
-        }
-        return result;
-    }
-
-    template <typename Distance>
-    static inline bool is_node_prunable(Distance const& greatest_dist, node_distance_type const& d)
-    {
-        return greatest_dist <= d;
-    }
-
     inline std::size_t max_count() const
     {
         return nearest_predicate_access::get(m_pred).count;
@@ -604,10 +535,9 @@ private:
 
     Predicates m_pred;
     
-    internal_stack_type internal_stack;
+    internal_heap_type internal_heap;
     std::vector< std::pair<value_distance_type, const value_type *> > neighbors;
     size_type current_neighbor;
-    node_distance_type next_closest_node_distance;
 
     strategy_type m_strategy;
 };

--- a/include/boost/geometry/index/detail/rtree/visitors/spatial_query.hpp
+++ b/include/boost/geometry/index/detail/rtree/visitors/spatial_query.hpp
@@ -4,8 +4,8 @@
 //
 // Copyright (c) 2011-2014 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2019.
-// Modifications copyright (c) 2019 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2019-2021.
+// Modifications copyright (c) 2019-2021 Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -35,7 +35,7 @@ struct spatial_query
 
     typedef typename allocators_type::size_type size_type;
 
-    static const unsigned predicates_len = index::detail::predicates_length<Predicates>::value;
+    static const std::size_t predicates_len = index::detail::predicates_length<Predicates>::value;
 
     inline spatial_query(parameters_type const& par, translator_type const& t, Predicates const& p, OutIter out_it)
         : tr(t), pred(p), out_iter(out_it), found_count(0), strategy(index::detail::get_strategy(par))
@@ -119,7 +119,7 @@ public:
     typedef typename rtree::elements_type<leaf>::type leaf_elements;
     typedef typename rtree::elements_type<leaf>::type::const_iterator leaf_iterator;
 
-    static const unsigned predicates_len = index::detail::predicates_length<Predicates>::value;
+    static const std::size_t predicates_len = index::detail::predicates_length<Predicates>::value;
 
     inline spatial_query_incremental()
         : m_translator(NULL)

--- a/include/boost/geometry/index/predicates.hpp
+++ b/include/boost/geometry/index/predicates.hpp
@@ -4,8 +4,8 @@
 //
 // Copyright (c) 2011-2018 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2019-2020.
-// Modifications copyright (c) 2019-2020 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2019-2021.
+// Modifications copyright (c) 2019-2021 Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -338,7 +338,7 @@ Only one \c nearest() predicate may be used in a query.
 */
 template <typename Geometry> inline
 detail::predicates::nearest<Geometry>
-nearest(Geometry const& geometry, unsigned k)
+nearest(Geometry const& geometry, std::size_t k)
 {
     return detail::predicates::nearest<Geometry>(geometry, k);
 }
@@ -368,7 +368,7 @@ Only one distance predicate (\c nearest() or \c path()) may be used in a query.
 */
 template <typename SegmentOrLinestring> inline
 detail::predicates::path<SegmentOrLinestring>
-path(SegmentOrLinestring const& linestring, unsigned k)
+path(SegmentOrLinestring const& linestring, std::size_t k)
 {
     return detail::predicates::path<SegmentOrLinestring>(linestring, k);
 }

--- a/include/boost/geometry/index/rtree.hpp
+++ b/include/boost/geometry/index/rtree.hpp
@@ -6,8 +6,8 @@
 // Copyright (c) 2011-2019 Adam Wulkiewicz, Lodz, Poland.
 // Copyright (c) 2020 Caian Benedicto, Campinas, Brazil.
 //
-// This file was modified by Oracle on 2019-2020.
-// Modifications copyright (c) 2019-2020 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2019-2021.
+// Modifications copyright (c) 2019-2021 Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -1082,7 +1082,7 @@ public:
         if ( !m_members.root )
             return 0;
 
-        static const unsigned distance_predicates_count = detail::predicates_count_distance<Predicates>::value;
+        static const std::size_t distance_predicates_count = detail::predicates_count_distance<Predicates>::value;
         static const bool is_distance_predicate = 0 < distance_predicates_count;
         BOOST_GEOMETRY_STATIC_ASSERT((distance_predicates_count <= 1),
             "Only one distance predicate can be passed.",
@@ -1252,7 +1252,7 @@ private:
         >
     qbegin_(Predicates const& predicates) const
     {
-        static const unsigned distance_predicates_count = detail::predicates_count_distance<Predicates>::value;
+        static const std::size_t distance_predicates_count = detail::predicates_count_distance<Predicates>::value;
         BOOST_GEOMETRY_STATIC_ASSERT((distance_predicates_count <= 1),
             "Only one distance predicate can be passed.",
             Predicates);
@@ -1319,7 +1319,7 @@ private:
         >
     qend_(Predicates const& predicates) const
     {
-        static const unsigned distance_predicates_count = detail::predicates_count_distance<Predicates>::value;
+        static const std::size_t distance_predicates_count = detail::predicates_count_distance<Predicates>::value;
         BOOST_GEOMETRY_STATIC_ASSERT((distance_predicates_count <= 1),
             "Only one distance predicate can be passed.",
             Predicates);
@@ -1916,7 +1916,7 @@ private:
     {
         BOOST_GEOMETRY_INDEX_ASSERT(m_members.root, "The root must exist");
 
-        static const unsigned distance_predicate_index = detail::predicates_find_distance<Predicates>::value;
+        static const std::size_t distance_predicate_index = detail::predicates_find_distance<Predicates>::value;
         detail::rtree::visitors::distance_query<
             members_holder,
             Predicates,


### PR DESCRIPTION
Before this PR unneeded nodes were traversed by the query iterator and by extension many unneeded neighbours were taken into consideration. This fixes: https://github.com/boostorg/geometry/issues/867

Additional improvement is that the neighbors that were already handled are not sorted again.

This PR also changes type `unsigned` to `size_t` in several places.