### PR TITLE
Add support for GC in intersection, sym_difference and union.

### DIFF
--- a/include/boost/geometry/algorithms/detail/intersection/gc.hpp
+++ b/include/boost/geometry/algorithms/detail/intersection/gc.hpp
@@ -1,0 +1,327 @@
+// Boost.Geometry
+
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+#ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_INTERSECTION_GC_HPP
+#define BOOST_GEOMETRY_ALGORITHMS_DETAIL_INTERSECTION_GC_HPP
+
+
+#include <tuple>
+
+#include <boost/geometry/algorithms/detail/intersection/interface.hpp>
+#include <boost/geometry/algorithms/detail/make_rtree.hpp>
+#include <boost/geometry/views/detail/geometry_collection_view.hpp>
+
+
+namespace boost { namespace geometry
+{
+
+#ifndef DOXYGEN_NO_DETAIL
+namespace detail { namespace intersection
+{
+
+
+template <typename GC, typename Multi>
+struct gc_can_move_element
+{
+    template <typename G>
+    using is_same_as_single = std::is_same<G, typename boost::range_value<Multi>::type>;
+    using gc_types = typename traits::geometry_types<GC>::type;
+    using found_type = typename util::sequence_find_if<gc_types, is_same_as_single>::type;
+    static const bool value = ! std::is_void<found_type>::value;
+};
+
+template <typename GC, typename Multi>
+struct gc_can_convert_element
+{
+    template <typename G>
+    using has_same_tag_as_single = std::is_same
+        <
+            typename geometry::tag<G>::type,
+            typename geometry::tag<typename boost::range_value<Multi>::type>::type
+        >;
+    using gc_types = typename traits::geometry_types<GC>::type;
+    using found_type = typename util::sequence_find_if<gc_types, has_same_tag_as_single>::type;
+    static const bool value = ! std::is_void<found_type>::value;
+};
+
+template
+<
+    typename GC, typename Multi,
+    std::enable_if_t<gc_can_move_element<GC, Multi>::value, int> = 0
+>
+inline void gc_move_multi_back_(GC& gc, Multi&& multi)
+{
+    range::emplace_back(gc, std::move(*boost::begin(multi)));
+}
+
+template
+<
+    typename GC, typename Multi,
+    std::enable_if_t<! gc_can_move_element<GC, Multi>::value && gc_can_convert_element<GC, Multi>::value, int> = 0
+>
+inline void gc_move_multi_back_(GC& gc, Multi&& multi)
+{
+    typename gc_can_convert_element<GC, Multi>::found_type single_out;
+    geometry::convert(*boost::begin(multi), single_out);
+    range::emplace_back(gc, std::move(single_out));
+}
+
+template
+<
+    typename GC, typename Multi,
+    std::enable_if_t<! gc_can_move_element<GC, Multi>::value && ! gc_can_convert_element<GC, Multi>::value, int> = 0
+>
+inline void gc_move_multi_back_(GC& gc, Multi&& multi)
+{
+    range::emplace_back(gc, std::move(multi));
+}
+
+template <typename GC, typename Multi>
+inline void gc_move_multi_back(GC& gc, Multi&& multi)
+{
+    if (! boost::empty(multi))
+    {
+        if (boost::size(multi) == 1)
+        {
+            gc_move_multi_back_(gc, std::move(multi));
+        }
+        else
+        {
+            range::emplace_back(gc, std::move(multi));
+        }
+    }
+}
+
+
+}} // namespace detail::intersection
+#endif // DOXYGEN_NO_DETAIL
+
+
+namespace resolve_collection
+{
+
+
+template
+<
+    typename Geometry1, typename Geometry2, typename GeometryOut
+>
+struct intersection
+    <
+        Geometry1, Geometry2, GeometryOut,
+        geometry_collection_tag, geometry_collection_tag, geometry_collection_tag
+    >
+{
+    // NOTE: for now require all of the possible output types
+    //       technically only a subset could be needed.
+    using multi_point_t = typename util::sequence_find_if
+        <
+            typename traits::geometry_types<GeometryOut>::type,
+            util::is_multi_point
+        >::type;
+    using multi_linestring_t = typename util::sequence_find_if
+        <
+            typename traits::geometry_types<GeometryOut>::type,
+            util::is_multi_linestring
+        >::type;
+    using multi_polygon_t = typename util::sequence_find_if
+        <
+            typename traits::geometry_types<GeometryOut>::type,
+            util::is_multi_polygon
+        >::type;
+    using tuple_out_t = boost::tuple<multi_point_t, multi_linestring_t, multi_polygon_t>;
+
+    template <typename Strategy>
+    static inline bool apply(Geometry1 const& geometry1,
+                             Geometry2 const& geometry2,
+                             GeometryOut& geometry_out,
+                             Strategy const& strategy)
+    {
+        bool result = false;
+        tuple_out_t out;
+
+        auto const rtree2 = detail::make_rtree_iterators(geometry2, strategy);
+        detail::visit_breadth_first([&](auto const& g1)
+        {
+            bool r = g1_prod_gc2(g1, rtree2, out, strategy);
+            result = result || r;
+            return true;
+        }, geometry1);
+
+        detail::intersection::gc_move_multi_back(geometry_out, boost::get<0>(out));
+        detail::intersection::gc_move_multi_back(geometry_out, boost::get<1>(out));
+        detail::intersection::gc_move_multi_back(geometry_out, boost::get<2>(out));
+
+        return result;
+    }
+
+private:
+    // Implemented as separate function because msvc is unable to do nested lambda capture
+    template <typename G1, typename Rtree2, typename TupleOut, typename Strategy>
+    static bool g1_prod_gc2(G1 const& g1, Rtree2 const& rtree2, TupleOut& out, Strategy const& strategy)
+    {
+        bool result = false;
+
+        using box1_t = detail::make_rtree_box_t<G1>;
+        box1_t b1 = geometry::return_envelope<box1_t>(g1, strategy);
+        detail::expand_by_epsilon(b1);
+
+        for (auto qit = rtree2.qbegin(index::intersects(b1)); qit != rtree2.qend(); ++qit)
+        {
+            traits::iter_visit<Geometry2>::apply([&](auto const& g2)
+            {
+                TupleOut inters_result;
+                using g2_t = util::remove_cref_t<decltype(g2)>;                
+                intersection<G1, g2_t, TupleOut>::apply(g1, g2, inters_result, strategy);
+
+                // TODO: If possible unionize based on adjacency lists, i.e. unionize
+                //       only the intersections of elements that intersect each other
+                //       as subgroups. So the result could contain merged intersections
+                //       of several groups, not only one.
+                // TODO: It'd probably be better to gather all of the parts first
+                //       and then merge them with merge_elements.
+                bool r0 = unionize_result<0>(inters_result, out, strategy);
+                bool r1 = unionize_result<1>(inters_result, out, strategy);
+                bool r2 = unionize_result<2>(inters_result, out, strategy);
+                result = result || r0 || r1 || r2;
+            }, qit->second);
+        }
+
+        return result;
+    }
+
+    template <std::size_t Index, typename Out, typename Strategy>
+    static bool unionize_result(Out const& inters_result, Out& out, Strategy const& strategy)
+    {
+        auto const& multi_result = boost::get<Index>(inters_result);
+        auto& multi_out = boost::get<Index>(out);
+        if (! boost::empty(multi_result))
+        {
+            std::remove_reference_t<decltype(multi_out)> temp_result;
+            call_union(multi_out, multi_result, temp_result, strategy);
+            multi_out = std::move(temp_result);
+            return true;
+        }
+        return false;
+    }
+
+    template <typename Out, typename Strategy, std::enable_if_t<! util::is_pointlike<Out>::value, int> = 0>
+    static void call_union(Out const& g1, Out const& g2, Out& out, Strategy const& strategy)
+    {
+        typedef typename geometry::rescale_overlay_policy_type
+            <
+                Out, Out, typename Strategy::cs_tag
+            >::type rescale_policy_type;
+        
+        rescale_policy_type robust_policy
+            = geometry::get_rescale_policy<rescale_policy_type>(
+                    g1, g2, strategy);
+
+        geometry::dispatch::intersection_insert
+            <
+                Out, Out, typename boost::range_value<Out>::type,
+                overlay_union
+            >::apply(g1,
+                     g2,
+                     robust_policy,
+                     geometry::range::back_inserter(out),
+                     strategy);
+    }
+
+    template <typename Out, typename Strategy, std::enable_if_t<util::is_pointlike<Out>::value, int> = 0>
+    static void call_union(Out const& g1, Out const& g2, Out& out, Strategy const& strategy)
+    {
+        detail::overlay::union_pointlike_pointlike_point
+            <
+                Out, Out, typename boost::range_value<Out>::type
+            >::apply(g1,
+                     g2,
+                     0, // dummy robust policy
+                     geometry::range::back_inserter(out),
+                     strategy);
+    }
+};
+
+template
+<
+    typename Geometry1, typename Geometry2, typename GeometryOut, typename Tag1
+>
+struct intersection
+    <
+        Geometry1, Geometry2, GeometryOut,
+        Tag1, geometry_collection_tag, geometry_collection_tag
+    >
+{
+    template <typename Strategy>
+    static inline bool apply(Geometry1 const& geometry1,
+                             Geometry2 const& geometry2,
+                             GeometryOut& geometry_out,
+                             Strategy const& strategy)
+    {
+        using gc_view_t = geometry::detail::geometry_collection_view<Geometry1>;
+        return intersection
+            <
+                gc_view_t, Geometry2, GeometryOut
+            >::apply(gc_view_t(geometry1), geometry2, geometry_out, strategy);
+    }
+};
+
+template
+<
+    typename Geometry1, typename Geometry2, typename GeometryOut, typename Tag2
+>
+struct intersection
+    <
+        Geometry1, Geometry2, GeometryOut,
+        geometry_collection_tag, Tag2, geometry_collection_tag
+    >
+{
+    template <typename Strategy>
+    static inline bool apply(Geometry1 const& geometry1,
+                             Geometry2 const& geometry2,
+                             GeometryOut& geometry_out,
+                             Strategy const& strategy)
+    {
+        using gc_view_t = geometry::detail::geometry_collection_view<Geometry2>;
+        return intersection
+            <
+                Geometry1, gc_view_t, GeometryOut
+            >::apply(geometry1, gc_view_t(geometry2), geometry_out, strategy);
+    }
+};
+
+template
+<
+    typename Geometry1, typename Geometry2, typename GeometryOut, typename Tag1, typename Tag2
+>
+struct intersection
+    <
+        Geometry1, Geometry2, GeometryOut,
+        Tag1, Tag2, geometry_collection_tag
+    >
+{
+    template <typename Strategy>
+    static inline bool apply(Geometry1 const& geometry1,
+                             Geometry2 const& geometry2,
+                             GeometryOut& geometry_out,
+                             Strategy const& strategy)
+    {
+        using gc1_view_t = geometry::detail::geometry_collection_view<Geometry1>;
+        using gc2_view_t = geometry::detail::geometry_collection_view<Geometry2>;
+        return intersection
+            <
+                gc1_view_t, gc2_view_t, GeometryOut
+            >::apply(gc1_view_t(geometry1), gc2_view_t(geometry2), geometry_out, strategy);
+    }
+};
+
+
+} // namespace resolve_collection
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_INTERSECTION_GC_HPP

--- a/include/boost/geometry/algorithms/detail/intersection/implementation.hpp
+++ b/include/boost/geometry/algorithms/detail/intersection/implementation.hpp
@@ -2,8 +2,8 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2014-2021.
-// Modifications copyright (c) 2014-2021, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014-2022.
+// Modifications copyright (c) 2014-2022, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -17,6 +17,7 @@
 
 #include <boost/geometry/algorithms/detail/intersection/areal_areal.hpp>
 #include <boost/geometry/algorithms/detail/intersection/box_box.hpp>
+#include <boost/geometry/algorithms/detail/intersection/gc.hpp>
 #include <boost/geometry/algorithms/detail/intersection/multi.hpp>
 
 #include <boost/geometry/strategies/relate/cartesian.hpp>

--- a/include/boost/geometry/algorithms/detail/intersection/multi.hpp
+++ b/include/boost/geometry/algorithms/detail/intersection/multi.hpp
@@ -2,8 +2,8 @@
 
 // Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2014, 2020.
-// Modifications copyright (c) 2014-2020, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014-2022.
+// Modifications copyright (c) 2014-2022, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -525,6 +525,40 @@ struct intersection_insert
                 // TODO: in general the result of difference should depend on the first argument
                 //       but this specialization calls L/A in reality so the first argument is linear.
                 //       So expect only L for difference?
+                std::conditional_t
+                    <
+                        (OverlayType == overlay_intersection),
+                        point_tag,
+                        void
+                    >,
+                linestring_tag
+            >
+{};
+
+template
+<
+    typename Linestring, typename MultiPolygon,
+    typename TupledOut,
+    overlay_type OverlayType,
+    bool ReverseMultiLinestring, bool ReverseMultiPolygon
+>
+struct intersection_insert
+    <
+        Linestring, MultiPolygon,
+        TupledOut,
+        OverlayType,
+        ReverseMultiLinestring, ReverseMultiPolygon,
+        linestring_tag, multi_polygon_tag, detail::tupled_output_tag,
+        linear_tag, areal_tag, detail::tupled_output_tag
+    > : detail::intersection::intersection_of_linestring_with_areal
+            <
+                ReverseMultiPolygon, TupledOut, OverlayType, true
+            >
+      , detail::expect_output
+            <
+                Linestring, MultiPolygon, TupledOut,
+                // NOTE: points can be the result only in case of intersection.
+                // TODO: union should require L and A
                 std::conditional_t
                     <
                         (OverlayType == overlay_intersection),

--- a/include/boost/geometry/algorithms/difference.hpp
+++ b/include/boost/geometry/algorithms/difference.hpp
@@ -15,6 +15,7 @@
 #define BOOST_GEOMETRY_ALGORITHMS_DIFFERENCE_HPP
 
 
+#include <boost/geometry/algorithms/detail/intersection/gc.hpp>
 #include <boost/geometry/algorithms/detail/intersection/multi.hpp>
 #include <boost/geometry/algorithms/detail/make_rtree.hpp>
 #include <boost/geometry/algorithms/detail/overlay/intersection_insert.hpp>
@@ -405,17 +406,7 @@ struct difference
 
             g1_minus_gc2(g1, rtree2, out, strategy);
 
-            if (! boost::empty(out))
-            {
-                if (boost::size(out) == 1)
-                {
-                    move_single_out(output_collection, out);
-                }
-                else
-                {
-                    range::emplace_back(output_collection, std::move(out));
-                }
-            }
+            detail::intersection::gc_move_multi_back(output_collection, out);
 
             return true;
         }, geometry1);
