### PR TITLE
[fix] get_turns with const geometries

### DIFF
--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info_helpers.hpp
@@ -50,8 +50,6 @@ template
 >
 struct side_calculator
 {
-    typedef typename UniqueSubRange1::point_type point1_type;
-    typedef typename UniqueSubRange2::point_type point2_type;
     typedef decltype(std::declval<Strategy>().side()) side_strategy_type;
 
     inline side_calculator(UniqueSubRange1 const& range_p,
@@ -76,13 +74,13 @@ struct side_calculator
     inline int pj_wrt_q1() const { return m_side_strategy.apply(get_qi(), get_qj(), get_pj()); }
     inline int pj_wrt_q2() const { return m_side_strategy.apply(get_qj(), get_qk(), get_pj()); }
 
-    inline point1_type const& get_pi() const { return m_range_p.at(0); }
-    inline point1_type const& get_pj() const { return m_range_p.at(1); }
-    inline point1_type const& get_pk() const { return m_range_p.at(2); }
+    inline auto const& get_pi() const { return m_range_p.at(0); }
+    inline auto const& get_pj() const { return m_range_p.at(1); }
+    inline auto const& get_pk() const { return m_range_p.at(2); }
 
-    inline point2_type const& get_qi() const { return m_range_q.at(0); }
-    inline point2_type const& get_qj() const { return m_range_q.at(1); }
-    inline point2_type const& get_qk() const { return m_range_q.at(2); }
+    inline auto const& get_qi() const { return m_range_q.at(0); }
+    inline auto const& get_qj() const { return m_range_q.at(1); }
+    inline auto const& get_qk() const { return m_range_q.at(2); }
 
     // Used side-strategy, owned by the calculator
     side_strategy_type m_side_strategy;
@@ -338,9 +336,6 @@ public:
 
     typedef typename intersection_policy_type::return_type result_type;
 
-    typedef typename UniqueSubRange1::point_type point1_type;
-    typedef typename UniqueSubRange2::point_type point2_type;
-
     typedef side_calculator
         <
             UniqueSubRange1, UniqueSubRange2, UmbrellaStrategy
@@ -366,13 +361,13 @@ public:
     inline bool p_is_last_segment() const { return m_range_p.is_last_segment(); }
     inline bool q_is_last_segment() const { return m_range_q.is_last_segment(); }
 
-    inline point1_type const& rpi() const { return m_side_calc.get_pi(); }
-    inline point1_type const& rpj() const { return m_side_calc.get_pj(); }
-    inline point1_type const& rpk() const { return m_side_calc.get_pk(); }
+    inline auto const& rpi() const { return m_side_calc.get_pi(); }
+    inline auto const& rpj() const { return m_side_calc.get_pj(); }
+    inline auto const& rpk() const { return m_side_calc.get_pk(); }
 
-    inline point2_type const& rqi() const { return m_side_calc.get_qi(); }
-    inline point2_type const& rqj() const { return m_side_calc.get_qj(); }
-    inline point2_type const& rqk() const { return m_side_calc.get_qk(); }
+    inline auto const& rqi() const { return m_side_calc.get_qi(); }
+    inline auto const& rqj() const { return m_side_calc.get_qj(); }
+    inline auto const& rqk() const { return m_side_calc.get_qk(); }
 
     inline side_calculator_type const& sides() const { return m_side_calc; }
     inline swapped_side_calculator_type const& swapped_sides() const
@@ -409,9 +404,6 @@ class intersection_info
         TurnPoint, UmbrellaStrategy, RobustPolicy> base;
 
 public:
-
-    typedef typename UniqueSubRange1::point_type point1_type;
-    typedef typename UniqueSubRange2::point_type point2_type;
 
     typedef typename UmbrellaStrategy::cs_tag cs_tag;
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
@@ -111,7 +111,7 @@ template
 >
 struct unique_sub_range_from_section
 {
-    typedef Point point_type;
+    using point_type = Point;
 
     unique_sub_range_from_section(Section const& section, signed_size_type index,
                           CircularIterator circular_iterator,
@@ -123,7 +123,7 @@ struct unique_sub_range_from_section
         , m_previous_point(previous)
         , m_current_point(current)
         , m_circular_iterator(circular_iterator)
-        , m_point_retrieved(false)
+        , m_next_point_retrieved(false)
         , m_strategy(strategy)
         , m_robust_policy(robust_policy)
     {}
@@ -158,18 +158,18 @@ struct unique_sub_range_from_section
 private :
     inline Point const& get_next_point() const
     {
-        if (! m_point_retrieved)
+        if (! m_next_point_retrieved)
         {
             advance_to_non_duplicate_next(m_current_point, m_circular_iterator);
-            m_point = *m_circular_iterator;
-            m_point_retrieved = true;
+            m_next_point_retrieved = true;
         }
-        return m_point;
+        return *m_circular_iterator;
     }
 
     inline void advance_to_non_duplicate_next(Point const& current, CircularIterator& circular_iterator) const
     {
-        typedef typename robust_point_type<Point, RobustPolicy>::type robust_point_type;
+        using box_point_type = typename geometry::point_type<typename Section::box_type>::type;
+        using robust_point_type = typename robust_point_type<box_point_type, RobustPolicy>::type;
         robust_point_type current_robust_point;
         robust_point_type next_robust_point;
         geometry::recalculate(current_robust_point, current, m_robust_policy);
@@ -199,8 +199,7 @@ private :
     Point const& m_previous_point;
     Point const& m_current_point;
     mutable CircularIterator m_circular_iterator;
-    mutable Point m_point;
-    mutable bool m_point_retrieved;
+    mutable bool m_next_point_retrieved;
     Strategy m_strategy;
     RobustPolicy m_robust_policy;
 };

--- a/include/boost/geometry/algorithms/detail/sections/section_functions.hpp
+++ b/include/boost/geometry/algorithms/detail/sections/section_functions.hpp
@@ -124,13 +124,14 @@ template
     typename Box,
     typename RobustPolicy
 >
-static inline bool preceding(int dir,
-                             Point const& point,
-                             Box const& point_box,
-                             Box const& other_box,
-                             RobustPolicy const& robust_policy)
+inline bool preceding(int dir,
+                      Point const& point,
+                      Box const& point_box,
+                      Box const& other_box,
+                      RobustPolicy const& robust_policy)
 {
-    typename geometry::robust_point_type<Point, RobustPolicy>::type robust_point;
+    using box_point_type = typename geometry::point_type<Box>::type;
+    typename geometry::robust_point_type<box_point_type, RobustPolicy>::type robust_point;
     geometry::recalculate(robust_point, point, robust_policy);
 
     // After recalculate() to prevent warning: 'robust_point' may be used uninitialized
@@ -148,11 +149,11 @@ template
     typename Box,
     typename RobustPolicy
 >
-static inline bool exceeding(int dir,
-                             Point const& point,
-                             Box const& point_box,
-                             Box const& other_box,
-                             RobustPolicy const& robust_policy)
+inline bool exceeding(int dir,
+                      Point const& point,
+                      Box const& point_box,
+                      Box const& other_box,
+                      RobustPolicy const& robust_policy)
 {
     return preceding<Dimension>(-dir, point, point_box, other_box, robust_policy);
 }

--- a/include/boost/geometry/geometries/register/point.hpp
+++ b/include/boost/geometry/geometries/register/point.hpp
@@ -18,10 +18,14 @@
 #ifndef BOOST_GEOMETRY_GEOMETRIES_REGISTER_POINT_HPP
 #define BOOST_GEOMETRY_GEOMETRIES_REGISTER_POINT_HPP
 
+#include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/coordinate_dimension.hpp>
+#include <boost/geometry/core/coordinate_system.hpp>
+#include <boost/geometry/core/coordinate_type.hpp>
+#include <boost/geometry/core/cs.hpp>
 
 #include <cstddef>
 #include <type_traits>
-
 
 #ifndef DOXYGEN_NO_SPECIALIZATIONS
 

--- a/test/algorithms/detail/sections/sectionalize_const.cpp
+++ b/test/algorithms/detail/sections/sectionalize_const.cpp
@@ -7,32 +7,15 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#include <geometry_test_common.hpp>
+#include <test_geometries/const_point.hpp>
 
-#include <boost/geometry.hpp>
-#include <boost/geometry/geometries/register/point.hpp>
+#include <boost/geometry/algorithms/area.hpp>
+#include <boost/geometry/algorithms/perimeter.hpp>
+#include <boost/geometry/algorithms/detail/sections/sectionalize.hpp>
 #include <boost/geometry/geometries/helper_geometry.hpp>
 
-class const_point
-{
-public:
-  const_point(double x0, double y0) : x(x0), y(y0) {}
+#include <geometry_test_common.hpp>
 
-  double GetX() const { return x; }
-  double GetY() const { return y; }
-private:
-  double x{0}, y{0};
-};
-
-BOOST_GEOMETRY_REGISTER_POINT_2D_CONST(const_point, double, boost::geometry::cs::cartesian, GetX(), GetY());
-
-using ring_of_const_point = std::vector<const_point>;
-
-// Register a vector of const_pos as a non-const-ring with const points
-namespace boost { namespace geometry { namespace traits {
-    template<> struct tag<ring_of_const_point> { typedef ring_tag type; };
-
-}}}
 
 template <std::size_t Dim, typename Geometry>
 void test_sectionalize_on_const(Geometry const& geometry, std::size_t expected_section_count)

--- a/test/algorithms/overlay/Jamfile
+++ b/test/algorithms/overlay/Jamfile
@@ -21,6 +21,7 @@ test-suite boost-geometry-algorithms-overlay
     [ run get_ring.cpp                     : : : : algorithms_get_ring ]
     [ run get_turn_info.cpp                : : : : algorithms_get_turn_info ]
     [ run get_turns.cpp                    : : : : algorithms_get_turns ]
+    [ run get_turns_const.cpp              : : : : algorithms_get_turns_const ]
     [ run get_turns_areal_areal.cpp        : : : : algorithms_get_turns_areal_areal ]
     [ run get_turns_areal_areal_sph.cpp    : : : : algorithms_get_turns_areal_areal_sph ]
     [ run get_turns_linear_areal.cpp       : : : : algorithms_get_turns_linear_areal ]

--- a/test/algorithms/overlay/get_turns_const.cpp
+++ b/test/algorithms/overlay/get_turns_const.cpp
@@ -1,0 +1,78 @@
+// Boost.Geometry
+// Unit Test
+
+// Copyright (c) 2022 Barend Gehrels, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <test_geometries/const_point.hpp>
+
+#include <boost/geometry/algorithms/detail/overlay/get_turns.hpp>
+
+#include <boost/geometry/strategies/default_strategy.hpp>
+#include <boost/geometry/strategies/relate/cartesian.hpp>
+#include <boost/geometry/geometries/helper_geometry.hpp>
+
+#include <geometry_test_common.hpp>
+
+
+template <typename Ring1, typename Ring2>
+void test_get_turns_on_const(Ring1 const &ring1, Ring2 const &ring2,
+    const std::vector<const_point>& expectation)
+{
+    namespace bg = boost::geometry;
+
+    using rescale_policy_type = bg::detail::no_rescale_policy;
+    using strategy_type = typename bg::strategies::relate::services::default_strategy<Ring1, Ring2>::type;
+
+    using point_type = typename bg::point_type<Ring1>::type;
+    using writable_point_type = typename bg::helper_geometry<point_type>::type;
+
+    using segment_ratio_type = typename bg::detail::segment_ratio_type
+        <
+            writable_point_type, rescale_policy_type
+        >::type;
+    using turn_info = bg::detail::overlay::turn_info
+        <
+            writable_point_type, segment_ratio_type
+        >;
+
+    std::vector<turn_info> turns;
+    strategy_type strategy;
+    bg::detail::get_turns::no_interrupt_policy policy;
+    bg::get_turns
+        <
+            false, false, bg::detail::overlay::assign_null_policy
+        >(ring1, ring2,  strategy, rescale_policy_type(), turns, policy);
+
+    BOOST_CHECK_EQUAL(turns.size(), expectation.size());
+
+    const double tolerance = 0.001;
+    for (std::size_t i = 0; i < turns.size() && i < expectation.size(); i++) 
+    {
+        BOOST_CHECK_CLOSE(expectation[i].GetX(), bg::get<0>(turns[i].point), tolerance);
+        BOOST_CHECK_CLOSE(expectation[i].GetY(), bg::get<1>(turns[i].point), tolerance);
+    }
+
+#ifdef BOOST_GEOMETRY_TEST_DEBUG
+    std::cout << bg::wkt(ring1) << " " << bg::wkt(ring2) << std::endl;
+    for (const auto& turn : turns) 
+    {
+        std::cout << bg::wkt(turn.point) << std::endl;
+    }
+#endif    
+}
+
+int test_main(int, char* [])
+{
+    // Construct two geometries with visually predictable intersections
+    ring_of_const_point rectangle{{2, 2}, {2, 4}, {4, 4}, {4, 2}, {2, 2}};
+    ring_of_const_point triangle{{1, 2}, {4, 5}, {5, 4}, {1, 2}};
+
+    test_get_turns_on_const(rectangle, triangle, {{2, 3}, {2, 2.5}, {3, 4}, {4, 3.5}});
+
+    return 0;
+}
+

--- a/test/test_geometries/const_point.hpp
+++ b/test/test_geometries/const_point.hpp
@@ -1,0 +1,38 @@
+// Boost.Geometry
+// Unit Test
+
+// Copyright (c) 2022 Barend Gehrels, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_TEST_TEST_GEOMETRIES_CONST_POINT_HPP
+#define BOOST_GEOMETRY_TEST_TEST_GEOMETRIES_CONST_POINT_HPP
+
+#include <boost/geometry/geometries/register/point.hpp>
+#include <vector>
+
+class const_point
+{
+public:
+    const_point(double x0, double y0) : x(x0), y(y0) {}
+
+    double GetX() const { return x; }
+    double GetY() const { return y; }
+private:
+    double x{0}, y{0};
+};
+
+BOOST_GEOMETRY_REGISTER_POINT_2D_CONST(const_point, double, boost::geometry::cs::cartesian, GetX(), GetY());
+
+using ring_of_const_point = std::vector<const_point>;
+
+// Register a vector of const_pos as a non-const-ring with const points
+namespace boost { namespace geometry { namespace traits {
+    template<> struct tag<ring_of_const_point> { typedef ring_tag type; };
+
+}}}
+
+
+#endif


### PR DESCRIPTION
Fixes #983 

After this, the using operations such as `disjoint` do still not work yet - they need to use the `helper_geometry_type` internally to calculate turns, etc.