### PR TITLE
Propagate umbrella strategy in buffer and overlay.

### DIFF
--- a/include/boost/geometry/algorithms/detail/buffer/buffered_piece_collection.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/buffered_piece_collection.hpp
@@ -3,8 +3,8 @@
 // Copyright (c) 2012-2014 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2016-2021.
-// Modifications copyright (c) 2016-2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2016-2022.
+// Modifications copyright (c) 2016-2022 Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -561,8 +561,8 @@ struct buffered_piece_collection
             turn_in_piece_visitor
                 <
                     typename geometry::cs_tag<point_type>::type,
-                    turn_vector_type, piece_vector_type, DistanceStrategy
-                > visitor(m_turns, m_pieces, m_distance_strategy);
+                    turn_vector_type, piece_vector_type, DistanceStrategy, Strategy
+                > visitor(m_turns, m_pieces, m_distance_strategy, m_strategy);
 
             geometry::partition
                 <

--- a/include/boost/geometry/algorithms/detail/overlay/get_distance_measure.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_distance_measure.hpp
@@ -1,6 +1,10 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2019 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2019-2021 Barend Gehrels, Amsterdam, the Netherlands.
+
+// This file was modified by Oracle on 2022.
+// Modifications copyright (c) 2022 Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -61,6 +65,11 @@ namespace detail_dispatch
 
 template <typename CalculationType, typename CsTag>
 struct get_distance_measure
+    : not_implemented<CsTag>
+{};
+
+template <typename CalculationType>
+struct get_distance_measure<CalculationType, spherical_tag>
 {
     // By default the distance measure is zero, no side difference
     using result_type = detail::distance_measure<CalculationType>;
@@ -73,6 +82,11 @@ struct get_distance_measure
         return result;
     }
 };
+
+template <typename CalculationType>
+struct get_distance_measure<CalculationType, geographic_tag>
+    : get_distance_measure<CalculationType, spherical_tag>
+{};
 
 template <typename CalculationType>
 struct get_distance_measure<CalculationType, cartesian_tag>
@@ -104,15 +118,14 @@ namespace detail
 // a negative means that p is to the right of p1-p2. And a positive value
 // means that p is to the left of p1-p2.
 
-template <typename SegmentPoint, typename Point>
-static distance_measure<typename select_coordinate_type<SegmentPoint, Point>::type>
-get_distance_measure(SegmentPoint const& p1, SegmentPoint const& p2, Point const& p)
+template <typename SegmentPoint, typename Point, typename Strategies>
+inline auto get_distance_measure(SegmentPoint const& p1, SegmentPoint const& p2, Point const& p,
+                                 Strategies const&)
 {
-    typedef typename geometry::cs_tag<Point>::type cs_tag;
     return detail_dispatch::get_distance_measure
             <
                 typename select_coordinate_type<SegmentPoint, Point>::type,
-                cs_tag
+                typename Strategies::cs_tag
             >::apply(p1, p2, p);
 
 }

--- a/include/boost/geometry/strategies/buffer/cartesian.hpp
+++ b/include/boost/geometry/strategies/buffer/cartesian.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021-2022, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -12,11 +12,7 @@
 
 
 #include <boost/geometry/strategies/buffer/services.hpp>