@@ -469,50 +460,6 @@ private:
     >
     static void multi_out_minus_g2(MultiOut& , G2 const& , Strategy const& )
     {}
-
-    template <typename Out>
-    struct can_move_single
-    {
-        template <typename G>
-        using is_same_as_single = std::is_same<G, typename boost::range_value<Out>::type>;
-        using gc_types = typename traits::geometry_types<Collection>::type;
-        using found_type = typename util::sequence_find_if<gc_types, is_same_as_single>::type;
-        static const bool value = ! std::is_void<found_type>::value;
-    };
-
-    template <typename Out>
-    struct can_convert_to_single
-    {
-        template <typename G>
-        using has_same_tag_as_single = std::is_same
-            <
-                typename geometry::tag<G>::type,
-                typename geometry::tag<typename boost::range_value<Out>::type>::type
-            >;
-        using gc_types = typename traits::geometry_types<Collection>::type;
-        using found_type = typename util::sequence_find_if<gc_types, has_same_tag_as_single>::type;
-        static const bool value = ! std::is_void<found_type>::value;
-    };
-
-    template <typename Out, std::enable_if_t<can_move_single<Out>::value, int> = 0>
-    static void move_single_out(Collection& gc, Out& out)
-    {
-        range::emplace_back(gc, std::move(*boost::begin(out)));
-    }
-
-    template <typename Out, std::enable_if_t<! can_move_single<Out>::value && can_convert_to_single<Out>::value, int> = 0>
-    static void move_single_out(Collection& gc, Out& out)
-    {
-        typename can_convert_to_single<Out>::found_type single_out;
-        geometry::convert(*boost::begin(out), single_out);
-        range::emplace_back(gc, std::move(single_out));
-    }
-
-    template <typename Out, std::enable_if_t<! can_move_single<Out>::value && ! can_convert_to_single<Out>::value, int> = 0>
-    static void move_single_out(Collection& gc, Out& out)
-    {
-        range::emplace_back(gc, std::move(out));
-    }
 };
 
 

--- a/include/boost/geometry/algorithms/sym_difference.hpp
+++ b/include/boost/geometry/algorithms/sym_difference.hpp
@@ -2,8 +2,8 @@
 
 // Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2015-2021.
-// Modifications copyright (c) 2015-2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2015-2022.
+// Modifications copyright (c) 2015-2022 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -20,12 +20,10 @@
 #include <iterator>
 #include <vector>
 
-#include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/static_visitor.hpp>
-#include <boost/variant/variant_fwd.hpp>
-
+#include <boost/geometry/algorithms/difference.hpp>
 #include <boost/geometry/algorithms/intersection.hpp>
 #include <boost/geometry/algorithms/union.hpp>
+#include <boost/geometry/geometries/adapted/boost_variant.hpp>
 #include <boost/geometry/geometries/multi_polygon.hpp>
 #include <boost/geometry/policies/robustness/get_rescale_policy.hpp>
 #include <boost/geometry/strategies/default_strategy.hpp>
@@ -512,7 +510,136 @@ inline OutputIterator sym_difference_insert(Geometry1 const& geometry1,
 #endif // DOXYGEN_NO_DETAIL
 
 
-namespace resolve_strategy {
+namespace resolve_collection
+{
+
+template
+<
+    typename Geometry1, typename Geometry2, typename Collection,
+    typename Tag1 = typename geometry::tag<Geometry1>::type,
+    typename Tag2 = typename geometry::tag<Geometry2>::type,
+    typename CollectionTag = typename geometry::tag<Collection>::type
+>
+struct sym_difference
+{
+    template <typename Strategy>
+    static void apply(Geometry1 const& geometry1,
+                      Geometry2 const& geometry2,
+                      Collection & output_collection,
+                      Strategy const& strategy)
+    {
+        typedef typename geometry::detail::output_geometry_value
+            <
+                Collection
+            >::type single_out;
+
+        detail::sym_difference::sym_difference_insert<single_out>(
+            geometry1, geometry2,
+            geometry::detail::output_geometry_back_inserter(output_collection),
+            strategy);
+    }
+};
+
+
+template <typename Geometry1, typename Geometry2, typename Collection>
+struct sym_difference
+    <
+        Geometry1, Geometry2, Collection,
+        geometry_collection_tag, geometry_collection_tag, geometry_collection_tag
+    >
+{
+    template <typename Strategy>
+    static void apply(Geometry1 const& geometry1,
+                      Geometry2 const& geometry2,
+                      Collection& output_collection,
+                      Strategy const& strategy)
+    {
+        Collection temp1, temp2;
+        resolve_collection::difference
+            <
+                Geometry1, Geometry2, Collection
+            >::apply(geometry1, geometry2, temp1, strategy);
+        resolve_collection::difference
+            <
+                Geometry2, Geometry1, Collection
+            >::apply(geometry2, geometry1, temp2, strategy);
+        resolve_collection::union_
+            <
+                Collection, Collection, Collection
+            >::apply(temp1, temp2, output_collection, strategy);
+    }
+};
+
+template <typename Geometry1, typename Geometry2, typename Collection, typename Tag1>
+struct sym_difference
+    <
+        Geometry1, Geometry2, Collection,
+        Tag1, geometry_collection_tag, geometry_collection_tag
+    >
+{
+    template <typename Strategy>
+    static void apply(Geometry1 const& geometry1,
+                      Geometry2 const& geometry2,
+                      Collection & output_collection,
+                      Strategy const& strategy)
+    {
+        using gc_view_t = geometry::detail::geometry_collection_view<Geometry1>;
+        sym_difference
+            <
+                gc_view_t, Geometry2, Collection
+            >::apply(gc_view_t(geometry1), geometry2, output_collection, strategy);
+    }
+};
+
+template <typename Geometry1, typename Geometry2, typename Collection, typename Tag2>
+struct sym_difference
+    <
+        Geometry1, Geometry2, Collection,
+        geometry_collection_tag, Tag2, geometry_collection_tag
+    >
+{
+    template <typename Strategy>
+    static void apply(Geometry1 const& geometry1,
+                      Geometry2 const& geometry2,
+                      Collection & output_collection,
+                      Strategy const& strategy)
+    {
+        using gc_view_t = geometry::detail::geometry_collection_view<Geometry2>;
+        sym_difference
+            <
+                Geometry1, gc_view_t, Collection
+            >::apply(geometry1, gc_view_t(geometry2), output_collection, strategy);
+    }
+};
+
+template <typename Geometry1, typename Geometry2, typename Collection, typename Tag1, typename Tag2>
+struct sym_difference
+    <
+        Geometry1, Geometry2, Collection,
+        Tag1, Tag2, geometry_collection_tag
+    >
+{
+    template <typename Strategy>
+    static void apply(Geometry1 const& geometry1,
+                      Geometry2 const& geometry2,
+                      Collection & output_collection,
+                      Strategy const& strategy)
+    {
+        using gc1_view_t = geometry::detail::geometry_collection_view<Geometry1>;
+        using gc2_view_t = geometry::detail::geometry_collection_view<Geometry2>;
+        sym_difference
+            <
+                gc1_view_t, gc2_view_t, Collection
+            >::apply(gc1_view_t(geometry1), gc2_view_t(geometry2), output_collection, strategy);
+    }
+};
+
+
+} // namespace resolve_collection
+
+
+namespace resolve_strategy
+{
 
 template
 <
@@ -527,15 +654,10 @@ struct sym_difference
                              Collection & output_collection,
                              Strategy const& strategy)
     {
-        typedef typename geometry::detail::output_geometry_value
+        resolve_collection::sym_difference
             <
-                Collection
-            >::type single_out;
-
-        detail::sym_difference::sym_difference_insert<single_out>(
-            geometry1, geometry2,
-            geometry::detail::output_geometry_back_inserter(output_collection),
-            strategy);
+                Geometry1, Geometry2, Collection
+            >::apply(geometry1, geometry2, output_collection, strategy);
     }
 };
 
@@ -582,10 +704,15 @@ struct sym_difference<default_strategy, false>
 } // resolve_strategy
 
 
-namespace resolve_variant
+namespace resolve_dynamic
 {
     
-template <typename Geometry1, typename Geometry2>
+template
+<
+    typename Geometry1, typename Geometry2,
+    typename Tag1 = typename geometry::tag<Geometry1>::type,
+    typename Tag2 = typename geometry::tag<Geometry2>::type
+>
 struct sym_difference
 {
     template <typename Collection, typename Strategy>
@@ -602,134 +729,60 @@ struct sym_difference
 };
 
 
-template <BOOST_VARIANT_ENUM_PARAMS(typename T), typename Geometry2>
-struct sym_difference<variant<BOOST_VARIANT_ENUM_PARAMS(T)>, Geometry2>
+template <typename DynamicGeometry1, typename Geometry2, typename Tag2>
+struct sym_difference<DynamicGeometry1, Geometry2, dynamic_geometry_tag, Tag2>
 {
     template <typename Collection, typename Strategy>
-    struct visitor: static_visitor<>
+    static void apply(DynamicGeometry1 const& geometry1, Geometry2 const& geometry2,
+                      Collection& output_collection, Strategy const& strategy)
     {
-        Geometry2 const& m_geometry2;
-        Collection& m_output_collection;
-        Strategy const& m_strategy;
-        
-        visitor(Geometry2 const& geometry2,
-                Collection& output_collection,
-                Strategy const& strategy)
-            : m_geometry2(geometry2)
-            , m_output_collection(output_collection)
-            , m_strategy(strategy)
-        {}
-        
-        template <typename Geometry1>
-        void operator()(Geometry1 const& geometry1) const
+        traits::visit<DynamicGeometry1>::apply([&](auto const& g1)
         {
-            sym_difference
+            resolve_strategy::sym_difference
                 <
-                    Geometry1,
-                    Geometry2
-                >::apply(geometry1, m_geometry2, m_output_collection, m_strategy);
-        }
-    };
-    
-    template <typename Collection, typename Strategy>
-    static inline void
-    apply(variant<BOOST_VARIANT_ENUM_PARAMS(T)> const& geometry1,
-          Geometry2 const& geometry2,
-          Collection& output_collection,
-          Strategy const& strategy)
-    {
-        boost::apply_visitor(visitor<Collection, Strategy>(geometry2,
-                                                           output_collection,
-                                                           strategy),
-                             geometry1);
+                    Strategy
+                >::apply(g1, geometry2, output_collection, strategy);
+        }, geometry1);
     }
 };
 
 
