### PR TITLE
Fix envelope of polygon containing pole.

### DIFF
--- a/include/boost/geometry/algorithms/detail/disjoint/segment_box.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/segment_box.hpp
@@ -5,8 +5,8 @@
 // Copyright (c) 2009-2014 Mateusz Loskot, London, UK.
 // Copyright (c) 2013-2014 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2013-2020.
-// Modifications copyright (c) 2013-2020, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013-2021.
+// Modifications copyright (c) 2013-2021, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
@@ -33,7 +33,6 @@
 #include <boost/geometry/algorithms/detail/envelope/segment.hpp>
 #include <boost/geometry/algorithms/detail/normalize.hpp>
 #include <boost/geometry/algorithms/dispatch/disjoint.hpp>
-#include <boost/geometry/algorithms/envelope.hpp>
 
 #include <boost/geometry/formulas/vertex_longitude.hpp>
 

--- a/include/boost/geometry/algorithms/detail/envelope/areal.hpp
+++ b/include/boost/geometry/algorithms/detail/envelope/areal.hpp
@@ -39,6 +39,11 @@ struct envelope_polygon
 
         if (geometry::is_empty(ext_ring))
         {
+            // TODO: In spherical and geographic this is ambiguous. A hole technically is a ring
+            // defining the outside so the envelope would cover more than half of the globe.
+            // So depending on what we want we could consider reversing holes before passing them
+            // below.
+
             // use dummy multi polygon to get the strategy because there is no multi ring concept
             using strategy_t = decltype(strategy.envelope(detail::dummy_multi_polygon(),
                                                           detail::dummy_box()));

--- a/include/boost/geometry/algorithms/detail/envelope/areal.hpp
+++ b/include/boost/geometry/algorithms/detail/envelope/areal.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2018 Oracle and/or its affiliates.
+// Copyright (c) 2018-2021 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -39,11 +39,14 @@ struct envelope_polygon
 
         if (geometry::is_empty(ext_ring))
         {
+            // use dummy multi polygon to get the strategy because there is no multi ring concept
+            using strategy_t = decltype(strategy.envelope(detail::dummy_multi_polygon(),
+                                                          detail::dummy_box()));
             // if the exterior ring is empty, consider the interior rings
             envelope_multi_range
                 <
                     envelope_range
-                >::apply(interior_rings(polygon), mbr, strategy);
+                >::template apply<strategy_t>(interior_rings(polygon), mbr, strategy);
         }
         else
         {

--- a/include/boost/geometry/algorithms/detail/envelope/areal.hpp
+++ b/include/boost/geometry/algorithms/detail/envelope/areal.hpp
@@ -22,12 +22,32 @@
 
 #include <boost/geometry/algorithms/dispatch/envelope.hpp>
 
+#include <boost/geometry/views/reversible_view.hpp>
+
 namespace boost { namespace geometry
 {
 
 #ifndef DOXYGEN_NO_DETAIL
 namespace detail { namespace envelope
 {
+
+
+struct envelope_hole
+{
+    template <typename Range, typename Box, typename Strategies>
+    static inline void apply(Range const& range, Box& mbr, Strategies const& strategies)
+    {
+        // Reverse holes to avoid calculating the envelope for the outside
+        // in spherical and geographic coordinate systems
+        detail::clockwise_view
+            <
+                Range const,
+                geometry::point_order<Range>::value == counterclockwise
+                    ? clockwise : counterclockwise
+            > view(range);
+        strategies.envelope(range, mbr).apply(view, mbr);
+    }
+};
 
 struct envelope_polygon
 {
@@ -39,18 +59,13 @@ struct envelope_polygon
 
         if (geometry::is_empty(ext_ring))
         {
-            // TODO: In spherical and geographic this is ambiguous. A hole technically is a ring
-            // defining the outside so the envelope would cover more than half of the globe.
-            // So depending on what we want we could consider reversing holes before passing them
-            // below.
-
             // use dummy multi polygon to get the strategy because there is no multi ring concept
             using strategy_t = decltype(strategy.envelope(detail::dummy_multi_polygon(),
                                                           detail::dummy_box()));
             // if the exterior ring is empty, consider the interior rings
             envelope_multi_range
                 <
-                    envelope_range
+                    envelope_hole
                 >::template apply<strategy_t>(interior_rings(polygon), mbr, strategy);
         }
         else

--- a/include/boost/geometry/algorithms/detail/envelope/geometry_collection.hpp
+++ b/include/boost/geometry/algorithms/detail/envelope/geometry_collection.hpp
@@ -30,26 +30,25 @@ namespace dispatch
 template <typename Collection>
 struct envelope<Collection, geometry_collection_tag>
 {
-    template <typename Geometry, typename Box, typename Strategy>
+    template <typename Geometry, typename Box, typename Strategies>
     static inline void apply(Geometry const& geometry,
                              Box& mbr,
-                             Strategy const& strategy)
+                             Strategies const& strategies)
     {
-        using strategy_t = decltype(strategy.envelope(geometry, mbr));
-        using state_t = typename strategy_t::template multi_state<Box>;
-
-        state_t state;
+        using strategy_t = decltype(strategies.envelope(geometry, mbr));
+        
+        typename strategy_t::template state<Box> state;
         detail::visit_breadth_first([&](auto const& g)
         {
             if (! geometry::is_empty(g))
             {
                 Box b;
-                envelope<util::remove_cref_t<decltype(g)>>::apply(g, b, strategy);
-                state.apply(b);
+                envelope<util::remove_cref_t<decltype(g)>>::apply(g, b, strategies);
+                strategy_t::apply(state, b);
             }
             return true;
         }, geometry);
-        state.result(mbr);
+        strategy_t::result(state, mbr);
     }
 };
 

--- a/include/boost/geometry/strategies/envelope/cartesian.hpp
+++ b/include/boost/geometry/strategies/envelope/cartesian.hpp
@@ -13,13 +13,14 @@
 
 #include <type_traits>
 
-#include <boost/geometry/strategy/cartesian/envelope.hpp>
+#include <boost/geometry/strategy/cartesian/envelope.hpp> // Not used, for backward compatibility
 #include <boost/geometry/strategy/cartesian/envelope_box.hpp>
-#include <boost/geometry/strategy/cartesian/envelope_point.hpp>
+#include <boost/geometry/strategy/cartesian/envelope_boxes.hpp>
 #include <boost/geometry/strategy/cartesian/envelope_multipoint.hpp>
+#include <boost/geometry/strategy/cartesian/envelope_point.hpp>
+#include <boost/geometry/strategy/cartesian/envelope_range.hpp>
 #include <boost/geometry/strategy/cartesian/envelope_segment.hpp>
 
-#include <boost/geometry/strategies/detail.hpp>
 #include <boost/geometry/strategies/envelope/services.hpp>
 #include <boost/geometry/strategies/expand/cartesian.hpp>
 
@@ -36,44 +37,54 @@ struct cartesian
 {
     template <typename Geometry, typename Box>
     static auto envelope(Geometry const&, Box const&,
-                         typename util::enable_if_point_t<Geometry> * = nullptr)
+                         util::enable_if_point_t<Geometry> * = nullptr)
     {
         return strategy::envelope::cartesian_point();
     }
 
     template <typename Geometry, typename Box>
     static auto envelope(Geometry const&, Box const&,
-                         typename util::enable_if_multi_point_t<Geometry> * = nullptr)
+                         util::enable_if_multi_point_t<Geometry> * = nullptr)
     {
         return strategy::envelope::cartesian_multipoint();
     }
 
     template <typename Geometry, typename Box>
     static auto envelope(Geometry const&, Box const&,
-                         typename util::enable_if_box_t<Geometry> * = nullptr)
+                         util::enable_if_box_t<Geometry> * = nullptr)
     {
         return strategy::envelope::cartesian_box();
     }
 
     template <typename Geometry, typename Box>
     static auto envelope(Geometry const&, Box const&,
-                         typename util::enable_if_segment_t<Geometry> * = nullptr)
+                         util::enable_if_segment_t<Geometry> * = nullptr)
     {
         return strategy::envelope::cartesian_segment<CalculationType>();
     }
 
     template <typename Geometry, typename Box>
     static auto envelope(Geometry const&, Box const&,
-                         typename util::enable_if_polysegmental_t<Geometry> * = nullptr)
+                         std::enable_if_t
+                            <
+                                util::is_linestring<Geometry>::value
+                             || util::is_ring<Geometry>::value
+                             || util::is_polygon<Geometry>::value
+                            > * = nullptr)
     {
-        return strategy::envelope::cartesian<CalculationType>();
+        return strategy::envelope::cartesian_range();
     }
 
     template <typename Geometry, typename Box>
     static auto envelope(Geometry const&, Box const&,
-                         typename util::enable_if_geometry_collection_t<Geometry> * = nullptr)
+                         std::enable_if_t
+                            <
+                                util::is_multi_linestring<Geometry>::value
+                             || util::is_multi_polygon<Geometry>::value
+                             || util::is_geometry_collection<Geometry>::value
+                            > * = nullptr)
     {
-        return strategy::envelope::cartesian<CalculationType>();
+        return strategy::envelope::cartesian_boxes();
     }
 };
 

