### PR TITLE
Fix const disjoint

### DIFF
--- a/include/boost/geometry/algorithms/detail/disjoint/areal_areal.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/areal_areal.hpp
@@ -30,6 +30,8 @@
 #include <boost/geometry/algorithms/detail/disjoint/linear_linear.hpp>
 #include <boost/geometry/algorithms/detail/disjoint/segment_box.hpp>
 
+#include <boost/geometry/geometries/helper_geometry.hpp>
+
 #include <boost/geometry/algorithms/for_each.hpp>
 
 
@@ -46,7 +48,8 @@ inline bool point_on_border_covered_by(Geometry1 const& geometry1,
                                        Geometry2 const& geometry2,
                                        Strategy const& strategy)
 {
-    typename geometry::point_type<Geometry1>::type pt;
+    using point_type = typename geometry::point_type<Geometry1>::type;
+    typename helper_geometry<point_type>::type pt;
     return geometry::point_on_border(pt, geometry1)
         && geometry::covered_by(pt, geometry2, strategy);
 }

--- a/include/boost/geometry/algorithms/detail/disjoint/linear_areal.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/linear_areal.hpp
@@ -51,6 +51,7 @@
 
 #include <boost/geometry/algorithms/dispatch/disjoint.hpp>
 
+#include <boost/geometry/geometries/helper_geometry.hpp>
 
 namespace boost { namespace geometry
 {
@@ -70,8 +71,8 @@ struct disjoint_no_intersections_policy
     template <typename Strategy>
     static inline bool apply(Geometry1 const& g1, Geometry2 const& g2, Strategy const& strategy)
     {
-        typedef typename point_type<Geometry1>::type point1_type;
-        point1_type p;
+        using point_type = typename point_type<Geometry1>::type;
+        typename helper_geometry<point_type>::type p;
         geometry::point_on_border(p, g1);
 
         return ! geometry::covered_by(p, g2, strategy);

--- a/include/boost/geometry/algorithms/detail/disjoint/linear_linear.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/linear_linear.hpp
@@ -33,6 +33,8 @@
 #include <boost/geometry/algorithms/detail/overlay/do_reverse.hpp>
 #include <boost/geometry/algorithms/detail/overlay/segment_as_subrange.hpp>
 
+#include <boost/geometry/geometries/helper_geometry.hpp>
+
 #include <boost/geometry/policies/disjoint_interrupt_policy.hpp>
 #include <boost/geometry/policies/robustness/no_rescale_policy.hpp>
 
@@ -91,20 +93,21 @@ struct disjoint_linear
                              Geometry2 const& geometry2,
                              Strategy const& strategy)
     {
-        typedef typename geometry::point_type<Geometry1>::type point_type;
-        typedef geometry::segment_ratio
+        using point_type = typename geometry::point_type<Geometry1>::type;
+        using mutable_point_type = typename helper_geometry<point_type>::type;
+        using ratio_type = geometry::segment_ratio
             <
                 typename coordinate_type<point_type>::type
-            > ratio_type;
-        typedef overlay::turn_info
+            > ;
+        using turn_info_type = overlay::turn_info
             <
-                point_type,
+                mutable_point_type,
                 ratio_type,
                 typename detail::get_turns::turn_operation_type
                         <
-                            Geometry1, Geometry2, ratio_type
+                            Geometry1, Geometry2, mutable_point_type, ratio_type
                         >::type
-            > turn_info_type;
+            >;
 
         std::deque<turn_info_type> turns;
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
@@ -926,24 +926,24 @@ struct get_turn_info_type<Geometry1, Geometry2, AssignPolicy, Tag1, Tag2, linear
     : overlay::get_turn_info_linear_areal<AssignPolicy>
 {};
 
-template <typename Geometry1, typename Geometry2, typename SegmentRatio,
+template <typename Geometry1, typename Geometry2, typename Point, typename SegmentRatio,
           typename Tag1 = typename tag<Geometry1>::type, typename Tag2 = typename tag<Geometry2>::type,
           typename TagBase1 = typename topological_tag_base<Geometry1>::type, typename TagBase2 = typename topological_tag_base<Geometry2>::type>
 struct turn_operation_type
 {
-    typedef overlay::turn_operation<typename point_type<Geometry1>::type, SegmentRatio> type;
+    using type = overlay::turn_operation<Point, SegmentRatio>;
 };
 
-template <typename Geometry1, typename Geometry2, typename SegmentRatio, typename Tag1, typename Tag2>
-struct turn_operation_type<Geometry1, Geometry2, SegmentRatio, Tag1, Tag2, linear_tag, linear_tag>
+template <typename Geometry1, typename Geometry2, typename Point, typename SegmentRatio, typename Tag1, typename Tag2>
+struct turn_operation_type<Geometry1, Geometry2, Point, SegmentRatio, Tag1, Tag2, linear_tag, linear_tag>
 {
-    typedef overlay::turn_operation_linear<typename point_type<Geometry1>::type, SegmentRatio> type;
+    using type = overlay::turn_operation_linear<Point, SegmentRatio>;
 };
 
-template <typename Geometry1, typename Geometry2, typename SegmentRatio, typename Tag1, typename Tag2>
-struct turn_operation_type<Geometry1, Geometry2, SegmentRatio, Tag1, Tag2, linear_tag, areal_tag>
+template <typename Geometry1, typename Geometry2, typename Point, typename SegmentRatio, typename Tag1, typename Tag2>
+struct turn_operation_type<Geometry1, Geometry2, Point, SegmentRatio, Tag1, Tag2, linear_tag, areal_tag>
 {
-    typedef overlay::turn_operation_linear<typename point_type<Geometry1>::type, SegmentRatio> type;
+    using type = overlay::turn_operation_linear<Point, SegmentRatio>;
 };
 
 }} // namespace detail::get_turns

--- a/include/boost/geometry/algorithms/detail/overlay/linear_linear.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/linear_linear.hpp
@@ -30,7 +30,7 @@
 
 #include <boost/geometry/algorithms/convert.hpp>
 
-
+#include <boost/geometry/geometries/helper_geometry.hpp>
 
 namespace boost { namespace geometry
 {
@@ -160,10 +160,14 @@ protected:
 
         detail::get_turns::no_interrupt_policy interrupt_policy;
 
+        using point_type = typename geometry::point_type<LinearGeometry1>::type;
+        using mutable_point_type = typename helper_geometry<point_type>::type;
+
         geometry::detail::relate::turns::get_turns
             <
                 LinearGeometry1,
                 LinearGeometry2,
+                mutable_point_type,
                 detail::get_turns::get_turn_info_type
                 <
                     LinearGeometry1,
@@ -231,10 +235,13 @@ public:
                                        OutputIterator oit,
                                        Strategy const& strategy)
     {
+        using point_type = typename geometry::point_type<Linear1>::type;
+        using mutable_point_type = typename helper_geometry<point_type>::type;
         typedef typename detail::relate::turns::get_turns
             <
                 Linear1,
                 Linear2,
+                mutable_point_type,
                 detail::get_turns::get_turn_info_type
                     <
                         Linear1,

--- a/include/boost/geometry/algorithms/detail/relate/areal_areal.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/areal_areal.hpp
@@ -29,12 +29,14 @@
 #include <boost/geometry/algorithms/detail/relate/boundary_checker.hpp>
 #include <boost/geometry/algorithms/detail/relate/follow_helpers.hpp>
 
+#include <boost/geometry/geometries/helper_geometry.hpp>
+
 namespace boost { namespace geometry
 {
 
 #ifndef DOXYGEN_NO_DETAIL
 namespace detail { namespace relate {
-    
+
 // WARNING!
 // TODO: In the worst case calling this Pred in a loop for MultiPolygon/MultiPolygon may take O(NM)
 // Use the rtree in this case!
@@ -85,9 +87,9 @@ public:
             return false;
         }
 
-        typedef typename geometry::point_type<Areal>::type point_type;
-        point_type pt;
-        bool const ok = boost::geometry::point_on_border(pt, areal);
+        using point_type = typename geometry::point_type<Areal>::type;
+        typename helper_geometry<point_type>::type pt;
+        bool const ok = geometry::point_on_border(pt, areal);
 
         // TODO: for now ignore, later throw an exception?
         if ( !ok )
@@ -102,7 +104,7 @@ public:
                                           m_other_areal,
                                           m_point_in_areal_strategy);
         //BOOST_GEOMETRY_ASSERT( pig != 0 );
-        
+
         // inside
         if ( pig > 0 )
         {
@@ -185,7 +187,7 @@ public:
                 }
             }
         }
-                    
+
         return m_flags != 3 && !m_result.interrupt;
     }
 
@@ -208,7 +210,7 @@ struct areal_areal
 
     typedef typename geometry::point_type<Geometry1>::type point1_type;
     typedef typename geometry::point_type<Geometry2>::type point2_type;
-    
+
     template <typename Result, typename Strategy>
     static inline void apply(Geometry1 const& geometry1, Geometry2 const& geometry2,
                              Result & result,
@@ -223,15 +225,18 @@ struct areal_areal
             return;
 
         // get and analyse turns
+        using point_type = typename geometry::point_type<Geometry1>::type;
+        using mutable_point_type = typename helper_geometry<point_type>::type;
+
         typedef typename turns::get_turns
             <
-                Geometry1, Geometry2
+                Geometry1, Geometry2, mutable_point_type
             >::template turn_info_type<Strategy>::type turn_type;
         std::vector<turn_type> turns;
 
         interrupt_policy_areal_areal<Result> interrupt_policy(geometry1, geometry2, result);
 
-        turns::get_turns<Geometry1, Geometry2>::apply(turns, geometry1, geometry2, interrupt_policy, strategy);
+        turns::get_turns<Geometry1, Geometry2, mutable_point_type>::apply(turns, geometry1, geometry2, interrupt_policy, strategy);
         if ( BOOST_GEOMETRY_CONDITION(result.interrupt) )
             return;
 
@@ -248,7 +253,7 @@ struct areal_areal
         for_each_disjoint_geometry_if<1, Geometry2>::apply(turns.begin(), turns.end(), geometry2, pred2);
         if ( BOOST_GEOMETRY_CONDITION(result.interrupt) )
             return;
-        
+
         if ( turns.empty() )
             return;
 
@@ -353,7 +358,7 @@ struct areal_areal
         inline bool apply(Range const& turns)
         {
             typedef typename boost::range_iterator<Range const>::type iterator;
-            
+
             for (iterator it = boost::begin(turns) ; it != boost::end(turns) ; ++it)
             {
                 per_turn<0>(*it);
@@ -469,7 +474,7 @@ struct areal_areal
                     {
                         m_exit_detected = false;
                     }
-                }                
+                }
                 /*else*/
                 if ( m_enter_detected /*m_previous_operation == overlay::operation_intersection*/ )
                 {
@@ -660,7 +665,7 @@ struct areal_areal
                 // TODO: throw an exception?
                 return; // ignore
             }
-                
+
             // TODO: possible optimization
             // if the range is an interior ring we may use other IPs generated for this single geometry
             // to know which other single geometries should be checked
@@ -713,12 +718,12 @@ struct areal_areal
 
             for ( TurnIt it = first ; it != last ; ++it )
             {
-                if ( it->operations[0].operation == overlay::operation_intersection 
+                if ( it->operations[0].operation == overlay::operation_intersection
                   && it->operations[1].operation == overlay::operation_intersection )
                 {
                     found_ii = true;
                 }
-                else if ( it->operations[0].operation == overlay::operation_union 
+                else if ( it->operations[0].operation == overlay::operation_union
                        && it->operations[1].operation == overlay::operation_union )
                 {
                     found_uu = true;
@@ -735,7 +740,7 @@ struct areal_areal
                 update<interior, interior, '2', transpose_result>(m_result);
                 m_flags |= 1;
 
-                //update<boundary, boundary, '0', transpose_result>(m_result);                
+                //update<boundary, boundary, '0', transpose_result>(m_result);
 
                 update<boundary, interior, '1', transpose_result>(m_result);
                 update<exterior, interior, '2', transpose_result>(m_result);
@@ -846,7 +851,7 @@ struct areal_areal
                 count = boost::numeric_cast<signed_size_type>(
                             geometry::num_interior_rings(
                                 detail::single_geometry(analyser.geometry, seg_id)));
-            
+
             for_no_turns_rings(analyser, turn, seg_id.ring_index + 1, count);
         }
 

--- a/include/boost/geometry/algorithms/detail/relate/follow_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/follow_helpers.hpp
@@ -368,8 +368,8 @@ inline bool turn_on_the_same_ip(Turn const& prev_turn, Turn const& curr_turn,
 template <boundary_query BoundaryQuery,
           typename Point,
           typename BoundaryChecker>
-static inline bool is_endpoint_on_boundary(Point const& pt,
-                                           BoundaryChecker & boundary_checker)
+inline bool is_endpoint_on_boundary(Point const& pt,
+                                    BoundaryChecker & boundary_checker)
 {
     return boundary_checker.template is_endpoint_boundary<BoundaryQuery>(pt);
 }
@@ -378,10 +378,10 @@ template <boundary_query BoundaryQuery,
           typename IntersectionPoint,
           typename OperationInfo,
           typename BoundaryChecker>
-static inline bool is_ip_on_boundary(IntersectionPoint const& ip,
-                                     OperationInfo const& operation_info,
-                                     BoundaryChecker & boundary_checker,
-                                     segment_identifier const& seg_id)
+inline bool is_ip_on_boundary(IntersectionPoint const& ip,
+                              OperationInfo const& operation_info,
+                              BoundaryChecker & boundary_checker,
+                              segment_identifier const& seg_id)
 {
     boost::ignore_unused(seg_id);
 

--- a/include/boost/geometry/algorithms/detail/relate/turns.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/turns.hpp
@@ -40,12 +40,13 @@ struct assign_policy
     static bool const include_degenerate = IncludeDegenerate;
 };
 
-// GET_TURNS
+// turn retriever, calling get_turns
 
 template
 <
     typename Geometry1,
     typename Geometry2,
+    typename Point,
     typename GetTurnPolicy = detail::get_turns::get_turn_info_type
         <
             Geometry1, Geometry2, assign_policy<>
@@ -53,8 +54,6 @@ template
 >
 struct get_turns
 {
-    typedef typename geometry::point_type<Geometry1>::type point1_type;
-
     template <typename Strategy>
     struct robust_policy_type
         : geometry::rescale_overlay_policy_type
@@ -72,16 +71,16 @@ struct get_turns
     >
     struct turn_info_type
     {
-        typedef typename segment_ratio_type<point1_type, RobustPolicy>::type ratio_type;
-        typedef overlay::turn_info
+        using ratio_type = typename segment_ratio_type<Point, RobustPolicy>::type;
+        using type = overlay::turn_info
             <
-                point1_type,
+                Point,
                 ratio_type,
                 typename detail::get_turns::turn_operation_type
                     <
-                        Geometry1, Geometry2, ratio_type
+                        Geometry1, Geometry2, Point, ratio_type
                     >::type
-            > type;
+            >;
     };
 
     template <typename Turns, typename InterruptPolicy, typename Strategy>

--- a/include/boost/geometry/algorithms/detail/touches/implementation.hpp
+++ b/include/boost/geometry/algorithms/detail/touches/implementation.hpp
@@ -34,6 +34,8 @@
 #include <boost/geometry/algorithms/num_geometries.hpp>
 #include <boost/geometry/algorithms/relate.hpp>
 
+#include <boost/geometry/geometries/helper_geometry.hpp>
+
 #include <boost/geometry/policies/robustness/no_rescale_policy.hpp>
 
 #include <boost/geometry/strategies/relate/cartesian.hpp>
@@ -211,7 +213,8 @@ inline bool point_on_border_within(Geometry1 const& geometry1,
                                    Geometry2 const& geometry2,
                                    Strategy const& strategy)
 {
-    typename geometry::point_type<Geometry1>::type pt;
+    using point_type = typename geometry::point_type<Geometry1>::type;
+    typename helper_geometry<point_type>::type pt;
     return geometry::point_on_border(pt, geometry1)
         && geometry::within(pt, geometry2, strategy);
 }
@@ -235,8 +238,9 @@ struct areal_areal
                              Geometry2 const& geometry2,
                              Strategy const& strategy)
     {
-        typedef typename geometry::point_type<Geometry1>::type point_type;
-        typedef detail::overlay::turn_info<point_type> turn_info;
+        using point_type = typename geometry::point_type<Geometry1>::type;
+        using mutable_point_type = typename helper_geometry<point_type>::type;
+        using turn_info = detail::overlay::turn_info<mutable_point_type>;
 
         std::deque<turn_info> turns;
         detail::touches::areal_interrupt_policy policy;

--- a/test/algorithms/overlay/test_get_turns.hpp
+++ b/test/algorithms/overlay/test_get_turns.hpp
@@ -184,6 +184,7 @@ void check_geometry_range(Geometry1 const& g1,
             <
                 Geometry1,
                 Geometry2,
+                point_type,
                 segment_ratio_type
             >::type
         > turn_info;

--- a/test/algorithms/relate/Jamfile
+++ b/test/algorithms/relate/Jamfile
@@ -16,6 +16,7 @@
 
 test-suite boost-geometry-algorithms-relate
     :
+    [ run relate_const.cpp              : : : : algorithms_relate_const ]
     [ run relate_areal_areal.cpp        : : : : algorithms_relate_areal_areal ]
     [ run relate_areal_areal_sph.cpp    : : : : algorithms_relate_areal_areal_sph ]
     [ run relate_linear_areal.cpp       : : : : algorithms_relate_linear_areal ]

--- a/test/algorithms/relate/relate_const.cpp
+++ b/test/algorithms/relate/relate_const.cpp
@@ -1,0 +1,63 @@
+// Boost.Geometry
+// Unit Test
+
+// Copyright (c) 2022 Barend Gehrels, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <test_geometries/const_point.hpp>
+
+#include <boost/geometry/algorithms/covered_by.hpp>
+#include <boost/geometry/algorithms/crosses.hpp>
+#include <boost/geometry/algorithms/disjoint.hpp>
+#include <boost/geometry/algorithms/intersects.hpp>
+#include <boost/geometry/algorithms/overlaps.hpp>
+#include <boost/geometry/algorithms/relate.hpp>
+#include <boost/geometry/algorithms/touches.hpp>
+#include <boost/geometry/algorithms/within.hpp>
+
+
+#include <geometry_test_common.hpp>
+
+
+template <typename Geometry1, typename Geometry2>
+void test_relate_const(Geometry1 const &geometry1, Geometry2 const &geometry2,
+    bool exp_cov, bool exp_crosses, bool exp_disjoint, bool exp_intersects,
+    bool exp_overlaps, bool exp_touches, bool exp_relate, bool exp_within)
+{
+    namespace bg = boost::geometry;
+
+    BOOST_CHECK_EQUAL(exp_cov, bg::covered_by(geometry1, geometry2));
+    BOOST_CHECK_EQUAL(exp_crosses, bg::crosses(geometry1, geometry2));
+    BOOST_CHECK_EQUAL(exp_disjoint, bg::disjoint(geometry1, geometry2));
+    BOOST_CHECK_EQUAL(exp_intersects, bg::intersects(geometry1, geometry2));
+    BOOST_CHECK_EQUAL(exp_overlaps, bg::overlaps(geometry1, geometry2));
+    BOOST_CHECK_EQUAL(exp_touches, bg::touches(geometry1, geometry2));
+    BOOST_CHECK_EQUAL(exp_relate, bg::relate(geometry1, geometry2, bg::de9im::mask("F0F******")));
+    BOOST_CHECK_EQUAL(exp_within, bg::within(geometry1, geometry2));
+}
+
+
+int test_main(int, char* [])
+{
+    ring_of_const_point const rectangle{{2, 2}, {2, 4}, {4, 4}, {4, 2}, {2, 2}};
+    ring_of_const_point const triangle{{1, 2}, {4, 5}, {5, 4}, {1, 2}};
+    linestring_of_const_point const diagonal{{0, 0}, {6, 6}};
+    linestring_of_const_point const horizontal{{0, 3}, {6, 3}};
+
+    // areal/areal
+    test_relate_const(rectangle, triangle, false, false, false, true, true, false, false, false);
+
+    // point/areal
+    test_relate_const(rectangle.front(), triangle, false, false, true, false, false, false, false, false);
+
+    // point/linear
+    test_relate_const(rectangle.front(), diagonal, true, false, false, true, false, false, false, true);
+
+    // linear/linear
+    test_relate_const(horizontal, diagonal, false, true, false, true, false, false, false, false);
+
+    return 0;
+}

--- a/test/algorithms/set_operations/check_turn_less.hpp
+++ b/test/algorithms/set_operations/check_turn_less.hpp
@@ -87,6 +87,7 @@ struct check_turn_less
             <
                 Geometry1,
                 Geometry2,
+                typename bg::point_type<Geometry1>::type,
                 bg::detail::get_turns::get_turn_info_type
                     <
                         Geometry1, Geometry2, assign_policy<>

--- a/test/algorithms/set_operations/test_get_turns_ll_invariance.hpp
+++ b/test/algorithms/set_operations/test_get_turns_ll_invariance.hpp
@@ -84,6 +84,7 @@ private:
             <
                 LinearGeometry1,
                 LinearGeometry2,
+                typename bg::point_type<LinearGeometry1>::type,
                 bg_detail::get_turns::get_turn_info_type
                     <
                         LinearGeometry1,
@@ -109,7 +110,7 @@ public:
 
         typedef typename bg_detail::relate::turns::get_turns
             <
-                Linear1, Linear2
+                Linear1, Linear2, typename bg::point_type<Linear1>::type
             >::template turn_info_type<strategy_type>::type turn_info;
 
         typedef std::vector<turn_info> turns_container;

--- a/test/robustness/overlay/areal_areal/interior_triangles.cpp
+++ b/test/robustness/overlay/areal_areal/interior_triangles.cpp
@@ -8,7 +8,9 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_GEOMETRY_NO_BOOST_TEST
+#ifndef BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE
 #define BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE
+#endif
 
 // NOTE: there is no randomness here. Count is to measure performance
 

--- a/test/test_geometries/const_point.hpp
+++ b/test/test_geometries/const_point.hpp
@@ -11,6 +11,7 @@
 #define BOOST_GEOMETRY_TEST_TEST_GEOMETRIES_CONST_POINT_HPP
 
 #include <boost/geometry/geometries/register/point.hpp>
+#include <deque>
 #include <vector>
 
 class const_point
@@ -31,6 +32,14 @@ using ring_of_const_point = std::vector<const_point>;
 // Register a vector of const_pos as a non-const-ring with const points
 namespace boost { namespace geometry { namespace traits {
     template<> struct tag<ring_of_const_point> { typedef ring_tag type; };
+
+}}}
+
+using linestring_of_const_point = std::deque<const_point>;
+
+// Register a vector of const_pos as a non-const-ring with const points
+namespace boost { namespace geometry { namespace traits {
+    template<> struct tag<linestring_of_const_point> { typedef linestring_tag type; };
 
 }}}
 

--- a/test/to_svg.hpp
+++ b/test/to_svg.hpp
@@ -190,9 +190,8 @@ inline void to_svg(G1 const& g1, G2 const& g2, G3 const& g3,
 
     bg::detail::relate::turns::get_turns
         <
-            G1, G2, turn_policy
+            G1, G2, point_type, turn_policy
         >::apply(turns, g1, g2, interrupt_policy, strategy);
-
     {
         using less = bg::detail::relate::turns::less
             <


### PR DESCRIPTION
Fixes #985 

Some pieces of the touched code become a bit simpler by this (for example avoiding an extra conversion).

There are some renamings as well, such as `get_turns` (this was really inconvenient, there is a namespace and a free function as well - and this does something different - so I call it `turn_retriever` now) and `define_turn_operation_type` i/o `turn_operation_type` (because that is there as well).

Also there are some white space changes (at end of lines), fixed by my editor.