### PR TITLE
[test] remove the non used KRAMER define and some other changes in testing is_valid

### DIFF
--- a/include/boost/geometry/core/config.hpp
+++ b/include/boost/geometry/core/config.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2019 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2019-2021 Barend Gehrels, Amsterdam, the Netherlands.
 
 // Copyright (c) 2018-2020 Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -22,10 +22,6 @@
 #if !defined(BOOST_NO_CXX11_HDR_TUPLE) && !defined(BOOST_NO_VARIADIC_TEMPLATES)
 #define BOOST_GEOMETRY_CXX11_TUPLE
 #endif
-
-// Defining this selects Kramer rule for segment-intersection
-// That is default behaviour.
-#define BOOST_GEOMETRY_USE_KRAMER_RULE
 
 // Rescaling is turned on, unless NO_ROBUSTNESS is defined
 // In future versions of Boost.Geometry, it will be turned off by default

--- a/test/algorithms/set_operations/difference/difference.cpp
+++ b/test/algorithms/set_operations/difference/difference.cpp
@@ -48,19 +48,10 @@ void test_all()
 
     typedef typename bg::coordinate_type<P>::type ct;
 
-    ut_settings sym_settings;
-#if ! defined(BOOST_GEOMETRY_USE_RESCALING)
-    sym_settings.sym_difference = false;
-#endif
-
-    ut_settings ignore_validity_settings;
-    ignore_validity_settings.set_test_validity(false);
-
     test_one<polygon, polygon, polygon>("simplex_normal",
         simplex_normal[0], simplex_normal[1],
         3, 12, 2.52636706856656,
-        3, 12, 3.52636706856656,
-        sym_settings);
+        3, 12, 3.52636706856656);
 
     test_one<polygon, polygon, polygon>("simplex_with_empty",
         simplex_normal[0], polygon_empty,
@@ -70,8 +61,7 @@ void test_all()
     test_one<polygon, polygon, polygon>(
             "star_ring", example_star, example_ring,
             5, 22, 1.1901714,
-            5, 27, 1.6701714,
-            sym_settings);
+            5, 27, 1.6701714);
 
     test_one<polygon, polygon, polygon>("two_bends",
         two_bends[0], two_bends[1],
@@ -81,8 +71,7 @@ void test_all()
     test_one<polygon, polygon, polygon>("star_comb_15",
         star_comb_15[0], star_comb_15[1],
         30, -1, 227.658275102812,
-        30, -1, 480.485775259312,
-        sym_settings);
+        30, -1, 480.485775259312);
 
     test_one<polygon, polygon, polygon>("new_hole",
         new_hole[0], new_hole[1],
@@ -115,17 +104,22 @@ void test_all()
         1, 5, 9.0,
         1, 5, 9.0);
 
-    test_one<polygon, polygon, polygon>("only_hole_intersections1",
-        only_hole_intersections[0], only_hole_intersections[1],
-        2, 10,  1.9090909,
-        4, 16, 10.9090909,
-        sym_settings);
+    {
+        ut_settings settings;
+        settings.sym_difference_validity = BG_IF_RESCALED(true, false);
 
-    test_one<polygon, polygon, polygon>("only_hole_intersection2",
-        only_hole_intersections[0], only_hole_intersections[2],
-        3, 20, 30.9090909,
-        4, 16, 10.9090909,
-        sym_settings);
+        test_one<polygon, polygon, polygon>("only_hole_intersections1",
+            only_hole_intersections[0], only_hole_intersections[1],
+            2, 10,  1.9090909,
+            4, 16, 10.9090909,
+            settings);
+
+        test_one<polygon, polygon, polygon>("only_hole_intersection2",
+            only_hole_intersections[0], only_hole_intersections[2],
+            3, 20, 30.9090909,
+            4, 16, 10.9090909,
+            settings);
+    }
 
     test_one<polygon, polygon, polygon>("first_within_second",
         first_within_second[1], first_within_second[0],
@@ -148,20 +142,24 @@ void test_all()
         4, 20, 11.533333,
         5, 26, 29.783333);
 