-template <typename Geometry1, BOOST_VARIANT_ENUM_PARAMS(typename T)>
-struct sym_difference<Geometry1, variant<BOOST_VARIANT_ENUM_PARAMS(T)> >
+template <typename Geometry1, typename DynamicGeometry2, typename Tag1>
+struct sym_difference<Geometry1, DynamicGeometry2, Tag1, dynamic_geometry_tag>
 {
     template <typename Collection, typename Strategy>
-    struct visitor: static_visitor<>
+    static void apply(Geometry1 const& geometry1, DynamicGeometry2 const& geometry2,
+                      Collection& output_collection, Strategy const& strategy)
     {
-        Geometry1 const& m_geometry1;
-        Collection& m_output_collection;
-        Strategy const& m_strategy;
-        
-        visitor(Geometry1 const& geometry1,
-                Collection& output_collection,
-                Strategy const& strategy)
-            : m_geometry1(geometry1)
-            , m_output_collection(output_collection)
-            , m_strategy(strategy)
-        {}
-        
-        template <typename Geometry2>
-        void operator()(Geometry2 const& geometry2) const
+        traits::visit<DynamicGeometry2>::apply([&](auto const& g2)
         {
-            sym_difference
+            resolve_strategy::sym_difference
                 <
-                    Geometry1,
-                    Geometry2
-                >::apply(m_geometry1, geometry2, m_output_collection, m_strategy);
-        }
-    };
-    
-    template <typename Collection, typename Strategy>
-    static inline void
-    apply(Geometry1 const& geometry1,
-          variant<BOOST_VARIANT_ENUM_PARAMS(T)> const& geometry2,
-          Collection& output_collection,
-          Strategy const& strategy)
-    {
-        boost::apply_visitor(visitor<Collection, Strategy>(geometry1,
-                                                           output_collection,
-                                                           strategy),
-                             geometry2);
+                    Strategy
+                >::apply(geometry1, g2, output_collection, strategy);
+        }, geometry2);
     }
 };
 
 
-template <BOOST_VARIANT_ENUM_PARAMS(typename T1), BOOST_VARIANT_ENUM_PARAMS(typename T2)>
-struct sym_difference<variant<BOOST_VARIANT_ENUM_PARAMS(T1)>, variant<BOOST_VARIANT_ENUM_PARAMS(T2)> >
+template <typename DynamicGeometry1, typename DynamicGeometry2>
+struct sym_difference<DynamicGeometry1, DynamicGeometry2, dynamic_geometry_tag, dynamic_geometry_tag>
 {
     template <typename Collection, typename Strategy>
-    struct visitor: static_visitor<>
+    static void apply(DynamicGeometry1 const& geometry1, DynamicGeometry2 const& geometry2,
+                      Collection& output_collection, Strategy const& strategy)
     {
-        Collection& m_output_collection;
-        Strategy const& m_strategy;
-        
-        visitor(Collection& output_collection, Strategy const& strategy)
-            : m_output_collection(output_collection)
-            , m_strategy(strategy)
-        {}
-        
-        template <typename Geometry1, typename Geometry2>
-        void operator()(Geometry1 const& geometry1,
-                        Geometry2 const& geometry2) const
+        traits::visit<DynamicGeometry1, DynamicGeometry2>::apply([&](auto const& g1, auto const& g2)
         {
-            sym_difference
+            resolve_strategy::sym_difference
                 <
-                    Geometry1,
-                    Geometry2
-                >::apply(geometry1, geometry2, m_output_collection, m_strategy);
-        }
-    };
-    
-    template <typename Collection, typename Strategy>
-    static inline void
-    apply(variant<BOOST_VARIANT_ENUM_PARAMS(T1)> const& geometry1,
-          variant<BOOST_VARIANT_ENUM_PARAMS(T2)> const& geometry2,
-          Collection& output_collection,
-          Strategy const& strategy)
-    {
-        boost::apply_visitor(visitor<Collection, Strategy>(output_collection,
-                                                           strategy),
-                             geometry1, geometry2);
+                    Strategy
+                >::apply(g1, g2, output_collection, strategy);
+        }, geometry1, geometry2);
     }
 };
     
-} // namespace resolve_variant
+} // namespace resolve_dynamic
 
 
 /*!
@@ -761,7 +814,7 @@ inline void sym_difference(Geometry1 const& geometry1,
                            Collection& output_collection,
                            Strategy const& strategy)
 {
-    resolve_variant::sym_difference
+    resolve_dynamic::sym_difference
         <
             Geometry1,
             Geometry2
@@ -793,7 +846,7 @@ inline void sym_difference(Geometry1 const& geometry1,
                            Geometry2 const& geometry2,
                            Collection& output_collection)
 {
-    resolve_variant::sym_difference
+    resolve_dynamic::sym_difference
         <
             Geometry1,
             Geometry2

--- a/include/boost/geometry/algorithms/union.hpp
+++ b/include/boost/geometry/algorithms/union.hpp
@@ -605,7 +605,7 @@ private:
                 }, boost::begin(gc2_view) + id.gc_id);
             }
         }
-
+        /*
         // L = L \ A
         {
             multi_linestring_t l;
@@ -623,7 +623,8 @@ private:
             multi_point_t p;
             subtract_greater_topodim(boost::get<0>(out), boost::get<1>(out), p, strategy);
             boost::get<0>(out) = std::move(p);
-        }        
+        }
+        */
     }
 
     template <typename G, typename Strategy, std::enable_if_t<util::is_pointlike<G>::value, int> = 0>
@@ -696,7 +697,7 @@ private:
         geometry::convert(g, a);
         detail::intersection::gc_move_multi_back(geometry_out, a);
     }
-
+    /*
     template <typename Multi1, typename Multi2, typename Strategy>
     static inline void subtract_greater_topodim(Multi1 const& multi1, Multi2 const& multi2, Multi1& multi_out, Strategy const& strategy)
     {
@@ -718,6 +719,7 @@ private:
                 geometry::detail::overlay::do_reverse<geometry::point_order<Multi2>::value, true>::value
             >::apply(multi1, multi2, robust_policy, range::back_inserter(multi_out), strategy);
     }
+    */
 };
 
 template

--- a/include/boost/geometry/algorithms/union.hpp
+++ b/include/boost/geometry/algorithms/union.hpp
@@ -2,8 +2,8 @@
 
 // Copyright (c) 2007-2014 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2014-2021.
-// Modifications copyright (c) 2014-2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014-2022.
+// Modifications copyright (c) 2014-2022 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -18,7 +18,9 @@
 
 #include <boost/range/value_type.hpp>
 
+#include <boost/geometry/algorithms/detail/intersection/gc.hpp>
 #include <boost/geometry/algorithms/detail/intersection/multi.hpp>
+#include <boost/geometry/algorithms/detail/make_rtree.hpp>
 #include <boost/geometry/algorithms/detail/overlay/intersection_insert.hpp>
 #include <boost/geometry/algorithms/detail/overlay/linear_linear.hpp>
 #include <boost/geometry/algorithms/detail/overlay/overlay.hpp>
@@ -26,6 +28,7 @@
 #include <boost/geometry/algorithms/not_implemented.hpp>
 #include <boost/geometry/core/point_order.hpp>
 #include <boost/geometry/core/reverse_dispatch.hpp>
+#include <boost/geometry/geometries/adapted/boost_variant.hpp>
 #include <boost/geometry/geometries/concepts/check.hpp>
 #include <boost/geometry/policies/robustness/get_rescale_policy.hpp>
 #include <boost/geometry/strategies/default_strategy.hpp>
@@ -34,7 +37,9 @@
 #include <boost/geometry/strategies/relate/geographic.hpp>
 #include <boost/geometry/strategies/relate/spherical.hpp>
 #include <boost/geometry/util/range.hpp>
-
+#include <boost/geometry/util/type_traits_std.hpp>
+#include <boost/geometry/views/detail/geometry_collection_view.hpp>
+#include <boost/geometry/views/detail/random_access_view.hpp>
 
 
 namespace boost { namespace geometry
@@ -375,28 +380,133 @@ inline OutputIterator union_insert(Geometry1 const& geometry1,
 }
 
 
+struct gc_element_id
+{
+    gc_element_id(unsigned int source_id_, std::size_t gc_id_)
+        : source_id(source_id_), gc_id(gc_id_)
+    {}
+
+    unsigned int source_id;
+    std::size_t gc_id;
+
+    friend bool operator<(gc_element_id const& left, gc_element_id const& right)
+    {
+        return left.source_id < right.source_id
+            || (left.source_id == right.source_id && left.gc_id < right.gc_id);
+    }
+};
+
+template <typename GC1View, typename GC2View, typename Strategy, typename IntersectingFun, typename DisjointFun>
+inline void gc_group_elements(GC1View const& gc1_view, GC2View const& gc2_view, Strategy const& strategy,
+                              IntersectingFun&& intersecting_fun,
+                              DisjointFun&& disjoint_fun)
+{
+    // NOTE: could be replaced with unordered_map and unordered_set
+    std::map<gc_element_id, std::set<gc_element_id>> adjacent;
+    
+    auto const rtree2 = detail::make_rtree_indexes(gc2_view, strategy);
+    // Create adjacency list based on intersecting envelopes of GC elements
+    for (std::size_t i = 0; i < boost::size(gc1_view); ++i)
+    {
+        traits::iter_visit<GC1View>::apply([&](auto const& g1)
+        {
+            using g1_t = util::remove_cref_t<decltype(g1)>;
+            using box1_t = detail::make_rtree_box_t<g1_t>;
+            box1_t b1 = geometry::return_envelope<box1_t>(g1, strategy);
+            detail::expand_by_epsilon(b1);
+
+            gc_element_id id1 = {0, i};
+            for (auto qit = rtree2.qbegin(index::intersects(b1)); qit != rtree2.qend(); ++qit)
+            {
+                gc_element_id id2 = {1, qit->second};
+                adjacent[id1].insert(id2);
+                adjacent[id2].insert(id1);
+            }
+        }, boost::begin(gc1_view) + i);
+    }
+
+    // Traverse the graph and build connected groups i.e. groups of intersecting envelopes
+    std::deque<gc_element_id> queue;
+    std::array<std::vector<bool>, 2> visited = {
+        std::vector<bool>(boost::size(gc1_view), false),
+        std::vector<bool>(boost::size(gc2_view), false)
+    };        
+    for (auto const& elem : adjacent)
+    {
+        std::vector<gc_element_id> group;
+        if (! visited[elem.first.source_id][elem.first.gc_id])
+        {
+            queue.push_back(elem.first);
+            visited[elem.first.source_id][elem.first.gc_id] = true;
+            group.push_back(elem.first);
+            while (! queue.empty())
+            {
+                gc_element_id e = queue.front();
+                queue.pop_front();
+                for (auto const& n : adjacent[e])
+                {
+                    if (! visited[n.source_id][n.gc_id])
+                    {
+                        queue.push_back(n);
+                        visited[n.source_id][n.gc_id] = true;
+                        group.push_back(n);
+                    }
+                }
+            }
+        }
+        if (! group.empty())
+        {
+            intersecting_fun(group);
+        }
+    }
+
+    {
+        std::vector<gc_element_id> group;
+        for (std::size_t i = 0; i < visited[0].size(); ++i)
+        {
+            if (! visited[0][i])
+            {
+                group.emplace_back(0, i);
+            }
+        }
+        for (std::size_t i = 0; i < visited[1].size(); ++i)
+        {
+            if (! visited[1][i])
+            {
+                group.emplace_back(1, i);
+            }
+        }
+        if (! group.empty())
+        {
+            disjoint_fun(group);
+        }
+    }
+}
+
+
 }} // namespace detail::union_
 #endif // DOXYGEN_NO_DETAIL
 
 
