### PR TITLE
[test] cleanup svg generation

### DIFF
--- a/test/algorithms/centroid.cpp
+++ b/test/algorithms/centroid.cpp
@@ -217,8 +217,6 @@ void test_large_integers()
     BOOST_CHECK_EQUAL(bg::get<1>(int_centroid), bg::get<1>(double_centroid_as_int));
 }
 
-//#include <to_svg.hpp>
-
 void test_large_doubles()
 {
     typedef bg::model::point<double, 2, bg::cs::cartesian> point;
@@ -238,9 +236,6 @@ void test_large_doubles()
     point pt_near_moved;
     bg::set<0>(pt_near_moved, bg::get<0>(pt_near) + 1074000.0);
     bg::set<1>(pt_near_moved, bg::get<1>(pt_near) + 703000.0);
-
-    //geom_to_svg(poly_far, pt_far, "far.svg");
-    //geom_to_svg(poly_near, pt_near, "near.svg");
 
     double d = bg::distance(pt_far, pt_near_moved);
     BOOST_CHECK(d < 0.1);

--- a/test/algorithms/overlay/get_turns_areal_areal.cpp
+++ b/test/algorithms/overlay/get_turns_areal_areal.cpp
@@ -17,8 +17,6 @@
 #include "test_get_turns.hpp"
 #include <boost/geometry/geometries/geometries.hpp>
 
-//TEST
-//#include <to_svg.hpp>
 
 template <typename T>
 void test_all()
@@ -36,9 +34,6 @@ void test_all()
         test_geometry<poly, poly>("POLYGON((-8042 -1485,-8042 250,-8042 250,15943 254,15943 -1485,-8042 -1485))",
                                   "POLYGON((-7901 -1485,-7901 529,-7901 529, 15802 544, 15802 -1485, -7901 -1485))",
                                   expected("iiu")("iui")("mcc")("cui"));
-        //to_svg<poly, poly>("POLYGON((-8042 -1485,-8042 250,15943 254,15943 -1485,-8042 -1485))",
-        //                   "POLYGON((-7901 -1485,-7901 529,15802 544, 15802 -1485, -7901 -1485))",
-        //                   "poly_poly_1.svg");
         test_geometry<poly, poly>("POLYGON((-7901 -1485,-7901 529,-7901 529, 15802 544, 15802 -1485, -7901 -1485))",
                                   "POLYGON((-8042 -1485,-8042 250,-8042 250,15943 254,15943 -1485,-8042 -1485))",
                                   expected("iui")("iiu")("mcc")("ciu"));

--- a/test/algorithms/overlay/get_turns_linear_areal.cpp
+++ b/test/algorithms/overlay/get_turns_linear_areal.cpp
@@ -20,8 +20,6 @@
 #include "test_get_turns.hpp"
 #include <boost/geometry/geometries/geometries.hpp>
 
-//TEST
-//#include <to_svg.hpp>
 
 template <typename T>
 void test_all()

--- a/test/algorithms/overlay/get_turns_linear_linear.cpp
+++ b/test/algorithms/overlay/get_turns_linear_linear.cpp
@@ -19,8 +19,6 @@
 #include "test_get_turns.hpp"
 #include <boost/geometry/geometries/geometries.hpp>
 
-//TEST
-//#include <to_svg.hpp>
 
 template <typename T>
 void test_all()
@@ -360,19 +358,6 @@ void test_all()
     //test_geometry<ls, ls>("LINESTRING(0 0,2 2,3 3,4 4)", "LINESTRING(0 0,1 1,4 4)", "1FFF0FFF2");
 
 
-    //if ( std::is_same<T, double>::value )
-    //{
-    //    to_svg<ls, ls>("LINESTRING(0 0,1 0,2 0,2.5 0,3 1)", "LINESTRING(0 0,2 0,2.5 0,3 1)", "test11.svg");
-    //    to_svg<ls, ls>("LINESTRING(0 0,1 0,2 0,2.5 0,3 1)", "LINESTRING(3 1,2.5 0,2 0,0 0)", "test12.svg");
-    //    to_svg<ls, ls>("LINESTRING(-1 1,0 0,1 0,4 0,5 5,10 5,15 0,20 0,30 0,31 1)", "LINESTRING(30 0,3 0,2.5 1,2 0,1 0,0 0,-1 -1)", "test21.svg");
-    //    to_svg<ls, ls>("LINESTRING(-1 1,0 0,1 0,4 0,5 5,10 5,15 0,20 0,30 0,31 1)", "LINESTRING(-1 -1,0 0,1 0,2 0,2.5 1,3 0,30 0)", "test22.svg");
-
-    //    to_svg<ls, ls>("LINESTRING(-1 1,0 0,1 0,4 0,5 5,10 5,15 0,31 0)", "LINESTRING(-1 -1,0 0,1 0,2 0,2.5 1,3 0,30 0)", "test31.svg");
-    //    to_svg<ls, ls>("LINESTRING(-1 1,0 0,1 0,4 0,5 5,10 5,15 0,31 0)", "LINESTRING(30 0,3 0,2.5 1,2 0,1 0,0 0,-1 -1)", "test32.svg");
-    //    to_svg<ls, ls>("LINESTRING(31 0,15 0,10 5,5 5,4 0,1 0,0 0,-1 1)", "LINESTRING(-1 -1,0 0,1 0,2 0,2.5 1,3 0,30 0)", "test33.svg");
-    //    to_svg<ls, ls>("LINESTRING(31 0,15 0,10 5,5 5,4 0,1 0,0 0,-1 1)", "LINESTRING(30 0,3 0,2.5 1,2 0,1 0,0 0,-1 -1)", "test34.svg");
-    //}
-
     // duplicated
     test_geometry<mls, mls>("MULTILINESTRING((0 0,10 0,30 0))",
                             "MULTILINESTRING((0 10,5 0,20 0,20 0,30 0),(2 0,2 0),(3 0,3 0,3 0))",
@@ -534,141 +519,3 @@ int test_main(int, char* [])
     return 0;
 }
 
-/*
-to_svg<ls, ls>("LINESTRING(0 0,2 0)", "LINESTRING(1 0,3 0)", "lsls0000.svg");
-to_svg<ls, ls>("LINESTRING(1 0,3 0)", "LINESTRING(2 0,0 0)", "lsls0001.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0)", "LINESTRING(3 0,1 0)", "lsls0002.svg");
-
-to_svg<ls, ls>("LINESTRING(0 0,1 0)", "LINESTRING(1 0,2 0)", "lsls0003.svg");
-to_svg<ls, ls>("LINESTRING(0 0,1 0)", "LINESTRING(2 0,1 0)", "lsls0004.svg");
-to_svg<ls, ls>("LINESTRING(1 0,2 0)", "LINESTRING(1 0,0 0)", "lsls0005.svg");
-
-to_svg<ls, ls>("LINESTRING(0 0,2 0)", "LINESTRING(0 0,2 0)", "lsls0006.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0)", "LINESTRING(2 0,0 0)", "lsls0007.svg");
-
-to_svg<ls, ls>("LINESTRING(0 0,3 0)", "LINESTRING(1 0,2 0)", "lsls0008.svg");
-to_svg<ls, ls>("LINESTRING(0 0,3 0)", "LINESTRING(2 0,1 0)", "lsls0009.svg");
-
-to_svg<ls, ls>("LINESTRING(0 0,1 0)", "LINESTRING(1 0,1 1)", "lsls00010.svg");
-to_svg<ls, ls>("LINESTRING(0 0,1 0)", "LINESTRING(1 1,1 0)", "lsls00011.svg");
-to_svg<ls, ls>("LINESTRING(0 0,1 0)", "LINESTRING(0 0,0 1)", "lsls00012.svg");
-to_svg<ls, ls>("LINESTRING(0 0,1 0)", "LINESTRING(0 1,0 0)", "lsls00013.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0)", "LINESTRING(1 0,1 1)", "lsls00014.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0)", "LINESTRING(1 1,1 0)", "lsls00015.svg");
-
-to_svg<ls, ls>("LINESTRING(0 0,2 0)", "LINESTRING(1 0,3 1)", "lsls00016.svg");
-
-to_svg<ls, ls>("LINESTRING(0 0,2 0)", "LINESTRING(2 0,1 0)", "lsls00017.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0)", "LINESTRING(0 0,1 0)", "lsls00018.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0)", "LINESTRING(1 0,0 0)", "lsls00019.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0)", "LINESTRING(1 0,2 0)", "lsls00020.svg");
-
-to_svg<ls, ls>("LINESTRING(0 0,2 0)", "LINESTRING(0 0,2 0)", "lsls000.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0,2 0,3 0)", "LINESTRING(0 0,2 0)", "lsls001.svg");
-to_svg<ls, ls>("LINESTRING(1 0,1 1)", "LINESTRING(0 0,1 0,2 0)", "lsls0020.svg");
-to_svg<ls, ls>("LINESTRING(1 0,0 0)", "LINESTRING(0 0,1 0,2 0)", "lsls0021.svg");
-to_svg<ls, ls>("LINESTRING(1 0,2 0)", "LINESTRING(0 0,1 0,2 0)", "lsls0022.svg");
-to_svg<ls, ls>("LINESTRING(1 1,1 0)", "LINESTRING(0 0,1 0,2 0)", "lsls0023.svg");
-to_svg<ls, ls>("LINESTRING(0 0,1 0)", "LINESTRING(0 0,1 0,2 0)", "lsls0024.svg");
-to_svg<ls, ls>("LINESTRING(2 0,1 0)", "LINESTRING(0 0,1 0,2 0)", "lsls0025.svg");
-to_svg<ls, ls>("LINESTRING(0 0,1 0,2 0)", "LINESTRING(1 0,1 1)", "lsls00200.svg");
-to_svg<ls, ls>("LINESTRING(0 0,1 0,2 0)", "LINESTRING(1 0,0 0)", "lsls00211.svg");
-to_svg<ls, ls>("LINESTRING(0 0,1 0,2 0)", "LINESTRING(1 0,2 0)", "lsls00222.svg");
-to_svg<ls, ls>("LINESTRING(0 0,1 0,2 0)", "LINESTRING(1 1,1 0)", "lsls00233.svg");
-to_svg<ls, ls>("LINESTRING(0 0,1 0,2 0)", "LINESTRING(0 0,1 0)", "lsls00244.svg");
-to_svg<ls, ls>("LINESTRING(0 0,1 0,2 0)", "LINESTRING(2 0,1 0)", "lsls00255.svg");
-
-to_svg<ls, ls>("LINESTRING(0 0,2 0,4 0,6 0,8 0)", "LINESTRING(1 0,3 0,5 0,6 0,9 0)", "lsls01.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0,4 0,4 4)", "LINESTRING(1 0,3 0,4 0,4 2,4 5)", "lsls02.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0,4 0,4 4)", "LINESTRING(1 0,4 0,4 4)", "lsls031.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0,4 0,4 4)", "LINESTRING(4 0,2 0,0 0)", "lsls032.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0,4 0,4 4)", "LINESTRING(4 0,2 2,0 2)", "lsls0321.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0,4 0,4 4)", "LINESTRING(4 0,2 0)", "lsls033.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0,4 0,4 4)", "LINESTRING(4 0,4 4)", "lsls034.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0,4 0,4 4)", "LINESTRING(4 0,3 1)", "lsls035.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0,4 0,4 4)", "LINESTRING(4 0,4 -1)", "lsls036.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0,4 0,4 4)", "LINESTRING(1 0,4 0,4 3)", "lsls04.svg");
-to_svg<ls, ls>("LINESTRING(1 0,2 0,4 0,6 0,8 0)", "LINESTRING(0 0,3 0,5 0,6 0,9 0)", "lsls05.svg");
-
-to_svg<ls, ls>("LINESTRING(0 0,10 0,10 10)", "LINESTRING(1 0,10 9)", "lsls061.svg");
-to_svg<ls, ls>("LINESTRING(0 0,10 0,10 10)", "LINESTRING(1 0,10 -9)", "lsls062.svg");
-to_svg<ls, ls>("LINESTRING(0 0,10 0,10 10)", "LINESTRING(1 0,-10 9)", "lsls063.svg");
-to_svg<ls, ls>("LINESTRING(0 0,10 0,10 10)", "LINESTRING(1 0,-10 -9)", "lsls064.svg");
-to_svg<ls, ls>("LINESTRING(0 0,1 0,10 9,10 10)", "LINESTRING(1 0,10 9)", "lsls065.svg");
-to_svg<ls, ls>("LINESTRING(0 0,10 0,10 10)", "LINESTRING(1 0,9 9)", "lsls071.svg");
-to_svg<ls, ls>("LINESTRING(0 0,10 0,10 10)", "LINESTRING(1 0,9 -9)", "lsls072.svg");
-to_svg<ls, ls>("LINESTRING(0 0,10 0,10 10)", "LINESTRING(1 0,-9 9)", "lsls073.svg");
-to_svg<ls, ls>("LINESTRING(0 0,10 0,10 10)", "LINESTRING(1 0,-9 -9)", "lsls074.svg");
-to_svg<ls, ls>("LINESTRING(0 0,1 0,10 0,10 10)", "LINESTRING(1 0,9 9)", "lsls081.svg");
-to_svg<ls, ls>("LINESTRING(0 0,1 0,10 0,10 10)", "LINESTRING(0 0,9 9)", "lsls082.svg");
-to_svg<ls, ls>("LINESTRING(0 0,1 0)", "LINESTRING(1 0,9 9)", "lsls083.svg");
-to_svg<ls, ls>("LINESTRING(0 0,1 0)", "LINESTRING(9 9,1 0)", "lsls084.svg");
-to_svg<ls, ls>("LINESTRING(0 0,1 0)", "LINESTRING(1 0,2 0)", "lsls085.svg");
-to_svg<ls, ls>("LINESTRING(0 0,1 0)", "LINESTRING(2 0,1 0)", "lsls086.svg");
-to_svg<ls, ls>("LINESTRING(0 0,10 0,10 10)", "LINESTRING(1 1,10 5)", "lsls091.svg");
-to_svg<ls, ls>("LINESTRING(0 0,10 0,10 5,10 10)", "LINESTRING(1 1,10 5)", "lsls092.svg");
-to_svg<ls, ls>("LINESTRING(0 0,10 0,10 10)", "LINESTRING(19 1,10 5)", "lsls093.svg");
-to_svg<ls, ls>("LINESTRING(0 0,10 0,10 5,10 10)", "LINESTRING(19 1,10 5)", "lsls094.svg");
-
-to_svg<ls, ls>("LINESTRING(5 3,1 1,3 3,2 2,0 0)", "LINESTRING(0 0,3 3,6 3)", "1F100F10T.svg");
-
-to_svg<ls, ls>("LINESTRING(0 0,2 0,4 0)", "LINESTRING(1 1,1 0,3 0,3 1)", "lsls_01.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0,4 0)", "LINESTRING(1 -1,1 0,3 0,3 -1)", "lsls_02.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0,4 0)", "LINESTRING(3 1,3 0,1 0,1 1)", "lsls_03.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0,4 0)", "LINESTRING(3 -1,3 0,1 0,1 -1)", "lsls_04.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0,3 0,4 0,6 0)", "LINESTRING(2 1,2 0,4 0,4 1)", "lsls_05.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0,3 0,4 0,6 0)", "LINESTRING(2 -1,2 0,4 0,4 -1)", "lsls_06.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0,3 0,4 0,6 0)", "LINESTRING(4 1,4 0,2 0,2 1)", "lsls_07.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0,3 0,4 0,6 0)", "LINESTRING(4 -1,4 0,2 0,2 -1)", "lsls_08.svg");
-
-to_svg<ls, ls>("LINESTRING(0 0,2 0,4 0)", "LINESTRING(1 1,1 0,2 0,3 0,3 1)", "lsls_11.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0,4 0)", "LINESTRING(1 -1,1 0,2 0,3 0,3 -1)", "lsls_12.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0,4 0)", "LINESTRING(3 1,3 0,2 0,1 0,1 1)", "lsls_13.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0,4 0)", "LINESTRING(3 -1,3 0,2 0,1 0,1 -1)", "lsls_14.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0,3 0,4 0,6 0)", "LINESTRING(2 1,2 0,3 0,4 0,4 1)", "lsls_15.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0,3 0,4 0,6 0)", "LINESTRING(2 -1,2 0,3 0,4 0,4 -1)", "lsls_16.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0,3 0,4 0,6 0)", "LINESTRING(4 1,4 0,3 0,2 0,2 1)", "lsls_17.svg");
-to_svg<ls, ls>("LINESTRING(0 0,2 0,3 0,4 0,6 0)", "LINESTRING(4 -1,4 0,3 0,2 0,2 -1)", "lsls_18.svg");
-
-to_svg<ls, ls>("LINESTRING(0 5,5 5,10 5,10 10,5 10,5 5,5 0)", "LINESTRING(0 5,5 5,5 10,10 10,10 5,5 5,5 0)", "lsls11.svg");
-to_svg<ls, ls>("LINESTRING(0 5,5 5,10 5,10 10,5 10,5 5,5 0)", "LINESTRING(5 0,5 5,10 5,10 10,5 10,5 5,0 5)", "lsls12.svg");
-to_svg<ls, ls>("LINESTRING(5 0,5 5,5 10,10 10,10 5,5 5,0 5)", "LINESTRING(0 5,5 5,5 10,10 10,10 5,5 5,5 0)", "lsls13.svg");
-to_svg<ls, ls>("LINESTRING(5 0,5 5,5 10,10 10,10 5,5 5,0 5)", "LINESTRING(5 0,5 5,10 5,10 10,5 10,5 5,0 5)", "lsls14.svg");
-
-to_svg<ls, ls>("LINESTRING(0 5,10 5,10 10,5 10,5 0)", "LINESTRING(0 5,5 5,5 10,10 10,10 5,5 5,5 0)", "lsls15.svg");
-to_svg<ls, ls>("LINESTRING(0 5,10 5,10 10,5 10,5 0)", "LINESTRING(5 0,5 10,10 10,10 5,0 5)", "lsls16.svg");
-to_svg<ls, ls>("LINESTRING(0 5,10 5)", "LINESTRING(5 0,5 10,10 10,10 5,0 5)", "lsls161.svg");
-to_svg<ls, ls>("LINESTRING(0 5,8 5,10 5)", "LINESTRING(5 0,5 10,10 10,10 5,0 5)", "lsls162.svg");
-to_svg<ls, ls>("LINESTRING(0 5,8 5)", "LINESTRING(5 0,5 10,10 10,10 5,0 5)", "lsls1631.svg");
-to_svg<ls, ls>("LINESTRING(0 5,1 5,7 5,8 5)", "LINESTRING(5 0,5 10,10 10,10 5,0 5)", "lsls1632.svg");
-to_svg<ls, ls>("LINESTRING(0 5,1 5,7 5,8 5)", "LINESTRING(5 10,10 10,10 5,0 5)", "lsls1633.svg");
-to_svg<ls, ls>("LINESTRING(0 5,8 4)", "LINESTRING(5 0,5 10,10 10,10 5,0 5)", "lsls1641.svg");
-to_svg<ls, ls>("LINESTRING(0 5,8 6)", "LINESTRING(5 0,5 10,10 10,10 5,0 5)", "lsls1642.svg");
-to_svg<ls, ls>("LINESTRING(1 5,8 4)", "LINESTRING(5 0,5 10,10 10,10 5,0 5)", "lsls1643.svg");
-to_svg<ls, ls>("LINESTRING(1 5,8 5)", "LINESTRING(5 0,5 10,10 10,10 5,0 5)", "lsls1644.svg");
-to_svg<ls, ls>("LINESTRING(0 5,5 5,8 4)", "LINESTRING(5 0,5 10,10 10,10 5,0 5)", "lsls165.svg");
-to_svg<ls, ls>("LINESTRING(0 5,5 5,8 5)", "LINESTRING(5 0,5 10,10 10,10 5,0 5)", "lsls166.svg");
-to_svg<ls, ls>("LINESTRING(0 5,5 5,8 5)", "LINESTRING(0 10,10 0,5 0,5 10,10 10,10 5,0 5)", "lsls167.svg");
-to_svg<ls, ls>("LINESTRING(0 5,5 5,8 5)", "LINESTRING(0 10,5 5,10 0,5 0,5 5,5 10,10 10,10 5,0 5)", "lsls168.svg");
-
-to_svg<ls, ls>("LINESTRING(0 0,0 10,10 10,10 0,0 0)", "LINESTRING(0 2,0 0,10 0,10 10,0 10,0 8,0 2)", "lsls1690.svg");
-to_svg<ls, ls>("LINESTRING(0 0,10 0,10 10,0 10,0 0)", "LINESTRING(0 8,0 0,10 0,10 10,0 10,0 8)", "lsls1691.svg");
-to_svg<ls, ls>("LINESTRING(0 0,10 0,10 10,0 10,0 0)", "LINESTRING(0 2,0 0,10 0,10 10,0 10,0 8)", "lsls1692.svg");
-to_svg<ls, ls>("LINESTRING(0 0,0 10,10 10,10 0,0 0)", "LINESTRING(0 2,0 0,10 0,10 10,0 10,0 8)", "lsls1693.svg");
-to_svg<ls, ls>("LINESTRING(0 2,0 0,10 0,10 10,0 10,0 8)", "LINESTRING(0 0,10 0,10 10,0 10,0 0)", "lsls1694.svg");
-to_svg<ls, ls>("LINESTRING(0 2,0 0,10 0,10 10,0 10,0 8)", "LINESTRING(0 0,0 10,10 10,10 0,0 0)", "lsls1695.svg");
-
-to_svg<ls>("LINESTRING(0 8,0 0,10 0,10 10,0 10,0 2)", "ls1.svg");
-to_svg<ls>("LINESTRING(8 8,0 0,10 0,10 10,0 10,8 2)", "ls2.svg");
-
-typedef bg::model::multi_linestring<ls> mls;
-to_svg<ls, mls>("LINESTRING(0 5,10 5,10 10,5 10,5 0)", "MULTILINESTRING((5 0,5 7),(5 8,5 10,10 10,10 5,0 5))", "lsls17.svg");
-to_svg<ls, mls>("LINESTRING(0 5,10 5,10 10,5 10,5 0)", "MULTILINESTRING((5 0,5 4,5 6,5 7),(5 8,5 10,10 10,10 5,0 5))", "lsls18.svg");
-to_svg<ls, mls>("LINESTRING(0 5,10 5,10 10,5 10,5 0)", "MULTILINESTRING((5 0,5 8),(5 7,5 10,10 10,10 5,0 5))", "lsls19.svg");
-to_svg<mls, ls>("MULTILINESTRING((5 0,5 7),(5 8,5 10,10 10,10 5,0 5))", "LINESTRING(0 5,10 5,10 10,5 10,5 0)", "lsls20.svg");
-to_svg<mls, ls>("MULTILINESTRING((5 0,5 8),(5 7,5 10,10 10,10 5,0 5))", "LINESTRING(0 5,10 5,10 10,5 10,5 0)", "lsls21.svg");
-
-to_svg<ls, ls>("LINESTRING(0 5,5 5,10 5,10 10,5 10,5 5,5 0)", "LINESTRING(0 5,5 5,0 10,10 10,10 5,5 5,5 0)", "lsls100.svg");
-
-to_svg<ls, ls>("LINESTRING(5 0,5 5,5 0)", "LINESTRING(0 5,5 5,0 10,2 10,5 5,5 10,10 10,10 5,5 5,10 2,10 0,8 0,5 5,5 0)", "lsls101.svg");
-*/

--- a/test/algorithms/overlay/get_turns_linear_linear_sph.cpp
+++ b/test/algorithms/overlay/get_turns_linear_linear_sph.cpp
@@ -275,20 +275,6 @@ void test_all()
 
     //test_geometry<ls, ls>("LINESTRING(0 0,2 2,3 3,4 4)", "LINESTRING(0 0,1 1,4 4)", "1FFF0FFF2");
 
-
-    //if ( std::is_same<T, double>::value )
-    //{
-    //    to_svg<ls, ls>("LINESTRING(0 0,1 0,2 0,2.5 0,3 1)", "LINESTRING(0 0,2 0,2.5 0,3 1)", "test11.svg");
-    //    to_svg<ls, ls>("LINESTRING(0 0,1 0,2 0,2.5 0,3 1)", "LINESTRING(3 1,2.5 0,2 0,0 0)", "test12.svg");
-    //    to_svg<ls, ls>("LINESTRING(-1 1,0 0,1 0,4 0,5 5,10 5,15 0,20 0,30 0,31 1)", "LINESTRING(30 0,3 0,2.5 1,2 0,1 0,0 0,-1 -1)", "test21.svg");
-    //    to_svg<ls, ls>("LINESTRING(-1 1,0 0,1 0,4 0,5 5,10 5,15 0,20 0,30 0,31 1)", "LINESTRING(-1 -1,0 0,1 0,2 0,2.5 1,3 0,30 0)", "test22.svg");
-
-    //    to_svg<ls, ls>("LINESTRING(-1 1,0 0,1 0,4 0,5 5,10 5,15 0,31 0)", "LINESTRING(-1 -1,0 0,1 0,2 0,2.5 1,3 0,30 0)", "test31.svg");
-    //    to_svg<ls, ls>("LINESTRING(-1 1,0 0,1 0,4 0,5 5,10 5,15 0,31 0)", "LINESTRING(30 0,3 0,2.5 1,2 0,1 0,0 0,-1 -1)", "test32.svg");
-    //    to_svg<ls, ls>("LINESTRING(31 0,15 0,10 5,5 5,4 0,1 0,0 0,-1 1)", "LINESTRING(-1 -1,0 0,1 0,2 0,2.5 1,3 0,30 0)", "test33.svg");
-    //    to_svg<ls, ls>("LINESTRING(31 0,15 0,10 5,5 5,4 0,1 0,0 0,-1 1)", "LINESTRING(30 0,3 0,2.5 1,2 0,1 0,0 0,-1 -1)", "test34.svg");
-    //}
-
     // duplicated
     test_geometry<mls, mls>("MULTILINESTRING((0 0,10 0,30 0))",
                             "MULTILINESTRING((0 10,5 0,20 0,20 0,30 0),(2 0,2 0),(3 0,3 0,3 0))",

--- a/test/algorithms/relate/relate_areal_areal.cpp
+++ b/test/algorithms/relate/relate_areal_areal.cpp
@@ -13,7 +13,6 @@
 
 #include "test_relate.hpp"
 
-//#include <to_svg.hpp>
 
 template <typename P>
 void test_polygon_polygon()

--- a/test/algorithms/relate/relate_linear_areal.cpp
+++ b/test/algorithms/relate/relate_linear_areal.cpp
@@ -15,8 +15,6 @@
 #include "test_relate.hpp"
 #include "nan_cases.hpp"
 
-//TEST
-//#include <to_svg.hpp>
 
 template <typename P>
 void test_linestring_polygon()

--- a/test/algorithms/relate/relate_linear_linear.cpp
+++ b/test/algorithms/relate/relate_linear_linear.cpp
@@ -12,8 +12,6 @@
 
 #include "test_relate.hpp"
 
-//TEST
-//#include <to_svg.hpp>
 
 template <typename P>
 void test_linestring_linestring()
@@ -174,8 +172,6 @@ void test_linestring_linestring()
     test_geometry<ls, ls>("LINESTRING(1 0,1 0)", "LINESTRING(0 0,1 0)", "F0FFFF102");
     test_geometry<ls, ls>("LINESTRING(1 0,1 0)", "LINESTRING(1 0,1 0)", "0FFFFFFF2");
     test_geometry<ls, ls>("LINESTRING(1 0,1 0)", "LINESTRING(0 0,0 0)", "FF0FFF0F2");
-
-    //to_svg<ls, ls>("LINESTRING(0 0,5 0)", "LINESTRING(5 0,10 0,5 5,5 0)", "test_relate_00.svg");
 
     // INVALID LINESTRINGS
     // 1-point LS (a Point) NOT disjoint

--- a/test/algorithms/relate/relate_linear_linear_sph.cpp
+++ b/test/algorithms/relate/relate_linear_linear_sph.cpp
@@ -172,8 +172,6 @@ void test_linestring_linestring()
     test_geometry<ls, ls>("LINESTRING(1 0,1 0)", "LINESTRING(1 0,1 0)", "0FFFFFFF2");
     test_geometry<ls, ls>("LINESTRING(1 0,1 0)", "LINESTRING(0 0,0 0)", "FF0FFF0F2");
 
-    //to_svg<ls, ls>("LINESTRING(0 0,5 0)", "LINESTRING(5 0,10 0,5 5,5 0)", "test_relate_00.svg");
-
     // INVALID LINESTRINGS
     // 1-point LS (a Point) NOT disjoint
     //test_geometry<ls, ls>("LINESTRING(1 0)", "LINESTRING(0 0,5 0)", "0FFFFF102");

--- a/test/algorithms/relate/relate_pointlike_geometry.cpp
+++ b/test/algorithms/relate/relate_pointlike_geometry.cpp
@@ -15,8 +15,6 @@
 #include "test_relate.hpp"
 #include "nan_cases.hpp"
 
-//TEST
-//#include <to_svg.hpp>
 
 template <typename P>
 void test_point_point()

--- a/test/algorithms/set_operations/test_set_ops_pointlike.hpp
+++ b/test/algorithms/set_operations/test_set_ops_pointlike.hpp
@@ -30,6 +30,10 @@
 #include <boost/geometry/io/wkt/write.hpp>
 #include <boost/geometry/policies/compare.hpp>
 
+#if defined(TEST_WITH_SVG)
+#include <boost/geometry/io/svg/svg_mapper.hpp>
+#endif
+
 namespace bg = ::boost::geometry;
 
 
@@ -48,15 +52,13 @@ void set_operation_output(std::string const& set_op_id,
     boost::ignore_unused(set_op_id, caseid, g1, g2, output);
 
 #if defined(TEST_WITH_SVG)
-    typedef typename bg::coordinate_type<G1>::type coordinate_type;
-    typedef typename bg::point_type<G1>::type point_type;
 
     std::ostringstream filename;
     filename << "svgs/" << set_op_id << "_" << caseid << ".svg";
 
     std::ofstream svg(filename.str().c_str());
 
-    bg::svg_mapper<point_type> mapper(svg, 500, 500);
+    bg::svg_mapper<typename bg::point_type<G1>::type> mapper(svg, 500, 500);
 
     mapper.add(g1);
     mapper.add(g2);

--- a/test/to_svg.hpp
+++ b/test/to_svg.hpp
@@ -28,25 +28,23 @@
 
 #include <string_from_type.hpp>
 
-template <typename G, typename Turns, typename Mapper>
-inline void turns_to_svg(Turns const& turns, Mapper & mapper, bool /*enrich*/ = false)
+template <typename Turns, typename Mapper>
+inline void turns_to_svg(Turns const& turns, Mapper& mapper)
 {
     namespace bg = boost::geometry;
-
-    // turn points in orange, + enrichment/traversal info
-    typedef typename bg::coordinate_type<G>::type coordinate_type;
-    typedef typename boost::range_value<Turns>::type turn_info;
 
     // Simple map to avoid two texts at same place (note that can still overlap!)
     std::map<std::pair<int, int>, int> offsets;
     int index = 0;
     int const margin = 5;
 
-    for (turn_info const& turn : turns)
+    for (auto const& turn : turns)
     {
+        using coordinate_type
+            = typename bg::coordinate_type<decltype(turn.point)>::type;
         int lineheight = 10;
         mapper.map(turn.point, "fill:rgb(255,128,0);"
-                "stroke:rgb(0,0,0);stroke-width:1", 3);
+                               "stroke:rgb(0,0,0);stroke-width:1", 3);
 
         {
             coordinate_type half = 0.5;
@@ -54,129 +52,49 @@ inline void turns_to_svg(Turns const& turns, Mapper & mapper, bool /*enrich*/ = 
             // Map characteristics
             // Create a rounded off point
             std::pair<int, int> p
-                = std::make_pair(
-                    boost::numeric_cast<int>(half
-                        + ten * bg::get<0>(turn.point)),
-                    boost::numeric_cast<int>(half
-                        + ten * bg::get<1>(turn.point))
-                    );
-        std::string style =  "fill:rgb(0,0,0);font-family:Arial;font-size:12px";
+                    = std::make_pair(
+                          boost::numeric_cast<int>(half
+                                                   + ten * bg::get<0>(turn.point)),
+                          boost::numeric_cast<int>(half
+                                                   + ten * bg::get<1>(turn.point))
+                          );
+            std::string style =  "fill:rgb(0,0,0);font-family:Arial;font-size:12px";
 
-        if (turn.discarded)
-        {
-            style =  "fill:rgb(92,92,92);font-family:Arial;font-size:10px";
-            lineheight = 6;
-        }
+            if (turn.discarded)
+            {
+                style =  "fill:rgb(92,92,92);font-family:Arial;font-size:10px";
+                lineheight = 6;
+            }
 
-        //if (! turn.discarded && ! turn.blocked() && ! turn.both(bg::detail::overlay::operation_union))
-        //if (! turn.discarded)
-        {
-            std::ostringstream out;
-            out << index
-                << ": " << bg::method_char(turn.method);
+            {
+                std::ostringstream out;
+                out << index
+                    << ": " << bg::method_char(turn.method)
+                    << (turn.discarded ? " (discarded)" : "")
+                    << (turn.blocked() ? " (blocked)" : "")
+                    << '\n';
 
-            if ( turn.discarded )
-                out << " (discarded)\n";
-            else if ( turn.blocked() )
-                out << " (blocked)\n";
-            else
+                out << bg::operation_char(turn.operations[0].operation)
+                        <<": seg: " << turn.operations[0].seg_id.source_index
+                       << ' ' << turn.operations[0].seg_id.multi_index
+                       << ' ' << turn.operations[0].seg_id.ring_index
+                       << ' ' << turn.operations[0].seg_id.segment_index << ", ";
+                out << "other: " << turn.operations[1].seg_id.source_index
+                    << ' ' << turn.operations[1].seg_id.multi_index
+                    << ' ' << turn.operations[1].seg_id.ring_index
+                    << ' ' << turn.operations[1].seg_id.segment_index;
+
                 out << '\n';
 
-            out << bg::operation_char(turn.operations[0].operation)
-                <<": seg: " << turn.operations[0].seg_id.source_index
-                << ' ' << turn.operations[0].seg_id.multi_index
-                << ' ' << turn.operations[0].seg_id.ring_index
-                << ' ' << turn.operations[0].seg_id.segment_index << ", ";
-            out << "other: " << turn.operations[1].seg_id.source_index
-                << ' ' << turn.operations[1].seg_id.multi_index
-                << ' ' << turn.operations[1].seg_id.ring_index
-                << ' ' << turn.operations[1].seg_id.segment_index;
-
-            /*if ( enrich )
-            {
-            out << ", ";
-            if (turn.operations[0].enriched.next_ip_index != -1)
-            {
-            out << "ip: " << turn.operations[0].enriched.next_ip_index;
-            }
-            else
-            {
-            out << "vx: " << turn.operations[0].enriched.travels_to_vertex_index
-            << " -> ip: "  << turn.operations[0].enriched.travels_to_ip_index;
-            }
-            }*/
-
-            out << '\n';
-
-            out << bg::operation_char(turn.operations[1].operation)
-                << ": seg: " << turn.operations[1].seg_id.source_index
-                << ' ' << turn.operations[1].seg_id.multi_index
-                << ' ' << turn.operations[1].seg_id.ring_index
-                << ' ' << turn.operations[1].seg_id.segment_index << ", ";
-            out << "other: " << turn.operations[0].seg_id.source_index
-                << ' ' << turn.operations[0].seg_id.multi_index
-                << ' ' << turn.operations[0].seg_id.ring_index
-                << ' ' << turn.operations[0].seg_id.segment_index;
-
-            /*if ( enrich )
-            {
-                out << ", ";
-                if (turn.operations[1].enriched.next_ip_index != -1)
-                {
-                    out << "ip: " << turn.operations[1].enriched.next_ip_index;
-                }
-                else
-                {
-                    out << "vx: " << turn.operations[1].enriched.travels_to_vertex_index
-                        << " -> ip: " << turn.operations[1].enriched.travels_to_ip_index;
-                }
-            }*/
-
-            //out << std::endl;
-
-            /*out
-
-                << std::setprecision(3)
-                << "dist: " << boost::numeric_cast<double>(turn.operations[0].enriched.distance)
-                << " / "  << boost::numeric_cast<double>(turn.operations[1].enriched.distance)
-                << std::endl
-                << "vis: " << bg::visited_char(turn.operations[0].visited)
-                << " / "  << bg::visited_char(turn.operations[1].visited);
-            */
-
-            /*
-                out << index
-                    << ": " << bg::operation_char(turn.operations[0].operation)
-                    << " " << bg::operation_char(turn.operations[1].operation)
-                    << " (" << bg::method_char(turn.method) << ")"
-                    << (turn.ignore() ? " (ignore) " : " ")
-                    << std::endl
-
-                    << "ip: " << turn.operations[0].enriched.travels_to_ip_index
-                    << "/"  << turn.operations[1].enriched.travels_to_ip_index;
-
-                if (turn.operations[0].enriched.next_ip_index != -1
-                    || turn.operations[1].enriched.next_ip_index != -1)
-                {
-                    out << " [" << turn.operations[0].enriched.next_ip_index
-                        << "/"  << turn.operations[1].enriched.next_ip_index
-                        << "]"
-                        ;
-                }
-                out << std::endl;
-
-
-                out
-                    << "vx:" << turn.operations[0].enriched.travels_to_vertex_index
-                    << "/"  << turn.operations[1].enriched.travels_to_vertex_index
-                    << std::endl
-
-                    << std::setprecision(3)
-                    << "dist: " << turn.operations[0].enriched.distance
-                    << " / "  << turn.operations[1].enriched.distance
-                    << std::endl
-                    */
-
+                out << bg::operation_char(turn.operations[1].operation)
+                        << ": seg: " << turn.operations[1].seg_id.source_index
+                        << ' ' << turn.operations[1].seg_id.multi_index
+                        << ' ' << turn.operations[1].seg_id.ring_index
+                        << ' ' << turn.operations[1].seg_id.segment_index << ", ";
+                out << "other: " << turn.operations[0].seg_id.source_index
+                    << ' ' << turn.operations[0].seg_id.multi_index
+                    << ' ' << turn.operations[0].seg_id.ring_index
+                    << ' ' << turn.operations[0].seg_id.segment_index;
 
 
                 offsets[p] += lineheight;
@@ -189,75 +107,6 @@ inline void turns_to_svg(Turns const& turns, Mapper & mapper, bool /*enrich*/ = 
     }
 }
 
-template <typename G1, typename P>
-inline void geom_to_svg(G1 const& g1,
-                        boost::geometry::svg_mapper<P> & mapper)
-{
-    mapper.add(g1);
-
-    mapper.map(g1, "fill-opacity:0.5;fill:rgb(153,204,0);"
-        "stroke:rgb(153,204,0);stroke-width:3");
-}
-
-template <typename G1, typename G2, typename P>
-inline void geom_to_svg(G1 const& g1, G2 const& g2,
-                        boost::geometry::svg_mapper<P> & mapper)
-{
-    mapper.add(g1);
-    mapper.add(g2);
-
-    mapper.map(g1, "fill-opacity:0.5;fill:rgb(153,204,0);"
-        "stroke:rgb(153,204,0);stroke-width:3");
-    mapper.map(g2, "fill-opacity:0.3;fill:rgb(51,51,153);"
-        "stroke:rgb(51,51,153);stroke-width:3");
-}
-
-template <typename G1>
-inline void geom_to_svg(G1 const& g1, std::string const& filename)
-{
-    namespace bg = boost::geometry;
-    typedef typename bg::point_type<G1>::type mapper_point_type;
-
-    std::ofstream svg(filename.c_str(), std::ios::trunc);
-    bg::svg_mapper<mapper_point_type> mapper(svg, 500, 500);
-
-    geom_to_svg(g1, mapper);
-}
-
-template <typename G1, typename G2>
-inline void geom_to_svg(G1 const& g1, G2 const& g2, std::string const& filename)
-{
-    namespace bg = boost::geometry;
-    typedef typename bg::point_type<G1>::type mapper_point_type;
-
-    std::ofstream svg(filename.c_str(), std::ios::trunc);
-    bg::svg_mapper<mapper_point_type> mapper(svg, 500, 500);
-
-    geom_to_svg(g1, g2, mapper);
-}
-
-template <typename G1>
-inline void geom_to_svg(std::string const& wkt1, std::string const& filename)
-{
-    namespace bg = boost::geometry;
-
-    G1 g1;
-    bg::read_wkt(wkt1, g1);
-    geom_to_svg(g1, filename);
-}
-
-template <typename G1, typename G2>
-inline void geom_to_svg(std::string const& wkt1, std::string const& wkt2, std::string const& filename)
-{
-    namespace bg = boost::geometry;
-
-    G1 g1;
-    G2 g2;
-    bg::read_wkt(wkt1, g1);
-    bg::read_wkt(wkt2, g2);
-    geom_to_svg(g1, g2, filename);
-}
-
 struct to_svg_assign_policy
 {
     static bool const include_no_turn = false;
@@ -266,46 +115,9 @@ struct to_svg_assign_policy
     static bool const include_start_turn = false;
 };
 
-template <typename G>
-inline void to_svg(G const& g, std::string const& filename, bool /*sort*/ = true)
-{
-    namespace bg = boost::geometry;
-
-    typedef typename bg::point_type<G>::type P;
-
-    std::ofstream svg(filename.c_str(), std::ios::trunc);
-
-    bg::svg_mapper<P> mapper(svg, 500, 500);
-
-    mapper.add(g);
-
-    mapper.map(g, "fill-opacity:0.5;fill:rgb(153,204,0);"
-        "stroke:rgb(153,204,0);stroke-width:3");
-
-    typedef bg::segment_ratio<double> sr;
-    typedef bg::detail::overlay::traversal_turn_info<P, sr> turn_info;
-    typedef bg::detail::overlay::assign_null_policy AssignPolicy;
-    //typedef to_svg_assign_policy AssignPolicy;
-
-    typedef std::deque<turn_info> Turns;
-    typedef bg::detail::self_get_turn_points::no_interrupt_policy InterruptPolicy;
-
-    Turns turns;
-    InterruptPolicy interrupt_policy;
-
-    typedef bg::detail::overlay::get_turn_info<AssignPolicy> TurnPolicy;
-
-    bg::detail::self_get_turn_points::get_turns
-        <
-            false, TurnPolicy
-        >::apply(g, bg::detail::no_rescale_policy(), turns, interrupt_policy);
-
-    turns_to_svg<G>(turns, mapper);
-}
-
 template <typename G1, typename G2, typename G3>
 inline void to_svg(G1 const& g1, G2 const& g2, G3 const& g3,
-                   std::string const& caseid, bool sort = true, bool use_old_turns_policy = false, bool enrich = false)
+                   std::string const& caseid)
 {
     namespace bg = boost::geometry;
 
@@ -329,9 +141,27 @@ inline void to_svg(G1 const& g1, G2 const& g2, G3 const& g3,
     mapper.add(g2);
     mapper.add(g3);
 
-    mapper.map(g1, "fill-opacity:0.5;fill:rgb(153,204,0);stroke:rgb(153,204,0);stroke-width:1;stroke-opacity:0.7;");
-    mapper.map(g2, "fill-opacity:0.3;fill:rgb(51,51,153);stroke:rgb(51,51,153);stroke-width:1;stroke-opacity:0.7;");
-    mapper.map(g3, "fill-opacity:0.5;fill:rgb(255,0,0);stroke:rgb(255,0,0);stroke-width:1;stroke-opacity:0.7;");
+    std::string const green = "rgb(153,204,0)";
+    std::string const blue = "rgb(51,51,153)";
+    std::string const red = "rgb(255,0,0)";
+    if (bg::util::is_linestring<G1>::value)
+    {
+        auto style = [](auto const fo, auto const& c)
+            { return "stroke:" + c + ";stroke-width:3;stroke-opacity:"
+                    + std::to_string(fo) + ";"; };
+        mapper.map(g1, style(0.5, green));
+        mapper.map(g2, style(0.3, blue));
+        mapper.map(g3, style(0.5, red));
+    }
+    else
+    {
+        auto style = [](auto const fo, auto const& c)
+            { return "fill-opacity:" + std::to_string(fo) + ";fill:" + c
+              + ";stroke:rgb(153,204,0);stroke-width:1;stroke-opacity:0.7;"; };
+        mapper.map(g1, style(0.5, green));
+        mapper.map(g2, style(0.3, blue));
+        mapper.map(g3, style(0.5, red));
+    }
 
     // GET TURNS
     
@@ -353,31 +183,18 @@ inline void to_svg(G1 const& g1, G2 const& g2, G3 const& g3,
     std::deque<turn_type> turns;
     bg::detail::get_turns::no_interrupt_policy interrupt_policy;
 
-    if (use_old_turns_policy)
-    {
-        static const bool Reverse1 = bg::detail::overlay::do_reverse<bg::point_order<G1>::value>::value;
-        static const bool Reverse2 = bg::detail::overlay::do_reverse<bg::point_order<G2>::value>::value;
-        bg::get_turns
-            <
-                Reverse1, Reverse2, to_svg_assign_policy
-            >(g1, g2, strategy, bg::detail::no_rescale_policy(), turns, interrupt_policy);
-    }
-    else
-    {
-        typedef bg::detail::get_turns::get_turn_info_type
-            <
-                G1, G2, to_svg_assign_policy
-            > TurnPolicy;
+    using turn_policy = bg::detail::get_turns::get_turn_info_type
+        <
+            G1, G2, to_svg_assign_policy
+        >;
 
-        bg::detail::relate::turns::get_turns
-            <
-                G1, G2, TurnPolicy
-            >::apply(turns, g1, g2, interrupt_policy, strategy);
-    }
+    bg::detail::relate::turns::get_turns
+        <
+            G1, G2, turn_policy
+        >::apply(turns, g1, g2, interrupt_policy, strategy);
 
-    if ( sort )
     {
-        typedef bg::detail::relate::turns::less
+        using less = bg::detail::relate::turns::less
             <
                 0,
                 bg::detail::relate::turns::less_op_xxx_linear
@@ -385,44 +202,11 @@ inline void to_svg(G1 const& g1, G2 const& g2, G3 const& g3,
                         0, bg::detail::relate::turns::op_to_int<>
                     >,
                 typename bg::cs_tag<G1>::type
-            > less;
+            >;
         std::sort(boost::begin(turns), boost::end(turns), less());
     }
 
-    /*if ( enrich )
-    {
-        typedef typename bg::strategy::side::services::default_strategy
-            <
-                typename bg::cs_tag<G1>::type
-            >::type side_strategy_type;
-
-        bg::enrich_intersection_points<bg::detail::overlay::do_reverse<bg::point_order<G1>::value>::value,
-                                       bg::detail::overlay::do_reverse<bg::point_order<G2>::value>::value>
-                (turns, bg::detail::overlay::operation_union,
-                 g1, g1,
-                 bg::detail::no_rescale_policy(),
-                 side_strategy_type());
-    }*/
-
-     turns_to_svg<G1>(turns, mapper, enrich);
-}
-
-template <typename G>
-inline void to_svg(std::string const& wkt, std::string const& filename)
-{
-    G g;
-    boost::geometry::read_wkt(wkt, g);
-    to_svg(g, filename);
-}
-
-template <typename G1, typename G2>
-inline void to_svg(std::string const& wkt1, std::string const& wkt2, std::string const& filename, bool sort = true, bool reverse_by_geometry_id = false, bool enrich = false)
-{
-    G1 g1;
-    G2 g2;
-    boost::geometry::read_wkt(wkt1, g1);
-    boost::geometry::read_wkt(wkt2, g2);
-    to_svg(g1, g2, filename, sort, reverse_by_geometry_id, enrich);
+    turns_to_svg(turns, mapper);
 }
 
 #endif // BOOST_GEOMETRY_TEST_TO_SVG_HPP


### PR DESCRIPTION
Small PR removing unused / commented svg generation in tests, and making sure all tests compile with TEST_WITH_SVG, and enhancing the SVG's for linestrings (diff lin/lin)