### PR TITLE
Add support for GeometryCollection in difference()

### DIFF
--- a/include/boost/geometry/algorithms/detail/make_rtree.hpp
+++ b/include/boost/geometry/algorithms/detail/make_rtree.hpp
@@ -1,0 +1,113 @@
+// Boost.Geometry
+
+// Copyright (c) 2022, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+#ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_MAKE_RTREE_HPP
+#define BOOST_GEOMETRY_ALGORITHMS_DETAIL_MAKE_RTREE_HPP
+
+#include <vector>
+
+#include <boost/range/begin.hpp>
+#include <boost/range/end.hpp>
+#include <boost/range/size.hpp>
+
+#include <boost/geometry/algorithms/detail/expand_by_epsilon.hpp>
+#include <boost/geometry/algorithms/detail/visit.hpp>
+#include <boost/geometry/algorithms/envelope.hpp>
+#include <boost/geometry/index/rtree.hpp>
+#include <boost/geometry/strategies/index/services.hpp>
+
+namespace boost { namespace geometry
+{
+
+
+#ifndef DOXYGEN_NO_DETAIL
+namespace detail
+{
+
+
+template <typename GC>
+using make_rtree_box_t = geometry::model::box
+    <
+        geometry::model::point
+            <
+                typename geometry::coordinate_type<GC>::type,
+                geometry::dimension<GC>::value,
+                typename geometry::coordinate_system<GC>::type
+            >
+    >;
+
+
+template <typename GC, typename Strategy>
+inline auto make_rtree_iterators(GC& gc, Strategy const& strategy)
+{
+    using box_t = make_rtree_box_t<GC>;
+    using iter_t = typename boost::range_iterator<GC>::type;
+
+    using rtree_param_t = index::rstar<4>;
+    using rtree_parameters_t = index::parameters<rtree_param_t, Strategy>;
+    using value_t = std::pair<box_t, iter_t>;
+    using rtree_t = index::rtree<value_t, rtree_parameters_t>;
+
+    // TODO: get rid of the temporary vector
+    auto const size = boost::size(gc);
+    std::vector<value_t> values;
+    values.reserve(size);
+
+    visit_breadth_first_impl<true>::apply([&](auto const& g, auto iter)
+    {
+        box_t b = geometry::return_envelope<box_t>(g, strategy);
+        detail::expand_by_epsilon(b);
+        values.emplace_back(b, iter);
+        return true;
+    }, gc);
+
+    return rtree_t(values.begin(), values.end(), rtree_parameters_t(rtree_param_t(), strategy));
+}
+
+
+template <typename GCView, typename Strategy>
+inline auto make_rtree_indexes(GCView const& gc, Strategy const& strategy)
+{
+    // TODO: static_assert for random-access non-recursive GCs
+    //       or only take random_access_view.
+
+    using box_t = make_rtree_box_t<GCView>;
+
+    using rtree_param_t = index::rstar<4>;
+    using rtree_parameters_t = index::parameters<rtree_param_t, Strategy>;
+    using value_t = std::pair<box_t, std::size_t>;
+    using rtree_t = index::rtree<value_t, rtree_parameters_t>;
+
+    // TODO: get rid of the temporary vector
+    std::size_t const size = boost::size(gc);
+    std::vector<value_t> values;
+    values.reserve(size);
+
+    auto const begin = boost::begin(gc);
+    for (std::size_t i = 0; i < size; ++i)
+    {
+        traits::iter_visit<GCView>::apply([&](auto const& g)
+        {
+            box_t b = geometry::return_envelope<box_t>(g, strategy);
+            detail::expand_by_epsilon(b);
+            values.emplace_back(b, i);
+        }, begin + i);
+    }
+
+    return rtree_t(values.begin(), values.end(), rtree_parameters_t(rtree_param_t(), strategy));
+}
+
+
+} // namespace detail
+#endif // DOXYGEN_NO_DETAIL
+
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_MAKE_RTREE_HPP

--- a/include/boost/geometry/algorithms/difference.hpp
+++ b/include/boost/geometry/algorithms/difference.hpp
@@ -558,6 +558,28 @@ struct difference
     }
 };
 
+template <typename Geometry1, typename Geometry2, typename Collection, typename Tag1, typename Tag2>
+struct difference
+    <
+        Geometry1, Geometry2, Collection,
+        Tag1, Tag2, geometry_collection_tag
+    >
+{
+    template <typename Strategy>
+    static void apply(Geometry1 const& geometry1,
+                      Geometry2 const& geometry2,
+                      Collection & output_collection,
+                      Strategy const& strategy)
+    {
+        using gc1_view_t = geometry::detail::geometry_collection_view<Geometry1>;
+        using gc2_view_t = geometry::detail::geometry_collection_view<Geometry2>;
+        difference
+            <
+                gc1_view_t, gc2_view_t, Collection
+            >::apply(gc1_view_t(geometry1), gc2_view_t(geometry2), output_collection, strategy);
+    }
+};
+
 
 } // namespace resolve_collection
 