-namespace resolve_strategy {
+namespace resolve_collection
+{
 
 template
 <
-    typename Strategy,
-    bool IsUmbrella = strategies::detail::is_umbrella_strategy<Strategy>::value
+    typename Geometry1, typename Geometry2, typename GeometryOut,
+    typename Tag1 = typename geometry::tag<Geometry1>::type,
+    typename Tag2 = typename geometry::tag<Geometry2>::type,
+    typename TagOut = typename geometry::tag<GeometryOut>::type
 >
 struct union_
 {
-    template <typename Geometry1, typename Geometry2, typename Collection>
-    static inline void apply(Geometry1 const& geometry1,
-                             Geometry2 const& geometry2,
-                             Collection & output_collection,
-                             Strategy const& strategy)
+    template <typename Strategy>
+    static void apply(Geometry1 const& geometry1, Geometry2 const& geometry2,
+                      GeometryOut & geometry_out, Strategy const& strategy)
     {
         typedef typename geometry::detail::output_geometry_value
             <
-                Collection
+            GeometryOut
             >::type single_out;
 
         typedef typename geometry::rescale_overlay_policy_type
@@ -414,8 +524,297 @@ struct union_
            <
                Geometry1, Geometry2, single_out
            >::apply(geometry1, geometry2, robust_policy,
-                    geometry::detail::output_geometry_back_inserter(output_collection),
+                    geometry::detail::output_geometry_back_inserter(geometry_out),
                     strategy);
+    }
+};
+
+template
+<
+    typename Geometry1, typename Geometry2, typename GeometryOut
+>
+struct union_
+    <
+        Geometry1, Geometry2, GeometryOut,
+        geometry_collection_tag, geometry_collection_tag, geometry_collection_tag
+    >
+{
+    // NOTE: for now require all of the possible output types
+    //       technically only a subset could be needed.
+    using multi_point_t = typename util::sequence_find_if
+        <
+            typename traits::geometry_types<GeometryOut>::type,
+            util::is_multi_point
+        >::type;
+    using multi_linestring_t = typename util::sequence_find_if
+        <
+            typename traits::geometry_types<GeometryOut>::type,
+            util::is_multi_linestring
+        >::type;
+    using multi_polygon_t = typename util::sequence_find_if
+        <
+            typename traits::geometry_types<GeometryOut>::type,
+            util::is_multi_polygon
+        >::type;
+    using tuple_out_t = boost::tuple<multi_point_t, multi_linestring_t, multi_polygon_t>;
+
+    template <typename Strategy>
+    static inline void apply(Geometry1 const& geometry1,
+                             Geometry2 const& geometry2,
+                             GeometryOut& geometry_out,
+                             Strategy const& strategy)
+    {
+        detail::random_access_view<Geometry1 const> gc1_view(geometry1);
+        detail::random_access_view<Geometry2 const> gc2_view(geometry2);
+        
+        detail::union_::gc_group_elements(gc1_view, gc2_view, strategy,
+            [&](auto const& inters_group)
+            {
+                tuple_out_t out;
+                merge_group(gc1_view, gc2_view, strategy, inters_group, out);
+                detail::intersection::gc_move_multi_back(geometry_out, boost::get<0>(out));
+                detail::intersection::gc_move_multi_back(geometry_out, boost::get<1>(out));
+                detail::intersection::gc_move_multi_back(geometry_out, boost::get<2>(out));
+            },
+            [&](auto const& disjoint_group)
+            {
+                copy_disjoint(gc1_view, gc2_view, disjoint_group, geometry_out);
+            });
+    }
+
+private:
+    template <typename GC1View, typename GC2View, typename Strategy, typename Group>
+    static inline void merge_group(GC1View const& gc1_view, GC2View const& gc2_view,
+                                   Strategy const& strategy, Group const& inters_group,
+                                   tuple_out_t& out)
+    {
+        for (auto const& id : inters_group)
+        {
+            if (id.source_id == 0)
+            {
+                traits::iter_visit<GC1View>::apply([&](auto const& g1)
+                {
+                    merge_one(out, g1, strategy);
+                }, boost::begin(gc1_view) + id.gc_id);
+            }
+            else
+            {
+                traits::iter_visit<GC2View>::apply([&](auto const& g2)
+                {
+                    merge_one(out, g2, strategy);
+                }, boost::begin(gc2_view) + id.gc_id);
+            }
+        }
+
+        // L = L \ A
+        {
+            multi_linestring_t l;
+            subtract_greater_topodim(boost::get<1>(out), boost::get<2>(out), l, strategy);
+            boost::get<1>(out) = std::move(l);
+        }
+        // P = P \ A
+        {
+            multi_point_t p;
+            subtract_greater_topodim(boost::get<0>(out), boost::get<2>(out), p, strategy);
+            boost::get<0>(out) = std::move(p);
+        }
+        // P = P \ L
+        {
+            multi_point_t p;
+            subtract_greater_topodim(boost::get<0>(out), boost::get<1>(out), p, strategy);
+            boost::get<0>(out) = std::move(p);
+        }        
+    }
+
+    template <typename G, typename Strategy, std::enable_if_t<util::is_pointlike<G>::value, int> = 0>
+    static inline void merge_one(tuple_out_t& out, G const& g, Strategy const& strategy)
+    {
+        multi_point_t p;
+        union_<multi_point_t, G, multi_point_t>::apply(boost::get<0>(out), g, p, strategy);
+        boost::get<0>(out) = std::move(p);
+    }
+
+    template <typename G, typename Strategy, std::enable_if_t<util::is_linear<G>::value, int> = 0>
+    static inline void merge_one(tuple_out_t& out, G const& g, Strategy const& strategy)
+    {
+        multi_linestring_t l;
+        union_<multi_linestring_t, G, multi_linestring_t>::apply(boost::get<1>(out), g, l, strategy);
+        boost::get<1>(out) = std::move(l);
+    }
+
+    template <typename G, typename Strategy, std::enable_if_t<util::is_areal<G>::value, int> = 0>
+    static inline void merge_one(tuple_out_t& out, G const& g, Strategy const& strategy)
+    {
+        multi_polygon_t a;
+        union_<multi_polygon_t, G, multi_polygon_t>::apply(boost::get<2>(out), g, a, strategy);
+        boost::get<2>(out) = std::move(a);
+    }
+
+    template <typename GC1View, typename GC2View, typename Group>
+    static inline void copy_disjoint(GC1View const& gc1_view, GC2View const& gc2_view,
+                                     Group const& disjoint_group, GeometryOut& geometry_out)
+    {
+        for (auto const& id : disjoint_group)
+        {
+            if (id.source_id == 0)
+            {
+                traits::iter_visit<GC1View>::apply([&](auto const& g1)
+                {
+                    copy_one(g1, geometry_out);
+                }, boost::begin(gc1_view) + id.gc_id);
+            }
+            else
+            {
+                traits::iter_visit<GC2View>::apply([&](auto const& g2)
+                {
+                    copy_one(g2, geometry_out);
+                }, boost::begin(gc2_view) + id.gc_id);
+            }
+        }
+    }
+
+    template <typename G, std::enable_if_t<util::is_pointlike<G>::value, int> = 0>
+    static inline void copy_one(G const& g, GeometryOut& geometry_out)
+    {
+        multi_point_t p;
+        geometry::convert(g, p);
+        detail::intersection::gc_move_multi_back(geometry_out, p);
+    }
+
+    template <typename G, std::enable_if_t<util::is_linear<G>::value, int> = 0>
+    static inline void copy_one(G const& g, GeometryOut& geometry_out)
+    {
+        multi_linestring_t l;
+        geometry::convert(g, l);
+        detail::intersection::gc_move_multi_back(geometry_out, l);
+    }
+
+    template <typename G, std::enable_if_t<util::is_areal<G>::value, int> = 0>
+    static inline void copy_one(G const& g, GeometryOut& geometry_out)
+    {
+        multi_polygon_t a;
+        geometry::convert(g, a);
+        detail::intersection::gc_move_multi_back(geometry_out, a);
+    }
+
+    template <typename Multi1, typename Multi2, typename Strategy>
+    static inline void subtract_greater_topodim(Multi1 const& multi1, Multi2 const& multi2, Multi1& multi_out, Strategy const& strategy)
+    {
+        using rescale_policy_type = typename geometry::rescale_overlay_policy_type
+            <
+                Multi1, Multi2
+            >::type;
+
+        rescale_policy_type robust_policy
+                = geometry::get_rescale_policy<rescale_policy_type>(
+                    multi1, multi2, strategy);
+
+        geometry::dispatch::intersection_insert
+            <
+                Multi1, Multi2,
+                typename boost::range_value<Multi1>::type,
+                overlay_difference,
+                geometry::detail::overlay::do_reverse<geometry::point_order<Multi1>::value>::value,
+                geometry::detail::overlay::do_reverse<geometry::point_order<Multi2>::value, true>::value
+            >::apply(multi1, multi2, robust_policy, range::back_inserter(multi_out), strategy);
+    }
+};
+
+template
+<
+    typename Geometry1, typename Geometry2, typename GeometryOut, typename Tag1
+>
+struct union_
+    <
+        Geometry1, Geometry2, GeometryOut,
+        Tag1, geometry_collection_tag, geometry_collection_tag
+    >
+{
+    template <typename Strategy>
+    static inline void apply(Geometry1 const& geometry1,
+                             Geometry2 const& geometry2,
+                             GeometryOut& geometry_out,
+                             Strategy const& strategy)
+    {
+        using gc_view_t = geometry::detail::geometry_collection_view<Geometry1>;
+        union_
+            <
+                gc_view_t, Geometry2, GeometryOut
+            >::apply(gc_view_t(geometry1), geometry2, geometry_out, strategy);
+    }
+};
+
+template
+<
+    typename Geometry1, typename Geometry2, typename GeometryOut, typename Tag2
+>
+struct union_
+    <
+        Geometry1, Geometry2, GeometryOut,
+        geometry_collection_tag, Tag2, geometry_collection_tag
+    >
+{
+    template <typename Strategy>
+    static inline void apply(Geometry1 const& geometry1,
+                             Geometry2 const& geometry2,
+                             GeometryOut& geometry_out,
+                             Strategy const& strategy)
+    {
+        using gc_view_t = geometry::detail::geometry_collection_view<Geometry2>;
+        union_
+            <
+                Geometry1, gc_view_t, GeometryOut
+            >::apply(geometry1, gc_view_t(geometry2), geometry_out, strategy);
+    }
+};
+
+template
+<
+    typename Geometry1, typename Geometry2, typename GeometryOut, typename Tag1, typename Tag2
+>
+struct union_
+    <
+        Geometry1, Geometry2, GeometryOut,
+        Tag1, Tag2, geometry_collection_tag
+    >
+{
+    template <typename Strategy>
+    static inline void apply(Geometry1 const& geometry1,
+                             Geometry2 const& geometry2,
+                             GeometryOut& geometry_out,
+                             Strategy const& strategy)
+    {
+        using gc1_view_t = geometry::detail::geometry_collection_view<Geometry1>;
+        using gc2_view_t = geometry::detail::geometry_collection_view<Geometry2>;
+        union_
+            <
+                gc1_view_t, gc2_view_t, GeometryOut
+            >::apply(gc1_view_t(geometry1), gc2_view_t(geometry2), geometry_out, strategy);
+    }
+};
+
+} // namespace resolve_collection
+
+
+namespace resolve_strategy {
+
+template
+<
+    typename Strategy,
+    bool IsUmbrella = strategies::detail::is_umbrella_strategy<Strategy>::value
+>
+struct union_
+{
+    template <typename Geometry1, typename Geometry2, typename Collection>
+    static inline void apply(Geometry1 const& geometry1,
+                             Geometry2 const& geometry2,
+                             Collection & output_collection,
+                             Strategy const& strategy)
+    {
+        resolve_collection::union_
+            <
+                Geometry1, Geometry2, Collection
+            >::apply(geometry1, geometry2, output_collection, strategy);
     }
 };
 
@@ -463,10 +862,15 @@ struct union_<default_strategy, false>
 } // resolve_strategy
 
 
-namespace resolve_variant
+namespace resolve_dynamic
 {
     
-template <typename Geometry1, typename Geometry2>
+template
+<
+    typename Geometry1, typename Geometry2,
+    typename Tag1 = typename geometry::tag<Geometry1>::type,
+    typename Tag2 = typename geometry::tag<Geometry2>::type
+>
 struct union_
 {
     template <typename Collection, typename Strategy>
@@ -494,134 +898,64 @@ struct union_
 };
 
 
-template <BOOST_VARIANT_ENUM_PARAMS(typename T), typename Geometry2>
-struct union_<variant<BOOST_VARIANT_ENUM_PARAMS(T)>, Geometry2>
+template <typename DynamicGeometry1, typename Geometry2, typename Tag2>
+struct union_<DynamicGeometry1, Geometry2, dynamic_geometry_tag, Tag2>
 {
     template <typename Collection, typename Strategy>
-    struct visitor: static_visitor<>
+    static inline void apply(DynamicGeometry1 const& geometry1, Geometry2 const& geometry2,
+                             Collection& output_collection, Strategy const& strategy)
     {
-        Geometry2 const& m_geometry2;
-        Collection& m_output_collection;
-        Strategy const& m_strategy;
-        
-        visitor(Geometry2 const& geometry2,
-                Collection& output_collection,
-                Strategy const& strategy)
-            : m_geometry2(geometry2)
-            , m_output_collection(output_collection)
-            , m_strategy(strategy)
-        {}
-        
-        template <typename Geometry1>
-        void operator()(Geometry1 const& geometry1) const
+        traits::visit<DynamicGeometry1>::apply([&](auto const& g1)
         {
             union_
                 <
-                    Geometry1,
+                    util::remove_cref_t<decltype(g1)>,
                     Geometry2
-                >::apply(geometry1, m_geometry2, m_output_collection, m_strategy);
-        }
-    };
-    
-    template <typename Collection, typename Strategy>
-    static inline void
-    apply(variant<BOOST_VARIANT_ENUM_PARAMS(T)> const& geometry1,
-          Geometry2 const& geometry2,
-          Collection& output_collection,
-          Strategy const& strategy)
-    {
-        boost::apply_visitor(visitor<Collection, Strategy>(geometry2,
-                                                           output_collection,
-                                                           strategy),
-                             geometry1);
+                >::apply(g1, geometry2, output_collection, strategy);
+        }, geometry1);
     }
 };
 
 
-template <typename Geometry1, BOOST_VARIANT_ENUM_PARAMS(typename T)>
-struct union_<Geometry1, variant<BOOST_VARIANT_ENUM_PARAMS(T)> >
+template <typename Geometry1, typename DynamicGeometry2, typename Tag1>
+struct union_<Geometry1, DynamicGeometry2, Tag1, dynamic_geometry_tag>
 {
     template <typename Collection, typename Strategy>
-    struct visitor: static_visitor<>
+    static inline void apply(Geometry1 const& geometry1, DynamicGeometry2 const& geometry2,
+                             Collection& output_collection, Strategy const& strategy)
     {
-        Geometry1 const& m_geometry1;
-        Collection& m_output_collection;
-        Strategy const& m_strategy;
-        
-        visitor(Geometry1 const& geometry1,
-                Collection& output_collection,
-                Strategy const& strategy)
-            : m_geometry1(geometry1)
-            , m_output_collection(output_collection)
-            , m_strategy(strategy)
-        {}
-        
-        template <typename Geometry2>
-        void operator()(Geometry2 const& geometry2) const
+        traits::visit<DynamicGeometry2>::apply([&](auto const& g2)
         {
             union_
                 <
                     Geometry1,
-                    Geometry2
-                >::apply(m_geometry1, geometry2, m_output_collection, m_strategy);
-        }
-    };
-    
-    template <typename Collection, typename Strategy>
-    static inline void
-    apply(Geometry1 const& geometry1,
-          variant<BOOST_VARIANT_ENUM_PARAMS(T)> const& geometry2,
-          Collection& output_collection,
-          Strategy const& strategy)
-    {
-        boost::apply_visitor(visitor<Collection, Strategy>(geometry1,
-                                                           output_collection,
-                                                           strategy),
-                             geometry2);
+                    util::remove_cref_t<decltype(g2)>
+                >::apply(geometry1, g2, output_collection, strategy);
+        }, geometry2);
     }
 };
 
 
