### PR TITLE
[strategies] Fix area strategy converter altered_strategy for boxes.

### DIFF
--- a/include/boost/geometry/strategies/area/geographic.hpp
+++ b/include/boost/geometry/strategies/area/geographic.hpp
@@ -86,8 +86,11 @@ struct strategy_converter<strategy::area::geographic<FP, SO, S, CT> >
             : strategies::area::geographic<FP, S, CT>(spheroid)
         {}
 
+        using strategies::area::geographic<FP, S, CT>::area;
+
         template <typename Geometry>
-        auto area(Geometry const&) const
+        auto area(Geometry const&,
+                  std::enable_if_t<! util::is_box<Geometry>::value> * = nullptr) const
         {
             return strategy::area::geographic<FP, SO, S, CT>(this->m_spheroid);
         }


### PR DESCRIPTION
This change allows the new box area strategy to be correctly returned from the umbrella strategy returned by the legacy strategy converter. Without this change the general/polygonal area strategy is returned for boxes.