--- a/include/boost/geometry/algorithms/difference.hpp
+++ b/include/boost/geometry/algorithms/difference.hpp
@@ -2,8 +2,8 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017-2021.
-// Modifications copyright (c) 2017-2021, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017-2022.
+// Modifications copyright (c) 2017-2022, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -15,12 +15,12 @@
 #define BOOST_GEOMETRY_ALGORITHMS_DIFFERENCE_HPP
 
 
-#include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/static_visitor.hpp>
-#include <boost/variant/variant_fwd.hpp>
-
 #include <boost/geometry/algorithms/detail/intersection/multi.hpp>
+#include <boost/geometry/algorithms/detail/make_rtree.hpp>
 #include <boost/geometry/algorithms/detail/overlay/intersection_insert.hpp>
+#include <boost/geometry/algorithms/detail/visit.hpp>
+#include <boost/geometry/core/geometry_types.hpp>
+#include <boost/geometry/geometries/adapted/boost_variant.hpp>
 #include <boost/geometry/policies/robustness/get_rescale_policy.hpp>
 #include <boost/geometry/strategies/default_strategy.hpp>
 #include <boost/geometry/strategies/detail.hpp>
@@ -28,6 +28,8 @@
 #include <boost/geometry/strategies/relate/geographic.hpp>
 #include <boost/geometry/strategies/relate/spherical.hpp>
 #include <boost/geometry/util/range.hpp>