--- a/include/boost/geometry/strategies/envelope/geographic.hpp
+++ b/include/boost/geometry/strategies/envelope/geographic.hpp
@@ -78,14 +78,23 @@ public:
 
     template <typename Geometry, typename Box>
     auto envelope(Geometry const&, Box const&,
+                  util::enable_if_linestring_t<Geometry> * = nullptr) const
+    {
+        return strategy::envelope::geographic_linestring
+            <
+                FormulaPolicy, Spheroid, CalculationType
+            >(base_t::m_spheroid);
+    }
+
+    template <typename Geometry, typename Box>
+    auto envelope(Geometry const&, Box const&,
                   std::enable_if_t
                     <
-                        util::is_linestring<Geometry>::value
-                     || util::is_ring<Geometry>::value
+                        util::is_ring<Geometry>::value
                      || util::is_polygon<Geometry>::value
                     > * = nullptr) const
     {
-        return strategy::envelope::geographic_range
+        return strategy::envelope::geographic_ring
             <
                 FormulaPolicy, Spheroid, CalculationType
             >(base_t::m_spheroid);

--- a/include/boost/geometry/strategies/envelope/geographic.hpp
+++ b/include/boost/geometry/strategies/envelope/geographic.hpp
@@ -13,10 +13,9 @@
 
 #include <type_traits>
 
-#include <boost/geometry/strategy/geographic/envelope.hpp>
+#include <boost/geometry/strategy/geographic/envelope.hpp> // Not used, for backward compatibility
+#include <boost/geometry/strategy/geographic/envelope_range.hpp>
 #include <boost/geometry/strategy/geographic/envelope_segment.hpp>
-
-#include <boost/geometry/strategy/geographic/expand_segment.hpp> // TEMP
 
 #include <boost/geometry/strategies/envelope/spherical.hpp>
 #include <boost/geometry/strategies/expand/geographic.hpp>
@@ -48,28 +47,28 @@ public:
 
     template <typename Geometry, typename Box>
     static auto envelope(Geometry const&, Box const&,
-                         typename util::enable_if_point_t<Geometry> * = nullptr)
+                         util::enable_if_point_t<Geometry> * = nullptr)
     {
         return strategy::envelope::spherical_point();
     }
 
     template <typename Geometry, typename Box>
     static auto envelope(Geometry const&, Box const&,
-                         typename util::enable_if_multi_point_t<Geometry> * = nullptr)
+                         util::enable_if_multi_point_t<Geometry> * = nullptr)
     {
         return strategy::envelope::spherical_multipoint();
     }
 
     template <typename Geometry, typename Box>
     static auto envelope(Geometry const&, Box const&,
-                         typename util::enable_if_box_t<Geometry> * = nullptr)
+                         util::enable_if_box_t<Geometry> * = nullptr)
     {
         return strategy::envelope::spherical_box();
     }
 
     template <typename Geometry, typename Box>
     auto envelope(Geometry const&, Box const&,
-                  typename util::enable_if_segment_t<Geometry> * = nullptr) const
+                  util::enable_if_segment_t<Geometry> * = nullptr) const
     {
         return strategy::envelope::geographic_segment
             <
@@ -79,9 +78,14 @@ public:
 
     template <typename Geometry, typename Box>
     auto envelope(Geometry const&, Box const&,
-                  typename util::enable_if_polysegmental_t<Geometry> * = nullptr) const
+                  std::enable_if_t
+                    <
+                        util::is_linestring<Geometry>::value
+                     || util::is_ring<Geometry>::value
+                     || util::is_polygon<Geometry>::value
+                    > * = nullptr) const
     {
-        return strategy::envelope::geographic
+        return strategy::envelope::geographic_range
             <
                 FormulaPolicy, Spheroid, CalculationType
             >(base_t::m_spheroid);
@@ -89,12 +93,14 @@ public:
 
     template <typename Geometry, typename Box>
     auto envelope(Geometry const&, Box const&,
-                  typename util::enable_if_geometry_collection_t<Geometry> * = nullptr) const
+                  std::enable_if_t
+                    <
+                        util::is_multi_linestring<Geometry>::value
+                     || util::is_multi_polygon<Geometry>::value
+                     || util::is_geometry_collection<Geometry>::value
+                    > * = nullptr) const
     {
-        return strategy::envelope::geographic
-            <
-                FormulaPolicy, Spheroid, CalculationType
-            >(base_t::m_spheroid);
+        return strategy::envelope::spherical_boxes();
     }
 };
 

--- a/include/boost/geometry/strategies/envelope/spherical.hpp
+++ b/include/boost/geometry/strategies/envelope/spherical.hpp
@@ -13,13 +13,14 @@
 
 #include <type_traits>
 
-#include <boost/geometry/strategy/spherical/envelope.hpp>
+#include <boost/geometry/strategy/spherical/envelope.hpp> // Not used, for backward compatibility
 #include <boost/geometry/strategy/spherical/envelope_box.hpp>
-#include <boost/geometry/strategy/spherical/envelope_point.hpp>
+#include <boost/geometry/strategy/spherical/envelope_boxes.hpp>
 #include <boost/geometry/strategy/spherical/envelope_multipoint.hpp>
+#include <boost/geometry/strategy/spherical/envelope_point.hpp>
+#include <boost/geometry/strategy/spherical/envelope_range.hpp>
 #include <boost/geometry/strategy/spherical/envelope_segment.hpp>
 
