### PR TITLE
[side] added side_rounded_input and robustness test

### DIFF
--- a/include/boost/geometry/strategies/cartesian/side_rounded_input.hpp
+++ b/include/boost/geometry/strategies/cartesian/side_rounded_input.hpp
@@ -1,0 +1,57 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2021 Tinko Bartels, Berlin, Germany.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_STRATEGY_CARTESIAN_SIDE_ROUNDED_INPUT_HPP
+#define BOOST_GEOMETRY_STRATEGY_CARTESIAN_SIDE_ROUNDED_INPUT_HPP
+
+
+#include <boost/geometry/core/config.hpp>
+
+#include <boost/geometry/strategies/side.hpp>
+
+#include <boost/geometry/util/select_calculation_type.hpp>
+
+namespace boost { namespace geometry
+{
+
+namespace strategy { namespace side
+{
+
+template <typename CalculationType = void, int Coeff1 = 5, int Coeff2 = 32>
+struct side_rounded_input
+{
+    using cs_tag = cartesian_tag;
+
+    template <typename P1, typename P2, typename P>
+    static inline int apply(P1 const& p1, P2 const& p2, P const& p)
+    {
+        using coor_t = typename select_calculation_type_alt<CalculationType, P1, P2, P>::type;
+
+        coor_t const p1_x = geometry::get<0>(p1);
+        coor_t const p1_y = geometry::get<1>(p1);
+        coor_t const p2_x = geometry::get<0>(p2);
+        coor_t const p2_y = geometry::get<1>(p2);
+        coor_t const p_x = geometry::get<0>(p);
+        coor_t const p_y = geometry::get<1>(p);
+
+        constexpr coor_t eps = std::numeric_limits<coor_t>::epsilon() / 2;
+        coor_t const det = (p1_x - p_x) * (p2_y - p_y) - (p1_y - p_y) * (p2_x - p_x);
+        coor_t const err_bound = (Coeff1 * eps + Coeff2 * eps * eps) *
+            (  (geometry::math::abs(p1_x) + geometry::math::abs(p_x))
+             * (geometry::math::abs(p2_y) + geometry::math::abs(p_y))
+             + (geometry::math::abs(p2_x) + geometry::math::abs(p_x))
+             * (geometry::math::abs(p1_y) + geometry::math::abs(p_y)));
+        return (det > err_bound) - (det < -err_bound);
+    }
+};
+
+}} // namespace strategy::side
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_STRATEGY_CARTESIAN_SIDE_ROUNDED_INPUT_HPP

--- a/test/strategies/Jamfile
+++ b/test/strategies/Jamfile
@@ -36,6 +36,7 @@ test-suite boost-geometry-strategies
     [ run segment_intersection_geo.cpp       : : : : strategies_segment_intersection_geo ]
     [ run segment_intersection_sph.cpp       : : : : strategies_segment_intersection_sph ]
     [ run spherical_side.cpp                 : : : : strategies_spherical_side ]
+    [ run side_rounded_input.cpp             : : : : strategies_side_rounded_input ]
     [ run thomas.cpp                         : : : : strategies_thomas ]
     [ run transform_cs.cpp                   : : : : strategies_transform_cs ]
     [ run transformer.cpp                    : : : : strategies_transformer ]

--- a/test/strategies/side_rounded_input.cpp
+++ b/test/strategies/side_rounded_input.cpp
@@ -1,0 +1,64 @@
+// Boost.Geometry
+// Unit Test
+
+// Copyright (c) 2022 Barend Gehrels, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <geometry_test_common.hpp>
+
+#include <boost/geometry/geometries/point.hpp>
+
+#include <boost/geometry/strategy/cartesian/side_robust.hpp>
+#include <boost/geometry/strategy/cartesian/side_by_triangle.hpp>
+#include <boost/geometry/strategies/cartesian/side_rounded_input.hpp>
+
+#include <boost/geometry/util/math.hpp>
+
+template <typename Point>
+void test_side_both_ways(std::string const& /*case_id*/, Point const& p1, Point const& p2, Point const& p3,
+                   int expected, int expected_rounded_input)
+{
+    int const side_cart = bg::strategy::side::services::default_strategy<bg::cartesian_tag>::type::apply(p1, p2, p3);
+    int const side_ri = bg::strategy::side::side_rounded_input<>::apply(p1, p2, p3);
+
+    BOOST_CHECK_EQUAL(side_cart, expected);
+    BOOST_CHECK_EQUAL(side_ri, expected_rounded_input);
+}
+
+template <typename Point>
+void test_side(std::string const& case_id, Point const& p1, Point const& p2, Point const& p3,
+                   int expected, int expected_rounded_input = -99)
+{
+    int const eri = expected_rounded_input == -99 ? expected : expected_rounded_input;
+    test_side_both_ways(case_id, p1, p2, p3, expected, eri);
+    test_side_both_ways(case_id, p2, p1, p3, -expected, -eri);
+}
+
+
+template <typename Point>
+void test_all()
+{
+    Point const p1(0.0, 0.0);
+    Point const p2(10.0, 10.0);
+    Point const left(5.0, 6.0);
+    Point const right(5.0, 4.0);
+    Point const on_segment(5.0, 5.0);
+
+    // This point is just off. For double, side_rounded_input should say it's on top
+    Point const just(5.0, 5.0 + 1.0e-15);
+
+    test_side("left", p1, p2, left, 1);
+    test_side("right", p1, p2, right, -1);
+    test_side("colinear", p1, p2, on_segment, 0);
+    test_side("just", p1, p2, just, 1, 0);
+}
+
+int test_main(int, char* [])
+{
+    test_all<bg::model::point<double, 2, bg::cs::cartesian> >();
+
+    return 0;
+}


### PR DESCRIPTION
Add algorithm created by @tinko92 , including a unit test.

The robustness test is not committed anymore in this PR (wip).

The next PR (for slopes) will use this side algorithm.

Old description:
---------------------------------------------------------------------------------------------------


Add robustness test for comparing intersection with sides, for the problem described in #993 

This test generates random segments and calculate the intersection points between them (if any).

If there is one, it uses a side calculation to verify if the intersection point is determined as on-both-segments.

Like this:
![image](https://user-images.githubusercontent.com/334849/163999161-4f9bd22a-4f2b-4a29-8f7f-244066d03a37.png)


It uses many side strategies we have (for cartesian) plus the new one of @tinko92 

The new one seems to be the best, by far:
* it returns nearly always 0 (correct) for the intersection point being on the two lines
* if an additional point is generated near the intersection point (bisecting_point), at a distance of several epsilons, it is determined as left or right (correct) of the two lines. That of course depends on the epsilon.

So this side strategy seems the best to be used in the `buffer` `turn_in_ring_winding` algorithm.

Herewith a sample output:

```
$ ./strategies/intersection_points_and_sides --count 1000000  --size 100 --multiplier 1.0e6 --type d

Test configuration:
  - Debug mode
  - No rescaling
  - Default test type: d

Results  type: d
  intersections: 231133
  errors (triangle): 223186 0
  errors (non robust): 224080 0
  errors (side robust fp 3): 231133 0
  errors (side robust eq 3): 230716 0
  errors (rounded): 48 2
  distance (avg): 2.6233714731400201749454688750541e-13
  distance (avg, rnd): 1.4256091165024009451598202213168e-16
  time: 3.558
```

As you can see, the errors using all the strategies we have are nearly as large as the samples. That means it is too precise (for this purpose) and always determines the intersection point either left or right of one (or both) of the two input lines. Which is inconvenient.
For the extra point they determine it as correct (related to previous conclusion). But if that point goes closer, the results are still not good:
```
  intersections: 231171
  errors (triangle): 223193 71469
  errors (non robust): 224073 71801
  errors (side robust fp 3): 231171 0
  errors (side robust eq 3): 230788 14626
  errors (rounded): 44 231171
```
So the strategy of @tinko92 is the only one where the intersection point is considered as ON both segments (nearly always) and if the point moves a bit away (about 1.0e5 epsilons) from it, usually considered as NOT on both segments.

I think this will fix at least buffer, and it explains why my previous (short) attempt to just replace it was not yet successful (I don't think I reported that yet), it is currently too different from the other strategies.

Also, it's less sensible to calculation type or field size.

To be continued.