-template <BOOST_VARIANT_ENUM_PARAMS(typename T1), BOOST_VARIANT_ENUM_PARAMS(typename T2)>
-struct union_<variant<BOOST_VARIANT_ENUM_PARAMS(T1)>, variant<BOOST_VARIANT_ENUM_PARAMS(T2)> >
+template <typename DynamicGeometry1, typename DynamicGeometry2>
+struct union_<DynamicGeometry1, DynamicGeometry2, dynamic_geometry_tag, dynamic_geometry_tag>
 {
     template <typename Collection, typename Strategy>
-    struct visitor: static_visitor<>
+    static inline void apply(DynamicGeometry1 const& geometry1, DynamicGeometry2 const& geometry2,
+                             Collection& output_collection, Strategy const& strategy)
     {
-        Collection& m_output_collection;
-        Strategy const& m_strategy;
-        
-        visitor(Collection& output_collection, Strategy const& strategy)
-            : m_output_collection(output_collection)
-            , m_strategy(strategy)
-        {}
-        
-        template <typename Geometry1, typename Geometry2>
-        void operator()(Geometry1 const& geometry1,
-                        Geometry2 const& geometry2) const
+        traits::visit<DynamicGeometry1, DynamicGeometry2>::apply([&](auto const& g1, auto const& g2)
         {
             union_
                 <
-                    Geometry1,
-                    Geometry2
-                >::apply(geometry1, geometry2, m_output_collection, m_strategy);
-        }
-    };
-    
-    template <typename Collection, typename Strategy>
-    static inline void
-    apply(variant<BOOST_VARIANT_ENUM_PARAMS(T1)> const& geometry1,
-          variant<BOOST_VARIANT_ENUM_PARAMS(T2)> const& geometry2,
-          Collection& output_collection,
-          Strategy const& strategy)
-    {
-        boost::apply_visitor(visitor<Collection, Strategy>(output_collection,
-                                                           strategy),
-                             geometry1, geometry2);
+                    util::remove_cref_t<decltype(g1)>,
+                    util::remove_cref_t<decltype(g2)>
+                >::apply(g1, g2, output_collection, strategy);
+        }, geometry1, geometry2);
     }
 };
+
     
