### PR TITLE
fix: use balance between distance-to-end and length-of-segments

### DIFF
--- a/include/boost/geometry/algorithms/detail/buffer/piece_border.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/piece_border.hpp
@@ -24,7 +24,6 @@
 #include <boost/geometry/algorithms/comparable_distance.hpp>
 #include <boost/geometry/algorithms/equals.hpp>
 #include <boost/geometry/algorithms/expand.hpp>
-#include <boost/geometry/algorithms/detail/buffer/buffer_box.hpp>
 #include <boost/geometry/algorithms/detail/buffer/buffer_policies.hpp>
 #include <boost/geometry/algorithms/detail/expand_by_epsilon.hpp>
 #include <boost/geometry/strategies/cartesian/turn_in_ring_winding.hpp>

--- a/include/boost/geometry/core/coordinate_promotion.hpp
+++ b/include/boost/geometry/core/coordinate_promotion.hpp
@@ -1,0 +1,111 @@
+// Boost.Geometry
+
+// Copyright (c) 2021 Barend Gehrels, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_CORE_COORDINATE_PROMOTION_HPP
+#define BOOST_GEOMETRY_CORE_COORDINATE_PROMOTION_HPP
+
+#include <boost/geometry/core/coordinate_type.hpp>
+
+// TODO: move this to a future headerfile implementing traits for these types
+#include <boost/rational.hpp>
+#include <boost/multiprecision/cpp_bin_float.hpp>
+#include <boost/multiprecision/cpp_int.hpp>
+
+namespace boost { namespace geometry
+{
+
+namespace traits
+{
+
+// todo
+
+} // namespace traits
+
+/*!
+    \brief Meta-function converting, if necessary, to "a floating point" type
+    \details
+        - if input type is integer, type is double
+        - else type is input type
+    \ingroup utility
+ */
+// TODO: replace with, or call, promoted_to_floating_point
+template <typename T, typename PromoteIntegerTo = double>
+struct promote_floating_point
+{
+    typedef std::conditional_t
+        <
+            std::is_integral<T>::value,
+            PromoteIntegerTo,
+            T
+        > type;
+};
+
+// TODO: replace with promoted_to_floating_point
+template <typename Geometry>
+struct fp_coordinate_type
+{
+    typedef typename promote_floating_point
+        <
+            typename coordinate_type<Geometry>::type
+        >::type type;
+};
+
+namespace detail
+{
+
+// Promote any integral type to double. Floating point
+// and other user defined types stay as they are, unless specialized.
+// TODO: we shold add a coordinate_promotion traits for promotion to
+// floating point or (larger) integer types.
+template <typename Type>
+struct promoted_to_floating_point
+{
+    using type = std::conditional_t
+        <
+            std::is_integral<Type>::value, double, Type
+        >;
+};
+
+// Boost.Rational goes to double
+template <typename T>
+struct promoted_to_floating_point<boost::rational<T>>
+{
+    using type = double;
+};
+
+// Any Boost.Multiprecision goes to double (for example int128_t),
+// unless specialized
+template <typename Backend>
+struct promoted_to_floating_point<boost::multiprecision::number<Backend>>
+{
+    using type = double;
+};
+
+// Boost.Multiprecision binary floating point numbers are used as FP.
+template <unsigned Digits>
+struct promoted_to_floating_point
+    <
+        boost::multiprecision::number
+            <
+                boost::multiprecision::cpp_bin_float<Digits>
+            >
+    >
+{
+    using type = boost::multiprecision::number
+        <
+            boost::multiprecision::cpp_bin_float<Digits>
+        >;
+};
+
+}
+
+
+}} // namespace boost::geometry
+
+
+#endif // BOOST_GEOMETRY_CORE_COORDINATE_PROMOTION_HPP

--- a/include/boost/geometry/core/coordinate_type.hpp
+++ b/include/boost/geometry/core/coordinate_type.hpp
@@ -22,7 +22,6 @@
 #include <boost/geometry/core/point_type.hpp>
 #include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tag.hpp>
-#include <boost/geometry/util/promote_floating_point.hpp>
 #include <boost/geometry/util/type_traits_std.hpp>
 
 
@@ -91,15 +90,6 @@ struct coordinate_type
         <
             typename tag<Geometry>::type,
             typename util::remove_cptrref<Geometry>::type
-        >::type type;
-};
-
-template <typename Geometry>
-struct fp_coordinate_type
-{
-    typedef typename promote_floating_point
-        <
-            typename coordinate_type<Geometry>::type
         >::type type;
 };
 

--- a/include/boost/geometry/core/radian_access.hpp
+++ b/include/boost/geometry/core/radian_access.hpp
@@ -27,8 +27,7 @@
 
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/cs.hpp>
-#include <boost/geometry/core/coordinate_type.hpp>
-
+#include <boost/geometry/core/coordinate_promotion.hpp>
 
 #include <boost/geometry/util/math.hpp>
 

--- a/include/boost/geometry/policies/robustness/get_rescale_policy.hpp
+++ b/include/boost/geometry/policies/robustness/get_rescale_policy.hpp
@@ -24,6 +24,7 @@
 
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/config.hpp>
+#include <boost/geometry/core/coordinate_promotion.hpp>
 #include <boost/geometry/core/tag_cast.hpp>
 
 #include <boost/geometry/algorithms/envelope.hpp>
@@ -37,7 +38,6 @@
 #include <boost/geometry/policies/robustness/no_rescale_policy.hpp>
 #include <boost/geometry/policies/robustness/rescale_policy.hpp>
 #include <boost/geometry/policies/robustness/robust_type.hpp>
-#include <boost/geometry/util/promote_floating_point.hpp>
 #include <boost/geometry/util/type_traits.hpp>
 
 // TEMP

--- a/include/boost/geometry/policies/robustness/segment_ratio.hpp
+++ b/include/boost/geometry/policies/robustness/segment_ratio.hpp
@@ -135,11 +135,15 @@ struct possibly_collinear<Type, false>
 template <typename Type>
 class segment_ratio
 {
-public :
-    typedef Type numeric_type;
+    // Type used for the approximation (a helper value)
+    // and for the edge value (0..1) (a helper function).
+    using floating_point_type =
+        typename detail::promoted_to_floating_point<Type>::type;
 
     // Type-alias for the type itself
-    typedef segment_ratio<Type> thistype;
+    using thistype = segment_ratio<Type>;
+
+public :
 
     inline segment_ratio()
         : m_numerator(0)
@@ -221,8 +225,8 @@ public :
         m_approximation =
             m_denominator == 0 ? 0
             : (
-                boost::numeric_cast<fp_type>(m_numerator) * scale()
-                / boost::numeric_cast<fp_type>(m_denominator)
+                boost::numeric_cast<floating_point_type>(m_numerator) * scale()
+                / boost::numeric_cast<floating_point_type>(m_denominator)
             );
     }
 
@@ -254,21 +258,16 @@ public :
         return m_numerator > m_denominator;
     }
 
-    inline bool near_end() const
+    //! Returns a value between 0.0 and 1.0
+    //! 0.0 means: exactly in the middle
+    //! 1.0 means: exactly on one of the edges (or even over it)
+    inline floating_point_type edge_value() const
     {
-        if (left() || right())
-        {
-            return false;
-        }
-
-        static fp_type const small_part_of_scale = scale() / 100;
-        return m_approximation < small_part_of_scale
-            || m_approximation > scale() - small_part_of_scale;
-    }
-
-    inline bool close_to(thistype const& other) const
-    {
-        return geometry::math::abs(m_approximation - other.m_approximation) < 50;
+        using fp = floating_point_type;
+        fp const one{1.0};
+        floating_point_type const result
+                = fp(2) * geometry::math::abs(fp(0.5) - m_approximation / scale());
+        return result > one ? one : result;
     }
 
     template <typename Threshold>
@@ -313,19 +312,7 @@ public :
     }
 #endif
 
-
-
 private :
