### PR TITLE
Change 4 broken postgis.org links to postgis.net

### DIFF
--- a/doc/reference/algorithms/covered_by.qbk
+++ b/doc/reference/algorithms/covered_by.qbk
@@ -15,7 +15,7 @@
 [heading_conformance_no_ogc __this_function__]
 [note Both PostGIS and Oracle contain an algorithm with the same name and the 
   same functionality.
-  See the [@http://www.postgis.org/docs/ST_CoveredBy.html PostGIS documentation]. 
+  See the [@https://postgis.net/docs/ST_CoveredBy.html PostGIS documentation].
 ]
 
 [include reference/status/covered_by_status.qbk]

--- a/doc/reference/algorithms/densify.qbk
+++ b/doc/reference/algorithms/densify.qbk
@@ -13,7 +13,7 @@
 
 [heading_conformance_no_ogc __this_function__]
 [note PostGIS contains an algorithm ST_Segmentize with the same functionality.
-  See the [@http://www.postgis.org/docs/ST_Segmentize.html PostGIS documentation]. 
+  See the [@https://postgis.net/docs/ST_Segmentize.html PostGIS documentation].
 ]
 
 [heading Behavior]

--- a/doc/reference/algorithms/perimeter.qbk
+++ b/doc/reference/algorithms/perimeter.qbk
@@ -15,7 +15,7 @@
 [heading_conformance_no_ogc __this_function__]
 [note PostGIS contains an algorithm with the same name and the 
   same functionality.
-  See the [@http://www.postgis.org/docs/ST_Perimeter.html PostGIS documentation]. 
+  See the [@https://postgis.net/docs/ST_Perimeter.html PostGIS documentation].
 ]
 
 [heading Behavior]

--- a/doc/reference/algorithms/simplify.qbk
+++ b/doc/reference/algorithms/simplify.qbk
@@ -15,7 +15,7 @@
 [heading_conformance_no_ogc __this_function__]
 [note PostGIS contains an algorithm with the same name and the 
   same functionality.
-  See the [@http://www.postgis.org/docs/ST_Simplify.html PostGIS documentation]. 
+  See the [@https://postgis.net/docs/ST_Simplify.html PostGIS documentation].
 ]
 [note SQL Server contains an algorithm Reduce() with the same functionality.
   See the [@http://msdn.microsoft.com/en-us/library/bb933814.aspx MSDN documentation].


### PR DESCRIPTION
This PR updates 4 broken links to http://www.postgis.org/... to point to https://postgis.net/... instead.