### PR TITLE
Allow different input and output types in simplify

### DIFF
--- a/include/boost/geometry/algorithms/simplify.hpp
+++ b/include/boost/geometry/algorithms/simplify.hpp
@@ -660,7 +660,7 @@ struct static_geometry_type
     using type = typename util::sequence_find_if
         <
             typename traits::geometry_types<DynamicGeometryOut>::type,
-            detail::simplify::has_same_tag_as<StaticGeometryIn>::pred
+            detail::simplify::has_same_tag_as<StaticGeometryIn>::template pred
         >::type;
 
     BOOST_GEOMETRY_STATIC_ASSERT(

--- a/include/boost/geometry/algorithms/simplify.hpp
+++ b/include/boost/geometry/algorithms/simplify.hpp
@@ -98,10 +98,8 @@ struct douglas_peucker_point
 \brief Implements the simplify algorithm.
 \details The douglas_peucker policy simplifies a linestring, ring or
     vector of points using the well-known Douglas-Peucker algorithm.
-\tparam Point the point type
-\tparam PointDistanceStrategy point-segment distance strategy to be used
-\note This strategy uses itself a point-segment-distance strategy which
-    can be specified
+\note This strategy uses itself a point-segment potentially comparable
+    distance strategy
 \author Barend and Maarten, 1995/1996
 \author Barend, revised for Generic Geometry Library, 2008
 */
@@ -417,8 +415,12 @@ private :
     }
 
 public :
-    template <typename Ring, typename Distance, typename Impl, typename Strategies>
-    static inline void apply(Ring const& ring, Ring& out, Distance const& max_distance,
+    template
+    <
+        typename RingIn, typename RingOut,
+        typename Distance, typename Impl, typename Strategies
+    >
+    static inline void apply(RingIn const& ring, RingOut& out, Distance const& max_distance,
                              Impl const& impl, Strategies const& strategies)
     {
         std::size_t const size = boost::size(ring);
@@ -427,7 +429,10 @@ public :
             return;
         }
 
-        bool const is_closed = closure<Ring>::value == closed;
+        bool const is_closed_in = geometry::closure<RingIn>::value == closed;
+        bool const is_closed_out = geometry::closure<RingOut>::value == closed;
+        bool const is_clockwise_in = geometry::point_order<RingIn>::value == clockwise;
+        bool const is_clockwise_out = geometry::point_order<RingOut>::value == clockwise;
 
         // TODO: instead of area() use calculate_point_order() ?
 
@@ -438,7 +443,7 @@ public :
         // Rotate it into a copied vector
         // (vector, because source type might not support rotation)
         // (duplicate end point will be simplified away)
-        typedef typename geometry::point_type<Ring>::type point_type;
+        typedef typename geometry::point_type<RingIn>::type point_type;
 
         std::vector<point_type> rotated;
         rotated.reserve(size + 1); // 1 because open rings are closed
@@ -477,7 +482,7 @@ public :
             // Do not duplicate the closing point
             auto rot_end = boost::end(ring);
             std::size_t rot_index = index;
-            if (is_closed && size > 1)
+            if (is_closed_in && size > 1)
             {
                 --rot_end;
                 if (rot_index == size - 1) { rot_index = 0; }
@@ -492,7 +497,7 @@ public :
             simplify_range<0>::apply(rotated, out, max_distance, impl, strategies);
 
             // Open output if needed
-            if (! is_closed && boost::size(out) > 1)
+            if (! is_closed_out && boost::size(out) > 1)
             {
                 range::pop_back(out);
             }
@@ -525,6 +530,11 @@ public :
             // Prepare next try
             visited_indexes.insert(index);
             rotated.clear();
+        }
+
+        if (BOOST_GEOMETRY_CONDITION(is_clockwise_in != is_clockwise_out))
+        {
+            std::reverse(boost::begin(out), boost::end(out));
         }
     }
 };
@@ -581,8 +591,12 @@ private:
     }
 
 public:
-    template <typename Polygon, typename Distance, typename Impl, typename Strategies>
-    static inline void apply(Polygon const& poly_in, Polygon& poly_out,
+    template
+    <
+        typename PolygonIn, typename PolygonOut,
+        typename Distance, typename Impl, typename Strategies
+    >
+    static inline void apply(PolygonIn const& poly_in, PolygonOut& poly_out,
                              Distance const& max_distance,
                              Impl const& impl, Strategies const& strategies)
     {
@@ -601,17 +615,20 @@ public:
 template<typename Policy>
 struct simplify_multi
 {
-    template <typename MultiGeometry, typename Distance, typename Impl, typename Strategies>
-    static inline void apply(MultiGeometry const& multi, MultiGeometry& out,
+    template
+    <
+        typename MultiGeometryIn, typename MultiGeometryOut,
+        typename Distance, typename Impl, typename Strategies
+    >
+    static inline void apply(MultiGeometryIn const& multi, MultiGeometryOut& out,
                              Distance const& max_distance,
                              Impl const& impl, Strategies const& strategies)
     {
         range::clear(out);
 
-        typedef typename boost::range_value<MultiGeometry>::type single_type;
+        using single_type = typename boost::range_value<MultiGeometryOut>::type;
 
-        for (typename boost::range_iterator<MultiGeometry const>::type
-                it = boost::begin(multi); it != boost::end(multi); ++it)
+        for (auto it = boost::begin(multi); it != boost::end(multi); ++it)
         {
             single_type single_out;
             Policy::apply(*it, single_out, max_distance, impl, strategies);
@@ -621,6 +638,35 @@ struct simplify_multi
             }
         }
     }
+};
+
+
+template <typename Geometry>
+struct has_same_tag_as
+{
+    template <typename OtherGeometry>
+    struct pred
+        : std::is_same
+            <
+                typename geometry::tag<Geometry>::type,
+                typename geometry::tag<OtherGeometry>::type
+            >
+    {};
+};
+
+template <typename StaticGeometryIn, typename DynamicGeometryOut>
+struct static_geometry_type
+{
+    using type = typename util::sequence_find_if
+        <
+            typename traits::geometry_types<DynamicGeometryOut>::type,
+            detail::simplify::has_same_tag_as<StaticGeometryIn>::pred
+        >::type;
+
+    BOOST_GEOMETRY_STATIC_ASSERT(
+        (! std::is_void<type>::value),
+        "Unable to find corresponding geometry in GeometryOut",
+        StaticGeometryIn, DynamicGeometryOut);
 };
 
 
@@ -634,48 +680,64 @@ namespace dispatch
 
 template
 <
-    typename Geometry,
-    typename Tag = typename tag<Geometry>::type
+    typename GeometryIn,
+    typename GeometryOut,
+    typename TagIn = typename tag<GeometryIn>::type,
+    typename TagOut = typename tag<GeometryOut>::type
 >
-struct simplify: not_implemented<Tag>
+struct simplify: not_implemented<TagIn, TagOut>
 {};
 
-template <typename Point>
-struct simplify<Point, point_tag>
+template <typename PointIn, typename PointOut>
+struct simplify<PointIn, PointOut, point_tag, point_tag>
 {
     template <typename Distance, typename Impl, typename Strategy>
-    static inline void apply(Point const& point, Point& out, Distance const& ,
+    static inline void apply(PointIn const& point, PointOut& out, Distance const& ,
                              Impl const& , Strategy const& )
     {
         geometry::convert(point, out);
     }
 };
 
-template <typename Segment>
-struct simplify<Segment, segment_tag>
+template <typename SegmentIn, typename SegmentOut>
+struct simplify<SegmentIn, SegmentOut, segment_tag, segment_tag>
     : detail::simplify::simplify_copy_assign
 {};
 
-template <typename Box>
-struct simplify<Box, box_tag>
+template <typename BoxIn, typename BoxOut>
+struct simplify<BoxIn, BoxOut, box_tag, box_tag>
     : detail::simplify::simplify_copy_assign
 {};
-
 
 // Linestring, keep 2 points (unless those points are the same)
-template <typename Linestring>
-struct simplify<Linestring, linestring_tag>
+template <typename LinestringIn, typename LinestringOut>
+struct simplify<LinestringIn, LinestringOut, linestring_tag, linestring_tag>
     : detail::simplify::simplify_range<2>
 {};
 
-template <typename Ring>
-struct simplify<Ring, ring_tag>
+template <typename RingIn, typename RingOut>
+struct simplify<RingIn, RingOut, ring_tag, ring_tag>
     : detail::simplify::simplify_ring
 {};
 
-template <typename Polygon>
-struct simplify<Polygon, polygon_tag>
+template <typename PolygonIn, typename PolygonOut>
+struct simplify<PolygonIn, PolygonOut, polygon_tag, polygon_tag>
     : detail::simplify::simplify_polygon
+{};
+
+template <typename MultiPointIn, typename MultiPointOut>
+struct simplify<MultiPointIn, MultiPointOut, multi_point_tag, multi_point_tag>
+    : detail::simplify::simplify_copy
+{};
+
+template <typename MultiLinestringIn, typename MultiLinestringOut>
+struct simplify<MultiLinestringIn, MultiLinestringOut, multi_linestring_tag, multi_linestring_tag>
+    : detail::simplify::simplify_multi<detail::simplify::simplify_range<2> >
+{};
+
+template <typename MultiPolygonIn, typename MultiPolygonOut>
+struct simplify<MultiPolygonIn, MultiPolygonOut, multi_polygon_tag, multi_polygon_tag>
+    : detail::simplify::simplify_multi<detail::simplify::simplify_polygon>
 {};
 
 
@@ -698,23 +760,6 @@ struct simplify_insert<Ring, ring_tag>
     : detail::simplify::simplify_range_insert
 {};
 
-template <typename MultiPoint>
-struct simplify<MultiPoint, multi_point_tag>
-    : detail::simplify::simplify_copy
-{};
-
-
-template <typename MultiLinestring>
-struct simplify<MultiLinestring, multi_linestring_tag>
-    : detail::simplify::simplify_multi<detail::simplify::simplify_range<2> >
-{};
-
-
-template <typename MultiPolygon>
-struct simplify<MultiPolygon, multi_polygon_tag>
-    : detail::simplify::simplify_multi<detail::simplify::simplify_polygon>
-{};
-
 
 } // namespace dispatch
 #endif // DOXYGEN_NO_DISPATCH
@@ -730,15 +775,15 @@ template
 >
 struct simplify
 {
-    template <typename Geometry, typename Distance>
-    static inline void apply(Geometry const& geometry,
-                             Geometry& out,
+    template <typename GeometryIn, typename GeometryOut, typename Distance>
+    static inline void apply(GeometryIn const& geometry,
+                             GeometryOut& out,
                              Distance const& max_distance,
                              Strategies const& strategies)
     {
         dispatch::simplify
             <
-                Geometry
+                GeometryIn, GeometryOut
             >::apply(geometry, out, max_distance,
                      detail::simplify::douglas_peucker(),
                      strategies);
@@ -748,9 +793,9 @@ struct simplify
 template <typename Strategy>
 struct simplify<Strategy, false>
 {
-    template <typename Geometry, typename Distance>
-    static inline void apply(Geometry const& geometry,
-                             Geometry& out,
+    template <typename GeometryIn, typename GeometryOut, typename Distance>
+    static inline void apply(GeometryIn const& geometry,
+                             GeometryOut& out,
                              Distance const& max_distance,
                              Strategy const& strategy)
     {
@@ -767,15 +812,23 @@ struct simplify<Strategy, false>
 template <>
 struct simplify<default_strategy, false>
 {
-    template <typename Geometry, typename Distance>
-    static inline void apply(Geometry const& geometry,
-                             Geometry& out,
+    template <typename GeometryIn, typename GeometryOut, typename Distance>
+    static inline void apply(GeometryIn const& geometry,
+                             GeometryOut& out,
                              Distance const& max_distance,
                              default_strategy)
     {
+        // NOTE: Alternatively take two geometry types in default_strategy
+        using cs_tag1_t = typename geometry::cs_tag<GeometryIn>::type;
+        using cs_tag2_t = typename geometry::cs_tag<GeometryOut>::type;
+        BOOST_GEOMETRY_STATIC_ASSERT(
+            (std::is_same<cs_tag1_t, cs_tag2_t>::value),
+            "Incompatible coordinate systems",
+            cs_tag1_t, cs_tag2_t);
+
         typedef typename strategies::simplify::services::default_strategy
             <
-                Geometry
+                GeometryIn
             >::type strategy_type;
 
         simplify
@@ -852,12 +905,17 @@ struct simplify_insert<default_strategy, false>
 
 namespace resolve_dynamic {
 
-template <typename Geometry, typename Tag = typename tag<Geometry>::type>
+template
+<
+    typename GeometryIn, typename GeometryOut,
+    typename TagIn = typename tag<GeometryIn>::type,
+    typename TagOut = typename tag<GeometryOut>::type
+>
 struct simplify
 {
     template <typename Distance, typename Strategy>
-    static inline void apply(Geometry const& geometry,
-                             Geometry& out,
+    static inline void apply(GeometryIn const& geometry,
+                             GeometryOut& out,
                              Distance const& max_distance,
                              Strategy const& strategy)
     {
@@ -865,40 +923,44 @@ struct simplify
     }
 };
 
-template <typename Geometry>
-struct simplify<Geometry, dynamic_geometry_tag>
+template <typename GeometryIn, typename GeometryOut>
+struct simplify<GeometryIn, GeometryOut, dynamic_geometry_tag, dynamic_geometry_tag>
 {
     template <typename Distance, typename Strategy>
-    static inline void apply(Geometry const& geometry,
-                             Geometry& out,
+    static inline void apply(GeometryIn const& geometry,
+                             GeometryOut& out,
                              Distance const& max_distance,
                              Strategy const& strategy)
     {
-        traits::visit<Geometry>::apply([&](auto const& g)
+        traits::visit<GeometryIn>::apply([&](auto const& g)
         {
             using geom_t = util::remove_cref_t<decltype(g)>;
-            geom_t o;
-            simplify<geom_t>::apply(g, o, max_distance, strategy);
+            using detail::simplify::static_geometry_type;            
+            using geom_out_t = typename static_geometry_type<geom_t, GeometryOut>::type;
+            geom_out_t o;
+            simplify<geom_t, geom_out_t>::apply(g, o, max_distance, strategy);
             out = std::move(o);
         }, geometry);
     }
 };
 
-template <typename Geometry>
-struct simplify<Geometry, geometry_collection_tag>
+template <typename GeometryIn, typename GeometryOut>
+struct simplify<GeometryIn, GeometryOut, geometry_collection_tag, geometry_collection_tag>
 {
     template <typename Distance, typename Strategy>
-    static inline void apply(Geometry const& geometry,
-                             Geometry& out,
+    static inline void apply(GeometryIn const& geometry,
+                             GeometryOut& out,
                              Distance const& max_distance,
                              Strategy const& strategy)
     {
         detail::visit_breadth_first([&](auto const& g)
         {
             using geom_t = util::remove_cref_t<decltype(g)>;
-            geom_t o;
-            simplify<geom_t>::apply(g, o, max_distance, strategy);
-            traits::emplace_back<Geometry>::apply(out, std::move(o));
+            using detail::simplify::static_geometry_type;            
+            using geom_out_t = typename static_geometry_type<geom_t, GeometryOut>::type;
+            geom_out_t o;
+            simplify<geom_t, geom_out_t>::apply(g, o, max_distance, strategy);
+            traits::emplace_back<GeometryOut>::apply(out, std::move(o));
             return true;
         }, geometry);
     }
@@ -911,6 +973,7 @@ struct simplify<Geometry, geometry_collection_tag>
 \brief Simplify a geometry using a specified strategy
 \ingroup simplify
 \tparam Geometry \tparam_geometry
+\tparam GeometryOut The output geometry
 \tparam Distance A numerical distance measure
 \tparam Strategy A type fulfilling a SimplifyStrategy concept
 \param strategy A strategy to calculate simplification
@@ -918,21 +981,22 @@ struct simplify<Geometry, geometry_collection_tag>
 \param out output geometry, simplified version of the input geometry
 \param max_distance distance (in units of input coordinates) of a vertex
     to other segments to be removed
-\param strategy simplify strategy to be used for simplification, might
-    include point-distance strategy
+\param strategy simplify strategy to be used for simplification
+\note The simplification is done with Douglas-Peucker algorithm
 
 \image html svg_simplify_country.png "The image below presents the simplified country"
 \qbk{distinguish,with strategy}
 */
-template<typename Geometry, typename Distance, typename Strategy>
-inline void simplify(Geometry const& geometry, Geometry& out,
+template<typename Geometry, typename GeometryOut, typename Distance, typename Strategy>
+inline void simplify(Geometry const& geometry, GeometryOut& out,
                      Distance const& max_distance, Strategy const& strategy)
 {
-    concepts::check<Geometry>();
+    concepts::check<Geometry const>();
+    concepts::check<GeometryOut>();
 
     geometry::clear(out);
 
-    resolve_dynamic::simplify<Geometry>::apply(geometry, out, max_distance, strategy);
+    resolve_dynamic::simplify<Geometry, GeometryOut>::apply(geometry, out, max_distance, strategy);
 }
 
 
@@ -942,21 +1006,22 @@ inline void simplify(Geometry const& geometry, Geometry& out,
 \brief Simplify a geometry
 \ingroup simplify
 \tparam Geometry \tparam_geometry
+\tparam GeometryOut The output geometry
 \tparam Distance \tparam_numeric
-\note This version of simplify simplifies a geometry using the default
-    strategy (Douglas Peucker),
 \param geometry input geometry, to be simplified
 \param out output geometry, simplified version of the input geometry
 \param max_distance distance (in units of input coordinates) of a vertex
     to other segments to be removed
+\note The simplification is done with Douglas-Peucker algorithm
 
 \qbk{[include reference/algorithms/simplify.qbk]}
  */
-template<typename Geometry, typename Distance>
-inline void simplify(Geometry const& geometry, Geometry& out,
+template<typename Geometry, typename GeometryOut, typename Distance>
+inline void simplify(Geometry const& geometry, GeometryOut& out,
                      Distance const& max_distance)
 {
-    concepts::check<Geometry>();
+    concepts::check<Geometry const>();
+    concepts::check<GeometryOut>();
 
     geometry::simplify(geometry, out, max_distance, default_strategy());
 }
@@ -976,8 +1041,7 @@ namespace detail { namespace simplify
 \param out output iterator, outputs all simplified points
 \param max_distance distance (in units of input coordinates) of a vertex
     to other segments to be removed
-\param strategy simplify strategy to be used for simplification,
-    might include point-distance strategy
+\param strategy simplify strategy to be used for simplification
 
 \qbk{distinguish,with strategy}
 \qbk{[include reference/algorithms/simplify.qbk]}

--- a/test/algorithms/simplify.cpp
+++ b/test/algorithms/simplify.cpp
@@ -17,11 +17,12 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #include <iterator>
-
+#include <vector>
 
 #include <algorithms/test_simplify.hpp>
 #include <boost/geometry/geometries/geometries.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
+#include <boost/geometry/geometries/register/ring.hpp>
 
 #include <test_geometries/wrapped_boost_array.hpp>
 #include <test_common/test_point.hpp>
@@ -308,6 +309,44 @@ void test_spherical()
 }
 
 
+template <typename P>
+struct ring : std::vector<P>
+{
+    ring(std::initializer_list<P> l)
+        : std::vector<P>(l)
+    {}
+};
+BOOST_GEOMETRY_REGISTER_RING_TEMPLATED(ring)
+
+void test_different_types()
+{
+    using point_t = bg::model::d2::point_xy<double>;
+    using ring_t = ::ring<point_t>;
+    using bg_ring_t = bg::model::ring<point_t>;
+    ring_t ring{{0, 0}, {10, 1}, {20, 2}, {30, 0}, {0, 0}};
+    bg_ring_t result;
+    bg::simplify(ring, result, 0.1);
+    BOOST_CHECK(boost::size(result) == 4);
+    BOOST_CHECK_CLOSE(bg::area(result), 30.0, 0.00001);
+
+    using var_t = boost::variant<point_t, ring_t>;
+    using bg_var_t = boost::variant<point_t, bg_ring_t>;
+    var_t var = ring;
+    bg_var_t result_var;
+    bg::simplify(var, result_var, 0.1);
+    BOOST_CHECK(bg::num_points(result_var) == 4);
+    BOOST_CHECK_CLOSE(bg::area(result_var), 30.0, 0.00001);
+
+    using gc_t = bg::model::geometry_collection<var_t>;
+    using bg_gc_t = bg::model::geometry_collection<bg_var_t>;
+    gc_t gc = {var};
+    bg_gc_t result_gc;
+    bg::simplify(gc, result_gc, 0.1);
+    BOOST_CHECK(bg::num_points(result_gc) == 4);
+    BOOST_CHECK_CLOSE(bg::area(result_gc), 30.0, 0.00001);
+}
+
+
 int test_main(int, char* [])
 {
     // Integer compiles, but simplify-process fails (due to distances)
@@ -319,14 +358,15 @@ int test_main(int, char* [])
 
     test_all<bg::model::d2::point_xy<float> >();
 
+#endif
+
     test_3d<bg::model::point<double, 3, bg::cs::cartesian> >();
 
     test_spherical<bg::model::point<double, 2, bg::cs::spherical_equatorial<bg::degree> > >();
 
     test_zigzag<bg::model::d2::point_xy<double> >();
 
-#endif
-
+    test_different_types();
 
     return 0;
 }

--- a/test/algorithms/simplify.cpp
+++ b/test/algorithms/simplify.cpp
@@ -310,28 +310,37 @@ void test_spherical()
 
 
 template <typename P>
-struct ring : std::vector<P>
+struct quad
 {
-    ring(std::initializer_list<P> l)
-        : std::vector<P>(l)
+    using iterator = P const*;
+    using const_iterator = P const*;
+
+    quad(P const& p0, P const& p1, P const& p2, P const& p3)
+        : m_arr{p0, p1, p2, p3, p0}
     {}
+
+    const_iterator begin() const { return m_arr; }
+    const_iterator end() const { return m_arr + 5; }
+
+private:
+    P m_arr[5];
 };
-BOOST_GEOMETRY_REGISTER_RING_TEMPLATED(ring)
+BOOST_GEOMETRY_REGISTER_RING_TEMPLATED(quad)
 
 void test_different_types()
 {
     using point_t = bg::model::d2::point_xy<double>;
-    using ring_t = ::ring<point_t>;
+    using quad_t = ::quad<point_t>;
     using bg_ring_t = bg::model::ring<point_t>;
-    ring_t ring{{0, 0}, {10, 1}, {20, 2}, {30, 0}, {0, 0}};
+    quad_t quad{{0, 0}, {10, 1}, {20, 2}, {30, 0}};
     bg_ring_t result;
-    bg::simplify(ring, result, 0.1);
+    bg::simplify(quad, result, 0.1);
     BOOST_CHECK(boost::size(result) == 4);
     BOOST_CHECK_CLOSE(bg::area(result), 30.0, 0.00001);
 
-    using var_t = boost::variant<point_t, ring_t>;
+    using var_t = boost::variant<point_t, quad_t>;
     using bg_var_t = boost::variant<point_t, bg_ring_t>;
-    var_t var = ring;
+    var_t var = quad;
     bg_var_t result_var;
     bg::simplify(var, result_var, 0.1);
     BOOST_CHECK(bg::num_points(result_var) == 4);


### PR DESCRIPTION
Requested in this comment: https://github.com/boostorg/geometry/commit/0f72af95f0ac94f94022c6e4b7831895c2291dde#commitcomment-76745077