### PR TITLE
Fix buffer for macos-11, clang-12.0.5, x86-64

### DIFF
--- a/include/boost/geometry/algorithms/detail/buffer/turn_in_piece_visitor.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/turn_in_piece_visitor.hpp
@@ -175,7 +175,7 @@ public:
             // unit tests of hard cases start to fail (5 in multi_polygon)
             // But it is acknowlegded that such a threshold depends on the
             // scale of the input.
-            if (state.m_min_distance > 1.0e-5 || ! state.m_close_to_offset)
+            if (state.m_min_distance > 1.0e-4 || ! state.m_close_to_offset)
             {
                 Turn& mutable_turn = m_turns[turn.turn_index];
                 mutable_turn.is_turn_traversable = false;

--- a/test/algorithms/buffer/buffer_multi_linestring.cpp
+++ b/test/algorithms/buffer/buffer_multi_linestring.cpp
@@ -212,6 +212,19 @@ void test_all()
     }
 #endif
 
+    {
+        // This issue was detected for CCW order and only CW is tested by default.
+        using polygon_ccw = bg::model::polygon<P, ! Clockwise>;
+        test_one
+            <
+                multi_linestring_type, polygon_ccw
+            >("mysql_33353637_macos11",
+              "MULTILINESTRING((0 10,10 0),(10 0,0 0),(0 0,10 10))",
+              bg::strategy::buffer::join_miter(10),
+              end_round32,
+              1, 0, 35307.0646,
+              100.0);
+    }
 }
 
 


### PR DESCRIPTION
On macos-11 with clang-12.0.5 for this case:
```
cmls_t mls;
bg::read_wkt("MULTILINESTRING((0 10,10 0),(10 0,0 0),(0 0,10 10))", mls);

cmpo_t mpo;
bg::buffer(mls, mpo,
            bg::strategy::buffer::distance_symmetric<double>(100),
            bg::strategy::buffer::side_straight(),
            bg::strategy::buffer::join_miter(10),
            bg::strategy::buffer::end_round(32),
            bg::strategy::buffer::point_circle(32));
```
wrong buffer is generated, should be green, is blue (this is a regression):
![obraz](https://user-images.githubusercontent.com/1226951/134337444-d4153616-bbfb-4a03-99e0-20a411bfcaba.png)

On this platform slightly different pieces and turns are generated. They are close to these generated for msvc-14.1:
![obraz](https://user-images.githubusercontent.com/1226951/134337926-92eec134-1908-4090-8512-12ae31349f4d.png)

So with msvc-14.1 there are two clusters: (turns 3 and 4) and (turns 22 and 31). With macos-11+clang-12 the former cluster is not generated because turns 3 and 4 are marked as not traversable due to the check of the min distance which for these turns is around 8e-5 and the threshold is set to 1e-5.

Btw, the comment states:
```
// This threshold is minimized to the point where fragile
// unit tests of hard cases start to fail (5 in multi_polygon)
// But it is acknowlegded that such a threshold depends on the
// scale of the input.
```
if this is the case shouldn't this number depend on the size of the input instead of being an absolute value (probably on both geometry size and buffer distance)?