### PR TITLE
Fix error checking for failure type in example

### DIFF
--- a/doc/src/examples/algorithms/is_valid_failure.cpp
+++ b/doc/src/examples/algorithms/is_valid_failure.cpp
@@ -32,7 +32,7 @@ int main()
 
     // if the invalidity is only due to lack of closing points and/or wrongly oriented rings, then bg::correct can fix it
     bool could_be_fixed = (failure == boost::geometry::failure_not_closed
-                           || boost::geometry::failure_wrong_orientation);
+                           || failure == boost::geometry::failure_wrong_orientation);
     std::cout << "is valid? " << (valid ? "yes" : "no") << std::endl;
     if (! valid)
     {


### PR DESCRIPTION
The [example](https://www.boost.org/doc/libs/1_76_0/libs/geometry/doc/html/geometry/reference/algorithms/is_valid/is_valid_2_with_failure_value.html#geometry.reference.algorithms.is_valid.is_valid_2_with_failure_value.example) checking if invalid geometry was fixable with `bg::correct` incorrectly assumes that all failures are fixable, instead of checking for specific failure reasons, as it was purporting to do.

It looks like it was written in bitflag-style, but [`validity_failure_type`](https://www.boost.org/doc/libs/1_76_0/libs/geometry/doc/html/geometry/reference/enumerations/validity_failure_type.html) is not a bitflag field (maybe it used to be?)

Discovered in https://github.com/cctbx/dxtbx/pull/411 as this raised a compiler warning from `-Wint-in-bool-context`:

```
geom_example.cpp: In function 'int main()':
geom_example.cpp:34:48: warning: enum constant in boolean context [-Wint-in-bool-context]
   34 |                            || boost::geometry::failure_wrong_orientation);
      |                                                ^~~~~~~~~~~~~~~~~~~~~~~~~
```