### PR TITLE
[test] exclude cpp_rational because it fails on develop

### DIFF
--- a/test/algorithms/set_operations/union/union_other_types.cpp
+++ b/test/algorithms/set_operations/union/union_other_types.cpp
@@ -142,7 +142,11 @@ int test_main(int, char* [])
     test_areal<point_xy<bm::number<bm::cpp_dec_float<50>>>>({});
 
     // Boost multi precision (rational)
+#if ! defined(BOOST_GEOMETRY_TEST_FAILURES)
+    // TODO: enable this again, it currently fails on develop branch, maybe
+    // because of a recent change in boost::multiprecision
     test_areal<point_xy<bm::cpp_rational>>({exclude::fp});
+#endif
 #if ! defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE)
     test_areal<point_xy<bm::checked_cpp_rational>>({exclude::fp});
 #endif


### PR DESCRIPTION
See discussions in #917, I propose to disable this test for now.
We still test the (probably more used) Boost MP types (bm::int128_t, bm::cpp_bin_float, bm::cpp_dec_float)