### PR TITLE
fix: small fixes to support boost multiprecision and rational

### DIFF
--- a/include/boost/geometry/algorithms/detail/buffer/piece_border.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/piece_border.hpp
@@ -24,7 +24,6 @@
 #include <boost/geometry/algorithms/comparable_distance.hpp>
 #include <boost/geometry/algorithms/equals.hpp>
 #include <boost/geometry/algorithms/expand.hpp>
-#include <boost/geometry/algorithms/detail/buffer/buffer_box.hpp>
 #include <boost/geometry/algorithms/detail/buffer/buffer_policies.hpp>
 #include <boost/geometry/algorithms/detail/expand_by_epsilon.hpp>
 #include <boost/geometry/strategies/cartesian/turn_in_ring_winding.hpp>

--- a/include/boost/geometry/algorithms/detail/overlay/approximately_equals.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/approximately_equals.hpp
@@ -34,7 +34,7 @@ inline bool approximately_equals(Point1 const& a, Point2 const& b,
     calc_t const& b1 = geometry::get<1>(b);
 
     math::detail::equals_factor_policy<calc_t> policy(a0, b0, a1, b1);
-    policy.factor *= multiplier;
+    policy.multiply_factor(multiplier);
 
     return math::detail::equals_by_policy(a0, b0, policy)
         && math::detail::equals_by_policy(a1, b1, policy);

--- a/include/boost/geometry/algorithms/detail/overlay/get_clusters.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_clusters.hpp
@@ -39,7 +39,9 @@ struct sweep_equal_policy
     static inline bool equals(P const& p1, P const& p2)
     {
         // Points within a kilo epsilon are considered as equal
-        return approximately_equals(p1, p2, 1000.0);
+        using coor_t = typename coordinate_type<P>::type;
+        const coor_t tolerance = 1000;
+        return approximately_equals(p1, p2, tolerance);
     }
 
     template <typename T>
@@ -47,7 +49,8 @@ struct sweep_equal_policy
     {
         // This threshold is an arbitrary value
         // as long as it is than the used kilo-epsilon
-        return value > 1.0e-3;
+        T const limit = T(1) / T(1000);
+        return value > limit;
     }
 };
 

--- a/include/boost/geometry/algorithms/detail/overlay/sort_by_side.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/sort_by_side.hpp
@@ -316,7 +316,8 @@ public :
         // then take a point (or more) further back.
         // The limit of offset avoids theoretical infinite loops.
         // In practice it currently walks max 1 point back in all cases.
-        double const tolerance = 1.0e9;
+        using ct_type = typename geometry::coordinate_type<Point>::type;
+        ct_type const tolerance = 1000 * 1000 * 1000;
         int offset = 0;
         while (approximately_equals(point_from, turn.point, tolerance)
                && offset > -10)

--- a/include/boost/geometry/algorithms/detail/sections/sectionalize.hpp
+++ b/include/boost/geometry/algorithms/detail/sections/sectionalize.hpp
@@ -783,22 +783,24 @@ inline void enlarge_sections(Sections& sections, Strategy const&)
 
     // It makes section a tiny bit too large, which might cause (a small number)
     // of more comparisons
-    for (typename boost::range_iterator<Sections>::type it = boost::begin(sections);
-        it != boost::end(sections);
-        ++it)
+    for (auto& section : sections)
     {
 #if defined(BOOST_GEOMETRY_USE_RESCALING)
         detail::sectionalize::expand_by_epsilon
             <
                 typename Strategy::cs_tag
-            >::apply(it->bounding_box);
+            >::apply(section.bounding_box);
 
 #else
         // Expand the box to avoid missing any intersection. The amount is
         // should be larger than epsilon. About the value itself: the smaller
         // it is, the higher the risk to miss intersections. The larger it is,
         // the more comparisons are made. So it should be on the high side.
-        detail::buffer::buffer_box(it->bounding_box, 0.001, it->bounding_box);
+        using gt = decltype(section.bounding_box);
+        using ct = typename geometry::coordinate_type<gt>::type;
+        ct const tolerance = ct(1) / ct(1000);
+        detail::buffer::buffer_box(section.bounding_box, tolerance,
+                                   section.bounding_box);
 #endif
     }
 }