-#include <boost/geometry/strategies/detail.hpp>
 #include <boost/geometry/strategies/envelope/services.hpp>
 #include <boost/geometry/strategies/expand/spherical.hpp>
 
@@ -47,44 +48,54 @@ struct spherical
 
     template <typename Geometry, typename Box>
     static auto envelope(Geometry const&, Box const&,
-                         typename util::enable_if_point_t<Geometry> * = nullptr)
+                         util::enable_if_point_t<Geometry> * = nullptr)
     {
         return strategy::envelope::spherical_point();
     }
 
     template <typename Geometry, typename Box>
     static auto envelope(Geometry const&, Box const&,
-                         typename util::enable_if_multi_point_t<Geometry> * = nullptr)
+                         util::enable_if_multi_point_t<Geometry> * = nullptr)
     {
         return strategy::envelope::spherical_multipoint();
     }
 
     template <typename Geometry, typename Box>
     static auto envelope(Geometry const&, Box const&,
-                         typename util::enable_if_box_t<Geometry> * = nullptr)
+                         util::enable_if_box_t<Geometry> * = nullptr)
     {
         return strategy::envelope::spherical_box();
     }
 
     template <typename Geometry, typename Box>
     static auto envelope(Geometry const&, Box const&,
-                         typename util::enable_if_segment_t<Geometry> * = nullptr)
+                         util::enable_if_segment_t<Geometry> * = nullptr)
     {
         return strategy::envelope::spherical_segment<CalculationType>();
     }
 
     template <typename Geometry, typename Box>
     static auto envelope(Geometry const&, Box const&,
-                         typename util::enable_if_polysegmental_t<Geometry> * = nullptr)
+                         std::enable_if_t
+                            <
+                                util::is_linestring<Geometry>::value
+                             || util::is_ring<Geometry>::value
+                             || util::is_polygon<Geometry>::value
+                            > * = nullptr)
     {
-        return strategy::envelope::spherical<CalculationType>();
+        return strategy::envelope::spherical_range<CalculationType>();
     }
 
     template <typename Geometry, typename Box>
     static auto envelope(Geometry const&, Box const&,
-                         typename util::enable_if_geometry_collection_t<Geometry> * = nullptr)
+                         std::enable_if_t
+                            <
+                                util::is_multi_linestring<Geometry>::value
+                             || util::is_multi_polygon<Geometry>::value
+                             || util::is_geometry_collection<Geometry>::value
+                            > * = nullptr)
     {
-        return strategy::envelope::spherical<CalculationType>();
+        return strategy::envelope::spherical_boxes();
     }
 };
 

--- a/include/boost/geometry/strategies/envelope/spherical.hpp
+++ b/include/boost/geometry/strategies/envelope/spherical.hpp
@@ -76,14 +76,20 @@ struct spherical
 
     template <typename Geometry, typename Box>
     static auto envelope(Geometry const&, Box const&,
+                         util::enable_if_linestring_t<Geometry> * = nullptr)
+    {
+        return strategy::envelope::spherical_linestring<CalculationType>();
+    }
+
+    template <typename Geometry, typename Box>
+    static auto envelope(Geometry const&, Box const&,
                          std::enable_if_t
                             <
-                                util::is_linestring<Geometry>::value
-                             || util::is_ring<Geometry>::value
+                                util::is_ring<Geometry>::value
                              || util::is_polygon<Geometry>::value
                             > * = nullptr)
     {
-        return strategy::envelope::spherical_range<CalculationType>();
+        return strategy::envelope::spherical_ring<CalculationType>();
     }
 
     template <typename Geometry, typename Box>

--- a/include/boost/geometry/strategies/envelope/spherical.hpp
+++ b/include/boost/geometry/strategies/envelope/spherical.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2020-2021, Oracle and/or its affiliates.
+// Copyright (c) 2020-2022, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -13,7 +13,6 @@
 
 #include <type_traits>
 
-#include <boost/geometry/strategy/spherical/envelope.hpp> // Not used, for backward compatibility
 #include <boost/geometry/strategy/spherical/envelope_box.hpp>
 #include <boost/geometry/strategy/spherical/envelope_boxes.hpp>
 #include <boost/geometry/strategy/spherical/envelope_multipoint.hpp>

--- a/include/boost/geometry/strategies/spherical/distance_segment_box.hpp
+++ b/include/boost/geometry/strategies/spherical/distance_segment_box.hpp
@@ -14,6 +14,7 @@
 #include <type_traits>
 
 #include <boost/geometry/algorithms/detail/distance/segment_to_box.hpp>
+#include <boost/geometry/algorithms/envelope.hpp>
 
 #include <boost/geometry/strategies/distance.hpp>
 #include <boost/geometry/strategies/normalize.hpp>

--- a/include/boost/geometry/strategy/cartesian/envelope_boxes.hpp
+++ b/include/boost/geometry/strategy/cartesian/envelope_boxes.hpp
@@ -1,0 +1,66 @@
+// Boost.Geometry
+
+// Copyright (c) 2021, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+#ifndef BOOST_GEOMETRY_STRATEGY_CARTESIAN_ENVELOPE_BOXES_HPP
+#define BOOST_GEOMETRY_STRATEGY_CARTESIAN_ENVELOPE_BOXES_HPP
+
+#include <boost/geometry/algorithms/detail/envelope/initialize.hpp>
+#include <boost/geometry/strategy/cartesian/expand_box.hpp>
+
+namespace boost { namespace geometry
+{
+
+namespace strategy { namespace envelope
+{
+
+class cartesian_boxes
+{
+public:
+    template <typename Box>
+    class state
+    {
+        friend cartesian_boxes;
+
+        Box m_box;
+        bool m_initialized = false;
+    };
+
+    template <typename Box>
+    static void apply(state<Box> & st, Box const& box)
+    {
+        if (! st.m_initialized)
+        {
+            st.m_box = box;
+            st.m_initialized = true;
+        }
+        else
+        {
+            strategy::expand::cartesian_box::apply(st.m_box, box);
+        }
+    }
+
+    template <typename Box>
+    static void result(state<Box> const& st, Box & box)
+    {
+        if (st.m_initialized)
+        {
+            box = st.m_box;
+        }
+        else
+        {
+            geometry::detail::envelope::initialize<Box, 0, dimension<Box>::value>::apply(box);
+        }
+    }
+};
+
+}} // namespace strategy::envelope
+
+}} //namepsace boost::geometry
+
+#endif // BOOST_GEOMETRY_STRATEGY_CARTESIAN_ENVELOPE_BOXES_HPP