+#include <boost/geometry/util/sequence.hpp>
+#include <boost/geometry/views/detail/geometry_collection_view.hpp>
 
 
 namespace boost { namespace geometry
@@ -37,14 +39,23 @@ namespace boost { namespace geometry
 namespace detail { namespace difference
 {
 
+
+// True if the result of difference can be different than Geometry1
+template <typename Geometry1, typename Geometry2>
+using is_subtractable_t = util::bool_constant
+    <
+        (geometry::topological_dimension<Geometry1>::value
+            <= geometry::topological_dimension<Geometry2>::value)
+    >;
+
+
 template
 <
     typename Geometry1,
     typename Geometry2,
     typename SingleOut,
     typename OutTag = typename detail::setop_insert_output_tag<SingleOut>::type,
-    bool ReturnGeometry1 = (topological_dimension<Geometry1>::value
-                            > topological_dimension<Geometry2>::value)
+    bool ReturnGeometry1 = (! is_subtractable_t<Geometry1, Geometry2>::value)
 >
 struct call_intersection_insert
 {
@@ -70,6 +81,26 @@ struct call_intersection_insert
             >::apply(geometry1, geometry2, robust_policy, out, strategy);
     }
 };
+
+
+template <typename Geometry1, typename Geometry2, typename SingleOut, typename OutTag>
+struct call_intersection_insert<Geometry1, Geometry2, SingleOut, OutTag, true>
+{
+    template <typename OutputIterator, typename RobustPolicy, typename Strategy>
+    static inline OutputIterator apply(Geometry1 const& geometry1,
+                                       Geometry2 const& ,
+                                       RobustPolicy const& ,
+                                       OutputIterator out,
+                                       Strategy const& )
+    {
+        return geometry::detail::convert_to_output
+            <
+                Geometry1,
+                SingleOut
+            >::apply(geometry1, out);
+    }
+};
+
 
 template
 <
@@ -268,8 +299,267 @@ inline OutputIterator difference_insert(Geometry1 const& geometry1,
 }
 
 
+template
+<
+    typename Geometry, typename Collection,
+    typename CastedTag = typename geometry::tag_cast
+        <
+            typename geometry::tag<Geometry>::type,
+            pointlike_tag, linear_tag, areal_tag
+        >::type
+>
+struct multi_output_type
+{
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE(
+        "Not implemented this Geometry type.",
+        Geometry, CastedTag);
+};
+
+template <typename Geometry, typename Collection>
+struct multi_output_type<Geometry, Collection, pointlike_tag>
+{
+    using type = typename util::sequence_find_if
+        <
+            typename traits::geometry_types<Collection>::type,
+            util::is_multi_point
+        >::type;
+};
+
+template <typename Geometry, typename Collection>
+struct multi_output_type<Geometry, Collection, linear_tag>
+{
+    using type = typename util::sequence_find_if
+        <
+            typename traits::geometry_types<Collection>::type,
+            util::is_multi_linestring
+        >::type;
+};
+
+template <typename Geometry, typename Collection>
+struct multi_output_type<Geometry, Collection, areal_tag>
+{
+    using type = typename util::sequence_find_if
+        <
+            typename traits::geometry_types<Collection>::type,
+            util::is_multi_polygon
+        >::type;
+};
+
+
 }} // namespace detail::difference
 #endif // DOXYGEN_NO_DETAIL
+
+
+namespace resolve_collection
+{
+
+
+template
+<
+    typename Geometry1, typename Geometry2, typename Collection,
+    typename Tag1 = typename geometry::tag<Geometry1>::type,
+    typename Tag2 = typename geometry::tag<Geometry2>::type,
+    typename CollectionTag = typename geometry::tag<Collection>::type
+>
+struct difference
+{
+    template <typename Strategy>
+    static void apply(Geometry1 const& geometry1,
+                      Geometry2 const& geometry2,
+                      Collection & output_collection,
+                      Strategy const& strategy)
+    {
+        using single_out = typename geometry::detail::output_geometry_value
+            <
+                Collection
+            >::type;
+
+        detail::difference::difference_insert<single_out>(
+            geometry1, geometry2,
+            geometry::detail::output_geometry_back_inserter(output_collection),
+            strategy);
+    }
+};
+
+template <typename Geometry1, typename Geometry2, typename Collection>
+struct difference
+    <
+        Geometry1, Geometry2, Collection,
+        geometry_collection_tag, geometry_collection_tag, geometry_collection_tag
+    >
+{
+    template <typename Strategy>
+    static void apply(Geometry1 const& geometry1,
+                      Geometry2 const& geometry2,
+                      Collection& output_collection,
+                      Strategy const& strategy)
+    {
+        auto const rtree2 = detail::make_rtree_iterators(geometry2, strategy);
+        detail::visit_breadth_first([&](auto const& g1)
+        {
+            // multi-point, multi-linestring or multi_polygon
+            typename detail::difference::multi_output_type
+                <
+                    util::remove_cref_t<decltype(g1)>, Collection
+                >::type out;
+
+            g1_minus_gc2(g1, rtree2, out, strategy);
+
+            if (! boost::empty(out))
+            {
+                if (boost::size(out) == 1)
+                {
+                    move_single_out(output_collection, out);
+                }
+                else
+                {
+                    range::emplace_back(output_collection, std::move(out));
+                }
+            }
+
+            return true;
+        }, geometry1);
+    }
+
+private:
+    // Implemented as separate function because msvc is unable to do nested lambda capture
+    template <typename G1, typename Rtree2, typename MultiOut, typename Strategy>
+    static void g1_minus_gc2(G1 const& g1, Rtree2 const& rtree2, MultiOut& out, Strategy const& strategy)
+    {
+        {
+            using single_out_t = typename geometry::detail::output_geometry_value<MultiOut>::type;
+            auto out_it = geometry::detail::output_geometry_back_inserter(out);
+            geometry::detail::convert_to_output<G1, single_out_t>::apply(g1, out_it);
+        }
+
+        using box1_t = detail::make_rtree_box_t<G1>;
+        box1_t b1 = geometry::return_envelope<box1_t>(g1, strategy);
+        detail::expand_by_epsilon(b1);
+
+        for (auto qit = rtree2.qbegin(index::intersects(b1)); qit != rtree2.qend(); ++qit)
+        {
+            traits::iter_visit<Geometry2>::apply([&](auto const& g2)
+            {
+                multi_out_minus_g2(out, g2, strategy);                
+            }, qit->second);
+
+            if (boost::empty(out))
+            {
+                return;
+            }
+        }
+    }
+
+    template
+    <
+        typename MultiOut, typename G2, typename Strategy,
+        std::enable_if_t<detail::difference::is_subtractable_t<MultiOut, G2>::value, int> = 0
+    >
+    static void multi_out_minus_g2(MultiOut& out, G2 const& g2, Strategy const& strategy)
+    {
+        MultiOut result;
+        difference<MultiOut, G2, MultiOut>::apply(out, g2, result, strategy);
+        out = std::move(result);
+    }
+
+    template
+    <
+        typename MultiOut, typename G2, typename Strategy,
+        std::enable_if_t<(! detail::difference::is_subtractable_t<MultiOut, G2>::value), int> = 0
+    >
+    static void multi_out_minus_g2(MultiOut& , G2 const& , Strategy const& )
+    {}
+
+    template <typename Out>
+    struct can_move_single
+    {
+        template <typename G>
+        using is_same_as_single = std::is_same<G, typename boost::range_value<Out>::type>;
+        using gc_types = typename traits::geometry_types<Collection>::type;
+        using found_type = typename util::sequence_find_if<gc_types, is_same_as_single>::type;
+        static const bool value = ! std::is_void<found_type>::value;
+    };
+
+    template <typename Out>
+    struct can_convert_to_single
+    {
+        template <typename G>
+        using has_same_tag_as_single = std::is_same
+            <
+                typename geometry::tag<G>::type,
+                typename geometry::tag<typename boost::range_value<Out>::type>::type
+            >;
+        using gc_types = typename traits::geometry_types<Collection>::type;
+        using found_type = typename util::sequence_find_if<gc_types, has_same_tag_as_single>::type;
+        static const bool value = ! std::is_void<found_type>::value;
+    };
+
+    template <typename Out, std::enable_if_t<can_move_single<Out>::value, int> = 0>
+    static void move_single_out(Collection& gc, Out& out)
+    {
+        range::emplace_back(gc, std::move(*boost::begin(out)));
+    }
+
+    template <typename Out, std::enable_if_t<! can_move_single<Out>::value && can_convert_to_single<Out>::value, int> = 0>
+    static void move_single_out(Collection& gc, Out& out)
+    {
+        typename can_convert_to_single<Out>::found_type single_out;
+        geometry::convert(*boost::begin(out), single_out);
+        range::emplace_back(gc, std::move(single_out));
+    }
+
+    template <typename Out, std::enable_if_t<! can_move_single<Out>::value && ! can_convert_to_single<Out>::value, int> = 0>
+    static void move_single_out(Collection& gc, Out& out)
+    {
+        range::emplace_back(gc, std::move(out));
+    }
+};
+
+
+template <typename Geometry1, typename Geometry2, typename Collection, typename Tag1>
+struct difference
+    <
+        Geometry1, Geometry2, Collection,
+        Tag1, geometry_collection_tag, geometry_collection_tag
+    >
+{
+    template <typename Strategy>
+    static void apply(Geometry1 const& geometry1,
+                      Geometry2 const& geometry2,
+                      Collection & output_collection,
+                      Strategy const& strategy)
+    {
+        using gc_view_t = geometry::detail::geometry_collection_view<Geometry1>;
+        difference
+            <
+                gc_view_t, Geometry2, Collection
+            >::apply(gc_view_t(geometry1), geometry2, output_collection, strategy);
+    }
+};
+
+template <typename Geometry1, typename Geometry2, typename Collection, typename Tag2>
+struct difference
+    <
+        Geometry1, Geometry2, Collection,
+        geometry_collection_tag, Tag2, geometry_collection_tag
+    >
+{
+    template <typename Strategy>
+    static void apply(Geometry1 const& geometry1,
+                      Geometry2 const& geometry2,
+                      Collection & output_collection,
+                      Strategy const& strategy)
+    {
+        using gc_view_t = geometry::detail::geometry_collection_view<Geometry2>;
+        difference
+            <
+                Geometry1, gc_view_t, Collection
+            >::apply(geometry1, gc_view_t(geometry2), output_collection, strategy);
+    }
+};
+
+
+} // namespace resolve_collection
 
 
 namespace resolve_strategy {
@@ -287,15 +577,10 @@ struct difference
                              Collection & output_collection,
                              Strategy const& strategy)
     {
-        typedef typename geometry::detail::output_geometry_value
+        resolve_collection::difference
             <
-                Collection
-            >::type single_out;
-
-        detail::difference::difference_insert<single_out>(
-            geometry1, geometry2,
-            geometry::detail::output_geometry_back_inserter(output_collection),
-            strategy);
+                Geometry1, Geometry2, Collection
+            >::apply(geometry1, geometry2, output_collection, strategy);
     }
 };
 