-} // namespace resolve_variant
+} // namespace resolve_dynamic
 
 
 /*!
@@ -654,7 +988,7 @@ inline void union_(Geometry1 const& geometry1,
                    Collection& output_collection,
                    Strategy const& strategy)
 {
-    resolve_variant::union_
+    resolve_dynamic::union_
         <
             Geometry1,
             Geometry2
@@ -687,7 +1021,7 @@ inline void union_(Geometry1 const& geometry1,
                    Geometry2 const& geometry2,
                    Collection& output_collection)
 {
-    resolve_variant::union_
+    resolve_dynamic::union_
         <
             Geometry1,
             Geometry2

--- a/include/boost/geometry/views/detail/random_access_view.hpp
+++ b/include/boost/geometry/views/detail/random_access_view.hpp
@@ -177,10 +177,26 @@ struct iter_visit<geometry::detail::random_access_view<GeometryCollection, false
     : geometry::detail::random_access_view_iter_visit<GeometryCollection>
 {};
 
+template <typename GeometryCollection>
+struct iter_visit<geometry::detail::random_access_view<GeometryCollection, true, false>>
+{
+    template <typename Function, typename Iterator>
+    static void apply(Function && function, Iterator iterator)
+    {
+        geometry::traits::iter_visit
+            <
+                std::remove_const_t<GeometryCollection>
+            >::apply(std::forward<Function>(function), iterator);
+    }
+};
+
 
 template <typename GeometryCollection, bool IsRandomAccess>
 struct geometry_types<geometry::detail::random_access_view<GeometryCollection, IsRandomAccess, false>>
-    : geometry_types<GeometryCollection>
+    : traits::geometry_types
+        <
+            std::remove_const_t<GeometryCollection>
+        >
 {};
 
 template <typename GeometryCollection, bool IsRandomAccess>

--- a/test/algorithms/set_operations/intersection/Jamfile
+++ b/test/algorithms/set_operations/intersection/Jamfile
@@ -24,6 +24,7 @@ test-suite boost-geometry-algorithms-intersection
     [ run intersection_linear_linear.cpp      : : : <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_intersection_linear_linear_alternative ]
     [ run intersection_areal_areal_linear.cpp : : : : algorithms_intersection_areal_areal_linear ]
     [ run intersection_box.cpp                : : : : algorithms_intersection_box ]
+    [ run intersection_gc.cpp                 : : : : algorithms_intersection_gc ]
     [ run intersection_pl_a.cpp               : : : : algorithms_intersection_pl_a ]
     [ run intersection_pl_l.cpp               : : : : algorithms_intersection_pl_l ]
     [ run intersection_pl_pl.cpp              : : : : algorithms_intersection_pl_pl ]

--- a/test/algorithms/set_operations/intersection/intersection_gc.cpp
+++ b/test/algorithms/set_operations/intersection/intersection_gc.cpp
@@ -1,0 +1,182 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2022, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+
+#include <geometry_test_common.hpp>
+
+#include <boost/geometry/algorithms/intersection.hpp>
+//#include <boost/geometry/geometries/adapted/boost_variant2.hpp>
+#include <boost/geometry/geometries/geometries.hpp>
+#include <boost/geometry/io/wkt/wkt.hpp>
+
+
+using pt_t = bg::model::point<double, 2, bg::cs::cartesian>;
+using ls_t = bg::model::linestring<pt_t>;
+using po_t = bg::model::polygon<pt_t>;
+using mpt_t = bg::model::multi_point<pt_t>;
+using mls_t = bg::model::multi_linestring<ls_t>;
+using mpo_t = bg::model::multi_polygon<po_t>;
+using var_t = boost::variant<pt_t, ls_t, po_t, mpt_t, mls_t, mpo_t>;
+//using var_t = boost::variant2::variant<pt_t, ls_t, po_t, mpt_t, mls_t, mpo_t>;
+using gc_t = bg::model::geometry_collection<var_t>;
+
+template <typename GC1, typename GC2>
+inline void check_one(GC1 const& out, GC2 const& expected)
+{
+    std::size_t out_size = boost::size(out);
+    std::size_t expected_size = boost::size(expected);
+    BOOST_CHECK(out_size == expected_size);
+    if (out_size == expected_size)
+    {
+        for (std::size_t i = 0; i < out_size; ++i)
+        {
+            bg::traits::iter_visit<GC1>::apply([&](auto const& o)
+            {
+                bg::traits::iter_visit<GC2>::apply([&](auto const& e)
+                {
+                    using o_t = typename bg::util::remove_cref<decltype(o)>::type;
+                    using e_t = typename bg::util::remove_cref<decltype(e)>::type;
+                    int oid = bg::geometry_id<o_t>::value;
+                    int eid = bg::geometry_id<e_t>::value;
+                    BOOST_CHECK_MESSAGE(oid == eid, oid << " and " << eid);
+                    bool elements_equal = bg::equals(o, e);
+                    BOOST_CHECK_MESSAGE(elements_equal, bg::wkt(o) << " and " << bg::wkt(e));
+                }, expected.begin() + i);
+            }, out.begin() + i);
+        }
+    }
+}
+
+
+void test_gc_gc_gc()
+{
+    const char* gc1_cstr = "GEOMETRYCOLLECTION("
+        "MULTIPOLYGON(((0 0, 0 10, 10 10, 10 0, 0 0), (1 1, 5 1, 5 5, 1 5, 1 1)), ((3 3, 3 4, 4 4, 4 3, 3 3))),"
+        "POLYGON((3 3, 3 10, 10 10, 10 3, 3 3)),"
+        "MULTILINESTRING((0 0, 5 5), (5 5, 11 5), (5 5, 5 11)),"
+        "LINESTRING(0 0, 2 2, 2 11),"
+        "MULTIPOINT(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 9 9, 10 10),"
+        "POINT(11 11)"
+    ")";
+    const char* gc2_cstr = "GEOMETRYCOLLECTION("
+        "POLYGON((4 0, 4 10, 6 10, 6 0, 4 0)),"
+        "POLYGON((0 4, 0 6, 10 6, 10 4, 0 4)),"
+        "POLYGON((3 3, 3 5, 5 5, 5 3, 3 3)),"
+        "MULTILINESTRING((1 1, 6 6), (5 1, 5 9), (2 2, 9 2)),"
+        "MULTIPOINT(9 9, 11 11, 1 9),"
+        "POINT(3 2)"
+    ")";
+    const char* expected_cstr = "GEOMETRYCOLLECTION("
+        "MULTIPOINT((1 1),(9 9),(1 9),(5 5),(5 5),(5 5),(5 5),(2 2),(3 3),(4 4),(6 6),(11 11)),"
+        "MULTILINESTRING((3 5,5 5,5 3),(4 3,4 4),(4 4,3 4),(3 3,4 4),(5 5,6 6),(5 1,5 3),(5 5,5 9),(5 2,9 2),(4 4,5 5),(5 5,6 5),(5 9,5 10),(6 5,10 5),(1 1,3 3),(2 4,2 6)),"
+        "POLYGON((6 6,10 6,10 4,6 4,6 3,6 0,4 0,4 1,5 1,5 3,4 3,3 3,3 5,1 5,1 4,0 4,0 6,4 6,4 10,6 10,6 6))"
+    ")";
+
+    gc_t gc1, gc2, expected;
+    bg::read_wkt(gc1_cstr, gc1);
+    bg::read_wkt(gc2_cstr, gc2);
+    bg::read_wkt(expected_cstr, expected);
+
+    gc_t out1, out2;
+    bg::intersection(gc1, gc2, out1);
+    bg::intersection(gc2, gc1, out2);
+
+    check_one(out1, expected);
+    check_one(out2, expected);
+}
+
+void test_gc_g_gc()
+{
+    const char* gc_cstr = "GEOMETRYCOLLECTION("
+        "MULTIPOLYGON(((0 0, 0 10, 10 10, 10 0, 0 0), (1 1, 5 1, 5 5, 1 5, 1 1)), ((3 3, 3 4, 4 4, 4 3, 3 3))),"
+        "POLYGON((3 3, 3 10, 10 10, 10 3, 3 3)),"
+        "MULTILINESTRING((0 0, 5 5), (5 5, 11 5), (5 5, 5 11)),"
+        "LINESTRING(0 0, 2 2, 2 11),"
+        "MULTIPOINT(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 9 9, 10 10),"
+        "POINT(11 11)"
+    ")";
+    const char* po_cstr = "POLYGON((4 0, 4 10, 6 10, 6 0, 4 0))";
+    const char* expected_cstr = "GEOMETRYCOLLECTION("
+        "MULTIPOINT((4 4),(5 5),(6 6)),"
+        "MULTILINESTRING((4 3,4 4),(4 4,5 5),(5 5,6 5),(5 5,5 10)),"
+        "POLYGON((6 10,6 3,6 0,4 0,4 1,5 1,5 3,4 3,4 10,6 10))"
+    ")";
+
+    gc_t gc, expected;
+    po_t po;
+    bg::read_wkt(gc_cstr, gc);
+    bg::read_wkt(po_cstr, po);
+    bg::read_wkt(expected_cstr, expected);
+
+    gc_t out;
+    bg::intersection(gc, po, out);
+
+    check_one(out, expected);
+}
+
+void test_g_gc_gc()
+{
+    const char* mpo_cstr = "MULTIPOLYGON(((0 0, 0 10, 10 10, 10 0, 0 0), (1 1, 5 1, 5 5, 1 5, 1 1)), ((3 3, 3 4, 4 4, 4 3, 3 3)))";
+    const char* gc_cstr = "GEOMETRYCOLLECTION("
+        "POLYGON((4 0, 4 10, 6 10, 6 0, 4 0)),"
+        "POLYGON((0 4, 0 6, 10 6, 10 4, 0 4)),"
+        "POLYGON((3 3, 3 5, 5 5, 5 3, 3 3)),"
+        "MULTILINESTRING((1 1, 6 6), (5 1, 5 9), (2 2, 9 2)),"
+        "MULTIPOINT(9 9, 11 11, 1 9),"
+        "POINT(3 2)"
+    ")";
+    const char* expected_cstr = "GEOMETRYCOLLECTION("
+        "MULTIPOINT((1 1),(9 9),(1 9)),"
+        "MULTILINESTRING((3 5,5 5,5 3),(4 3,4 4),(4 4,3 4),(3 3,4 4),(5 5,6 6),(5 1,5 3),(5 5,5 9),(5 2,9 2)),"
+        "MULTIPOLYGON(((3 4,4 4,4 3,3 3,3 4)),((6 6,10 6,10 4,6 4,6 0,4 0,4 1,5 1,5 5,4 5,1 5,1 4,0 4,0 6,4 6,4 10,6 10,6 6)))"
+    ")";
+
+    mpo_t mpo;
+    gc_t gc, expected;    
+    bg::read_wkt(mpo_cstr, mpo);
+    bg::read_wkt(gc_cstr, gc);    
+    bg::read_wkt(expected_cstr, expected);
+
+    gc_t out;
+    bg::intersection(mpo, gc, out);
+
+    check_one(out, expected);
+}
+
+void test_g_g_gc()
+{
+    const char* mpo_cstr = "MULTIPOLYGON(((0 0, 0 10, 10 10, 10 0, 0 0), (1 1, 5 1, 5 5, 1 5, 1 1)), ((3 3, 3 4, 4 4, 4 3, 3 3)))";
+    const char* po_cstr = "POLYGON((4 0, 4 10, 6 10, 6 0, 4 0))";
+    const char* expected_cstr = "GEOMETRYCOLLECTION("
+        "LINESTRING(4 3,4 4),"
+        "POLYGON((4 10,6 10,6 0,4 0,4 1,5 1,5 5,4 5,4 10))"
+    ")";
+
+    mpo_t mpo;
+    po_t po;
+    gc_t expected;    
+    bg::read_wkt(mpo_cstr, mpo);
+    bg::read_wkt(po_cstr, po);
+    bg::read_wkt(expected_cstr, expected);
+
+    gc_t out;
+    bg::intersection(mpo, po, out);
+
+    check_one(out, expected);
+}
+
+int test_main(int, char* [])
+{
+    test_gc_gc_gc();
+    test_gc_g_gc();
+    test_g_gc_gc();
+    test_g_g_gc();
+
+    return 0;
+}

--- a/test/algorithms/set_operations/sym_difference/Jamfile
+++ b/test/algorithms/set_operations/sym_difference/Jamfile
@@ -4,8 +4,8 @@
 # Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
 # Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 #
-# This file was modified by Oracle on 2014, 2015, 2020.
-# Modifications copyright (c) 2014-2020, Oracle and/or its affiliates.
+# This file was modified by Oracle on 2014-2022.
+# Modifications copyright (c) 2014-2022, Oracle and/or its affiliates.
 #
 # Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 # Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -18,5 +18,6 @@ test-suite boost-geometry-algorithms-sym_difference
     :
     [ run sym_difference_areal_areal.cpp   : : : : algorithms_sym_difference_areal_areal ]
     [ run sym_difference_linear_linear.cpp : : : : algorithms_sym_difference_linear_linear ]
+    [ run sym_difference_gc.cpp            : : : : algorithms_sym_difference_gc ]
 	[ run sym_difference_tupled.cpp        : : : : algorithms_sym_difference_tupled ]
     ;

--- a/test/algorithms/set_operations/sym_difference/sym_difference_gc.cpp
+++ b/test/algorithms/set_operations/sym_difference/sym_difference_gc.cpp
@@ -72,8 +72,17 @@ void test_gc_gc_gc()
         "MULTIPOINT(9 9, 11 11, 1 9),"
         "POINT(3 2)"
     ")";
+    // Result if the elements of union are subtracted
+    /*
     const char* expected_cstr = "GEOMETRYCOLLECTION("
         "MULTILINESTRING((2 2,4 2),(10 5,11 5),(5 10,5 11),(2 2,2 4),(2 10,2 11)),"
+        "MULTIPOLYGON(((10 4,10 3,10 0,6 0,6 4,10 4)),((6 6,6 10,10 10,10 6,6 6)),((0 6,0 10,4 10,4 6,0 6)),((4 1,4 3,5 3,5 1,4 1)),((4 1,4 0,0 0,0 4,1 4,1 1,4 1)),((1 4,1 5,3 5,3 4,1 4)))"
+    ")";
+    */
+    // Result if the elements of union are not subtracted
+    const char* expected_cstr = "GEOMETRYCOLLECTION("
+        "MULTIPOINT((3 2),(0 0),(7 7),(8 8),(10 10)),"
+        "MULTILINESTRING((2 2,5 2),(0 0,1 1),(10 5,11 5),(5 10,5 11),(2 2,2 4),(2 6,2 11)),"
         "MULTIPOLYGON(((10 4,10 3,10 0,6 0,6 4,10 4)),((6 6,6 10,10 10,10 6,6 6)),((0 6,0 10,4 10,4 6,0 6)),((4 1,4 3,5 3,5 1,4 1)),((4 1,4 0,0 0,0 4,1 4,1 1,4 1)),((1 4,1 5,3 5,3 4,1 4)))"
     ")";
 
@@ -101,8 +110,19 @@ void test_gc_g_gc()
         "POINT(11 11)"
     ")";
     const char* po_cstr = "POLYGON((4 0, 4 10, 6 10, 6 0, 4 0))";
+    // Result if the elements of union are subtracted
+    /*
     const char* expected_cstr = "GEOMETRYCOLLECTION("
         "MULTILINESTRING((1 1,3 3),(10 5,11 5),(5 10,5 11)),"
+        "MULTIPOLYGON(((6 10,10 10,10 3,10 0,6 0,6 10)),((4 3,5 3,5 1,4 1,4 3)),((4 3,3 3,3 5,1 5,1 1,4 1,4 0,0 0,0 10,4 10,4 3))),"
+        "LINESTRING(0 0, 2 2, 2 11),"
+        "POINT(11 11)"
+    ")";
+    */
+    // Result if the elements of union are not subtracted
+    const char* expected_cstr = "GEOMETRYCOLLECTION("
+        "MULTIPOINT((0 0),(1 1),(2 2),(3 3),(7 7),(8 8),(9 9),(10 10)),"
+        "MULTILINESTRING((0 0,4 4),(6 5,11 5),(5 10,5 11)),"
         "MULTIPOLYGON(((6 10,10 10,10 3,10 0,6 0,6 10)),((4 3,5 3,5 1,4 1,4 3)),((4 3,3 3,3 5,1 5,1 1,4 1,4 0,0 0,0 10,4 10,4 3))),"
         "LINESTRING(0 0, 2 2, 2 11),"
         "POINT(11 11)"
@@ -131,8 +151,18 @@ void test_g_gc_gc()
         "MULTIPOINT(9 9, 11 11, 1 9),"
         "POINT(3 2)"
     ")";
+    // Result if the elements of union are subtracted
+    /*
     const char* expected_cstr = "GEOMETRYCOLLECTION("
         "MULTILINESTRING((1 1,3 3),(2 2,4 2)),"
+        "MULTIPOLYGON(((6 4,10 4,10 0,6 0,6 4)),((10 6,6 6,6 10,10 10,10 6)),((4 6,0 6,0 10,4 10,4 6)),((5 5,5 3,5 1,4 1,4 4,1 4,1 5,5 5)),((4 1,4 0,0 0,0 4,1 4,1 1,4 1))),"
+        "POINT(11 11)"
+    ")";
+    */
+    // Result if the elements of union are not subtracted
+    const char* expected_cstr = "GEOMETRYCOLLECTION("
+        "POINT(3 2)"
+        "MULTILINESTRING((1 1,3 3),(4 4,5 5),(2 2,5 2)),"
         "MULTIPOLYGON(((6 4,10 4,10 0,6 0,6 4)),((10 6,6 6,6 10,10 10,10 6)),((4 6,0 6,0 10,4 10,4 6)),((5 5,5 3,5 1,4 1,4 4,1 4,1 5,5 5)),((4 1,4 0,0 0,0 4,1 4,1 1,4 1))),"
         "POINT(11 11)"
     ")";