-    // NOTE: if this typedef is used then fp_type is non-fundamental type
-    // if Type is non-fundamental type
-    //typedef typename promote_floating_point<Type>::type fp_type;
-
-    // TODO: What with user-defined numeric types?
-    //       Shouldn't here is_integral be checked?
-    typedef std::conditional_t
-        <
-            std::is_floating_point<Type>::value, Type, double
-        > fp_type;
 
     Type m_numerator;
     Type m_denominator;
@@ -335,12 +322,19 @@ private :
     // Boost.Rational is used if the approximations are close.
     // Reason: performance, Boost.Rational does a GCD by default and also the
     // comparisons contain while-loops.
-    fp_type m_approximation;
+    floating_point_type m_approximation;
 
-
-    static inline fp_type scale()
+    inline bool close_to(thistype const& other) const
     {
-        return 1000000.0;
+        static floating_point_type const threshold{50.0};
+        return geometry::math::abs(m_approximation - other.m_approximation)
+                < threshold;
+    }
+
+    static inline floating_point_type scale()
+    {
+        static floating_point_type const fp_scale{1000000.0};
+        return fp_scale;
     }
 };
 

--- a/include/boost/geometry/policies/robustness/segment_ratio.hpp
+++ b/include/boost/geometry/policies/robustness/segment_ratio.hpp
@@ -19,8 +19,8 @@
 #include <boost/rational.hpp>
 
 #include <boost/geometry/core/assert.hpp>
+#include <boost/geometry/core/coordinate_promotion.hpp>
 #include <boost/geometry/util/math.hpp>
-#include <boost/geometry/util/promote_floating_point.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/strategies/cartesian/azimuth.hpp
+++ b/include/boost/geometry/strategies/cartesian/azimuth.hpp
@@ -14,10 +14,10 @@
 #include <cmath>
 
 #include <boost/geometry/core/tags.hpp>
+#include <boost/geometry/core/coordinate_promotion.hpp>
 
 #include <boost/geometry/strategies/azimuth.hpp>
 
