### PR TITLE
Fix c++20 compilation errors related to conditional expression

### DIFF
--- a/include/boost/geometry/policies/robustness/segment_ratio.hpp
+++ b/include/boost/geometry/policies/robustness/segment_ratio.hpp
@@ -225,7 +225,7 @@ public:
         }
 
         m_approximation =
-            m_denominator == zero_instance() ? 0
+            m_denominator == zero_instance() ? floating_point_type{0}
             : (
                 boost::numeric_cast<floating_point_type>(m_numerator) * scale()
                 / boost::numeric_cast<floating_point_type>(m_denominator)


### PR DESCRIPTION
Fix c++20 compilation errors related to conditional expression with int and floating_point_type

A floating_point_type with implicit conversions can lead to this C++20 compilation error:

boost\geometry\policies\robustness\segment_ratio.hpp(232,1): error C2445: result type of conditional expression is ambiguous: types 'int' and '<floating_point_type>' can be converted to multiple common types