--- a/test/algorithms/set_operations/sym_difference/sym_difference_gc.cpp
+++ b/test/algorithms/set_operations/sym_difference/sym_difference_gc.cpp
@@ -1,0 +1,181 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2022, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+
+#include <geometry_test_common.hpp>
+
+#include <boost/geometry/algorithms/sym_difference.hpp>
+//#include <boost/geometry/geometries/adapted/boost_variant2.hpp>
+#include <boost/geometry/geometries/geometries.hpp>
+#include <boost/geometry/io/wkt/wkt.hpp>
+
+
+using pt_t = bg::model::point<double, 2, bg::cs::cartesian>;
+using ls_t = bg::model::linestring<pt_t>;
+using po_t = bg::model::polygon<pt_t>;
+using mpt_t = bg::model::multi_point<pt_t>;
+using mls_t = bg::model::multi_linestring<ls_t>;
+using mpo_t = bg::model::multi_polygon<po_t>;
+using var_t = boost::variant<pt_t, ls_t, po_t, mpt_t, mls_t, mpo_t>;
+//using var_t = boost::variant2::variant<pt_t, ls_t, po_t, mpt_t, mls_t, mpo_t>;
+using gc_t = bg::model::geometry_collection<var_t>;
+
+template <typename GC1, typename GC2>
+inline void check_one(GC1 const& out, GC2 const& expected)
+{
+    std::size_t out_size = boost::size(out);
+    std::size_t expected_size = boost::size(expected);
+    BOOST_CHECK(out_size == expected_size);
+    if (out_size == expected_size)
+    {
+        for (std::size_t i = 0; i < out_size; ++i)
+        {
+            bg::traits::iter_visit<GC1>::apply([&](auto const& o)
+            {
+                bg::traits::iter_visit<GC2>::apply([&](auto const& e)
+                {
+                    using o_t = typename bg::util::remove_cref<decltype(o)>::type;
+                    using e_t = typename bg::util::remove_cref<decltype(e)>::type;
+                    int oid = bg::geometry_id<o_t>::value;
+                    int eid = bg::geometry_id<e_t>::value;
+                    BOOST_CHECK_MESSAGE(oid == eid, oid << " and " << eid);
+                    bool elements_equal = bg::equals(o, e);
+                    BOOST_CHECK_MESSAGE(elements_equal, bg::wkt(o) << " and " << bg::wkt(e));
+                }, expected.begin() + i);
+            }, out.begin() + i);
+        }
+    }
+}
+
+
+void test_gc_gc_gc()
+{
+    const char* gc1_cstr = "GEOMETRYCOLLECTION("
+        "MULTIPOLYGON(((0 0, 0 10, 10 10, 10 0, 0 0), (1 1, 5 1, 5 5, 1 5, 1 1)), ((3 3, 3 4, 4 4, 4 3, 3 3))),"
+        "POLYGON((3 3, 3 10, 10 10, 10 3, 3 3)),"
+        "MULTILINESTRING((0 0, 5 5), (5 5, 11 5), (5 5, 5 11)),"
+        "LINESTRING(0 0, 2 2, 2 11),"
+        "MULTIPOINT(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 9 9, 10 10),"
+        "POINT(11 11)"
+    ")";
+    const char* gc2_cstr = "GEOMETRYCOLLECTION("
+        "POLYGON((4 0, 4 10, 6 10, 6 0, 4 0)),"
+        "POLYGON((0 4, 0 6, 10 6, 10 4, 0 4)),"
+        "POLYGON((3 3, 3 5, 5 5, 5 3, 3 3)),"
+        "MULTILINESTRING((1 1, 6 6), (5 1, 5 9), (2 2, 9 2)),"
+        "MULTIPOINT(9 9, 11 11, 1 9),"
+        "POINT(3 2)"
+    ")";
+    const char* expected_cstr = "GEOMETRYCOLLECTION("
+        "MULTILINESTRING((2 2,4 2),(10 5,11 5),(5 10,5 11),(2 2,2 4),(2 10,2 11)),"
+        "MULTIPOLYGON(((10 4,10 3,10 0,6 0,6 4,10 4)),((6 6,6 10,10 10,10 6,6 6)),((0 6,0 10,4 10,4 6,0 6)),((4 1,4 3,5 3,5 1,4 1)),((4 1,4 0,0 0,0 4,1 4,1 1,4 1)),((1 4,1 5,3 5,3 4,1 4)))"
+    ")";
+
+    gc_t gc1, gc2, expected;
+    bg::read_wkt(gc1_cstr, gc1);
+    bg::read_wkt(gc2_cstr, gc2);
+    bg::read_wkt(expected_cstr, expected);
+
+    gc_t out1, out2;
+    bg::sym_difference(gc1, gc2, out1);
+    bg::sym_difference(gc2, gc1, out2);
+
+    check_one(out1, expected);
+    check_one(out2, expected);
+}
+
+void test_gc_g_gc()
+{
+    const char* gc_cstr = "GEOMETRYCOLLECTION("
+        "MULTIPOLYGON(((0 0, 0 10, 10 10, 10 0, 0 0), (1 1, 5 1, 5 5, 1 5, 1 1)), ((3 3, 3 4, 4 4, 4 3, 3 3))),"
+        "POLYGON((3 3, 3 10, 10 10, 10 3, 3 3)),"
+        "MULTILINESTRING((0 0, 5 5), (5 5, 11 5), (5 5, 5 11)),"
+        "LINESTRING(0 0, 2 2, 2 11),"
+        "MULTIPOINT(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 9 9, 10 10),"
+        "POINT(11 11)"
+    ")";
+    const char* po_cstr = "POLYGON((4 0, 4 10, 6 10, 6 0, 4 0))";
+    const char* expected_cstr = "GEOMETRYCOLLECTION("
+        "MULTILINESTRING((1 1,3 3),(10 5,11 5),(5 10,5 11)),"
+        "MULTIPOLYGON(((6 10,10 10,10 3,10 0,6 0,6 10)),((4 3,5 3,5 1,4 1,4 3)),((4 3,3 3,3 5,1 5,1 1,4 1,4 0,0 0,0 10,4 10,4 3))),"
+        "LINESTRING(0 0, 2 2, 2 11),"
+        "POINT(11 11)"
+    ")";
+
+    gc_t gc, expected;
+    po_t po;
+    bg::read_wkt(gc_cstr, gc);
+    bg::read_wkt(po_cstr, po);
+    bg::read_wkt(expected_cstr, expected);
+
+    gc_t out;
+    bg::sym_difference(gc, po, out);
+
+    check_one(out, expected);
+}
+
+void test_g_gc_gc()
+{
+    const char* mpo_cstr = "MULTIPOLYGON(((0 0, 0 10, 10 10, 10 0, 0 0), (1 1, 5 1, 5 5, 1 5, 1 1)), ((3 3, 3 4, 4 4, 4 3, 3 3)))";
+    const char* gc_cstr = "GEOMETRYCOLLECTION("
+        "POLYGON((4 0, 4 10, 6 10, 6 0, 4 0)),"
+        "POLYGON((0 4, 0 6, 10 6, 10 4, 0 4)),"
+        "POLYGON((3 3, 3 5, 5 5, 5 3, 3 3)),"
+        "MULTILINESTRING((1 1, 6 6), (5 1, 5 9), (2 2, 9 2)),"
+        "MULTIPOINT(9 9, 11 11, 1 9),"
+        "POINT(3 2)"
+    ")";
+    const char* expected_cstr = "GEOMETRYCOLLECTION("
+        "MULTILINESTRING((1 1,3 3),(2 2,4 2)),"
+        "MULTIPOLYGON(((6 4,10 4,10 0,6 0,6 4)),((10 6,6 6,6 10,10 10,10 6)),((4 6,0 6,0 10,4 10,4 6)),((5 5,5 3,5 1,4 1,4 4,1 4,1 5,5 5)),((4 1,4 0,0 0,0 4,1 4,1 1,4 1))),"
+        "POINT(11 11)"
+    ")";
+
+    mpo_t mpo;
+    gc_t gc, expected;    
+    bg::read_wkt(mpo_cstr, mpo);
+    bg::read_wkt(gc_cstr, gc);    
+    bg::read_wkt(expected_cstr, expected);
+
+    gc_t out;
+    bg::sym_difference(mpo, gc, out);
+
+    check_one(out, expected);
+}
+
+void test_g_g_gc()
+{
+    const char* mpo_cstr = "MULTIPOLYGON(((0 0, 0 10, 10 10, 10 0, 0 0), (1 1, 5 1, 5 5, 1 5, 1 1)), ((3 3, 3 4, 4 4, 4 3, 3 3)))";
+    const char* po_cstr = "POLYGON((4 0, 4 10, 6 10, 6 0, 4 0))";
+    const char* expected_cstr = "GEOMETRYCOLLECTION("
+        "MULTIPOLYGON(((6 0,6 10,10 10,10 0,6 0)),((4 1,4 3,3 3,3 4,4 4,4 5,5 5,5 1,4 1)),((4 1,4 0,0 0,0 10,4 10,4 5,1 5,1 1,4 1)))"
+    ")";
+
+    mpo_t mpo;
+    po_t po;
+    gc_t expected;    
+    bg::read_wkt(mpo_cstr, mpo);
+    bg::read_wkt(po_cstr, po);
+    bg::read_wkt(expected_cstr, expected);
+
+    gc_t out;
+    bg::sym_difference(mpo, po, out);
+
+    check_one(out, expected);
+}
+
+int test_main(int, char* [])
+{
+    test_gc_gc_gc();
+    test_gc_g_gc();
+    test_g_gc_gc();
+    test_g_g_gc();
+
+    return 0;
+}

--- a/test/algorithms/set_operations/union/Jamfile
+++ b/test/algorithms/set_operations/union/Jamfile
@@ -4,8 +4,8 @@
 # Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
 # Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 #
-# This file was modified by Oracle on 2014, 2015, 2017, 2018, 2020.
-# Modifications copyright (c) 2014-2020, Oracle and/or its affiliates.
+# This file was modified by Oracle on 2014-2022.
+# Modifications copyright (c) 2014-2022, Oracle and/or its affiliates.
 #
 # Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 # Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -22,6 +22,7 @@ test-suite boost-geometry-algorithms-union
     [ run union_multi.cpp         : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_union_multi_alternative ]
     [ run union_aa_geo.cpp        : : : : algorithms_union_aa_geo ]
     [ run union_aa_sph.cpp        : : : : algorithms_union_aa_sph ]
+    [ run union_gc.cpp            : : : : algorithms_union_gc ]
     [ run union_linear_linear.cpp : : : : algorithms_union_linear_linear ]
     [ run union_pl_pl.cpp         : : : : algorithms_union_pl_pl ]
     [ run union_tupled.cpp        : : : : algorithms_union_tupled ]

--- a/test/algorithms/set_operations/union/union_gc.cpp
+++ b/test/algorithms/set_operations/union/union_gc.cpp
@@ -72,9 +72,18 @@ void test_gc_gc_gc()
         "MULTIPOINT(9 9, 11 11, 1 9),"
         "POINT(3 2)"
     ")";
+    /*
+    // Result if the elements are subtracted
     const char* expected_cstr = "GEOMETRYCOLLECTION("
         "POINT(11 11),"
         "MULTILINESTRING((1 1,2 2,2 4),(2 10,2 11),(2 2,3 3),(2 2,4 2),(10 5,11 5),(5 10,5 11)),"
+        "POLYGON((10 10,10 3,10 0,4 0,0 0,0 10,10 10),(3 4,1 4,1 1,4 1,4 3,3 3,3 4))"
+    ")";
+    */
+    // Result if elements are not subtracted
+    const char* expected_cstr = "GEOMETRYCOLLECTION("
+        "MULTIPOINT((11 11),(3 2),(9 9),(1 9),(0 0),(1 1),(2 2),(3 3),(4 4),(5 5),(6 6),(7 7),(8 8),(10 10)),"
+        "MULTILINESTRING((0 0,2 2,2 11),(2 2,6 6),(5 1,5 9),(2 2,9 2),(5 5,11 5),(5 9,5 11)),"
         "POLYGON((10 10,10 3,10 0,4 0,0 0,0 10,10 10),(3 4,1 4,1 1,4 1,4 3,3 3,3 4))"
     ")";
 
@@ -102,8 +111,19 @@ void test_gc_g_gc()
         "POINT(11 11)"
     ")";
     const char* po_cstr = "POLYGON((4 0, 4 10, 6 10, 6 0, 4 0))";