-#include <boost/geometry/util/promote_floating_point.hpp>
 #include <boost/geometry/util/select_most_precise.hpp>
 
 namespace boost { namespace geometry

--- a/include/boost/geometry/strategies/geographic/distance.hpp
+++ b/include/boost/geometry/strategies/geographic/distance.hpp
@@ -17,6 +17,7 @@
 #define BOOST_GEOMETRY_STRATEGIES_GEOGRAPHIC_DISTANCE_HPP
 
 
+#include <boost/geometry/core/coordinate_promotion.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/radian_access.hpp>
 #include <boost/geometry/core/radius.hpp>
@@ -32,7 +33,6 @@
 
 #include <boost/geometry/util/math.hpp>
 #include <boost/geometry/util/normalize_spheroidal_coordinates.hpp>
-#include <boost/geometry/util/promote_floating_point.hpp>
 #include <boost/geometry/util/select_calculation_type.hpp>
 
 #include <boost/geometry/geometries/point_xy.hpp>

--- a/include/boost/geometry/strategies/geographic/distance_cross_track.hpp
+++ b/include/boost/geometry/strategies/geographic/distance_cross_track.hpp
@@ -21,6 +21,7 @@
 
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/coordinate_promotion.hpp>
 #include <boost/geometry/core/radian_access.hpp>
 #include <boost/geometry/core/tags.hpp>
 
@@ -37,7 +38,6 @@
 #include <boost/geometry/formulas/vincenty_direct.hpp>
 
 #include <boost/geometry/util/math.hpp>
-#include <boost/geometry/util/promote_floating_point.hpp>
 #include <boost/geometry/util/select_calculation_type.hpp>
 #include <boost/geometry/util/normalize_spheroidal_coordinates.hpp>
 

--- a/include/boost/geometry/strategies/geographic/distance_segment_box.hpp
+++ b/include/boost/geometry/strategies/geographic/distance_segment_box.hpp
@@ -13,6 +13,8 @@
 
 #include <boost/geometry/srs/spheroid.hpp>
 
+#include <boost/geometry/core/coordinate_promotion.hpp>
+
 #include <boost/geometry/algorithms/detail/distance/segment_to_box.hpp>
 
 #include <boost/geometry/strategies/distance.hpp>
@@ -26,7 +28,6 @@
 #include <boost/geometry/strategies/spherical/distance_segment_box.hpp>
 #include <boost/geometry/strategies/spherical/point_in_point.hpp>
 
-#include <boost/geometry/util/promote_floating_point.hpp>
 #include <boost/geometry/util/select_calculation_type.hpp>
 
 namespace boost { namespace geometry

--- a/include/boost/geometry/strategies/geographic/mapping_ssf.hpp
+++ b/include/boost/geometry/strategies/geographic/mapping_ssf.hpp
@@ -17,10 +17,10 @@
 
 #include <boost/core/ignore_unused.hpp>
 
+#include <boost/geometry/core/coordinate_promotion.hpp>
 #include <boost/geometry/core/radius.hpp>
 
 #include <boost/geometry/util/math.hpp>
-#include <boost/geometry/util/promote_floating_point.hpp>
 #include <boost/geometry/util/select_calculation_type.hpp>
 
 #include <boost/geometry/strategies/side.hpp>

--- a/include/boost/geometry/strategies/geographic/side.hpp
+++ b/include/boost/geometry/strategies/geographic/side.hpp
@@ -16,6 +16,7 @@
 
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/coordinate_promotion.hpp>
 #include <boost/geometry/core/radian_access.hpp>
 #include <boost/geometry/core/radius.hpp>
 
@@ -32,7 +33,6 @@
 #include <boost/geometry/strategy/geographic/envelope.hpp>
 
 #include <boost/geometry/util/math.hpp>
-#include <boost/geometry/util/promote_floating_point.hpp>
 #include <boost/geometry/util/select_calculation_type.hpp>
 
 namespace boost { namespace geometry

--- a/include/boost/geometry/strategies/spherical/distance_cross_track.hpp
+++ b/include/boost/geometry/strategies/spherical/distance_cross_track.hpp
@@ -24,6 +24,7 @@
 
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/coordinate_promotion.hpp>
 #include <boost/geometry/core/radian_access.hpp>
 #include <boost/geometry/core/tags.hpp>
 
@@ -36,7 +37,6 @@
 #include <boost/geometry/strategies/spherical/intersection.hpp>
 
 #include <boost/geometry/util/math.hpp>
-#include <boost/geometry/util/promote_floating_point.hpp>
 #include <boost/geometry/util/select_calculation_type.hpp>
 
 #ifdef BOOST_GEOMETRY_DEBUG_CROSS_TRACK

--- a/include/boost/geometry/strategies/spherical/distance_haversine.hpp
+++ b/include/boost/geometry/strategies/spherical/distance_haversine.hpp
@@ -17,6 +17,7 @@
 
 
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/coordinate_promotion.hpp>
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/radian_access.hpp>
 
@@ -26,7 +27,6 @@
 #include <boost/geometry/strategies/spherical/get_radius.hpp>
 
 #include <boost/geometry/util/math.hpp>
-#include <boost/geometry/util/promote_floating_point.hpp>
 #include <boost/geometry/util/select_calculation_type.hpp>
 
 

--- a/include/boost/geometry/strategies/spherical/point_in_point.hpp
+++ b/include/boost/geometry/strategies/spherical/point_in_point.hpp
@@ -28,6 +28,7 @@
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/radian_access.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
+#include <boost/geometry/core/coordinate_promotion.hpp>
 #include <boost/geometry/core/coordinate_system.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/cs.hpp>

--- a/include/boost/geometry/strategies/spherical/side_by_cross_track.hpp
+++ b/include/boost/geometry/strategies/spherical/side_by_cross_track.hpp
@@ -16,6 +16,7 @@
 #define BOOST_GEOMETRY_STRATEGIES_SPHERICAL_SIDE_BY_CROSS_TRACK_HPP
 
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/coordinate_promotion.hpp>
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/radian_access.hpp>
 
@@ -26,7 +27,6 @@
 #include <boost/geometry/strategies/spherical/point_in_point.hpp>
 
 #include <boost/geometry/util/math.hpp>
-#include <boost/geometry/util/promote_floating_point.hpp>
 #include <boost/geometry/util/select_calculation_type.hpp>
 
 namespace boost { namespace geometry

--- a/include/boost/geometry/strategies/spherical/ssf.hpp
+++ b/include/boost/geometry/strategies/spherical/ssf.hpp
@@ -16,10 +16,10 @@
 
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/coordinate_promotion.hpp>
 #include <boost/geometry/core/radian_access.hpp>
 
 #include <boost/geometry/util/math.hpp>
-#include <boost/geometry/util/promote_floating_point.hpp>
 #include <boost/geometry/util/select_calculation_type.hpp>
 
 #include <boost/geometry/strategy/spherical/envelope.hpp>

--- a/include/boost/geometry/strategies/strategy_transform.hpp
+++ b/include/boost/geometry/strategies/strategy_transform.hpp
@@ -30,10 +30,10 @@
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/radian_access.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
+#include <boost/geometry/core/coordinate_promotion.hpp>
 #include <boost/geometry/strategies/transform.hpp>
 
 #include <boost/geometry/util/math.hpp>
-#include <boost/geometry/util/promote_floating_point.hpp>
 #include <boost/geometry/util/select_coordinate_type.hpp>
 
 namespace boost { namespace geometry

--- a/include/boost/geometry/strategies/transform/matrix_transformers.hpp
+++ b/include/boost/geometry/strategies/transform/matrix_transformers.hpp
@@ -33,9 +33,9 @@
 
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
+#include <boost/geometry/core/coordinate_promotion.hpp>
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/util/math.hpp>
-#include <boost/geometry/util/promote_floating_point.hpp>
 #include <boost/geometry/util/select_coordinate_type.hpp>
 #include <boost/geometry/util/select_most_precise.hpp>
 

--- a/include/boost/geometry/util/promote_floating_point.hpp
+++ b/include/boost/geometry/util/promote_floating_point.hpp
@@ -18,35 +18,9 @@
 #ifndef BOOST_GEOMETRY_UTIL_PROMOTE_FLOATING_POINT_HPP
 #define BOOST_GEOMETRY_UTIL_PROMOTE_FLOATING_POINT_HPP
 
+#include <boost/config/header_deprecated.hpp>
+BOOST_HEADER_DEPRECATED("boost/geometry/core/coordinate_promotion.hpp")
 
-#include <type_traits>
-
-
-namespace boost { namespace geometry
-{
-
-
-/*!
-    \brief Meta-function converting, if necessary, to "a floating point" type
-    \details
-        - if input type is integer, type is double
-        - else type is input type
-    \ingroup utility
- */
-
-template <typename T, typename PromoteIntegerTo = double>
-struct promote_floating_point
-{
-    typedef std::conditional_t
-        <
-            std::is_integral<T>::value,
-            PromoteIntegerTo,
-            T
-        > type;
-};
-
-
-}} // namespace boost::geometry
-
+#include <boost/geometry/core/coordinate_promotion.hpp>
 
 #endif // BOOST_GEOMETRY_UTIL_PROMOTE_FLOATING_POINT_HPP

--- a/test/algorithms/buffer/buffer_linestring.cpp
+++ b/test/algorithms/buffer/buffer_linestring.cpp
@@ -430,7 +430,7 @@ int test_main(int, char* [])
 #endif
 
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(2, 4, 9, 4);
+    BoostGeometryWriteExpectedFailures(2, 4, 11, 3);
 #endif
 
     return 0;

--- a/test/algorithms/buffer/buffer_multi_polygon.cpp
+++ b/test/algorithms/buffer/buffer_multi_polygon.cpp
@@ -686,7 +686,7 @@ int test_main(int, char* [])
 #endif
 
 #if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(5, 1, 3, 4);
+    BoostGeometryWriteExpectedFailures(3, 1, 3, 3);
 #endif
 
     return 0;

--- a/test/algorithms/set_operations/difference/difference_areal_linear.cpp
+++ b/test/algorithms/set_operations/difference/difference_areal_linear.cpp
@@ -240,8 +240,8 @@ int test_main(int, char* [])
     test_all<bg::model::d2::point_xy<double> >();
 
     test_ticket_10835<int>
-        ("MULTILINESTRING((5239 2113,5233 2114),(4794 2205,1020 2986))",
-         "MULTILINESTRING((5239 2113,5233 2114),(4794 2205,1460 2895))");
+        ("MULTILINESTRING((5239 2113,5232 2115),(4794 2205,1020 2986))",
+         "MULTILINESTRING((5239 2113,5232 2115),(4794 2205,1460 2895))");
 
     test_ticket_10835<double>
         ("MULTILINESTRING((5239 2113,5232.52 2114.34),(4794.39 2205,1020 2986))",

--- a/test/algorithms/set_operations/difference/difference_multi_spike.cpp
+++ b/test/algorithms/set_operations/difference/difference_multi_spike.cpp
@@ -20,6 +20,7 @@ void test_spikes_in_ticket_8364()
 {
     ut_settings ignore_validity;
     ignore_validity.set_test_validity(false);
+    ignore_validity.validity_of_sym = false;
 
     // See: https://svn.boost.org/trac/boost/ticket/8364
     //_TPolygon<T> polygon( "MULTIPOLYGON(((1031 1056,3232 1056,3232 2856,1031 2856)))" );
@@ -30,44 +31,27 @@ void test_spikes_in_ticket_8364()
     //polygon -= _TPolygon<T>( "MULTIPOLYGON(((1032 2556,1032 2130,1778 2556)),((3234 2580,2136 2760,1778 2556,3234 2556)))" ); USED IN STEP 4
     // NOTE: polygons below are closed and clockwise
 
-    typedef typename bg::coordinate_type<P>::type ct;
     typedef bg::model::polygon<P, ClockWise, Closed> polygon;
     typedef bg::model::multi_polygon<polygon> multi_polygon;
 
     // The difference of polygons below result in a spike. The spike should be there, it was also generated in ttmath,
     // and (e.g.) in SQL Server. However, using int-coordinates, the spike makes the polygon invalid. Therefore it is now (since August 2013) checked and removed.
 
-#ifdef BOOST_GEOMETRY_TEST_FAILURES
-    // TODO: commented working at ii/validity, this changes the area slightly, to be checked
     // So using int's, the spike is removed automatically. Therefore there is one polygon less, and less points. Also area differs
     test_one<polygon, multi_polygon, multi_polygon>("ticket_8364_step3",
         "MULTIPOLYGON(((3232 2532,2136 2790,1032 1764,1032 1458,1032 1212,2136 2328,3232 2220,3232 1056,1031 1056,1031 2856,3232 2856,3232 2532)))",
         "MULTIPOLYGON(((1032 2130,2052 2712,1032 1764,1032 2130)),((3234 2580,3234 2532,2558 2690,3234 2580)),((2558 2690,2136 2760,2052 2712,2136 2790,2558 2690)))",
-        2,
-        if_typed<ct, int>(19, 22),
-        if_typed<ct, int>(2775595.5, 2775256.487954), // SQL Server: 2775256.47588724
-        3,
-        -1, // don't check point-count
-        if_typed<ct, int>(7893.0, 7810.487954), // SQL Server: 7810.48711165739
-        if_typed<ct, int>(1, 5),
-        -1,
-        if_typed<ct, int>(2783349.5, 2775256.487954 + 7810.487954),
-        ignore_validity);
-#endif
+        count_set(2, 3), -1, expectation_limits(2775256, 2775610), // SQL Server: 2775256.47588724
+        3, -1, expectation_limits(7810, 7893), // SQL Server: 7810.48711165739
+        count_set(2, 6), ignore_validity);
 
     // TODO: behaviour is not good yet. It is changed at introduction of self-turns.
     test_one<polygon, multi_polygon, multi_polygon>("ticket_8364_step4",
         "MULTIPOLYGON(((2567 2688,2136 2790,2052 2712,1032 2130,1032 1764,1032 1458,1032 1212,2136 2328,3232 2220,3232 1056,1031 1056,1031 2856,3232 2856,3232 2580,2567 2688)))",
         "MULTIPOLYGON(((1032 2556,1778 2556,1032 2130,1032 2556)),((3234 2580,3234 2556,1778 2556,2136 2760,3234 2580)))",
-        if_typed<ct, int>(1, 2),
-        if_typed<ct, int>(17, 20),
-        if_typed<ct, int>(2615783.5, 2616029.559567), // SQL Server: 2616029.55616044
-        1,
-        if_typed<ct, int>(9, 11),
-        if_typed<ct, int>(161133.5, 161054.559567), // SQL Server: 161054.560110092
-        if_typed<ct, int>(1, 3),
-        if_typed<ct, int>(25, 31),
-        if_typed<ct, int>(2776875.5, 2616029.559567 + 161054.559567));
+        count_set(1, 2), -1, expectation_limits(2615783, 2616030), // SQL Server: 2616029.55616044
+        1, -1, expectation_limits(161054, 161134), // SQL Server: 161054.560110092
+        count_set(1, 3));
 }
 
 template <typename P, bool ClockWise, bool Closed>
@@ -76,7 +60,6 @@ void test_spikes_in_ticket_8365()
     // See: https://svn.boost.org/trac/boost/ticket/8365
     // NOTE: polygons below are closed and clockwise
 
-    typedef typename bg::coordinate_type<P>::type ct;
     typedef bg::model::polygon<P, ClockWise, Closed> polygon;
     typedef bg::model::multi_polygon<polygon> multi_polygon;
 
@@ -85,13 +68,11 @@ void test_spikes_in_ticket_8365()
         "MULTIPOLYGON(((5388 1560,4650 1722,3912 1884,4650 1398)),((2442 3186,1704 3348,966 2700,1704 3024)))",
         2,
         18,
-        if_typed<ct, int>(7975092.5, 7975207.6047877), // SQL Server:
+        expectation_limits(7975092.5, 7975207.6047877),
         2,
         -1,
-        if_typed<ct, int>(196.5, 197.1047877), // SQL Server:
-        if_typed<ct, int>(3, 4),
-        -1,
-        if_typed<ct, int>(7975092.5 + 196.5, 7975207.6047877 + 197.1047877));
+        expectation_limits(196.5, 198.5),
+        count_set(2, 4));
 }
 
 
@@ -109,6 +90,7 @@ int test_main(int, char* [])
     test_spikes_in_ticket_8364<bg::model::d2::point_xy<int>, false, false>();
     test_spikes_in_ticket_8365<bg::model::d2::point_xy<int>, true, true >();
     test_spikes_in_ticket_8365<bg::model::d2::point_xy<int>, false, false >();
+
     return 0;
 }
 