@@ -343,17 +628,20 @@ struct difference<default_strategy, false>
 } // resolve_strategy
 
 
-namespace resolve_variant
+namespace resolve_dynamic
 {
-    
-template <typename Geometry1, typename Geometry2>
+
+template
+<
+    typename Geometry1, typename Geometry2,
+    typename Tag1 = typename geometry::tag<Geometry1>::type,
+    typename Tag2 = typename geometry::tag<Geometry2>::type
+>
 struct difference
 {
     template <typename Collection, typename Strategy>
-    static inline void apply(Geometry1 const& geometry1,
-                             Geometry2 const& geometry2,
-                             Collection& output_collection,
-                             Strategy const& strategy)
+    static void apply(Geometry1 const& geometry1, Geometry2 const& geometry2,
+                      Collection& output_collection, Strategy const& strategy)
     {
         resolve_strategy::difference
             <
@@ -362,135 +650,58 @@ struct difference
     }
 };
 
-
-template <BOOST_VARIANT_ENUM_PARAMS(typename T), typename Geometry2>
-struct difference<variant<BOOST_VARIANT_ENUM_PARAMS(T)>, Geometry2>
+template <typename DynamicGeometry1, typename Geometry2, typename Tag2>
+struct difference<DynamicGeometry1, Geometry2, dynamic_geometry_tag, Tag2>
 {
     template <typename Collection, typename Strategy>
-    struct visitor: static_visitor<>
+    static void apply(DynamicGeometry1 const& geometry1, Geometry2 const& geometry2,
+                      Collection& output_collection, Strategy const& strategy)
     {
-        Geometry2 const& m_geometry2;
-        Collection& m_output_collection;
-        Strategy const& m_strategy;
-        
-        visitor(Geometry2 const& geometry2,
-                Collection& output_collection,
-                Strategy const& strategy)
-            : m_geometry2(geometry2)
-            , m_output_collection(output_collection)
-            , m_strategy(strategy)
-        {}
-        
-        template <typename Geometry1>
-        void operator()(Geometry1 const& geometry1) const
+        traits::visit<DynamicGeometry1>::apply([&](auto const& g1)
         {
-            difference
+            resolve_strategy::difference
                 <
-                    Geometry1,
-                    Geometry2
-                >::apply(geometry1, m_geometry2, m_output_collection, m_strategy);
-        }
-    };
-    
-    template <typename Collection, typename Strategy>
-    static inline void
-    apply(variant<BOOST_VARIANT_ENUM_PARAMS(T)> const& geometry1,
-          Geometry2 const& geometry2,
-          Collection& output_collection,
-          Strategy const& strategy)
-    {
-        boost::apply_visitor(visitor<Collection, Strategy>(geometry2,
-                                                           output_collection,
-                                                           strategy),
-                             geometry1);
+                    Strategy
+                >::apply(g1, geometry2, output_collection, strategy);
+        }, geometry1);
     }
 };
 