--- a/include/boost/geometry/util/math.hpp
+++ b/include/boost/geometry/util/math.hpp
@@ -139,6 +139,12 @@ struct equals_factor_policy
         return factor;
     }
 
+    template <typename E>
+    void multiply_factor(E const& multiplier)
+    {
+        factor *= multiplier;
+    }
+
     T factor;
 };
 
@@ -153,6 +159,8 @@ struct equals_factor_policy<T, false>
     {
         return T(1);
     }
+
+    void multiply_factor(T const& ) {}
 };
 
 template <typename Type,

--- a/test/algorithms/detail/approximately_equals.cpp
+++ b/test/algorithms/detail/approximately_equals.cpp
@@ -96,5 +96,10 @@ int test_main(int, char* [])
     test_all<bg::model::point<double, 2, bg::cs::cartesian>>(m, 23);
     test_all<bg::model::point<float, 2, bg::cs::cartesian>>(m, 23);
 
+    // MP is not a floating point type, therefore approximately_equal
+    // is behaves as exact and returns only true if they are identical.
+    // This takes 334 steps (then "d" above is 0.0)
+    test_all<bg::model::point<mp_test_type, 2, bg::cs::cartesian>>(m, 334);
+
     return 0;
 }

--- a/test/algorithms/overlay/multi_overlay_cases.hpp
+++ b/test/algorithms/overlay/multi_overlay_cases.hpp
@@ -26,6 +26,15 @@ static std::string case_multi_simplex[2] =
     "MULTIPOLYGON(((3 0,0 3,4 5,3 0)))"
 };
 
+// To support exact behavior in integer coordinates
+static std::string case_multi_rectangular[2] =
+{
+    "MULTIPOLYGON(((100 100,100 200,200 200,200 100,100 100)),"
+                 "((300 100,300 200,400 200,400 100,300 100),"
+                   "(325 125,375 125,375 175,325 175,325 125)))",
+    "MULTIPOLYGON(((150 50,150 150,350 150,350 50,150 50)))"
+};
+
 // To mix multi/single
 static std::string case_single_simplex = "POLYGON((3 0,0 3,4 5,3 0))";
 

--- a/test/algorithms/set_operations/union/Jamfile
+++ b/test/algorithms/set_operations/union/Jamfile
@@ -24,5 +24,6 @@ test-suite boost-geometry-algorithms-union
     [ run union_multi.cpp         : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE
                                         : algorithms_union_multi ]
     [ run union_pl_pl.cpp         : : : : algorithms_union_pl_pl ]
-	[ run union_tupled.cpp        : : : : algorithms_union_tupled ]
+    [ run union_tupled.cpp        : : : : algorithms_union_tupled ]
+    [ run union_other_types.cpp   : : : : algorithms_union_other_types ]
     ;

--- a/test/algorithms/set_operations/union/union_multi.cpp
+++ b/test/algorithms/set_operations/union/union_multi.cpp
@@ -201,6 +201,8 @@ void test_areal()
     TEST_UNION(case_140_multi, 2, 1, -1, 64.953);
     TEST_UNION(case_141_multi, 1, 0, -1, 100.0);
 
+    TEST_UNION(case_multi_rectangular, 1, 1, -1, 33125);
+
     test_one<Polygon, MultiPolygon, MultiPolygon>("case_recursive_boxes_1",
         case_recursive_boxes_1[0], case_recursive_boxes_1[1],
         1, 1, 16, 97.0);