-#include <boost/geometry/strategies/distance/detail.hpp>
-#include <boost/geometry/strategies/relate/cartesian.hpp>
-
-#include <boost/geometry/strategies/cartesian/distance_projected_point.hpp>
-#include <boost/geometry/strategies/cartesian/distance_pythagoras.hpp>
+#include <boost/geometry/strategies/distance/cartesian.hpp>
 
 
 namespace boost { namespace geometry
@@ -27,21 +23,8 @@ namespace strategies { namespace buffer
 
 template <typename CalculationType = void>
 struct cartesian
-    : public strategies::relate::cartesian<CalculationType>
-{
-    // Additional strategies for simplify()
-
-    template <typename Geometry1, typename Geometry2>
-    static auto distance(Geometry1 const&, Geometry2 const&,
-                         distance::detail::enable_if_ps_t<Geometry1, Geometry2> * = nullptr)
-    {
-        return strategy::distance::projected_point
-            <
-                CalculationType,
-                strategy::distance::pythagoras<CalculationType>
-            >();
-    }
-};
+    : public strategies::distance::cartesian<CalculationType>
+{};
 
 
 namespace services

--- a/include/boost/geometry/strategies/buffer/geographic.hpp
+++ b/include/boost/geometry/strategies/buffer/geographic.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021-2022, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -12,10 +12,7 @@
 
 
 #include <boost/geometry/strategies/buffer/services.hpp>
-#include <boost/geometry/strategies/distance/detail.hpp>
-#include <boost/geometry/strategies/relate/geographic.hpp>
-
-#include <boost/geometry/strategies/geographic/distance_cross_track.hpp>
+#include <boost/geometry/strategies/distance/geographic.hpp>
 
 
 namespace boost { namespace geometry
@@ -32,9 +29,9 @@ template
     typename CalculationType = void
 >
 class geographic
-    : public strategies::relate::geographic<FormulaPolicy, Spheroid, CalculationType>
+    : public strategies::distance::geographic<FormulaPolicy, Spheroid, CalculationType>
 {
-    using base_t = strategies::relate::geographic<FormulaPolicy, Spheroid, CalculationType>;
+    using base_t = strategies::distance::geographic<FormulaPolicy, Spheroid, CalculationType>;
 
 public:
     geographic() = default;
@@ -42,18 +39,6 @@ public:
     explicit geographic(Spheroid const& spheroid)
         : base_t(spheroid)
     {}
-
-    // Additional strategies for simplify()
-
-    template <typename Geometry1, typename Geometry2>
-    auto distance(Geometry1 const&, Geometry2 const&,
-                  distance::detail::enable_if_ps_t<Geometry1, Geometry2> * = nullptr) const
-    {
-        return strategy::distance::geographic_cross_track
-            <
-                FormulaPolicy, Spheroid, CalculationType
-            >(base_t::m_spheroid);
-    }
 };
 
 

--- a/include/boost/geometry/strategies/buffer/spherical.hpp
+++ b/include/boost/geometry/strategies/buffer/spherical.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021-2022, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -12,11 +12,7 @@
 
 
 #include <boost/geometry/strategies/buffer/services.hpp>
-#include <boost/geometry/strategies/distance/detail.hpp>
-#include <boost/geometry/strategies/relate/spherical.hpp>
-
-#include <boost/geometry/strategies/spherical/distance_cross_track.hpp>
-#include <boost/geometry/strategies/spherical/distance_haversine.hpp>
+#include <boost/geometry/strategies/distance/spherical.hpp>
 
 
 namespace boost { namespace geometry
@@ -31,9 +27,9 @@ template
     typename CalculationType = void
 >
 class spherical
-    : public strategies::relate::detail::spherical<RadiusTypeOrSphere, CalculationType>
+    : public strategies::distance::detail::spherical<RadiusTypeOrSphere, CalculationType>
 {
-    using base_t = strategies::relate::detail::spherical<RadiusTypeOrSphere, CalculationType>;
+    using base_t = strategies::distance::detail::spherical<RadiusTypeOrSphere, CalculationType>;
 
 public:
     spherical() = default;
@@ -42,19 +38,6 @@ public:
     explicit spherical(RadiusOrSphere const& radius_or_sphere)
         : base_t(radius_or_sphere)
     {}
-
-    // Additional strategies for simplify()
-
-    template <typename Geometry1, typename Geometry2>
-    auto distance(Geometry1 const&, Geometry2 const&,
-                  distance::detail::enable_if_ps_t<Geometry1, Geometry2> * = nullptr) const
-    {
-        return strategy::distance::cross_track
-            <
-                CalculationType,
-                strategy::distance::haversine<typename base_t::radius_type, CalculationType>
-            >(base_t::radius());
-    }
 };
 
 

--- a/test/algorithms/buffer/buffer_multi_point.cpp
+++ b/test/algorithms/buffer/buffer_multi_point.cpp
@@ -3,8 +3,8 @@
 
 // Copyright (c) 2012-2019 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2020.
-// Modifications copyright (c) 2020 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2020-2022.
+// Modifications copyright (c) 2020-2022 Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -84,9 +84,9 @@ void test_all()
             115057490003226.125, ut_settings(1.0));
 
     {
-        typename bg::strategies::relate::services::default_strategy
+        typename bg::strategies::buffer::services::default_strategy
             <
-                multi_point_type, multi_point_type
+                multi_point_type
             >::type strategy;
 
         multi_point_type g;

--- a/test/algorithms/buffer/buffer_piece_border.cpp
+++ b/test/algorithms/buffer/buffer_piece_border.cpp
@@ -3,8 +3,8 @@
 
 // Copyright (c) 2020 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2020.
-// Modifications copyright (c) 2020 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2020-2022.
+// Modifications copyright (c) 2020-2022 Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -103,7 +103,7 @@ Border setup_piece_border(Ring& ring, Ring& original,
 
     typedef typename bg::point_type<Ring>::type point_type;
 
-    bg::strategies::relate::cartesian<> strategy;
+    bg::strategies::buffer::cartesian<> strategy;
 
     border.get_properties_of_border(false, point_type(), strategy);
 
@@ -155,10 +155,11 @@ template <typename Point, typename Border, typename Mapper>
 void test_point(std::string const& wkt, bool expected, Border const& border,
                 Mapper& mapper, std::string const& color)
 {
+    bg::strategies::buffer::cartesian<> strategy;
     typename Border::state_type state;
     Point point;
     bg::read_wkt(wkt, point);
-    border.point_on_piece(point, false, false, state);
+    border.point_on_piece(point, strategy, false, false, state);
     bool const on_piece = state.code() == 1;
     BOOST_CHECK_MESSAGE(on_piece == expected,
                         " expected: " << expected

--- a/test/algorithms/buffer/test_buffer_geo.hpp
+++ b/test/algorithms/buffer/test_buffer_geo.hpp
@@ -3,8 +3,8 @@
 
 // Copyright (c) 2018-2019 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2020.
-// Modifications copyright (c) 2020 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2020-2022.
+// Modifications copyright (c) 2020-2022 Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -51,7 +51,7 @@ void test_one_geo(std::string const& caseid,
     // TODO: If area is for calculation of the orientation of points in a ring
     //   and accuracy is an issue, then instead calculate_point_order should
     //   probably be used instead of area.
-    bg::strategies::relate::geographic
+    bg::strategies::buffer::geographic
         <
             bg::strategy::thomas, bg::srs::spheroid<long double>, long double
         > strategy;


### PR DESCRIPTION
Furthermore:
- pass umbrella strategy to some algorithms which were using default strategy.
- derive buffer umbrella strategies from distance strategies.