--- a/test/algorithms/set_operations/difference/test_difference.hpp
+++ b/test/algorithms/set_operations/difference/test_difference.hpp
@@ -59,19 +59,44 @@
 #  include <boost/geometry/algorithms/detail/overlay/debug_turn_info.hpp>
 #endif
 
+enum difference_type
+{
+    difference_a, difference_b, difference_sym
+};
 
 struct ut_settings : ut_base_settings
 {
     double percentage;
     bool sym_difference;
-    bool sym_difference_validity = true;
+    bool validity_of_sym = true;
     bool remove_spikes = false;
+
+    // The validity check gives sometimes false negatives.
+    // boost::geometry::is_valid can return FALSE while it is valid.
+    // (especially at touch in combination with a u/u turn)
+    // For now, the cases where this is the case are skipped for validity check.
+    bool validity_false_negative_a = false;
+    bool validity_false_negative_b = false;
+    bool validity_false_negative_sym = false;
 
     explicit ut_settings(double p = 0.0001, bool validity = true, bool sd = true)
         : ut_base_settings(validity)
         , percentage(p)
         , sym_difference(sd)
     {}
+
+    bool test_validity_of_diff(difference_type dtype) const
+    {
+        bool const sym = dtype == difference_sym;
+        bool const a = dtype == difference_a;
+        bool const b = dtype == difference_b;
+
+        return sym && validity_false_negative_sym ? false
+            : a && validity_false_negative_a ? false
+            : b && validity_false_negative_b ? false
+            : sym ? (validity_of_sym || BG_IF_TEST_FAILURES)
+            : test_validity();
+    }
 
 };
 
@@ -137,7 +162,7 @@ std::string test_difference(std::string const& caseid, G1 const& g1, G2 const& g
         const count_set& expected_count,
         int expected_rings_count, int expected_point_count,
         expectation_limits const& expected_area,
-        bool sym,
+        difference_type dtype,
         ut_settings const& settings)
 {
     typedef typename bg::coordinate_type<G1>::type coordinate_type;
@@ -145,8 +170,7 @@ std::string test_difference(std::string const& caseid, G1 const& g1, G2 const& g
 
     bg::model::multi_polygon<OutputType> result;
 
-
-    if (sym)
+    if (dtype == difference_sym)
     {
         bg::sym_difference(g1, g2, result);
     }
@@ -167,7 +191,7 @@ std::string test_difference(std::string const& caseid, G1 const& g1, G2 const& g
             <
                 G1, G2
             >::type strategy_type;
-        if (sym)
+        if (dtype == difference_sym)
         {
             bg::sym_difference(g1, g2, result_s, strategy_type());
         }
@@ -191,12 +215,7 @@ std::string test_difference(std::string const& caseid, G1 const& g1, G2 const& g
     typename bg::default_area_result<G1>::type const area = bg::area(result);
 
 #if ! defined(BOOST_GEOMETRY_NO_BOOST_TEST)
-    bool const test_validity
-            = sym
-            ? (settings.sym_difference_validity || BG_IF_TEST_FAILURES)
-            : settings.test_validity();
-
-    if (test_validity)
+    if (settings.test_validity_of_diff(dtype))
     {
         // std::cout << bg::dsv(result) << std::endl;
         typedef bg::model::multi_polygon<OutputType> result_type;
@@ -218,7 +237,7 @@ std::string test_difference(std::string const& caseid, G1 const& g1, G2 const& g
         typename setop_output_type<OutputType>::type
             inserted, array_with_one_empty_geometry;
         array_with_one_empty_geometry.push_back(OutputType());
-        if (sym)
+        if (dtype == difference_sym)
         {
             boost::copy(array_with_one_empty_geometry,
                 bg::detail::sym_difference::sym_difference_insert<OutputType>
@@ -287,12 +306,12 @@ template <typename OutputType, typename G1, typename G2>
 std::string test_difference(std::string const& caseid, G1 const& g1, G2 const& g2,
         const count_set&  expected_count, int expected_point_count,
         expectation_limits const& expected_area,
-        bool sym,
+        difference_type dtype,
         ut_settings const& settings)
 {
     return test_difference<OutputType>(caseid, g1, g2,
         expected_count, -1, expected_point_count, expected_area,
-        sym, settings);
+        dtype, settings);
 }
 
 #ifdef BOOST_GEOMETRY_CHECK_WITH_POSTGIS
@@ -331,7 +350,7 @@ std::string test_one(std::string const& caseid,
 #if ! defined(BOOST_GEOMETRY_TEST_DIFFERENCE_ONLY_B)
     result = test_difference<OutputType>(caseid + "_a", g1, g2,
         expected_count1, expected_rings_count1, expected_point_count1,
-        expected_area1, false, settings);
+        expected_area1, difference_a, settings);
 #endif
 #if defined(BOOST_GEOMETRY_TEST_DIFFERENCE_ONLY_A)
     return result;
@@ -339,7 +358,7 @@ std::string test_one(std::string const& caseid,
 
     test_difference<OutputType>(caseid + "_b", g2, g1,
         expected_count2, expected_rings_count2, expected_point_count2,
-        expected_area2, false, settings);
+        expected_area2, difference_b, settings);
 
 #if defined(BOOST_GEOMETRY_TEST_DIFFERENCE_ONLY_B)
     return result;
@@ -354,7 +373,7 @@ std::string test_one(std::string const& caseid,
             expected_rings_count_s,
             expected_point_count_s,
             expected_area_s,
-            true, settings);
+            difference_sym, settings);
     }
     return result;
 }
@@ -383,6 +402,7 @@ std::string test_one(std::string const& caseid,
         settings);
 }
 
+// Version with expectations of symmetric: all specified
 template <typename OutputType, typename G1, typename G2>
 std::string test_one(std::string const& caseid,
         std::string const& wkt1, std::string const& wkt2,
@@ -404,6 +424,30 @@ std::string test_one(std::string const& caseid,
         settings);
 }
 
+// Version with expectations of symmetric: specify only count
+template <typename OutputType, typename G1, typename G2>
+std::string test_one(std::string const& caseid,
+        std::string const& wkt1, std::string const& wkt2,
+        const count_set&  expected_count1,
+        int expected_point_count1,
+        expectation_limits const& expected_area1,
+        const count_set&  expected_count2,
+        int expected_point_count2,
+        expectation_limits const& expected_area2,
+        const count_set&  expected_count_s,
+        ut_settings const& settings = ut_settings())
+{
+    return test_one<OutputType, G1, G2>(caseid, wkt1, wkt2,
+        expected_count1, -1, expected_point_count1, expected_area1,
+        expected_count2, -1, expected_point_count2, expected_area2,
+        expected_count_s, -1,
+        expected_point_count1 >= 0 && expected_point_count2 >= 0
+            ? (expected_point_count1 + expected_point_count2) : -1,
+        expected_area1 + expected_area2,
+        settings);
+}
+
+// Version with expectations of symmetric: all automatically
 template <typename OutputType, typename G1, typename G2>
 std::string test_one(std::string const& caseid,
         std::string const& wkt1, std::string const& wkt2,

--- a/test/algorithms/set_operations/sym_difference/sym_difference_areal_areal.cpp
+++ b/test/algorithms/set_operations/sym_difference/sym_difference_areal_areal.cpp
@@ -75,7 +75,7 @@ struct test_sym_difference_of_areal_geometries
                 PolygonOut
             >(case_id, areal1, areal2,
               expected_polygon_count, expected_point_count, expected_area,
-              true, settings);
+              difference_sym, settings);
     }
 };
 

--- a/test/robustness/overlay/areal_areal/general_intersection_precision.cpp
+++ b/test/robustness/overlay/areal_areal/general_intersection_precision.cpp
@@ -1,7 +1,7 @@
 // Boost.Geometry
 // Robustness Test
 
-// Copyright (c) 2019 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2019-2021 Barend Gehrels, Amsterdam, the Netherlands.
 
 // This file was modified by Oracle on 2021.
 // Modifications copyright (c) 2021, Oracle and/or its affiliates.
@@ -10,6 +10,8 @@
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_GEOMETRY_NO_ROBUSTNESS
 
 #include <iostream>
 #include <iomanip>
@@ -42,11 +44,22 @@ static std::string case_c[2] =
     "MULTIPOLYGON(((1 1,0 1,0 3,1 3,1 1)))"
     };
 