-
-template <typename Geometry1, BOOST_VARIANT_ENUM_PARAMS(typename T)>
-struct difference<Geometry1, variant<BOOST_VARIANT_ENUM_PARAMS(T)> >
+template <typename Geometry1, typename DynamicGeometry2, typename Tag1>
+struct difference<Geometry1, DynamicGeometry2, Tag1, dynamic_geometry_tag>
 {
     template <typename Collection, typename Strategy>
-    struct visitor: static_visitor<>
+    static void apply(Geometry1 const& geometry1, DynamicGeometry2 const& geometry2,
+                      Collection& output_collection, Strategy const& strategy)
     {
-        Geometry1 const& m_geometry1;
-        Collection& m_output_collection;
-        Strategy const& m_strategy;
-        
-        visitor(Geometry1 const& geometry1,
-                Collection& output_collection,
-                Strategy const& strategy)
-            : m_geometry1(geometry1)
-            , m_output_collection(output_collection)
-            , m_strategy(strategy)
-        {}
-        
-        template <typename Geometry2>
-        void operator()(Geometry2 const& geometry2) const
+        traits::visit<DynamicGeometry2>::apply([&](auto const& g2)
         {
-            difference
+            resolve_strategy::difference
                 <
-                    Geometry1,
-                    Geometry2
-                >::apply(m_geometry1, geometry2, m_output_collection, m_strategy);
-        }
-    };
-    
-    template <typename Collection, typename Strategy>
-    static inline void
-    apply(Geometry1 const& geometry1,
-          variant<BOOST_VARIANT_ENUM_PARAMS(T)> const& geometry2,
-          Collection& output_collection,
-          Strategy const& strategy)
-    {
-        boost::apply_visitor(visitor<Collection, Strategy>(geometry1,
-                                                           output_collection,
-                                                           strategy),
-                             geometry2);
+                    Strategy
+                >::apply(geometry1, g2, output_collection, strategy);
+        }, geometry2);
     }
 };
 
-
-template <BOOST_VARIANT_ENUM_PARAMS(typename T1), BOOST_VARIANT_ENUM_PARAMS(typename T2)>
-struct difference<variant<BOOST_VARIANT_ENUM_PARAMS(T1)>, variant<BOOST_VARIANT_ENUM_PARAMS(T2)> >
+template <typename DynamicGeometry1, typename DynamicGeometry2>
+struct difference<DynamicGeometry1, DynamicGeometry2, dynamic_geometry_tag, dynamic_geometry_tag>
 {
     template <typename Collection, typename Strategy>
-    struct visitor: static_visitor<>
+    static void apply(DynamicGeometry1 const& geometry1, DynamicGeometry2 const& geometry2,
+                      Collection& output_collection, Strategy const& strategy)
     {
-        Collection& m_output_collection;
-        Strategy const& m_strategy;
-        
-        visitor(Collection& output_collection, Strategy const& strategy)
-            : m_output_collection(output_collection)
-            , m_strategy(strategy)
-        {}
-        
-        template <typename Geometry1, typename Geometry2>
-        void operator()(Geometry1 const& geometry1,
-                        Geometry2 const& geometry2) const
+        traits::visit<DynamicGeometry1, DynamicGeometry2>::apply([&](auto const& g1, auto const& g2)
         {
-            difference
+            resolve_strategy::difference
                 <
-                    Geometry1,
-                    Geometry2
-                >::apply(geometry1, geometry2, m_output_collection, m_strategy);
-        }
-    };
-    
-    template <typename Collection, typename Strategy>
-    static inline void
-    apply(variant<BOOST_VARIANT_ENUM_PARAMS(T1)> const& geometry1,
-          variant<BOOST_VARIANT_ENUM_PARAMS(T2)> const& geometry2,
-          Collection& output_collection,
-          Strategy const& strategy)
-    {
-        boost::apply_visitor(visitor<Collection, Strategy>(output_collection,
-                                                           strategy),
-                             geometry1, geometry2);
+                    Strategy
+                >::apply(g1, g2, output_collection, strategy);
+        }, geometry1, geometry2);
     }
 };