--- a/include/boost/geometry/strategy/cartesian/envelope_range.hpp
+++ b/include/boost/geometry/strategy/cartesian/envelope_range.hpp
@@ -1,0 +1,56 @@
+// Boost.Geometry
+
+// Copyright (c) 2021, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+#ifndef BOOST_GEOMETRY_STRATEGY_CARTESIAN_ENVELOPE_RANGE_HPP
+#define BOOST_GEOMETRY_STRATEGY_CARTESIAN_ENVELOPE_RANGE_HPP
+
+#include <boost/range/begin.hpp>
+#include <boost/range/end.hpp>
+
+#include <boost/geometry/algorithms/detail/envelope/initialize.hpp>
+#include <boost/geometry/strategy/cartesian/envelope_point.hpp>
+#include <boost/geometry/strategy/cartesian/expand_point.hpp>
+
+namespace boost { namespace geometry
+{
+
+namespace strategy { namespace envelope
+{
+
+class cartesian_range
+{
+public:
+    template <typename Range, typename Box>
+    static inline void apply(Range const& range, Box& mbr)
+    {
+        auto it = boost::begin(range);
+        auto const end = boost::end(range);
+        if (it == end)
+        {
+            // initialize box (assign inverse)
+            geometry::detail::envelope::initialize<Box>::apply(mbr);
+            return;
+        }
+
+        // initialize box with the first point
+        envelope::cartesian_point::apply(*it, mbr);
+
+        // consider now the remaining points in the range (if any)
+        for (++it; it != end; ++it)
+        {
+            expand::cartesian_point::apply(mbr, *it);
+        }
+    }
+};
+
+}} // namespace strategy::envelope
+
+}} //namepsace boost::geometry
+
+#endif // BOOST_GEOMETRY_STRATEGY_CARTESIAN_ENVELOPE_RANGE_HPP

--- a/include/boost/geometry/strategy/geographic/envelope_range.hpp
+++ b/include/boost/geometry/strategy/geographic/envelope_range.hpp
@@ -14,13 +14,14 @@
 #include <boost/geometry/strategy/geographic/expand_segment.hpp>
 #include <boost/geometry/strategy/spherical/envelope_range.hpp>
 