-    test_one<polygon, polygon, polygon>("intersect_holes_intersect_and_disjoint",
-        intersect_holes_intersect_and_disjoint[0], intersect_holes_intersect_and_disjoint[1],
-        2, 16, 15.75,
-        3, 17, 6.75,
-        ignore_validity_settings);
+    {
+        ut_settings settings;
+        settings.sym_difference_validity = BG_IF_RESCALED(false, true);
+        test_one<polygon, polygon, polygon>("intersect_holes_intersect_and_disjoint",
+            intersect_holes_intersect_and_disjoint[0], intersect_holes_intersect_and_disjoint[1],
+            2, 16, 15.75,
+            3, 17, 6.75,
+            settings);
 
-    test_one<polygon, polygon, polygon>("intersect_holes_intersect_and_touch",
-        intersect_holes_intersect_and_touch[0], intersect_holes_intersect_and_touch[1],
-        3, 21, 16.25,
-        3, 17, 6.25,
-        ignore_validity_settings);
+        test_one<polygon, polygon, polygon>("intersect_holes_intersect_and_touch",
+            intersect_holes_intersect_and_touch[0], intersect_holes_intersect_and_touch[1],
+            3, 21, 16.25,
+            3, 17, 6.25,
+            settings);
+    }
 
     {
-        ut_settings settings = sym_settings;
+        ut_settings settings;
         settings.percentage = 0.01;
         test_one<polygon, polygon, polygon>("intersect_holes_new_ring",
             intersect_holes_new_ring[0], intersect_holes_new_ring[1],
@@ -180,17 +178,20 @@ void test_all()
         2, 14, 16.0,
         2, 10, 6.0);
 
-    test_one<polygon, polygon, polygon>("intersect_holes_intersect",
-        intersect_holes_intersect[0], intersect_holes_intersect[1],
-        2, 16, 15.75,
-        2, 12, 5.75,
-        ignore_validity_settings);
+    {
+        ut_settings settings;
+        settings.sym_difference_validity = BG_IF_RESCALED(false, true);
+        test_one<polygon, polygon, polygon>("intersect_holes_intersect",
+            intersect_holes_intersect[0], intersect_holes_intersect[1],
+            2, 16, 15.75,
+            2, 12, 5.75,
+            settings);
+    }
 
     test_one<polygon, polygon, polygon>(
             "case4", case_4[0], case_4[1],
             6, 28, 2.77878787878788,
-            4, 22, 4.77878787878788,
-            sym_settings);
+            4, 22, 4.77878787878788);
 
     test_one<polygon, polygon, polygon>(
             "case5", case_5[0], case_5[1],
@@ -248,7 +249,8 @@ void test_all()
     TEST_DIFFERENCE(case_precision_9, optional(), optional_sliver(), 1, 59.0, count_set(1, 2));
     TEST_DIFFERENCE_WITH(case_precision_10, optional(), optional_sliver(), 1, 59, count_set(1, 2), ut_settings(0.001));
 
-#if ! defined(BOOST_GEOMETRY_USE_KRAMER_RULE) || defined(BOOST_GEOMETRY_TEST_FAILURES)
+#if defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
+    // Fails without rescaling
     TEST_DIFFERENCE(case_precision_11, optional(), optional_sliver(), 1, 59.0, count_set(1, 2));
 #endif
 
@@ -295,12 +297,10 @@ void test_all()
 
     if ( BOOST_GEOMETRY_CONDITION((boost::is_same<ct, double>::value)) )
     {
-        test_one<polygon, polygon, polygon>("buffer_mp2",
-            buffer_mp2[0], buffer_mp2[1],
-            1, 91, 12.09857,
-            1, 155, 24.19714,
-            {1, 2}, -1, 12.09857 + 24.19714,
-            sym_settings);
+        ut_settings settings;
+        settings.sym_difference_validity = BG_IF_RESCALED(true, false);
+        TEST_DIFFERENCE_WITH(buffer_mp2, 1, 12.09857, 1, 24.19714,
+            count_set(1, 2), settings);
     }
 
     /*** TODO: self-tangencies for difference
@@ -364,14 +364,12 @@ void test_all()
         geos_3[0], geos_3[1],
         1, -1, 16211128.5,
         1, -1, 13180420.0,
-        {1, 2}, -1, 16211128.5 + 13180420.0,
-        sym_settings);
+        {1, 2}, -1, 16211128.5 + 13180420.0);
 
     test_one<polygon, polygon, polygon>("geos_4",
         geos_4[0], geos_4[1],
         1, -1, 971.9163115,
-        1, -1, 1332.4163115,
-        sym_settings);
+        1, -1, 1332.4163115);
 
     test_one<polygon, polygon, polygon>("ggl_list_20110306_javier",
         ggl_list_20110306_javier[0], ggl_list_20110306_javier[1],
@@ -391,16 +389,15 @@ void test_all()
         1, 58456.4964294434,
         1);
 
-#if defined(BOOST_GEOMETRY_USE_RESCALING) \
-    || ! defined(BOOST_GEOMETRY_USE_KRAMER_RULE) \
-    || defined(BOOST_GEOMETRY_TEST_FAILURES)
+    {
+      ut_settings settings(0.0001, false);
       // Symmetric difference should output one polygon
       // Using rescaling, it currently outputs two.
       TEST_DIFFERENCE_WITH(ggl_list_20110820_christophe,
           1, 2.8570121719168924,
           1, 64.498061986388564,
-          count_set(1, 2), ut_settings(0.0001, false));
-#endif
+          count_set(1, 2), settings);
+    }
 
     test_one<polygon, polygon, polygon>("ggl_list_20120717_volker",
         ggl_list_20120717_volker[0], ggl_list_20120717_volker[1],
@@ -428,6 +425,7 @@ void test_all()
         // With rescaling, difference of output a-b and a sym b is invalid
         ut_settings settings;
         settings.set_test_validity(BG_IF_RESCALED(false, true));
+        settings.sym_difference_validity = BG_IF_RESCALED(false, true);
         TEST_DIFFERENCE_WITH(ggl_list_20190307_matthieu_1,
                 count_set(1, 2), 0.18461532,
                 count_set(1, 2), 0.617978,
@@ -472,8 +470,7 @@ void test_all()
     test_one<polygon, polygon, polygon>("ticket_10108_a",
             ticket_10108_a[0], ticket_10108_a[1],
             1, 4,  {0.0145036, 0.0145037},
-            1, 4,  0.029019232,
-            sym_settings);
+            1, 4,  0.029019232);
 #endif
 
     test_one<polygon, polygon, polygon>("ticket_10108_b",
@@ -504,14 +501,12 @@ void test_all()
         test_one<polygon, polygon, ring>(
                 "star_ring_ring", example_star, example_ring,
                 5, 22, 1.1901714,
-                5, 27, 1.6701714,
-                sym_settings);
+                5, 27, 1.6701714);
 
         test_one<polygon, ring, polygon>(
                 "ring_star_ring", example_ring, example_star,
                 5, 27, 1.6701714,
-                5, 22, 1.1901714,
-                sym_settings);
+                5, 22, 1.1901714);
 
         static std::string const clip = "POLYGON((2.5 0.5,5.5 2.5))";
 
@@ -530,18 +525,15 @@ void test_all()
         test_one<polygon, polygon_ccw, polygon_ccw>(
                 "star_ring_ccw", example_star, example_ring,
                 5, 22, 1.1901714,
-                5, 27, 1.6701714,
-                sym_settings);
+                5, 27, 1.6701714);
         test_one<polygon, polygon, polygon_ccw>(
                 "star_ring_ccw1", example_star, example_ring,
                 5, 22, 1.1901714,
-                5, 27, 1.6701714,
-                sym_settings);
+                5, 27, 1.6701714);
         test_one<polygon, polygon_ccw, polygon>(
                 "star_ring_ccw2", example_star, example_ring,
                 5, 22, 1.1901714,
-                5, 27, 1.6701714,
-                sym_settings);
+                5, 27, 1.6701714);
     }
 
     // Multi/box (should be moved to multi)
@@ -568,10 +560,15 @@ void test_all()
                     optional(), optional_sliver(1.0e-5),
                     count_set(1, 2));
 
-    TEST_DIFFERENCE(issue_838,
-                    count_set(1, 2), expectation_limits(0.000026, 0.0002823),
-                    count_set(1, 2), expectation_limits(0.67257, 0.67499),
-                    count_set(2, 3, 4));
+    {
+        ut_settings settings;
+        settings.set_test_validity(BG_IF_RESCALED(true, false));
+        TEST_DIFFERENCE_WITH(issue_838,
+            count_set(1, 2), expectation_limits(0.000026, 0.0002823),
+            count_set(1, 2), expectation_limits(0.67257, 0.67499),
+            count_set(2, 3, 4),
+            settings);
+    }
 
     TEST_DIFFERENCE(mysql_21977775, 2, 160.856568913, 2, 92.3565689126, 4);
     TEST_DIFFERENCE(mysql_21965285, 1, 92.0, 1, 14.0, 1);
@@ -579,13 +576,13 @@ void test_all()
     TEST_DIFFERENCE(mysql_23023665_2, 1, 96.0, 1, 16.0, 2);
     TEST_DIFFERENCE(mysql_23023665_3, 1, 225.0, 1, 66.0, 2);
     TEST_DIFFERENCE(mysql_23023665_5, 2, 165.23735, 2, 105.73735, 4);
-#if defined(BOOST_GEOMETRY_USE_RESCALING) \
-    || ! defined(BOOST_GEOMETRY_USE_KRAMER_RULE) \
-    || defined(BOOST_GEOMETRY_TEST_FAILURES)
-    // Testcases going wrong with Kramer's rule and no rescaling
-    TEST_DIFFERENCE(mysql_23023665_6, 2, 105.68756, 3, 10.18756, 5);
+    {
+        // Without recaling it is invalid
+        ut_settings settings;
+        settings.set_test_validity(BG_IF_RESCALED(true, false));
+        TEST_DIFFERENCE_WITH(mysql_23023665_6, 2, 105.68756, 3, 10.18756, 5, settings);
+    }
     TEST_DIFFERENCE(mysql_23023665_13, 3, 99.74526, 3, 37.74526, 6);
-#endif
 }
 
 
@@ -629,7 +626,8 @@ int test_main(int, char* [])
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
     // Not yet fully tested for float and long double.
     // The difference algorithm can generate (additional) slivers
-    BoostGeometryWriteExpectedFailures(12, 5, 11, 6);
+    // Many of the failures are self-intersection points.
+    BoostGeometryWriteExpectedFailures(12, 10, 17, 12);
 #endif
 
     return 0;

--- a/test/algorithms/set_operations/difference/difference_multi.cpp
+++ b/test/algorithms/set_operations/difference/difference_multi.cpp
@@ -152,25 +152,19 @@ void test_areal()
         TEST_DIFFERENCE_WITH(0, 1, ggl_list_20120221_volker, 2, 7962.66, 2, 2775258.93, 4);
     }
 
+#if ! defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
     {
-        // With rescaling, A is invalid (this is a robustness problem) and the other
-        // output is discarded because of zero area
-        // POSTGIS areas: 3.75893745345145, 2.5810000723917e-15
+        // 1: Very small sliver for B (discarded when rescaling)
+        // 2: sym difference is not considered as valid
+        // 3: with rescaling A is considered as invalid (robustness problem)
         ut_settings settings;
-        settings.sym_difference = BG_IF_RESCALED(false, true);
-        settings.set_test_validity(BG_IF_RESCALED(false, true));
-#if defined(BOOST_GEOMETRY_USE_RESCALING) || ! defined(BOOST_GEOMETRY_USE_KRAMER_RULE)
-        // No output for B
-        TEST_DIFFERENCE_WITH(0, 1, bug_21155501, 1, 3.758937, 0, 0.0, 1);
-#else
-        // Very small sliver for B, and sym difference is not considered valid
-        settings.set_test_validity(false);
+        settings.sym_difference_validity = false;
         TEST_DIFFERENCE_WITH(0, 1, bug_21155501,
                              (count_set(1, 4)), expectation_limits(3.75893, 3.75894),
                              (count_set(1, 4)), (expectation_limits(1.776357e-15, 7.661281e-15)),
                              (count_set(2, 5)));
-#endif
     }
+#endif
 
 #if defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
     {
@@ -178,6 +172,7 @@ void test_areal()
         // Without rescaling, one ring is missing (for a and s)
         ut_settings settings;
         settings.set_test_validity(BG_IF_RESCALED(false, true));
+        settings.sym_difference_validity = BG_IF_RESCALED(false, true);
         TEST_DIFFERENCE_WITH(0, 1, ticket_9081,
                              2, 0.0907392476356186,
                              4, 0.126018011439877,
@@ -400,14 +395,14 @@ void test_areal()
     TEST_DIFFERENCE(case_precision_m2, count_set(1, 2), 1.0, 1, 57.75, count_set(2, 3));
 
     {
-        ut_settings sym_settings;
-        sym_settings.sym_difference = BG_IF_RESCALED(true, BG_IF_TEST_FAILURES);
+        ut_settings settings;
+        settings.sym_difference = BG_IF_RESCALED(true, BG_IF_TEST_FAILURES);
         test_one<Polygon, MultiPolygon, MultiPolygon>("mysql_21965285_b",
             mysql_21965285_b[0],
             mysql_21965285_b[1],
             2, -1, 183.71376870369406,
             2, -1, 131.21376870369406,
-            sym_settings);
+            settings);
     }
 
     TEST_DIFFERENCE(mysql_regression_1_65_2017_08_31,
@@ -473,10 +468,6 @@ void test_specific_areal()
     }
 
     {
-#if defined(BOOST_GEOMETRY_USE_KRAMER) || defined(BOOST_GEOMETRY_TEST_FAILURES)
-        // Fails completely with general line form intersection
-        // There is something with scale.
-        // TODO GENERAL FORM
         const std::string a_min_b =
             TEST_DIFFERENCE(ticket_10661, 2, 1441632.5, 2, 13167454, 4);
 
@@ -485,17 +476,14 @@ void test_specific_areal()
             1, 8, 825192.0,
             1, 10, expectation_limits(27226370, 27842812),
             1, -1, 825192.0 + 27226370.5);
-#endif
     }
 
     {
         ut_settings settings;
         settings.sym_difference = false;
 
-#if defined(BOOST_GEOMETRY_USE_KRAMER) || defined(BOOST_GEOMETRY_TEST_FAILURES)
         TEST_DIFFERENCE_WITH(0, 1, ticket_9942, 4, expectation_limits(7427727.5), 4,
                              expectation_limits(130083, 131507), 4);
-#endif
         TEST_DIFFERENCE_WITH(0, 1, ticket_9942a, 2,
                              expectation_limits(412676, 413184), 2,
                              expectation_limits(76779, 76925), 4);
@@ -525,7 +513,7 @@ int test_main(int, char* [])
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
     // Not yet fully tested for float.
     // The difference algorithm can generate (additional) slivers
-    BoostGeometryWriteExpectedFailures(22, 12, 16, 7);
+    BoostGeometryWriteExpectedFailures(28, 15, 19, 10);
 #endif
 
     return 0;

--- a/test/algorithms/set_operations/difference/test_difference.hpp
+++ b/test/algorithms/set_operations/difference/test_difference.hpp
@@ -65,13 +65,13 @@ struct ut_settings : ut_base_settings
 {
     double percentage;
     bool sym_difference;
-    bool remove_spikes;
+    bool sym_difference_validity = true;
+    bool remove_spikes = false;
 
-    explicit ut_settings(double p = 0.0001, bool tv = true, bool sd = true)
-        : ut_base_settings(tv)
+    explicit ut_settings(double p = 0.0001, bool validity = true, bool sd = true)
+        : ut_base_settings(validity)
         , percentage(p)
         , sym_difference(sd)
-        , remove_spikes(false)
     {}
 
 };
@@ -192,7 +192,12 @@ std::string test_difference(std::string const& caseid, G1 const& g1, G2 const& g
     typename bg::default_area_result<G1>::type const area = bg::area(result);
 
 #if ! defined(BOOST_GEOMETRY_NO_BOOST_TEST)
-    if (settings.test_validity())
+    bool const test_validity
+            = sym
+            ? (settings.sym_difference_validity || BG_IF_TEST_FAILURES)
+            : settings.test_validity();
+
+    if (test_validity)
     {
         // std::cout << bg::dsv(result) << std::endl;
         typedef bg::model::multi_polygon<OutputType> result_type;

--- a/test/algorithms/set_operations/intersection/intersection.cpp
+++ b/test/algorithms/set_operations/intersection/intersection.cpp
@@ -232,10 +232,8 @@ void test_areal()
     TEST_INTERSECTION(ggl_list_20190307_matthieu_1, 2, -1, 0.035136);
     TEST_INTERSECTION(ggl_list_20190307_matthieu_2, 1, -1, 3.64285);
 
-#if defined(BOOST_GEOMETRY_USE_RESCALING) || ! defined(BOOST_GEOMETRY_USE_KRAMER_RULE) || defined(BOOST_GEOMETRY_TEST_FAILURES)
     test_one<Polygon, Polygon, Polygon>("buffer_rt_f", buffer_rt_f[0], buffer_rt_f[1],
                 1, 4, expectation_limits(0.00029437, 0.000294380));
-#endif
     test_one<Polygon, Polygon, Polygon>("buffer_rt_g", buffer_rt_g[0], buffer_rt_g[1],
                 1, 0, 2.914213562373);
 
@@ -950,7 +948,7 @@ int test_main(int, char* [])
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
     // llb_touch generates a polygon with 1 point and is therefore invalid everywhere
     // TODO: this should be easy to fix
-    BoostGeometryWriteExpectedFailures(5, 2, 6, 1);
+    BoostGeometryWriteExpectedFailures(6, 2, 7, 1);
 #endif
 
     return 0;

--- a/test/algorithms/set_operations/intersection/intersection_multi.cpp
+++ b/test/algorithms/set_operations/intersection/intersection_multi.cpp
@@ -367,13 +367,13 @@ void test_areal()
     // Result is wrong with rescaling
     TEST_INTERSECTION(issue_630_a, 1, -1, 0.1770);
 #endif
-#if ! defined(BOOST_GEOMETRY_USE_KRAMER_RULE) || defined(BOOST_GEOMETRY_TEST_FAILURES)
-    // Two cases produce either too large, or no output if Kramer rule is used
+
     TEST_INTERSECTION(issue_630_b, 1, -1, expectation_limits(0.1713911, 0.1714));
-    TEST_INTERSECTION(issue_630_c, 1, -1, 0.1770);
-#endif
 
 #if ! defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
+    // Result is missing with rescaling
+    TEST_INTERSECTION(issue_630_c, 1, -1, 0.1770);
+
     // Result is missing with rescaling
     TEST_INTERSECTION(issue_643, 1, -1, 3.4615);
 #endif

--- a/test/algorithms/set_operations/union/union_multi.cpp
+++ b/test/algorithms/set_operations/union/union_multi.cpp
@@ -422,13 +422,13 @@ void test_areal()
     // Failure with rescaling
     TEST_UNION(issue_630_a, 1, 0, -1, 2.200326);
 #endif
+
     TEST_UNION(issue_630_b, 1, 0, -1, 1.675976);
-#if ! defined(BOOST_GEOMETRY_USE_KRAMER_RULE) || defined(BOOST_GEOMETRY_TEST_FAILURES)
-    // Failure with Kramer rule, it doesn't generate any output
-    TEST_UNION(issue_630_c, 1, 0, -1, 1.670367);
-#endif
 
 #if ! defined(BOOST_GEOMETRY_USE_RESCALING) || defined(BOOST_GEOMETRY_TEST_FAILURES)
+    // With rescaling the smaller rectangle is added on top of the outer polygon
+    TEST_UNION(issue_630_c, 1, 0, -1, 1.670367);
+
     // With rescaling the small polygon is added on top of the outer polygon
     TEST_UNION(issue_643, 1, 0, -1, 80.0);
 #endif
@@ -441,13 +441,8 @@ void test_areal()
     TEST_UNION(issue_888_34, 15, 0, -1, 0.3017459);
     TEST_UNION(issue_888_37, 52, 3, -1, 0.4033294);
 
-#if defined(BOOST_GEOMETRY_USE_KRAMER_RULE)
-    // Two polygons, should ideally be merged
-    TEST_UNION(mail_2019_01_21_johan, 2, 0, -1, 0.00058896);
-#else
-    // Correct: one polygon
-    TEST_UNION(mail_2019_01_21_johan, 1, 0, -1, 0.00058896);
-#endif
+    // One or two polygons, the ideal case is 1
+    TEST_UNION(mail_2019_01_21_johan, count_set(1, 2), 0, -1, 0.00058896);
 
     TEST_UNION(mysql_23023665_7, 1, 1, -1, 99.19494);
     TEST_UNION(mysql_23023665_8, 1, 2, -1, 1400.0);

--- a/test/geometry_test_common.hpp
+++ b/test/geometry_test_common.hpp
@@ -132,18 +132,18 @@ struct mathematical_policy
 
 struct ut_base_settings
 {
-    explicit ut_base_settings(bool val = true)
+    explicit ut_base_settings(bool validity = true)
         : m_test_validity(true)
     {
-        set_test_validity(val);
+        set_test_validity(validity);
     }
 
-    inline void set_test_validity(bool val)
+    inline void set_test_validity(bool validity)
     {
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
-        boost::ignore_unused(val);
+        boost::ignore_unused(validity);
 #else
-        m_test_validity = val;
+        m_test_validity = validity;
 #endif
     }
 
@@ -206,11 +206,6 @@ inline void BoostGeometryWriteTestConfiguration()
 #endif
 #if defined(BOOST_GEOMETRY_USE_RESCALING)
     std::cout << "  - Using rescaling" << std::endl;
-#endif
-#if defined(BOOST_GEOMETRY_USE_KRAMER_RULE)
-    std::cout << "  - Using Kramer rule" << std::endl;
-#else
-    std::cout << "  - Using general form" << std::endl;
 #endif
 #if defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE)
     std::cout << "  - Testing only one type" << std::endl;


### PR DESCRIPTION
The objective of this PR is removing the define `BOOST_GEOMETRY_USE_KRAMER` because it's always used.
Last year I tried to change that by using the generic form instead. That's possible but didn't give much improvements and some regressions, and needed more and more conditions and tuning.

So it's redundant now, and I applied some other changes in tests, for example in difference where the symmetric difference was actually never tested without rescaling (I forgot that earlier).