### PR TITLE
Fix simplify for open rings and improve it

### DIFF
--- a/test/algorithms/simplify.cpp
+++ b/test/algorithms/simplify.cpp
@@ -5,8 +5,8 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2021.
-// Modifications copyright (c) 2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2021-2022.
+// Modifications copyright (c) 2021-2022 Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
@@ -200,10 +200,19 @@ void test_all()
         "POLYGON((0 0,0 10,10 10,10 0,0 0),(5 5,6 6,5 6,5 5))",
         "POLYGON((0 0,0 10,10 10,10 0,0 0))", 5.0);
 
-//    // Non-closed version
-//    test_geometry<bg::model::polygon<P, true, false> >(
-//        "POLYGON((1 0,0 0,0 4,4 4,4 0))",
-//        "POLYGON((0 0,0 4,4 4,4 0))", 0.1);
+    // Non-closed version
+    test_geometry<bg::model::polygon<P, true, false> >(
+        "POLYGON((1 0,0 0,0 4,4 4,4 0))",
+        "POLYGON((0 0,0 4,4 4,4 0))", 0.1);
+    test_geometry<bg::model::polygon<P, true, false> >(
+        "POLYGON((0 0,0 1,1 1,1 0))",
+        "POLYGON((0 0,0 1,1 1,1 0))", 0.1);
+
+    // Non-closed, ccw version
+    // https://github.com/boostorg/geometry/issues/956
+    test_geometry<bg::model::polygon<P, false, false> >(
+        "POLYGON((0 0,0.4 0,0.4 0.4))",
+        "POLYGON((0 0,0.4 0,0.4 0.4))", 0);
 
 
     {


### PR DESCRIPTION
Fix for https://github.com/boostorg/geometry/issues/956

Furthermore:
- avoid duplicating closing point for closed rings while rotating the range
- use more efficient strategy while calculating index of opposite point