-    
-} // namespace resolve_variant
+
+} // namespace resolve_dynamic
 
 
 /*!
@@ -521,7 +732,7 @@ inline void difference(Geometry1 const& geometry1,
                        Collection& output_collection,
                        Strategy const& strategy)
 {
-    resolve_variant::difference
+    resolve_dynamic::difference
         <
             Geometry1,
             Geometry2
@@ -552,7 +763,7 @@ inline void difference(Geometry1 const& geometry1,
                        Geometry2 const& geometry2,
                        Collection& output_collection)
 {
-    resolve_variant::difference
+    resolve_dynamic::difference
         <
             Geometry1,
             Geometry2

--- a/include/boost/geometry/views/detail/geometry_collection_view.hpp
+++ b/include/boost/geometry/views/detail/geometry_collection_view.hpp
@@ -1,0 +1,84 @@
+// Boost.Geometry
+
+// Copyright (c) 2022, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+#ifndef BOOST_GEOMETRY_VIEWS_GEOMETRY_COLLECTION_VIEW_HPP
+#define BOOST_GEOMETRY_VIEWS_GEOMETRY_COLLECTION_VIEW_HPP
+
+#include <boost/core/addressof.hpp>
+
+#include <boost/geometry/core/geometry_types.hpp>
+#include <boost/geometry/core/tag.hpp>
+#include <boost/geometry/core/tags.hpp>
+#include <boost/geometry/core/visit.hpp>
+#include <boost/geometry/util/sequence.hpp>
+
+namespace boost { namespace geometry
+{
+
+namespace detail
+{
+
+
+template <typename Geometry>
+class geometry_collection_view
+{
+public:
+    using iterator = Geometry const*;
+    using const_iterator = Geometry const*;
+
+    explicit geometry_collection_view(Geometry const& geometry)
+        : m_geometry(geometry)
+    {}
+
+    const_iterator begin() const { return boost::addressof(m_geometry); }
+    const_iterator end() const { return boost::addressof(m_geometry) + 1; }
+
+private:
+    Geometry const& m_geometry;
+};
+
+} // namespace detail
+
+
+#ifndef DOXYGEN_NO_TRAITS_SPECIALIZATIONS
+namespace traits
+{
+
+template <typename Geometry>
+struct tag<geometry::detail::geometry_collection_view<Geometry>>
+{
+    using type = geometry_collection_tag;
+};
+
+
+template <typename Geometry>
+struct geometry_types<geometry::detail::geometry_collection_view<Geometry>>
+{
+    using type = util::type_sequence<Geometry>;
+};
+
+
+template <typename Geometry>
+struct iter_visit<geometry::detail::geometry_collection_view<Geometry>>
+{
+    template <typename Function, typename Iterator>
+    static void apply(Function && function, Iterator iterator)
+    {
+        function(*iterator);
+    }
+};
+
+
+} // namespace traits
+#endif // DOXYGEN_NO_TRAITS_SPECIALIZATIONS
+
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_VIEWS_GEOMETRY_COLLECTION_VIEW_HPP

--- a/test/algorithms/set_operations/difference/Jamfile
+++ b/test/algorithms/set_operations/difference/Jamfile
@@ -4,8 +4,8 @@
 # Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
 # Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 #
-# This file was modified by Oracle on 2014, 2015, 2019, 2020.
-# Modifications copyright (c) 2014-2020, Oracle and/or its affiliates.
+# This file was modified by Oracle on 2014-2022.
+# Modifications copyright (c) 2014-2022, Oracle and/or its affiliates.
 #
 # Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 # Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -22,6 +22,7 @@ test-suite boost-geometry-algorithms-difference
     [ run difference_multi.cpp              : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_difference_multi_alternative ]
     [ run difference_multi_spike.cpp        : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_difference_multi_spike ]
     [ run difference_areal_linear.cpp       : : : : algorithms_difference_areal_linear ]
+    [ run difference_gc.cpp                 : : : : algorithms_difference_gc ]
     [ run difference_l_a_sph.cpp            : : : : algorithms_difference_l_a_sph ]
     [ run difference_linear_linear.cpp      : : : : algorithms_difference_linear_linear ]
     [ run difference_multi_areal_linear.cpp : : : : algorithms_difference_multi_areal_linear ]

--- a/test/algorithms/set_operations/difference/difference_gc.cpp
+++ b/test/algorithms/set_operations/difference/difference_gc.cpp
@@ -159,11 +159,33 @@ void test_g_gc_gc()
     check_one(out, expected);
 }
 
+void test_g_g_gc()
+{
+    const char* mpo_cstr = "MULTIPOLYGON(((0 0, 0 10, 10 10, 10 0, 0 0), (1 1, 5 1, 5 5, 1 5, 1 1)), ((3 3, 3 4, 4 4, 4 3, 3 3)))";
+    const char* po_cstr = "POLYGON((4 0, 4 10, 6 10, 6 0, 4 0))";
+    const char* expected_cstr = "GEOMETRYCOLLECTION("
+        "MULTIPOLYGON(((0 0, 0 10, 4 10, 4 5, 1 5, 1 1, 4 1, 4 0, 0 0)), ((3 3, 3 4, 4 4, 4 3, 3 3)), ((6 0, 6 10, 10 10, 10 0, 6 0)))"
+    ")";
+
+    mpo_t mpo;
+    po_t po;
+    gc_t expected;    
+    bg::read_wkt(mpo_cstr, mpo);
+    bg::read_wkt(po_cstr, po);
+    bg::read_wkt(expected_cstr, expected);
+
+    gc_t out;
+    bg::difference(mpo, po, out);
+
+    check_one(out, expected);
+}
+
 int test_main(int, char* [])
 {
     test_gc_gc_gc();
     test_gc_g_gc();
     test_g_gc_gc();
+    test_g_g_gc();
 
     return 0;
 }

--- a/test/algorithms/set_operations/difference/difference_gc.cpp
+++ b/test/algorithms/set_operations/difference/difference_gc.cpp
@@ -1,0 +1,169 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2022, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+
+#include <geometry_test_common.hpp>
+
+#include <boost/geometry/algorithms/difference.hpp>
+#include <boost/geometry/geometries/adapted/boost_variant2.hpp>
+#include <boost/geometry/geometries/geometries.hpp>
+#include <boost/geometry/io/wkt/wkt.hpp>
+
+
+using pt_t = bg::model::point<double, 2, bg::cs::cartesian>;
+using ls_t = bg::model::linestring<pt_t>;
+using po_t = bg::model::polygon<pt_t>;
+using mpt_t = bg::model::multi_point<pt_t>;
+using mls_t = bg::model::multi_linestring<ls_t>;
+using mpo_t = bg::model::multi_polygon<po_t>;
+using var_t = boost::variant<pt_t, ls_t, po_t, mpt_t, mls_t, mpo_t>;
+//using var_t = boost::variant2::variant<pt_t, ls_t, po_t, mpt_t, mls_t, mpo_t>;
+using gc_t = bg::model::geometry_collection<var_t>;
+
+template <typename GC1, typename GC2>
+inline void check_one(GC1 const& out, GC2 const& expected)
+{
+    std::size_t out_size = boost::size(out);
+    std::size_t expected_size = boost::size(expected);
+    BOOST_CHECK(out_size == expected_size);
+    if (out_size == expected_size)
+    {
+        for (std::size_t i = 0; i < out_size; ++i)
+        {
+            bg::traits::iter_visit<GC1>::apply([&](auto const& o)
+            {
+                bg::traits::iter_visit<GC2>::apply([&](auto const& e)
+                {
+                    using o_t = typename bg::util::remove_cref<decltype(o)>::type;
+                    using e_t = typename bg::util::remove_cref<decltype(e)>::type;
+                    int oid = bg::geometry_id<o_t>::value;
+                    int eid = bg::geometry_id<e_t>::value;
+                    BOOST_CHECK_MESSAGE(oid == eid, oid << " and " << eid);
+                    bool elements_equal = bg::equals(o, e);
+                    BOOST_CHECK_MESSAGE(elements_equal, bg::wkt(o) << " and " << bg::wkt(e));
+                }, expected.begin() + i);
+            }, out.begin() + i);
+        }
+    }
+}
+
+
+void test_gc_gc_gc()
+{
+    const char* gc1_cstr = "GEOMETRYCOLLECTION("
+        "MULTIPOLYGON(((0 0, 0 10, 10 10, 10 0, 0 0), (1 1, 5 1, 5 5, 1 5, 1 1)), ((3 3, 3 4, 4 4, 4 3, 3 3))),"
+        "POLYGON((3 3, 3 10, 10 10, 10 3, 3 3)),"
+        "MULTILINESTRING((0 0, 5 5), (5 5, 11 5), (5 5, 5 11)),"
+        "LINESTRING(0 0, 2 2, 2 11),"
+        "MULTIPOINT(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 9 9, 10 10),"
+        "POINT(11 11)"
+    ")";
+    const char* gc2_cstr = "GEOMETRYCOLLECTION("
+        "POLYGON((4 0, 4 10, 6 10, 6 0, 4 0)),"
+        "POLYGON((0 4, 0 6, 10 6, 10 4, 0 4)),"
+        "POLYGON((3 3, 3 5, 5 5, 5 3, 3 3)),"
+        "MULTILINESTRING((1 1, 6 6), (5 1, 5 9), (2 2, 9 2)),"
+        "MULTIPOINT(9 9, 11 11, 1 9),"
+        "POINT(3 2)"
+    ")";
+    const char* expected1_cstr = "GEOMETRYCOLLECTION("
+        "MULTIPOLYGON(((0 0, 0 4, 1 4, 1 1, 4 1, 4 0, 0 0)), ((0 6, 0 10, 4 10, 4 6, 0 6)), ((6 6, 6 10, 10 10, 10 6, 6 6)), ((6 0, 6 4, 10 4, 10 0, 6 0))),"
+        "MULTIPOLYGON(((3 6, 3 10, 4 10, 4 6, 3 6)), ((6 3, 6 4, 10 4, 10 3, 6 3)), ((6 6, 6 10, 10 10, 10 6, 6 6))),"
+        "MULTILINESTRING((0 0, 1 1), (10 5, 11 5), (5 10, 5 11)),"
+        "MULTILINESTRING((0 0, 1 1), (2 2, 2 4), (2 6, 2 11)),"
+        "MULTIPOINT(0 0, 7 7, 8 8, 10 10)"
+    ")";
+    const char* expected2_cstr = "GEOMETRYCOLLECTION("
+        "POLYGON((4 1, 4 3, 5 3, 5 1, 4 1)),"
+        "POLYGON((1 4, 1 5, 3 5, 3 4, 1 4)),"
+        "LINESTRING(2 2, 5 2),"
+        "POINT(3 2)"
+        ")";
+
+    gc_t gc1, gc2, expected1, expected2;
+    bg::read_wkt(gc1_cstr, gc1);
+    bg::read_wkt(gc2_cstr, gc2);
+    bg::read_wkt(expected1_cstr, expected1);
+    bg::read_wkt(expected2_cstr, expected2);
+
+    gc_t out1, out2;
+    bg::difference(gc1, gc2, out1);
+    bg::difference(gc2, gc1, out2);
+
+    check_one(out1, expected1);
+    check_one(out2, expected2);
+}
+
+void test_gc_g_gc()
+{
+    const char* gc_cstr = "GEOMETRYCOLLECTION("
+        "MULTIPOLYGON(((0 0, 0 10, 10 10, 10 0, 0 0), (1 1, 5 1, 5 5, 1 5, 1 1)), ((3 3, 3 4, 4 4, 4 3, 3 3))),"
+        "POLYGON((3 3, 3 10, 10 10, 10 3, 3 3)),"
+        "MULTILINESTRING((0 0, 5 5), (5 5, 11 5), (5 5, 5 11)),"
+        "LINESTRING(0 0, 2 2, 2 11),"
+        "MULTIPOINT(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 9 9, 10 10),"
+        "POINT(11 11)"
+    ")";
+    const char* po_cstr = "POLYGON((4 0, 4 10, 6 10, 6 0, 4 0))";
+    const char* expected_cstr = "GEOMETRYCOLLECTION("
+        "MULTIPOLYGON(((0 0, 0 10, 4 10, 4 5, 1 5, 1 1, 4 1, 4 0, 0 0)), ((6 0, 6 10, 10 10, 10 0, 6 0)), ((3 3, 3 4, 4 4, 4 3, 3 3))),"
+        "MULTIPOLYGON(((3 3, 3 10, 4 10, 4 3, 3 3)), ((6 3, 6 10, 10 10, 10 3, 6 3))),"
+        "MULTILINESTRING((0 0, 4 4), (6 5, 11 5), (5 10, 5 11)),"
+        "LINESTRING(0 0, 2 2, 2 11),"
+        "MULTIPOINT(0 0, 1 1, 2 2, 3 3, 7 7, 8 8, 9 9, 10 10),"
+        "POINT(11 11)"
+    ")";
+
+    gc_t gc, expected;
+    po_t po;
+    bg::read_wkt(gc_cstr, gc);
+    bg::read_wkt(po_cstr, po);
+    bg::read_wkt(expected_cstr, expected);
+
+    gc_t out;
+    bg::difference(gc, po, out);
+
+    check_one(out, expected);
+}
+
+void test_g_gc_gc()
+{
+    const char* mpo_cstr = "MULTIPOLYGON(((0 0, 0 10, 10 10, 10 0, 0 0), (1 1, 5 1, 5 5, 1 5, 1 1)), ((3 3, 3 4, 4 4, 4 3, 3 3)))";
+    const char* gc_cstr = "GEOMETRYCOLLECTION("
+        "POLYGON((4 0, 4 10, 6 10, 6 0, 4 0)),"
+        "POLYGON((0 4, 0 6, 10 6, 10 4, 0 4)),"
+        "POLYGON((3 3, 3 5, 5 5, 5 3, 3 3)),"
+        "MULTILINESTRING((1 1, 6 6), (5 1, 5 9), (2 2, 9 2)),"
+        "MULTIPOINT(9 9, 11 11, 1 9),"
+        "POINT(3 2)"
+    ")";
+    const char* expected_cstr = "GEOMETRYCOLLECTION("
+        "MULTIPOLYGON(((0 0, 0 4, 1 4, 1 1, 4 1, 4 0, 0 0)), ((0 6, 0 10, 4 10, 4 6, 0 6)), ((6 6, 6 10, 10 10, 10 6, 6 6)), ((6 0, 6 4, 10 4, 10 0, 6 0)))"
+    ")";
+
+    mpo_t mpo;
+    gc_t gc, expected;    
+    bg::read_wkt(mpo_cstr, mpo);
+    bg::read_wkt(gc_cstr, gc);    
+    bg::read_wkt(expected_cstr, expected);
+
+    gc_t out;
+    bg::difference(mpo, gc, out);
+
+    check_one(out, expected);
+}
+
+int test_main(int, char* [])
+{
+    test_gc_gc_gc();
+    test_gc_g_gc();
+    test_g_gc_gc();
+
+    return 0;
+}


### PR DESCRIPTION
Add also:
- `make_rtree()` utility making an rtree of GC elements
- `geometry_collection_view<>` allowing to represent any geometry as GC
- tests

This PR also adds support for difference(g1, g2) where topological dimension of g1 is greater than of g2 so the result is always g1, e.g. Polygon \ MultiPoint.