+struct test_settings
+{
+    bool verbose{false};
+    bool do_output{false};
+
+    // Settings currently not modifiable, and still giving quite some errors
+    double start_bound{1.0e-2};
+    double step_factor{50.0};  // on each side -> 100 steps per factor
+    int max_factor{10000};
+};
+
 template <bg::overlay_type OverlayType, typename Geometry>
 bool test_overlay(std::string const& caseid,
         Geometry const& g1, Geometry const& g2,
         double expected_area,
-        bool do_output)
+        test_settings const& settings)
 {
 
     typedef typename boost::range_value<Geometry>::type geometry_out;
@@ -62,9 +75,9 @@ bool test_overlay(std::string const& caseid,
             OverlayType
         > overlay;
 
-    typedef typename bg::strategy::intersection::services::default_strategy
+    typedef typename bg::strategies::relate::services::default_strategy
         <
-            typename bg::cs_tag<Geometry>::type
+            Geometry, Geometry
         >::type strategy_type;
 
     strategy_type strategy;
@@ -86,7 +99,7 @@ bool test_overlay(std::string const& caseid,
     const double detected_area = bg::area(result);
     if (std::fabs(detected_area - expected_area) > 0.01)
     {
-        if (do_output)
+        if (settings.do_output)
         {
             std::cout << "ERROR: " << caseid << std::setprecision(18)
                       << " detected=" << detected_area
@@ -118,9 +131,9 @@ template <bg::overlay_type OverlayType, typename MultiPolygon>
 std::size_t test_case(std::size_t& error_count,
         std::size_t case_index, std::size_t i, std::size_t j,
         std::size_t min_vertex_index, std::size_t max_vertex_index,
-        double x, double y, double expectation,
+        double offset_x, double offset_y, double expectation,
         MultiPolygon const& poly1, MultiPolygon const& poly2,
-        bool do_output)
+        test_settings const settings)
 {
     std::size_t n = 0;
     for (std::size_t k = min_vertex_index; k <= max_vertex_index; k++, ++n)
@@ -130,21 +143,23 @@ std::size_t test_case(std::size_t& error_count,
         switch (case_index)
         {
             case 2 :
-                update(bg::interior_rings(poly2_adapted.front()).front(), x, y, k);
+                update(bg::interior_rings(poly2_adapted.front()).front(), offset_x, offset_y, k);
                 break;
             default :
-                update(bg::exterior_ring(poly2_adapted.front()), x, y, k);
+                update(bg::exterior_ring(poly2_adapted.front()), offset_x, offset_y, k);
                 break;
         }
 
         std::ostringstream out;
         out << "case_" << i << "_" << j << "_" << k;
-        if (! test_overlay<OverlayType>(out.str(), poly1, poly2_adapted, expectation, do_output))
+        if (! test_overlay<OverlayType>(out.str(), poly1, poly2_adapted, expectation, settings))
         {
-            if (error_count == 0)
+            if (error_count == 0 && ! settings.do_output)
             {
                 // First failure is always reported
-                test_overlay<OverlayType>(out.str(), poly1, poly2_adapted, expectation, true);
+                test_settings adapted = settings;
+                adapted.do_output = true;
+                test_overlay<OverlayType>(out.str(), poly1, poly2_adapted, expectation, adapted);
             }
             error_count++;
         }
@@ -155,7 +170,7 @@ std::size_t test_case(std::size_t& error_count,
 template <typename T, bool Clockwise, bg::overlay_type OverlayType>
 std::size_t test_all(std::size_t case_index, std::size_t min_vertex_index,
                      std::size_t max_vertex_index,
-                     double expectation, bool do_output)
+                     double expectation, test_settings const& settings)
 {
     typedef bg::model::point<T, 2, bg::cs::cartesian> point_type;
     typedef bg::model::polygon<point_type, Clockwise> polygon;
@@ -177,21 +192,25 @@ std::size_t test_all(std::size_t case_index, std::size_t min_vertex_index,
 
     std::size_t error_count = 0;
     std::size_t n = 0;
-    for (double factor = 1.0; factor > 1.0e-10; factor /= 10.0)
+    for (int factor = 1; factor < settings.max_factor; factor *= 2)
     {
         std::size_t i = 0;
-        double const bound = 1.0e-5 * factor;
-        double const step = 1.0e-6 * factor;
-        for (double x = -bound; x <= bound; x += step, ++i)
+        double const bound = settings.start_bound / factor;
+        double const step = bound / settings.step_factor;
+        if (settings.verbose)
+        {
+            std::cout << "--> use " << bound << " " << step << std::endl;
+        }
+        for (double offset_x = -bound; offset_x <= bound; offset_x += step, ++i)
         {
             std::size_t j = 0;
-            for (double y = -bound; y <= bound; y += step, ++j, ++n)
+            for (double offset_y = -bound; offset_y <= bound; offset_y += step, ++j, ++n)
             {
                 n += test_case<OverlayType>(error_count,
                                             case_index, i, j,
-                                       min_vertex_index, max_vertex_index,
-                                       x, y, expectation,
-                                       poly1, poly2, do_output);
+                                            min_vertex_index, max_vertex_index,
+                                            offset_x, offset_y, expectation,
+                                            poly1, poly2, settings);
             }
         }
     }
@@ -205,22 +224,17 @@ std::size_t test_all(std::size_t case_index, std::size_t min_vertex_index,
 
 int test_main(int argc, char** argv)
 {
-    typedef double coordinate_type;
+    BoostGeometryWriteTestConfiguration();
+    using coor_t = default_test_type;
 
-    const double factor = argc > 1 ? atof(argv[1]) : 2.0;
-    const bool do_output = argc > 2 && atol(argv[2]) == 1;
+    test_settings settings;
+    settings.do_output = argc > 2 && atol(argv[2]) == 1;
 
-    std::cout << std::endl << " -> TESTING "
-              << string_from_type<coordinate_type>::name()
-              << " " << factor
-              << std::endl;
-
-    test_all<coordinate_type, true, bg::overlay_union>(1, 0, 3, 22.0, do_output);
-    test_all<coordinate_type, true, bg::overlay_union>(2, 0, 3, 73.0, do_output);
-    test_all<coordinate_type, true, bg::overlay_intersection>(3, 1, 2, 2.0, do_output);
-    test_all<coordinate_type, true, bg::overlay_union>(3, 1, 2, 14.0, do_output);
+    // Test three polygons, for the last test two types of intersections
+    test_all<coor_t, true, bg::overlay_union>(1, 0, 3, 22.0, settings);
+    test_all<coor_t, true, bg::overlay_union>(2, 0, 3, 73.0, settings);
+    test_all<coor_t, true, bg::overlay_intersection>(3, 1, 2, 2.0, settings);
+    test_all<coor_t, true, bg::overlay_union>(3, 1, 2, 14.0, settings);
 
     return 0;
- }
-
-
+}

--- a/test/robustness/overlay/areal_areal/interior_triangles.cpp
+++ b/test/robustness/overlay/areal_areal/interior_triangles.cpp
@@ -1,13 +1,17 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 // Robustness Test
 
-// Copyright (c) 2009-2020 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2009-2021 Barend Gehrels, Amsterdam, the Netherlands.
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_GEOMETRY_NO_BOOST_TEST
+#define BOOST_GEOMETRY_NO_ROBUSTNESS
+#define BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE
+
+// NOTE: there is no randomness here. Count is to measure performance
 
 #include <test_overlay_p_q.hpp>
 
@@ -113,8 +117,10 @@ int main(int argc, char** argv)
             ("count_y", po::value<int>(&count_y)->default_value(10), "Triangle count in y-direction")
             ("offset", po::value<int>(&offset)->default_value(0), "Offset of second triangle in x-direction")
             ("diff", po::value<bool>(&settings.also_difference)->default_value(false), "Include testing on difference")
+#if ! defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE)
             ("ccw", po::value<bool>(&ccw)->default_value(false), "Counter clockwise polygons")
             ("open", po::value<bool>(&open)->default_value(false), "Open polygons")
+#endif
             ("wkt", po::value<bool>(&settings.wkt)->default_value(false), "Create a WKT of the inputs, for all tests")
             ("svg", po::value<bool>(&settings.svg)->default_value(false), "Create a SVG for all tests")
         ;
@@ -129,6 +135,7 @@ int main(int argc, char** argv)
             return 1;
         }
 
+#if ! defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE)
         if (ccw && open)
         {
             test_all<default_test_type, false, false>(count, count_x, count_y, offset, settings);
@@ -142,6 +149,7 @@ int main(int argc, char** argv)
             test_all<default_test_type, true, false>(count, count_x, count_y, offset, settings);
         }
         else
+#endif
         {
             test_all<default_test_type, true, true>(count, count_x, count_y, offset, settings);
         }

--- a/test/robustness/overlay/areal_areal/intersection_pies.cpp
+++ b/test/robustness/overlay/areal_areal/intersection_pies.cpp
@@ -1,13 +1,15 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 // Robustness Test
 
-// Copyright (c) 2009-2020 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2009-2021 Barend Gehrels, Amsterdam, the Netherlands.
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_GEOMETRY_NO_BOOST_TEST
+#define BOOST_GEOMETRY_NO_ROBUSTNESS
+#define BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE
 
 #include <test_overlay_p_q.hpp>
 
@@ -256,8 +258,10 @@ int main(int argc, char** argv)
             ("help", "Help message")
             ("multi", po::value<bool>(&multi)->default_value(false), "Multiple tangencies at one point")
             ("diff", po::value<bool>(&settings.also_difference)->default_value(false), "Include testing on difference")
+#if ! defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE)
             ("ccw", po::value<bool>(&ccw)->default_value(false), "Counter clockwise polygons")
             ("open", po::value<bool>(&open)->default_value(false), "Open polygons")
+#endif
             ("wkt", po::value<bool>(&settings.wkt)->default_value(false), "Create a WKT of the inputs, for all tests")
             ("svg", po::value<bool>(&settings.svg)->default_value(false), "Create a SVG for all tests")
         ;
@@ -273,6 +277,7 @@ int main(int argc, char** argv)
         }
 
         // template par's are: CoordinateType, Clockwise, Closed
+#if ! defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE)
         if (ccw && open)
         {
             test_all<default_test_type, false, false>(multi, single_selftangent, settings);
@@ -286,6 +291,7 @@ int main(int argc, char** argv)
             test_all<default_test_type, true, false>(multi, single_selftangent, settings);
         }
         else
+#endif
         {
             test_all<default_test_type, true, true>(multi, single_selftangent, settings);
         }

--- a/test/robustness/overlay/areal_areal/intersection_stars.cpp
+++ b/test/robustness/overlay/areal_areal/intersection_stars.cpp
@@ -1,13 +1,17 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 // Robustness Test
 
-// Copyright (c) 2009-2020 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2009-2021 Barend Gehrels, Amsterdam, the Netherlands.
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_GEOMETRY_NO_BOOST_TEST
+#define BOOST_GEOMETRY_NO_ROBUSTNESS
+#define BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE
+
+// NOTE: there is no randomness here. Count is to measure performance
 
 #include <test_overlay_p_q.hpp>
 
@@ -109,12 +113,14 @@ void test_type(int count, int min_points, int max_points, T rotation, p_q_settin
 template <typename T>
 void test_all(std::string const& type, int count, int min_points, int max_points, T rotation, p_q_settings settings)
 {
+#if ! defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE)
     if (type == "float")
     {
         settings.tolerance = 1.0e-3;
         test_type<float, float>(count, min_points, max_points, rotation, settings);
     }
     else if (type == "double")
+#endif
     {
         test_type<double, double>(count, min_points, max_points, rotation, settings);
     }
@@ -130,7 +136,7 @@ int main(int argc, char** argv)
 
         int count = 1;
         //int seed = static_cast<unsigned int>(std::time(0));
-        std::string type = "float";
+        std::string type = "double";
         int min_points = 9;
         int max_points = 9;
         bool ccw = false;
@@ -140,15 +146,17 @@ int main(int argc, char** argv)
 
         description.add_options()
             ("help", "Help message")
-            //("seed", po::value<int>(&seed), "Initialization seed for random generator")
+           // ("seed", po::value<int>(&seed), "Initialization seed for random generator")
             ("count", po::value<int>(&count)->default_value(1), "Number of tests")
             ("diff", po::value<bool>(&settings.also_difference)->default_value(false), "Include testing on difference")
             ("min_points", po::value<int>(&min_points)->default_value(9), "Minimum number of points")
             ("max_points", po::value<int>(&max_points)->default_value(9), "Maximum number of points")
             ("rotation", po::value<double>(&rotation)->default_value(1.0e-13), "Rotation angle")
+#if ! defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE)
             ("ccw", po::value<bool>(&ccw)->default_value(false), "Counter clockwise polygons")
             ("open", po::value<bool>(&open)->default_value(false), "Open polygons")
-            ("type", po::value<std::string>(&type)->default_value("float"), "Type (float,double)")
+            ("type", po::value<std::string>(&type)->default_value("double"), "Type (float,double)")
+#endif
             ("wkt", po::value<bool>(&settings.wkt)->default_value(false), "Create a WKT of the inputs, for all tests")
             ("svg", po::value<bool>(&settings.svg)->default_value(false), "Create a SVG for all tests")
         ;

--- a/test/robustness/overlay/areal_areal/intersects.cpp
+++ b/test/robustness/overlay/areal_areal/intersects.cpp
@@ -1,13 +1,17 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 // Robustness Test
 
-// Copyright (c) 2011-2020 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2011-2021 Barend Gehrels, Amsterdam, the Netherlands.
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_GEOMETRY_NO_BOOST_TEST
+#define BOOST_GEOMETRY_NO_ROBUSTNESS
+#define BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE
+
+// NOTE: there is no randomness here. Count is to measure performance
 
 #include <test_overlay_p_q.hpp>
 
@@ -43,9 +47,8 @@ inline void make_polygon(MultiPolygon& mp, int count_x, int count_y, int index, 
 }
 
 
-
 template <typename MultiPolygon>
-void test_intersects(int count_x, int count_y, int width_x, p_q_settings const& settings)
+void test_intersects(int index, int count_x, int count_y, int width_x, p_q_settings const& settings)
 {
     MultiPolygon mp;
 
@@ -64,6 +67,10 @@ void test_intersects(int count_x, int count_y, int width_x, p_q_settings const& 
         std::ostringstream filename;
         filename << "intersects_"
             << string_from_type<coordinate_type>::name()
+            << "_" << index
+            << "_" << count_x
+            << "_" << count_y
+            << "_" << width_x
             << ".svg";
 
         std::ofstream svg(filename.str().c_str());
@@ -92,7 +99,7 @@ void test_all(int count, int count_x, int count_y, int width_x, p_q_settings con
 
     for(int i = 0; i < count; i++)
     {
-        test_intersects<multi_polygon>(count_x, count_y, width_x, settings);
+        test_intersects<multi_polygon>(i, count_x, count_y, width_x, settings);
     }
     auto const t = std::chrono::high_resolution_clock::now();
     auto const elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(t - t0).count();
@@ -123,8 +130,10 @@ int main(int argc, char** argv)
             ("count_x", po::value<int>(&count_x)->default_value(10), "Triangle count in x-direction")
             ("count_y", po::value<int>(&count_y)->default_value(10), "Triangle count in y-direction")
             ("width_x", po::value<int>(&width_x)->default_value(7), "Width of triangle in x-direction")
+#if ! defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE)
             ("ccw", po::value<bool>(&ccw)->default_value(false), "Counter clockwise polygons")
             ("open", po::value<bool>(&open)->default_value(false), "Open polygons")
+#endif
             ("wkt", po::value<bool>(&settings.wkt)->default_value(false), "Create a WKT of the inputs, for all tests")
             ("svg", po::value<bool>(&settings.svg)->default_value(false), "Create a SVG for all tests")
         ;
@@ -139,6 +148,7 @@ int main(int argc, char** argv)
             return 1;
         }
 
+#if ! defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE)
         if (ccw && open)
         {
             test_all<default_test_type, false, false>(count, count_x, count_y, width_x, settings);
@@ -152,6 +162,7 @@ int main(int argc, char** argv)
             test_all<default_test_type, true, false>(count, count_x, count_y, width_x, settings);
         }
         else
+#endif
         {
             test_all<default_test_type, true, true>(count, count_x, count_y, width_x, settings);
         }

--- a/test/robustness/overlay/areal_areal/random_ellipses_stars.cpp
+++ b/test/robustness/overlay/areal_areal/random_ellipses_stars.cpp
@@ -1,13 +1,15 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 // Robustness Test
 
-// Copyright (c) 2009-2020 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2009-2021 Barend Gehrels, Amsterdam, the Netherlands.
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_GEOMETRY_NO_BOOST_TEST
+#define BOOST_GEOMETRY_NO_ROBUSTNESS
+#define BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE
 
 #include <test_overlay_p_q.hpp>
 
@@ -166,11 +168,13 @@ void test_type(int seed, int count, p_q_settings const& settings)
 template <bool Clockwise, bool Closed>
 void test_all(std::string const& type, int seed, int count, p_q_settings settings)
 {
+#if ! defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE)
     if (type == "float")
     {
         test_type<float, Clockwise, Closed>(seed, count, settings);
     }
     else if (type == "double")
+#endif
     {
         test_type<double, Clockwise, Closed>(seed, count, settings);
     }
@@ -187,7 +191,7 @@ int main(int argc, char** argv)
 
         int count = 1;
         int seed = static_cast<unsigned int>(std::time(0));
-        std::string type = "float";
+        std::string type = "double";
         bool ccw = false;
         bool open = false;
         p_q_settings settings;
@@ -197,9 +201,11 @@ int main(int argc, char** argv)
             ("seed", po::value<int>(&seed), "Initialization seed for random generator")
             ("count", po::value<int>(&count)->default_value(1), "Number of tests")
             ("diff", po::value<bool>(&settings.also_difference)->default_value(false), "Include testing on difference")
+#if ! defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE)
             ("ccw", po::value<bool>(&ccw)->default_value(false), "Counter clockwise polygons")
             ("open", po::value<bool>(&open)->default_value(false), "Open polygons")
-            ("type", po::value<std::string>(&type)->default_value("float"), "Type (float,double)")
+            ("type", po::value<std::string>(&type)->default_value("double"), "Type (float,double)")
+#endif
             ("wkt", po::value<bool>(&settings.wkt)->default_value(false), "Create a WKT of the inputs, for all tests")
             ("svg", po::value<bool>(&settings.svg)->default_value(false), "Create a SVG for all tests")
         ;
@@ -214,6 +220,7 @@ int main(int argc, char** argv)
             return 1;
         }
 
+#if ! defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE)
         if (ccw && open)
         {
             test_all<false, false>(type, seed, count, settings);
@@ -227,6 +234,7 @@ int main(int argc, char** argv)
             test_all<true, false>(type, seed, count, settings);
         }
         else
+#endif
         {
             test_all<true, true>(type, seed, count, settings);
         }

--- a/test/robustness/overlay/areal_areal/recursive_polygons.cpp
+++ b/test/robustness/overlay/areal_areal/recursive_polygons.cpp
@@ -1,13 +1,15 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 // Robustness Test
 
-// Copyright (c) 2009-2020 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2009-2021 Barend Gehrels, Amsterdam, the Netherlands.
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_GEOMETRY_NO_BOOST_TEST
+#define BOOST_GEOMETRY_NO_ROBUSTNESS
+#define BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE
 
 #include <test_overlay_p_q.hpp>
 
@@ -174,8 +176,10 @@ int main(int argc, char** argv)
             ("level", po::value<int>(&level)->default_value(3), "Level to reach (higher->slower)")
             ("size", po::value<int>(&field_size)->default_value(10), "Size of the field")
             ("form", po::value<std::string>(&form)->default_value("box"), "Form of the polygons (box, triangle)")
+#if ! defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE)
             ("ccw", po::value<bool>(&ccw)->default_value(false), "Counter clockwise polygons")
             ("open", po::value<bool>(&open)->default_value(false), "Open polygons")
+#endif
             ("wkt", po::value<bool>(&settings.wkt)->default_value(false), "Create a WKT of the inputs, for all tests")
             ("svg", po::value<bool>(&settings.svg)->default_value(false), "Create a SVG for all tests")
         ;
@@ -193,7 +197,7 @@ int main(int argc, char** argv)
 
         bool triangular = form != "box";
 
-
+#if ! defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE)
         if (ccw && open)
         {
             test_all<default_test_type, false, false>(seed, count, field_size, level, triangular, settings);
@@ -207,6 +211,7 @@ int main(int argc, char** argv)
             test_all<default_test_type, true, false>(seed, count, field_size, level, triangular, settings);
         }
         else
+#endif
         {
             test_all<default_test_type, true, true>(seed, count, field_size, level, triangular, settings);
         }

--- a/test/robustness/overlay/areal_areal/star_comb.cpp
+++ b/test/robustness/overlay/areal_areal/star_comb.cpp
@@ -1,13 +1,15 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 // Robustness Test
 
-// Copyright (c) 2009-2020 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2009-2021 Barend Gehrels, Amsterdam, the Netherlands.
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_GEOMETRY_NO_BOOST_TEST
+#define BOOST_GEOMETRY_NO_ROBUSTNESS
+#define BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE
 
 #include <test_overlay_p_q.hpp>
 
@@ -98,8 +100,10 @@ int main(int argc, char** argv)
             ("count", po::value<int>(&count)->default_value(1), "Number of tests")
             ("point_count", po::value<int>(&point_count)->default_value(1), "Number of points in the star")
             ("diff", po::value<bool>(&settings.also_difference)->default_value(false), "Include testing on difference")
+#if ! defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE)
             ("ccw", po::value<bool>(&ccw)->default_value(false), "Counter clockwise polygons")
             ("open", po::value<bool>(&open)->default_value(false), "Open polygons")
+#endif
             ("wkt", po::value<bool>(&settings.wkt)->default_value(false), "Create a WKT of the inputs, for all tests")
             ("svg", po::value<bool>(&settings.svg)->default_value(false), "Create a SVG for all tests")
         ;
@@ -117,7 +121,7 @@ int main(int argc, char** argv)
         int star_point_count = point_count * 2 + 1;
         int comb_comb_count = point_count;
 
-
+#if ! defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE)
         if (ccw && open)
         {
             test_all<default_test_type, false, false>(count, star_point_count, comb_comb_count, factor1, factor2, do_union, settings);
@@ -131,6 +135,7 @@ int main(int argc, char** argv)
             test_all<default_test_type, true, false>(count, star_point_count, comb_comb_count, factor1, factor2, do_union, settings);
         }
         else
+#endif
         {
             test_all<default_test_type, true, true>(count, star_point_count, comb_comb_count, factor1, factor2, do_union, settings);
         }

--- a/test/robustness/overlay/areal_areal/test_overlay_p_q.hpp
+++ b/test/robustness/overlay/areal_areal/test_overlay_p_q.hpp
@@ -1,7 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 // Robustness Test
 
-// Copyright (c) 2009-2020 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2009-2021 Barend Gehrels, Amsterdam, the Netherlands.
 
 // This file was modified by Oracle on 2021.
 // Modifications copyright (c) 2021, Oracle and/or its affiliates.
@@ -40,21 +40,16 @@
 
 struct p_q_settings
 {
-    bool svg;
-    bool also_difference;
-    bool validity;
-    bool wkt;
-    bool verify_area;
-    double tolerance;
+    bool svg{false};
+    bool also_difference{false};
+    bool validity{false};
+    bool wkt{false};
+    bool verify_area{false};
+    double tolerance{1.0e-3};
+    bool verbose{false};
 
-    p_q_settings()
-        : svg(false)
-        , also_difference(false)
-        , validity(false)
-        , wkt(false)
-        , verify_area(false)
-        , tolerance(1.0e-3) // since rescaling to integer the tolerance should be less. Was originally 1.0e-6
-    {}
+    // NOTE: since rescaling to integer the tolerance is less.
+    // Was originally 1.0e-6 TODO: restore
 };
 
 template <typename Geometry>
@@ -209,6 +204,7 @@ static bool test_overlay_p_q(std::string const& caseid,
     }
 
     bool svg = settings.svg;
+    bool wkt = settings.wkt;
 
     if (wrong || settings.wkt)
     {
@@ -216,53 +212,66 @@ static bool test_overlay_p_q(std::string const& caseid,
         {
             result = false;
             svg = true;
+            wkt = true;
         }
-        bg::unique(out_i);
-        bg::unique(out_u);
 
-        std::cout
-            << "type: " << string_from_type<CalculationType>::name()
-            << " id: " << caseid
-            << " area i: " << area_i
-            << " area u: " << area_u
-            << " area p: " << area_p
-            << " area q: " << area_q
-            << " sum: " << sum;
-
-        if (settings.also_difference)
+        if (settings.verbose)
         {
             std::cout
-                << " area d1: " << area_d1
-                << " area d2: " << area_d2;
-        }
-        std::cout
-            << std::endl
-            << std::setprecision(9)
-            << " p: " << bg::wkt(p) << std::endl
-            << " q: " << bg::wkt(q) << std::endl
-            << " i: " << bg::wkt(out_i) << std::endl
-            << " u: " << bg::wkt(out_u) << std::endl
-            ;
+                << "type: " << string_from_type<CalculationType>::name()
+                << " id: " << caseid
+                << " area i: " << area_i
+                << " area u: " << area_u
+                << " area p: " << area_p
+                << " area q: " << area_q
+                << " sum: " << sum;
 
+            if (settings.also_difference)
+            {
+                std::cout
+                        << " area d1: " << area_d1
+                        << " area d2: " << area_d2;
+            }
+            std::cout
+                    << std::endl
+                    << std::setprecision(9)
+                    << " p: " << bg::wkt(p) << std::endl
+                    << " q: " << bg::wkt(q) << std::endl
+                    << " i: " << bg::wkt(out_i) << std::endl
+                    << " u: " << bg::wkt(out_u) << std::endl;
+        }
     }
 
-    if(svg)
+    std::string filename;
     {
-        std::ostringstream filename;
-        filename << "overlay_" << caseid << "_"
+        std::ostringstream out;
+        out << "overlay_" << caseid << "_"
             << string_from_type<coordinate_type>::name();
         if (!std::is_same<coordinate_type, CalculationType>::value)
         {
-            filename << string_from_type<CalculationType>::name();
+            out << string_from_type<CalculationType>::name();
         }
-
-        filename
+        out
 #if defined(BOOST_GEOMETRY_USE_RESCALING)
-            << "_rescaled"
+             << "_rescaled"
 #endif
-            << ".svg";
+             << ".";
+        filename = out.str();
+    }
 
-        std::ofstream svg(filename.str().c_str());
+    if (wkt)
+    {
+        std::ofstream stream(filename + "wkt");
+        // Stream input WKT's
+        stream << bg::wkt(p) << std::endl;
+        stream << bg::wkt(q) << std::endl;
+        // If you need the output WKT, then stream out_i and out_u
+    }
+
+
+    if (svg)
+    {
+        std::ofstream svg(filename + "svg");
 
         bg::svg_mapper<point_type> mapper(svg, 500, 500);
 

--- a/test/robustness/overlay/buffer/recursive_polygons_buffer.cpp
+++ b/test/robustness/overlay/buffer/recursive_polygons_buffer.cpp
@@ -1,7 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 // Robustness Test
 
-// Copyright (c) 2012-2020 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2012-2021 Barend Gehrels, Amsterdam, the Netherlands.
 
 // This file was modified by Oracle on 2015-2021.
 // Modifications copyright (c) 2015-2021 Oracle and/or its affiliates.
@@ -13,6 +13,8 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_GEOMETRY_NO_BOOST_TEST
+#define BOOST_GEOMETRY_NO_ROBUSTNESS
+#define BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE
 
 #if defined(_MSC_VER)
 #  pragma warning( disable : 4244 )


### PR DESCRIPTION
I indicated in a comment what the actual fix is.

**NOTE**: several `is_valid` checks in difference tests are false negatives. I noticed already earlier some of them, but now it was in the test I concentrated on (for mysql). **We should fix that.** I explicitly skip those validity checks now, otherwise we cannot detect good enough if we're improving.

This one for example:
![uu_false_positive](https://user-images.githubusercontent.com/334849/129066321-a25cfa96-b6f9-487a-826e-55dd359f08f2.png)

And this one:
![c_false_positive_mysql](https://user-images.githubusercontent.com/334849/129066361-7564dde8-4551-4939-bf86-83dab5e7d25e.png)