+    // Result if the elements are subtracted
+    /*
     const char* expected_cstr = "GEOMETRYCOLLECTION("
         "MULTILINESTRING((1 1,3 3),(10 5,11 5),(5 10,5 11)),"
+        "POLYGON((10 10,10 3,10 0,4 0,0 0,0 10,10 10),(3 5,1 5,1 1,4 1,4 3,3 3,3 5)),"
+        "LINESTRING(0 0, 2 2, 2 11),"
+        "POINT(11 11)"
+    ")";
+    */
+    // Result if elements are not subtracted
+    const char* expected_cstr = "GEOMETRYCOLLECTION("
+        "MULTIPOINT((0 0),(1 1),(2 2),(3 3),(4 4),(5 5),(6 6),(7 7),(8 8),(9 9),(10 10)),"
+        "MULTILINESTRING((0 0,5 5),(5 5,11 5),(5 5,5 11)),"
         "POLYGON((10 10,10 3,10 0,4 0,0 0,0 10,10 10),(3 5,1 5,1 1,4 1,4 3,3 3,3 5)),"
         "LINESTRING(0 0, 2 2, 2 11),"
         "POINT(11 11)"
@@ -132,9 +152,18 @@ void test_g_gc_gc()
         "MULTIPOINT(9 9, 11 11, 1 9),"
         "POINT(3 2)"
     ")";
+    // Result if the elements are subtracted
+    /*
     const char* expected_cstr = "GEOMETRYCOLLECTION("
         "POINT(11 11),"
         "MULTILINESTRING((1 1,3 3),(2 2,4 2)),"
+        "POLYGON((0 10,10 10,10 4,10 0,4 0,0 0,0 10),(3 4,1 4,1 1,4 1,4 3,3 3,3 4))"
+    ")";
+    */
+    // Result if elements are not subtracted
+    const char* expected_cstr = "GEOMETRYCOLLECTION("
+        "MULTIPOINT((3 2),(9 9),(11 11),(1 9)),"
+        "MULTILINESTRING((1 1,6 6),(5 1,5 9),(2 2,9 2)),"
         "POLYGON((0 10,10 10,10 4,10 0,4 0,0 0,0 10),(3 4,1 4,1 1,4 1,4 3,3 3,3 4))"
     ")";
 

--- a/test/algorithms/set_operations/union/union_gc.cpp
+++ b/test/algorithms/set_operations/union/union_gc.cpp
@@ -1,0 +1,182 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2022, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+
+// Licensed under the Boost Software License version 1.0.
+// http://www.boost.org/users/license.html
+
+
+#include <geometry_test_common.hpp>
+
+#include <boost/geometry/algorithms/union.hpp>
+//#include <boost/geometry/geometries/adapted/boost_variant2.hpp>
+#include <boost/geometry/geometries/geometries.hpp>
+#include <boost/geometry/io/wkt/wkt.hpp>
+
+
+using pt_t = bg::model::point<double, 2, bg::cs::cartesian>;
+using ls_t = bg::model::linestring<pt_t>;
+using po_t = bg::model::polygon<pt_t>;
+using mpt_t = bg::model::multi_point<pt_t>;
+using mls_t = bg::model::multi_linestring<ls_t>;
+using mpo_t = bg::model::multi_polygon<po_t>;
+using var_t = boost::variant<pt_t, ls_t, po_t, mpt_t, mls_t, mpo_t>;
+//using var_t = boost::variant2::variant<pt_t, ls_t, po_t, mpt_t, mls_t, mpo_t>;
+using gc_t = bg::model::geometry_collection<var_t>;
+
+template <typename GC1, typename GC2>
+inline void check_one(GC1 const& out, GC2 const& expected)
+{
+    std::size_t out_size = boost::size(out);
+    std::size_t expected_size = boost::size(expected);
+    BOOST_CHECK(out_size == expected_size);
+    if (out_size == expected_size)
+    {
+        for (std::size_t i = 0; i < out_size; ++i)
+        {
+            bg::traits::iter_visit<GC1>::apply([&](auto const& o)
+            {
+                bg::traits::iter_visit<GC2>::apply([&](auto const& e)
+                {
+                    using o_t = typename bg::util::remove_cref<decltype(o)>::type;
+                    using e_t = typename bg::util::remove_cref<decltype(e)>::type;
+                    int oid = bg::geometry_id<o_t>::value;
+                    int eid = bg::geometry_id<e_t>::value;
+                    BOOST_CHECK_MESSAGE(oid == eid, oid << " and " << eid);
+                    bool elements_equal = bg::equals(o, e);
+                    BOOST_CHECK_MESSAGE(elements_equal, bg::wkt(o) << " and " << bg::wkt(e));
+                }, expected.begin() + i);
+            }, out.begin() + i);
+        }
+    }
+}
+
+
+void test_gc_gc_gc()
+{
+    const char* gc1_cstr = "GEOMETRYCOLLECTION("
+        "MULTIPOLYGON(((0 0, 0 10, 10 10, 10 0, 0 0), (1 1, 5 1, 5 5, 1 5, 1 1)), ((3 3, 3 4, 4 4, 4 3, 3 3))),"
+        "POLYGON((3 3, 3 10, 10 10, 10 3, 3 3)),"
+        "MULTILINESTRING((0 0, 5 5), (5 5, 11 5), (5 5, 5 11)),"
+        "LINESTRING(0 0, 2 2, 2 11),"
+        "MULTIPOINT(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 9 9, 10 10),"
+        "POINT(11 11)"
+    ")";
+    const char* gc2_cstr = "GEOMETRYCOLLECTION("
+        "POLYGON((4 0, 4 10, 6 10, 6 0, 4 0)),"
+        "POLYGON((0 4, 0 6, 10 6, 10 4, 0 4)),"
+        "POLYGON((3 3, 3 5, 5 5, 5 3, 3 3)),"
+        "MULTILINESTRING((1 1, 6 6), (5 1, 5 9), (2 2, 9 2)),"
+        "MULTIPOINT(9 9, 11 11, 1 9),"
+        "POINT(3 2)"
+    ")";
+    const char* expected_cstr = "GEOMETRYCOLLECTION("
+        "POINT(11 11),"
+        "MULTILINESTRING((1 1,2 2,2 4),(2 10,2 11),(2 2,3 3),(2 2,4 2),(10 5,11 5),(5 10,5 11)),"
+        "POLYGON((10 10,10 3,10 0,4 0,0 0,0 10,10 10),(3 4,1 4,1 1,4 1,4 3,3 3,3 4))"
+    ")";
+
+    gc_t gc1, gc2, expected;
+    bg::read_wkt(gc1_cstr, gc1);
+    bg::read_wkt(gc2_cstr, gc2);
+    bg::read_wkt(expected_cstr, expected);
+
+    gc_t out1, out2;
+    bg::union_(gc1, gc2, out1);
+    bg::union_(gc2, gc1, out2);
+
+    check_one(out1, expected);
+    check_one(out2, expected);
+}
+
+void test_gc_g_gc()
+{
+    const char* gc_cstr = "GEOMETRYCOLLECTION("
+        "MULTIPOLYGON(((0 0, 0 10, 10 10, 10 0, 0 0), (1 1, 5 1, 5 5, 1 5, 1 1)), ((3 3, 3 4, 4 4, 4 3, 3 3))),"
+        "POLYGON((3 3, 3 10, 10 10, 10 3, 3 3)),"
+        "MULTILINESTRING((0 0, 5 5), (5 5, 11 5), (5 5, 5 11)),"
+        "LINESTRING(0 0, 2 2, 2 11),"
+        "MULTIPOINT(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 9 9, 10 10),"
+        "POINT(11 11)"
+    ")";
+    const char* po_cstr = "POLYGON((4 0, 4 10, 6 10, 6 0, 4 0))";
+    const char* expected_cstr = "GEOMETRYCOLLECTION("
+        "MULTILINESTRING((1 1,3 3),(10 5,11 5),(5 10,5 11)),"
+        "POLYGON((10 10,10 3,10 0,4 0,0 0,0 10,10 10),(3 5,1 5,1 1,4 1,4 3,3 3,3 5)),"
+        "LINESTRING(0 0, 2 2, 2 11),"
+        "POINT(11 11)"
+    ")";
+
+    gc_t gc, expected;
+    po_t po;
+    bg::read_wkt(gc_cstr, gc);
+    bg::read_wkt(po_cstr, po);
+    bg::read_wkt(expected_cstr, expected);
+
+    gc_t out;
+    bg::union_(gc, po, out);
+
+    check_one(out, expected);
+}
+
+void test_g_gc_gc()
+{
+    const char* mpo_cstr = "MULTIPOLYGON(((0 0, 0 10, 10 10, 10 0, 0 0), (1 1, 5 1, 5 5, 1 5, 1 1)), ((3 3, 3 4, 4 4, 4 3, 3 3)))";
+    const char* gc_cstr = "GEOMETRYCOLLECTION("
+        "POLYGON((4 0, 4 10, 6 10, 6 0, 4 0)),"
+        "POLYGON((0 4, 0 6, 10 6, 10 4, 0 4)),"
+        "POLYGON((3 3, 3 5, 5 5, 5 3, 3 3)),"
+        "MULTILINESTRING((1 1, 6 6), (5 1, 5 9), (2 2, 9 2)),"
+        "MULTIPOINT(9 9, 11 11, 1 9),"
+        "POINT(3 2)"
+    ")";
+    const char* expected_cstr = "GEOMETRYCOLLECTION("
+        "POINT(11 11),"
+        "MULTILINESTRING((1 1,3 3),(2 2,4 2)),"
+        "POLYGON((0 10,10 10,10 4,10 0,4 0,0 0,0 10),(3 4,1 4,1 1,4 1,4 3,3 3,3 4))"
+    ")";
+
+    mpo_t mpo;
+    gc_t gc, expected;    
+    bg::read_wkt(mpo_cstr, mpo);
+    bg::read_wkt(gc_cstr, gc);    
+    bg::read_wkt(expected_cstr, expected);
+
+    gc_t out;
+    bg::union_(mpo, gc, out);
+
+    check_one(out, expected);
+}
+
+void test_g_g_gc()
+{
+    const char* mpo_cstr = "MULTIPOLYGON(((0 0, 0 10, 10 10, 10 0, 0 0), (1 1, 5 1, 5 5, 1 5, 1 1)), ((3 3, 3 4, 4 4, 4 3, 3 3)))";
+    const char* po_cstr = "POLYGON((4 0, 4 10, 6 10, 6 0, 4 0))";
+    const char* expected_cstr = "GEOMETRYCOLLECTION("
+        "POLYGON((10 10,10 0,4 0,0 0,0 10,10 10),(4 1,4 3,3 3,3 4,4 4,4 5,1 5,1 1,4 1))"
+    ")";
+
+    mpo_t mpo;
+    po_t po;
+    gc_t expected;    
+    bg::read_wkt(mpo_cstr, mpo);
+    bg::read_wkt(po_cstr, po);
+    bg::read_wkt(expected_cstr, expected);
+
+    gc_t out;
+    bg::union_(mpo, po, out);
+
+    check_one(out, expected);
+}
+
+int test_main(int, char* [])
+{
+    test_gc_gc_gc();
+    test_gc_g_gc();
+    test_g_gc_gc();
+    test_g_g_gc();
+
+    return 0;
+}


### PR DESCRIPTION
These algorithms calculate the intermediate results based on the bounding boxes of elements of GCs and these results are merged together based on topological dimension. So e.g. parts of linestrings of GC1 that are intersecting any linear or areal geometry from GC2 are merged into multilinestring(s).

The next step could be to subtract the results from each other to prevent them occupying the same space. It's not clear to me what the result of set operations should be for GCs because they are not well defined by the standard. I decided to leave these geometries as they are, so potentially intersecting each other, in order not to loose information.

If merging of elements of the result is desired one may call `merge_elements()` afterwards.

For example the intersection of GC1:

![gc1](https://user-images.githubusercontent.com/1226951/171644972-c8d85eef-820b-4455-bbc6-451f0aef777e.png)

and GC2:

![gc2](https://user-images.githubusercontent.com/1226951/171645144-41dcacab-b947-4000-ba54-47bcc17bafe2.png)

is:

![result](https://user-images.githubusercontent.com/1226951/171645555-8641bd6a-d24f-459f-912c-0722eb1b3afa.png)

Note that some of the linestrings are results of touching polygons, so intersecting boundaries.