--- a/test/algorithms/set_operations/union/union_other_types.cpp
+++ b/test/algorithms/set_operations/union/union_other_types.cpp
@@ -1,0 +1,95 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+// Unit Test
+
+// Copyright (c) 2021 Barend Gehrels, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_GEOMETRY_NO_ROBUSTNESS
+
+#include <geometry_test_common.hpp>
+#include <algorithms/overlay/multi_overlay_cases.hpp>
+
+#include <boost/geometry/algorithms/correct.hpp>
+#include <boost/geometry/algorithms/union.hpp>
+#include <boost/geometry/io/wkt/wkt.hpp>
+#include <boost/geometry/geometries/geometries.hpp>
+
+#include <algorithms/overlay/multi_overlay_cases.hpp>
+
+#include <boost/geometry/geometries/point_xy.hpp>
+#include <boost/geometry/geometries/multi_polygon.hpp>
+
+#include <boost/geometry/util/rational.hpp>
+
+template <typename Geometry>
+void test_one(std::string const& case_id,
+              std::string const& wkt1, std::string const& wkt2,
+              typename bg::coordinate_type<Geometry>::type const& expected_area)
+{
+    Geometry g1;
+    bg::read_wkt(wkt1, g1);
+
+    Geometry g2;
+    bg::read_wkt(wkt2, g2);
+
+    bg::correct(g1);
+    bg::correct(g2);
+
+    Geometry clip;
+
+    bg::union_(g1, g2, clip);
+
+    auto const area = bg::area(clip);
+
+    BOOST_CHECK_MESSAGE(bg::math::equals(expected_area, area),
+            "union: " << case_id
+            << " #area expected: " << expected_area
+            << " detected: " << area
+            << " type: " << (string_from_type<typename bg::coordinate_type<Geometry>::type>::name()));
+
+}
+
+template <typename Point>
+void test_areal()
+{
+    using polygon = bg::model::polygon<Point>;
+    using multi_polygon = bg::model::multi_polygon<polygon>;
+
+    // Intended tests: only 3:
+    // - one simple case (rectangular)
+    // - (TODO) one test with diagonals (but all intersection points should be on the integer grid)
+    // - (TODO) one test currently often failing because of FP problems
+
+    test_one<multi_polygon>("case_multi_rectangular",
+        case_multi_rectangular[0], case_multi_rectangular[1], 33125);
+}
+
+
+int test_main(int, char* [])
+{
+    namespace bm = boost::multiprecision;
+
+    using bg::model::d2::point_xy;
+
+    // Our reference types
+    test_areal<point_xy<long int>>();
+    test_areal<point_xy<long double>>();
+
+    // Boost multi precision (int)
+    test_areal<point_xy<bm::int128_t>>();
+
+    // Boost multi precision (float)
+    test_areal<point_xy<bm::number<bm::cpp_bin_float<5> >>>();
+    test_areal<point_xy<bm::number<bm::cpp_bin_float<10> >>>();
+    test_areal<point_xy<bm::number<bm::cpp_bin_float<50> >>>();
+    test_areal<point_xy<bm::number<bm::cpp_bin_float<100> >>>();
+
+    // Boost rational compiles, and is correct
+    // (because it's rectangular, some other input is currently incorrect)
+    test_areal<point_xy<boost::rational<int>>>();
+
+    return 0;
+}

--- a/test/string_from_type.hpp
+++ b/test/string_from_type.hpp
@@ -47,7 +47,8 @@ template <> struct string_from_type<int>
 template <> struct string_from_type<long>
 { static std::string name() { return "l"; }  };
 
-template <> struct string_from_type<boost::multiprecision::cpp_bin_float_100>
+template <typename Backend>
+struct string_from_type<boost::multiprecision::number<Backend>>
 { static std::string name() { return "m"; }  };
 
 // this is what g++ and clang++ use


### PR DESCRIPTION
Because of the first version of previous PR (errors in rational), I added a small unit test for this type and Boost multi precision. There were some small fixes necessary, mainly in new functions.

The new test case looks like this and is supported and correct (even using boost rational).

![rectangular](https://user-images.githubusercontent.com/334849/129909792-ad4dd10e-84e2-4433-9ca5-a028f8f19aa4.png)

The first test (the simplex) was incorrect for boost rational, and give different results with or without my other PR (because of diagonals), so I left that out for now).

![multi_simplex](https://user-images.githubusercontent.com/334849/129910205-672d1bc1-5f0a-4c5a-81f7-726411e299e5.png)