+// TEMP - get rid of this dependency
+#include <boost/geometry/strategies/geographic/point_in_poly_winding.hpp>
+
 namespace boost { namespace geometry
 {
 
 namespace strategy { namespace envelope
 {
-
-// TODO: divide into geographic_linestring and geographic_ring
 
 template
 <
@@ -28,29 +29,76 @@ template
     typename Spheroid = geometry::srs::spheroid<double>,
     typename CalculationType = void
 >
-class geographic_range
+class geographic_linestring
 {
 public:
     using model_type = Spheroid;
 
-    geographic_range()
+    geographic_linestring()
         : m_spheroid()
     {}
 
-    explicit geographic_range(Spheroid const& spheroid)
+    explicit geographic_linestring(Spheroid const& spheroid)
         : m_spheroid(spheroid)
     {}
 
     template <typename Range, typename Box>
     void apply(Range const& range, Box& mbr) const
     {
-        detail::spheroidal_range(range, mbr,
-                                 envelope::geographic_segment
+        detail::spheroidal_linestring(range, mbr,
+                                      envelope::geographic_segment
+                                        <
+                                            FormulaPolicy, Spheroid, CalculationType
+                                        >(m_spheroid),
+                                      expand::geographic_segment
+                                        <
+                                            FormulaPolicy, Spheroid, CalculationType
+                                        >(m_spheroid));
+    }
+
+    Spheroid model() const
+    {
+        return m_spheroid;
+    }
+
+private:
+    Spheroid m_spheroid;
+};
+
+template
+<
+    typename FormulaPolicy = strategy::andoyer,
+    typename Spheroid = geometry::srs::spheroid<double>,
+    typename CalculationType = void
+>
+class geographic_ring
+{
+public:
+    using model_type = Spheroid;
+
+    geographic_ring()
+        : m_spheroid()
+    {}
+
+    explicit geographic_ring(Spheroid const& spheroid)
+        : m_spheroid(spheroid)
+    {}
+
+    template <typename Range, typename Box>
+    void apply(Range const& range, Box& mbr) const
+    {
+        detail::spheroidal_ring(range, mbr,
+                                envelope::geographic_segment
                                     <
                                         FormulaPolicy, Spheroid, CalculationType
                                     >(m_spheroid),
-                                 expand::geographic_segment
+                                expand::geographic_segment
                                     <
+                                        FormulaPolicy, Spheroid, CalculationType
+                                    >(m_spheroid),
+                                within::geographic_winding
+                                    <
+                                        void, void,
                                         FormulaPolicy, Spheroid, CalculationType
                                     >(m_spheroid));
     }

--- a/include/boost/geometry/strategy/geographic/envelope_range.hpp
+++ b/include/boost/geometry/strategy/geographic/envelope_range.hpp
@@ -14,8 +14,8 @@
 #include <boost/geometry/strategy/geographic/expand_segment.hpp>
 #include <boost/geometry/strategy/spherical/envelope_range.hpp>
 
-// TEMP - get rid of this dependency
-#include <boost/geometry/strategies/geographic/point_in_poly_winding.hpp>
+// Get rid of this dependency?
+#include <boost/geometry/strategies/spherical/point_in_poly_winding.hpp>
 
 namespace boost { namespace geometry
 {
@@ -96,11 +96,11 @@ public:
                                     <
                                         FormulaPolicy, Spheroid, CalculationType
                                     >(m_spheroid),
-                                within::geographic_winding
+                                within::detail::spherical_winding_base
                                     <
-                                        void, void,
-                                        FormulaPolicy, Spheroid, CalculationType
-                                    >(m_spheroid));
+                                        envelope::detail::side_of_pole<CalculationType>,
+                                        CalculationType
+                                    >());
     }
 
     Spheroid model() const

--- a/include/boost/geometry/strategy/geographic/envelope_range.hpp
+++ b/include/boost/geometry/strategy/geographic/envelope_range.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021-2022, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -45,15 +45,15 @@ public:
     template <typename Range, typename Box>
     void apply(Range const& range, Box& mbr) const
     {
-        detail::spheroidal_linestring(range, mbr,
-                                      envelope::geographic_segment
-                                        <
-                                            FormulaPolicy, Spheroid, CalculationType
-                                        >(m_spheroid),
-                                      expand::geographic_segment
-                                        <
-                                            FormulaPolicy, Spheroid, CalculationType
-                                        >(m_spheroid));
+        auto const envelope_s = envelope::geographic_segment
+            <
+                FormulaPolicy, Spheroid, CalculationType
+            >(m_spheroid);
+        auto const expand_s = expand::geographic_segment
+            <
+                FormulaPolicy, Spheroid, CalculationType
+            >(m_spheroid);
+        detail::spheroidal_linestring(range, mbr, envelope_s, expand_s);
     }
 
     Spheroid model() const
@@ -87,20 +87,19 @@ public:
     template <typename Range, typename Box>
     void apply(Range const& range, Box& mbr) const
     {
-        detail::spheroidal_ring(range, mbr,
-                                envelope::geographic_segment
-                                    <
-                                        FormulaPolicy, Spheroid, CalculationType
-                                    >(m_spheroid),
-                                expand::geographic_segment
-                                    <
-                                        FormulaPolicy, Spheroid, CalculationType
-                                    >(m_spheroid),
-                                within::detail::spherical_winding_base
-                                    <
-                                        envelope::detail::side_of_pole<CalculationType>,
-                                        CalculationType
-                                    >());
+        auto const envelope_s = envelope::geographic_segment
+            <
+                FormulaPolicy, Spheroid, CalculationType
+            >(m_spheroid);
+        auto const expand_s = expand::geographic_segment
+            <
+                FormulaPolicy, Spheroid, CalculationType
+            >(m_spheroid);
+        auto const within_s = within::detail::spherical_winding_base
+            <
+                envelope::detail::side_of_pole<CalculationType>, CalculationType
+            >();
+        detail::spheroidal_ring(range, mbr, envelope_s, expand_s, within_s);
     }
 
     Spheroid model() const

--- a/include/boost/geometry/strategy/geographic/envelope_range.hpp
+++ b/include/boost/geometry/strategy/geographic/envelope_range.hpp
@@ -1,0 +1,71 @@
+// Boost.Geometry
+
+// Copyright (c) 2021, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+#ifndef BOOST_GEOMETRY_STRATEGY_GEOGRAPHIC_ENVELOPE_RANGE_HPP
+#define BOOST_GEOMETRY_STRATEGY_GEOGRAPHIC_ENVELOPE_RANGE_HPP
+
+#include <boost/geometry/strategy/geographic/envelope_segment.hpp>
+#include <boost/geometry/strategy/geographic/expand_segment.hpp>
+#include <boost/geometry/strategy/spherical/envelope_range.hpp>
+
+namespace boost { namespace geometry
+{
+
+namespace strategy { namespace envelope
+{
+
+// TODO: divide into geographic_linestring and geographic_ring
+
+template
+<
+    typename FormulaPolicy = strategy::andoyer,
+    typename Spheroid = geometry::srs::spheroid<double>,
+    typename CalculationType = void
+>
+class geographic_range
+{
+public:
+    using model_type = Spheroid;
+
+    geographic_range()
+        : m_spheroid()
+    {}
+
+    explicit geographic_range(Spheroid const& spheroid)
+        : m_spheroid(spheroid)
+    {}
+
+    template <typename Range, typename Box>
+    void apply(Range const& range, Box& mbr) const
+    {
+        detail::spheroidal_range(range, mbr,
+                                 envelope::geographic_segment
+                                    <
+                                        FormulaPolicy, Spheroid, CalculationType
+                                    >(m_spheroid),
+                                 expand::geographic_segment
+                                    <
+                                        FormulaPolicy, Spheroid, CalculationType
+                                    >(m_spheroid));
+    }
+
+    Spheroid model() const
+    {
+        return m_spheroid;
+    }
+
+private:
+    Spheroid m_spheroid;
+};
+
+}} // namespace strategy::envelope
+
+}} //namepsace boost::geometry
+
+#endif // BOOST_GEOMETRY_STRATEGY_GEOGRAPHIC_ENVELOPE_RANGE_HPP

--- a/include/boost/geometry/strategy/spherical/envelope_boxes.hpp
+++ b/include/boost/geometry/strategy/spherical/envelope_boxes.hpp
@@ -1,0 +1,59 @@
+// Boost.Geometry
+
+// Copyright (c) 2021, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+#ifndef BOOST_GEOMETRY_STRATEGY_SPHERICAL_ENVELOPE_BOXES_HPP
+#define BOOST_GEOMETRY_STRATEGY_SPHERICAL_ENVELOPE_BOXES_HPP
+
+#include <vector>
+
+#include <boost/geometry/algorithms/detail/envelope/initialize.hpp>
+#include <boost/geometry/algorithms/detail/envelope/range_of_boxes.hpp>
+
+namespace boost { namespace geometry
+{
+
+namespace strategy { namespace envelope
+{
+
+class spherical_boxes
+{
+public:
+    template <typename Box>
+    class state
+    {
+        friend spherical_boxes;
+
+        std::vector<Box> m_boxes;
+    };
+
+    template <typename Box>
+    static void apply(state<Box> & st, Box const& box)
+    {
+        st.m_boxes.push_back(box);
+    }
+
+    template <typename Box>
+    static void result(state<Box> const& st, Box & box)
+    {
+        if (! st.m_boxes.empty())
+        {
+            geometry::detail::envelope::envelope_range_of_boxes::apply(st.m_boxes, box);
+        }
+        else
+        {
+            geometry::detail::envelope::initialize<Box, 0, dimension<Box>::value>::apply(box);
+        }
+    }
+};
+
+}} // namespace strategy::envelope
+
+}} //namepsace boost::geometry
+
+#endif // BOOST_GEOMETRY_STRATEGY_SPHERICAL_ENVELOPE_BOXES_HPP

--- a/include/boost/geometry/strategy/spherical/envelope_range.hpp
+++ b/include/boost/geometry/strategy/spherical/envelope_range.hpp
@@ -1,0 +1,93 @@
+// Boost.Geometry
+
+// Copyright (c) 2021, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+#ifndef BOOST_GEOMETRY_STRATEGY_SPHERICAL_ENVELOPE_RANGE_HPP
+#define BOOST_GEOMETRY_STRATEGY_SPHERICAL_ENVELOPE_RANGE_HPP
+
+#include <boost/geometry/algorithms/detail/envelope/initialize.hpp>
+#include <boost/geometry/geometries/segment.hpp>
+#include <boost/geometry/strategy/spherical/envelope_point.hpp>
+#include <boost/geometry/strategy/spherical/envelope_segment.hpp>
+#include <boost/geometry/strategy/spherical/expand_segment.hpp>
+#include <boost/geometry/views/closeable_view.hpp>
+
+namespace boost { namespace geometry
+{
+
+namespace strategy { namespace envelope
+{
+
+#ifndef DOXYGEN_NO_DETAIL
+namespace detail
+{
+
+template <typename Range, typename Box, typename EnvelopeStrategy, typename ExpandStrategy>
+inline void spheroidal_range(Range const& range, Box& mbr,
+                             EnvelopeStrategy const& envelope_strategy,
+                             ExpandStrategy const& expand_strategy)
+{
+    geometry::detail::closed_view<Range const> closed_range(range);
+
+    auto it = boost::begin(closed_range);
+    auto const end = boost::end(closed_range);
+    if (it == end)
+    {
+        // initialize box (assign inverse)
+        geometry::detail::envelope::initialize<Box>::apply(mbr);
+        return;
+    }
+
+    auto prev = it;
+    ++it;
+    if (it == end)
+    {
+        // initialize box with the first point
+        envelope::spherical_point::apply(*prev, mbr);
+        return;
+    }
+
+    // initialize box with the first segment
+    envelope_strategy.apply(*prev, *it, mbr);
+
+    // consider now the remaining segments in the range (if any)
+    prev = it;
+    ++it;
+    while (it != end)
+    {
+        using point_t = typename boost::range_value<Range>::type;
+        geometry::model::referring_segment<point_t const> const seg(*prev, *it);
+        expand_strategy.apply(mbr, seg);
+        prev = it;
+        ++it;
+    }
+}
+
+} // namespace detail
+#endif // DOXYGEN_NO_DETAIL
+
+// TODO: divide into spherical_linestring and spherical_ring
+
+template <typename CalculationType = void>
+class spherical_range
+{
+public:
+    template <typename Range, typename Box>
+    static inline void apply(Range const& range, Box& mbr)
+    {
+        detail::spheroidal_range(range, mbr,
+                                 envelope::spherical_segment<CalculationType>(),
+                                 expand::spherical_segment<CalculationType>());
+    }
+};
+
+}} // namespace strategy::envelope
+
+}} //namepsace boost::geometry
+
+#endif // BOOST_GEOMETRY_STRATEGY_SPHERICAL_ENVELOPE_RANGE_HPP

--- a/include/boost/geometry/strategy/spherical/envelope_range.hpp
+++ b/include/boost/geometry/strategy/spherical/envelope_range.hpp
@@ -10,12 +10,18 @@
 #ifndef BOOST_GEOMETRY_STRATEGY_SPHERICAL_ENVELOPE_RANGE_HPP
 #define BOOST_GEOMETRY_STRATEGY_SPHERICAL_ENVELOPE_RANGE_HPP
 
+#include <boost/geometry/algorithms/assign.hpp>
 #include <boost/geometry/algorithms/detail/envelope/initialize.hpp>
 #include <boost/geometry/geometries/segment.hpp>
 #include <boost/geometry/strategy/spherical/envelope_point.hpp>
 #include <boost/geometry/strategy/spherical/envelope_segment.hpp>
 #include <boost/geometry/strategy/spherical/expand_segment.hpp>
 #include <boost/geometry/views/closeable_view.hpp>
+
+// TEMP - get rid of these dependencies
+#include <boost/geometry/algorithms/detail/within/point_in_geometry.hpp>
+#include <boost/geometry/strategies/spherical/point_in_poly_winding.hpp>
+
 
 namespace boost { namespace geometry
 {
@@ -28,14 +34,12 @@ namespace detail
 {
 
 template <typename Range, typename Box, typename EnvelopeStrategy, typename ExpandStrategy>
-inline void spheroidal_range(Range const& range, Box& mbr,
-                             EnvelopeStrategy const& envelope_strategy,
-                             ExpandStrategy const& expand_strategy)
+inline void spheroidal_linestring(Range const& range, Box& mbr,
+                                  EnvelopeStrategy const& envelope_strategy,
+                                  ExpandStrategy const& expand_strategy)
 {
-    geometry::detail::closed_view<Range const> closed_range(range);
-
-    auto it = boost::begin(closed_range);
-    auto const end = boost::end(closed_range);
+    auto it = boost::begin(range);
+    auto const end = boost::end(range);
     if (it == end)
     {
         // initialize box (assign inverse)
@@ -68,21 +72,125 @@ inline void spheroidal_range(Range const& range, Box& mbr,
     }
 }
 
+
+template <typename Ring, typename WithinStrategy>
+inline bool pole_within(bool north_pole, Ring const& ring, WithinStrategy const& within_strategy)
+{
+    if (boost::size(ring) < core_detail::closure::minimum_ring_size
+                                <
+                                    geometry::closure<Ring>::value
+                                >::value)
+    {
+        return false;
+    }
+
+    using point_t = typename geometry::point_type<Ring>::type;
+    using coord_t = typename geometry::coordinate_type<point_t>::type;
+    using units_t = typename geometry::detail::cs_angular_units<point_t>::type;
+    using constants_t = math::detail::constants_on_spheroid<coord_t, units_t>;
+    point_t point;
+    geometry::assign_zero(point);
+    if (north_pole)
+    {
+        geometry::set<1>(point, constants_t::max_latitude());
+    }
+    else
+    {
+        geometry::set<1>(point, constants_t::min_latitude());
+    }
+    geometry::detail::closed_clockwise_view<Ring const> view(ring);
+    return geometry::detail::within::point_in_range(point, view, within_strategy) > 0;
+}
+
+template <typename Range, typename Box, typename EnvelopeStrategy, typename ExpandStrategy, typename WithinStrategy>
+inline void spheroidal_ring(Range const& range, Box& mbr,
+                            EnvelopeStrategy const& envelope_strategy,
+                            ExpandStrategy const& expand_strategy,
+                            WithinStrategy const& within_strategy)
+{
+    geometry::detail::closed_view<Range const> closed_range(range);
+
+    spheroidal_linestring(closed_range, mbr, envelope_strategy, expand_strategy);
+    
+    using coord_t = typename geometry::coordinate_type<Box>::type;
+    using point_t = typename geometry::point_type<Box>::type;    
+    using units_t = typename geometry::detail::cs_angular_units<point_t>::type;
+    using constants_t = math::detail::constants_on_spheroid<coord_t, units_t>;
+    coord_t const two_pi = constants_t::period();
+    coord_t const lon_min = geometry::get<0, 0>(mbr);
+    coord_t const lon_max = geometry::get<1, 0>(mbr);
+    // If box covers the whole longitude range it is possible that the ring contains
+    // one of the poles.
+    // TODO: Technically it is possible that a reversed ring may cover more than
+    // half of the globe and mbr of it's linear ring may be small and not cover the
+    // longitude range.
+    if (lon_max - lon_min >= two_pi)
+    {
+        coord_t const lat_n_pole = constants_t::max_latitude();
+        coord_t const lat_s_pole = constants_t::min_latitude();
+        coord_t lat_min = geometry::get<0, 1>(mbr);
+        coord_t lat_max = geometry::get<1, 1>(mbr);
+        // Normalize box latitudes, just in case
+        if (math::equals(lat_min, lat_s_pole))
+        {
+            lat_min = lat_s_pole;
+        }
+        if (math::equals(lat_max, lat_n_pole))
+        {
+            lat_max = lat_n_pole;
+        }
+
+        // TODO - implement something simpler than within strategy because here
+        // we know that neither min nor max is a pole so there is no segment which
+        // contains a pole, no endpoint, no vertex at pole, there are no antipodal
+        // points. So many special cases can be ignored.
+        if (lat_max < lat_n_pole)
+        {
+            if (pole_within(true, range, within_strategy))
+            {
+                lat_max = lat_n_pole;
+            }
+        }
+        if (lat_min > lat_s_pole)
+        {
+            if (pole_within(false, range, within_strategy))
+            {
+                lat_min = lat_s_pole;
+            }
+        }
+
+        geometry::set<0, 1>(mbr, lat_min);
+        geometry::set<1, 1>(mbr, lat_max);
+    }
+}
+
 } // namespace detail
 #endif // DOXYGEN_NO_DETAIL
 
-// TODO: divide into spherical_linestring and spherical_ring
-
 template <typename CalculationType = void>
-class spherical_range
+class spherical_linestring
 {
 public:
     template <typename Range, typename Box>
     static inline void apply(Range const& range, Box& mbr)
     {
-        detail::spheroidal_range(range, mbr,
-                                 envelope::spherical_segment<CalculationType>(),
-                                 expand::spherical_segment<CalculationType>());
+        detail::spheroidal_linestring(range, mbr,
+                                      envelope::spherical_segment<CalculationType>(),
+                                      expand::spherical_segment<CalculationType>());
+    }
+};
+
+template <typename CalculationType = void>
+class spherical_ring
+{
+public:
+    template <typename Range, typename Box>
+    static inline void apply(Range const& range, Box& mbr)
+    {
+        detail::spheroidal_ring(range, mbr,
+                                envelope::spherical_segment<CalculationType>(),
+                                expand::spherical_segment<CalculationType>(),
+                                within::spherical_winding<void, void, CalculationType>());
     }
 };
 

--- a/include/boost/geometry/views/detail/closed_clockwise_view.hpp
+++ b/include/boost/geometry/views/detail/closed_clockwise_view.hpp
@@ -67,6 +67,31 @@ private:
 #endif // DOXYGEN_NO_DETAIL
 
 
+#ifndef DOXYGEN_NO_TRAITS_SPECIALIZATIONS
+namespace traits
+{
+
+template <typename Range, closure_selector Closure, order_selector Order>
+struct tag<detail::closed_clockwise_view<Range, Closure, Order> >
+    : geometry::tag<Range>
+{};
+
+template <typename Range, closure_selector Closure, order_selector Order>
+struct point_order<detail::closed_clockwise_view<Range, Closure, Order> >
+{
+    static const order_selector value = clockwise;
+};
+
+template <typename Range, closure_selector Closure, order_selector Order>
+struct closure<detail::closed_clockwise_view<Range, Closure, Order> >
+{
+    static const closure_selector value = closed;
+};
+
+} // namespace traits
+#endif // DOXYGEN_NO_TRAITS_SPECIALIZATIONS
+
+
 }} // namespace boost::geometry
 
 

--- a/test/algorithms/envelope_expand/envelope_on_spheroid.cpp
+++ b/test/algorithms/envelope_expand/envelope_on_spheroid.cpp
@@ -2736,14 +2736,20 @@ BOOST_AUTO_TEST_CASE( envelope_cw_ring )
     tester::apply("r28cw",
                   from_wkt<G>("POLYGON((),(0 -80,-90 -80,-180 -80,90 -80,0 -80))"),
                   -180, -90, 180, -80);
-
-    typedef bg::model::polygon<point_type, false> G2;
-    typedef test_envelope_on_sphere_or_spheroid<G2, B> tester2;
-    tester2::apply("r27ccw",
-                   from_wkt<G2>("POLYGON((),(0 80,-90 80,-180 80,90 80,0 80))"),
-                   -180, 80, 180, 90);
-    tester2::apply("r28ccw",
-                   from_wkt<G2>("POLYGON((),(0 -80,90 -80,-180 -80,-90 -80,0 -80))"),
-                   -180, -90, 180, -80);
 }
 
+BOOST_AUTO_TEST_CASE(envelope_ccw_ring)
+{
+    typedef bg::cs::spherical_equatorial<bg::degree> coordinate_system_type;
+    typedef bg::model::point<double, 2, coordinate_system_type> point_type;
+    typedef bg::model::polygon<point_type, false> G;
+    typedef bg::model::box<point_type> B;
+    typedef test_envelope_on_sphere_or_spheroid<G, B> tester;
+
+    tester::apply("r27ccw",
+                  from_wkt<G>("POLYGON((),(0 80,-90 80,-180 80,90 80,0 80))"),
+                  -180, 80, 180, 90);
+    tester::apply("r28ccw",
+                  from_wkt<G>("POLYGON((),(0 -80,90 -80,-180 -80,-90 -80,0 -80))"),
+                  -180, -90, 180, -80);
+}

--- a/test/algorithms/envelope_expand/envelope_on_spheroid.cpp
+++ b/test/algorithms/envelope_expand/envelope_on_spheroid.cpp
@@ -2710,20 +2710,40 @@ BOOST_AUTO_TEST_CASE( envelope_cw_ring )
 #endif
 
     // From disjoint  https://svn.boost.org/trac/boost/ticket/9162
+    // Polygons containing poles
     tester::apply("r22cw",
                   from_wkt<G>("POLYGON((0 80,-90 80,-180 80,90 80,0 80))"),
                   -180, 80, 180, 90);
     tester::apply("r23cw",
                   from_wkt<G>("POLYGON((0 -80,90 -80,-180 -80,-90 -80,0 -80))"),
                   -180, -90, 180, -80);
+    // Polygons greater than half of the globe
     tester::apply("r24cw",
                   from_wkt<G>("POLYGON((0 80,90 80,-180 80,-90 80,0 80))"),
                   -180, -90, 180, 82.892923889553458);
     tester::apply("r25cw",
                   from_wkt<G>("POLYGON((0 -80,-90 -80,-180 -80,90 -80,0 -80))"),
                   -180, -82.892923889553458, 180, 90);
+    // Normal test case
     tester::apply("r26cw",
                   from_wkt<G>("POLYGON((30 0,30 30,90 30, 90 0, 30 0))"),
                   30, 0, 90, 33.690067525979771);
+
+    // Invalid polygons with holes containing poles
+    tester::apply("r27cw",
+                  from_wkt<G>("POLYGON((),(0 80,90 80,-180 80,-90 80,0 80))"),
+                  -180, 80, 180, 90);
+    tester::apply("r28cw",
+                  from_wkt<G>("POLYGON((),(0 -80,-90 -80,-180 -80,90 -80,0 -80))"),
+                  -180, -90, 180, -80);
+
+    typedef bg::model::polygon<point_type, false> G2;
+    typedef test_envelope_on_sphere_or_spheroid<G2, B> tester2;
+    tester2::apply("r27ccw",
+                   from_wkt<G2>("POLYGON((),(0 80,-90 80,-180 80,90 80,0 80))"),
+                   -180, 80, 180, 90);
+    tester2::apply("r28ccw",
+                   from_wkt<G2>("POLYGON((),(0 -80,90 -80,-180 -80,-90 -80,0 -80))"),
+                   -180, -90, 180, -80);
 }
 

--- a/test/algorithms/envelope_expand/envelope_on_spheroid.cpp
+++ b/test/algorithms/envelope_expand/envelope_on_spheroid.cpp
@@ -2493,16 +2493,18 @@ BOOST_AUTO_TEST_CASE( envelope_cw_ring )
     typedef bg::model::box<point_type> B;
     typedef test_envelope_on_sphere_or_spheroid<G, B> tester;
 
-    //double const eps = std::numeric_limits<double>::epsilon();
+    double const eps = std::numeric_limits<double>::epsilon();
 
     tester::apply("r01cw",
                   from_wkt<G>("POLYGON((0 10,0 45,50 10,0 10))"),
                   0, 10, 50, 45);
-#if 0
+
+#ifdef BOOST_GEOMETRY_TEST_ENABLE_FAILING
     // ring that contains both the north and south poles in its interior
     tester::apply("r01cw-r",
                   from_wkt<G>("POLYGON((0 10,50 10,0 45,0 10))"),
                   -180, -90, 180, 90);
+#endif
 
     // ring that contains the north pole in its interior
     tester::apply("r02cw",
@@ -2528,10 +2530,12 @@ BOOST_AUTO_TEST_CASE( envelope_cw_ring )
                   -180, -90, 180, -10);
     //                  -180, -19.42540014068282, 180, 90);
 
+#ifdef BOOST_GEOMETRY_TEST_ENABLE_FAILING
     // ring that has the north pole as vertex and contains the south pole
     tester::apply("r04cw",
                   from_wkt<G>("POLYGON((0 0,-50 90,-50 0,0 0))"),
                   -180, -90, 180, 90);
+#endif
 
     // ring that has the north pole as vertex
     tester::apply("r04cw-r",
@@ -2561,10 +2565,12 @@ BOOST_AUTO_TEST_CASE( envelope_cw_ring )
                   from_wkt<G>("POLYGON((0 0,-50 0,-50 90,0 0))"),
                   -50, 0, 0, 90);
 
+#ifdef BOOST_GEOMETRY_TEST_ENABLE_FAILING
     // ring that goes through the south pole and contains the north pole
     tester::apply("r09cw",
                   from_wkt<G>("POLYGON((0 0,0 -90,50 0,0 0))"),
                   -180, -90, 180, 90);
+#endif
 
     // ring that goes through the south pole
     tester::apply("r09cw-r",
@@ -2599,11 +2605,13 @@ BOOST_AUTO_TEST_CASE( envelope_cw_ring )
                   from_wkt<G>("POLYGON((100 45,0 45,-100 45,-100 90,100 45))"),
                   -100, 45, 100, 90);
 
+#ifdef BOOST_GEOMETRY_TEST_ENABLE_FAILING
     // ring that represents the complement of a spherical cap
     // near the north pole
     tester::apply("r13cw-r",
                   from_wkt<G>("POLYGON((-100 45,0 45,100 45,100 90,-100 45))"),
                   -180, -90, 180, 90);
+#endif
 
     // ring that represents the complement of a spherical cap
     // that touches the south pole
@@ -2611,10 +2619,12 @@ BOOST_AUTO_TEST_CASE( envelope_cw_ring )
                   from_wkt<G>("POLYGON((-100 45,0 45,100 45,100 -90,-100 45))"),
                   -100, -90, 100, 57.26759279038765);
 
+#ifdef BOOST_GEOMETRY_TEST_ENABLE_FAILING
     // ring that represents a spherical cap that touches the south pole
     tester::apply("r14cw-r",
                   from_wkt<G>("POLYGON((100 45,0 45,-100 45,-100 -90,100 45))"),
                   -180, -90, 180, 90);
+#endif
 
     // ring with edge that goes through the south pole
     tester::apply("r15cw",
@@ -2632,6 +2642,7 @@ BOOST_AUTO_TEST_CASE( envelope_cw_ring )
                   from_wkt<G>("POLYGON((-50 -80,-50 -40,-30 -40,-30 -80,-50 -80))"),
                   -50, -80.14892388341609, -30, -40);
 
+#ifdef BOOST_GEOMETRY_TEST_ENABLE_FAILING
     // ring that lies in the lower hemisphere and contains both poles
     tester::apply("r16-r",
                   from_wkt<G>("POLYGON((-50 -80,-30 -80,-30 -40,-50 -40,-50 -80))"),
@@ -2641,26 +2652,31 @@ BOOST_AUTO_TEST_CASE( envelope_cw_ring )
     tester::apply("r17cw",
                   from_wkt<G>("POLYGON((50 0,50 -90,100 0,50 0))"),
                   -180, -90, 180, 90);
+#endif
 
     // ring that goes through the south pole
     tester::apply("r17cw-r",
                   from_wkt<G>("POLYGON((50 0,100 0,100 -90,50 0))"),
                   50, -90, 100, 0);
 
+#ifdef BOOST_GEOMETRY_TEST_ENABLE_FAILING
     // ring that goes through the south pole and contains the north pole
     tester::apply("r18cw",
                   from_wkt<G>("POLYGON((50 0,50 -90,460 0,50 0))"),
                   -180, -90, 180, 90);
+#endif
 
     // ring that goes through the south pole
     tester::apply("r18cw-r",
                   from_wkt<G>("POLYGON((50 0,460 0,100 -90,50 0))"),
                   50, -90, 100, 0);
 
+#ifdef BOOST_GEOMETRY_TEST_ENABLE_FAILING
     // ring that goes through the south pole and contains the north pole
     tester::apply("r19cw",
                   from_wkt<G>("POLYGON((50 0,50 -90,-260 0,50 0))"),
                   -180, -90, 180, 90);
+#endif
 
     // ring that goes through the south pole
     tester::apply("r19cw-r",
@@ -2672,10 +2688,12 @@ BOOST_AUTO_TEST_CASE( envelope_cw_ring )
                   from_wkt<G>("POLYGON((10 0,10 90,20 0,20 -90,10 0))"),
                   10, -90, 20, 90); // SUCCEEDS FOR WRONG REASON
 
+#ifdef BOOST_GEOMETRY_TEST_ENABLE_FAILING
     // ring that goes through both poles
     tester::apply("r20cw-r",
                   from_wkt<G>("POLYGON((10 0,10 -90,20 0,20 90,10 0))"),
-        -180, -90, 180, 90); // FAILS NOW
+                  -180, -90, 180, 90);
+#endif
 
     // ring that goes through both poles and its boundary forms
     // a great circle
@@ -2683,11 +2701,29 @@ BOOST_AUTO_TEST_CASE( envelope_cw_ring )
                   from_wkt<G>("POLYGON((-10 0,-10 90,170 0,170 -90,-10 0))"),
                   -10, -90, 170, 90); // SUCCEEDS FOR WRONG REASON
 
+#ifdef BOOST_GEOMETRY_TEST_ENABLE_FAILING
     // ring that goes through both poles and its boundary forms
     // a great circle
     tester::apply("r21cw-r",
                   from_wkt<G>("POLYGON((-10 0,-10 -90,170 0,170 90,-10 0))"),
-                  170, -90, 350, 90); // FAILS NOW
+                  170, -90, 350, 90);
 #endif
+
+    // From disjoint  https://svn.boost.org/trac/boost/ticket/9162
+    tester::apply("r22cw",
+                  from_wkt<G>("POLYGON((0 80,-90 80,-180 80,90 80,0 80))"),
+                  -180, 80, 180, 90);
+    tester::apply("r23cw",
+                  from_wkt<G>("POLYGON((0 -80,90 -80,-180 -80,-90 -80,0 -80))"),
+                  -180, -90, 180, -80);
+    tester::apply("r24cw",
+                  from_wkt<G>("POLYGON((0 80,90 80,-180 80,-90 80,0 80))"),
+                  -180, -90, 180, 82.892923889553458);
+    tester::apply("r25cw",
+                  from_wkt<G>("POLYGON((0 -80,-90 -80,-180 -80,90 -80,0 -80))"),
+                  -180, -82.892923889553458, 180, 90);
+    tester::apply("r26cw",
+                  from_wkt<G>("POLYGON((30 0,30 30,90 30, 90 0, 30 0))"),
+                  30, 0, 90, 33.690067525979771);
 }
 

