### PR TITLE
Fix spherical and geographic envelope for near meridian segments

### DIFF
--- a/include/boost/geometry/strategy/spherical/envelope_segment.hpp
+++ b/include/boost/geometry/strategy/spherical/envelope_segment.hpp
@@ -125,7 +125,6 @@ private:
                                         CalculationType const& a2)
     {
         // azimuths a1 and a2 are assumed to be in radians
-        BOOST_GEOMETRY_ASSERT(! math::equals(a1, a2));
 
         static CalculationType const pi_half = math::half_pi<CalculationType>();
 
@@ -163,12 +162,6 @@ private:
 
         CalculationType lat1_rad = math::as_radian<Units>(lat1);
         CalculationType lat2_rad = math::as_radian<Units>(lat2);
-
-        if (math::equals(a1, a2))
-        {
-            // the segment must lie on the equator or is very short or is meridian
-            return;
-        }
 
         if (lat1 > lat2)
         {

--- a/test/algorithms/envelope_expand/envelope_on_spheroid.cpp
+++ b/test/algorithms/envelope_expand/envelope_on_spheroid.cpp
@@ -2074,6 +2074,15 @@ BOOST_AUTO_TEST_CASE( envelope_sphere_linestring )
                   from_wkt<G>("LINESTRING(-170 0,160 0)"),
                   160, 0, 190, 0);
 
+    // https://github.com/boostorg/geometry/issues/935
+    tester::apply("github_issue_935",
+                  from_wkt<G>("LINESTRING(4.5055430885891123e-05 -2.7518149670422367e-06,\
+                                          4.5055130529987143e-05 8.2400127103300943e-07,\
+                                          4.5054830174083163e-05 4.3998175091082556e-06)"),
+                  4.5054830174083163e-05, -2.7518149670422367e-06,
+                  4.5055430885891123e-05, 4.3998175091082556e-06);
+
+
     double eps = std::numeric_limits<double>::epsilon();
     double heps = eps / 2;
 
@@ -2205,6 +2214,14 @@ BOOST_AUTO_TEST_CASE( envelope_spheroid_linestring )
     tester::apply("l10c",
                   from_wkt<G>("LINESTRING(-170 0,160 0)"),
                   160, 0, 190, 0);
+
+    // https://github.com/boostorg/geometry/issues/935
+    tester::apply("github_issue_935",
+                  from_wkt<G>("LINESTRING(4.5055430885891123e-05 -2.7518149670422367e-06,\
+                                          4.5055130529987143e-05 8.2400127103300943e-07,\
+                                          4.5054830174083163e-05 4.3998175091082556e-06)"),
+                  4.5054830174083163e-05, -2.7518149670422367e-06,
+                  4.5055430885891123e-05, 4.3998175091082556e-06);
 
     double eps = std::numeric_limits<double>::epsilon();
     double heps = eps / 2;


### PR DESCRIPTION
This PR proposes a fix for https://github.com/boostorg/geometry/issues/935