--- a/test/algorithms/envelope_expand/envelope_on_spheroid.cpp
+++ b/test/algorithms/envelope_expand/envelope_on_spheroid.cpp
@@ -1,7 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 // Unit Test
 
-// Copyright (c) 2015-2021, Oracle and/or its affiliates.
+// Copyright (c) 2015-2022, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle


### PR DESCRIPTION
This PR fixes spherical and geographic envelope for polygons containing poles. Currently the envelope of a polygon is the envelope of the linear ring. If a polygon is a polar cap then the result is incorrect because the envelope should contain the pole even if it's above or below linear ring.

If an envelope covers the whole longitude range then poles are checked to see whether or not they are inside the ring. This check is done with `point_in_poly` strategy with custom `pole_side` strategy to avoid costly calculation done in regular side strategies.

Additional changes:
- envelope strategy previously used for linear and polygonal geometries as well as multi geometries is divided into three strategies: one for linestring, one for ring and one for range of boxes which is used for multi geometries,
- `point_iterator` and `segment_iterator` are no longer used (ranges are processed in strategies based on CS),
- `clockwise_view`, `closed_view` and `closed_clockwise_view` are adapted to geometry concepts based on the input `Range` which allows passing them as geometries into various algorithms,
- test are added and other that were previously disabled are enabled.