### PR TITLE
Allow const inputs in buffer()

### DIFF
--- a/include/boost/geometry/algorithms/detail/buffer/buffered_piece_collection.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/buffered_piece_collection.hpp
@@ -694,7 +694,7 @@ struct buffered_piece_collection
             return;
         }
 
-        if (! input_ring.empty())
+        if (! boost::empty(input_ring))
         {
             // Assign the ring to the original_ring collection
             // For rescaling, it is recalculated. Without rescaling, it
@@ -705,8 +705,7 @@ struct buffered_piece_collection
             using view_type = detail::closed_clockwise_view<InputRing const>;
             view_type const view(input_ring);
 
-            for (typename boost::range_iterator<view_type const>::type it =
-                boost::begin(view); it != boost::end(view); ++it)
+            for (auto it = boost::begin(view); it != boost::end(view); ++it)
             {
                 clockwise_ring.push_back(*it);
             }

--- a/include/boost/geometry/geometries/helper_geometry.hpp
+++ b/include/boost/geometry/geometries/helper_geometry.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2015-2020, Oracle and/or its affiliates.
+// Copyright (c) 2015-2022, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -12,15 +12,19 @@
 #define BOOST_GEOMETRY_GEOMETRIES_HELPER_GEOMETRY_HPP
 
 
-#include <boost/geometry/core/cs.hpp>
+#include <boost/geometry/core/closure.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
+#include <boost/geometry/core/cs.hpp>
+#include <boost/geometry/core/point_order.hpp>
 #include <boost/geometry/core/point_type.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/geometries/box.hpp>
+#include <boost/geometry/geometries/linestring.hpp>
 #include <boost/geometry/geometries/point.hpp>
+#include <boost/geometry/geometries/ring.hpp>
 
 #include <boost/geometry/algorithms/not_implemented.hpp>
 
@@ -69,23 +73,50 @@ struct helper_geometry : not_implemented<Geometry>
 template <typename Point, typename NewCoordinateType, typename NewUnits>
 struct helper_geometry<Point, NewCoordinateType, NewUnits, point_tag>
 {
-    typedef typename detail::helper_geometries::helper_point
+    using type = typename detail::helper_geometries::helper_point
         <
             Point, NewCoordinateType, NewUnits
-        >::type type;
+        >::type;
 };
 
 
 template <typename Box, typename NewCoordinateType, typename NewUnits>
 struct helper_geometry<Box, NewCoordinateType, NewUnits, box_tag>
 {
-    typedef model::box
+    using type = model::box
         <
             typename helper_geometry
                 <
                     typename point_type<Box>::type, NewCoordinateType, NewUnits
                 >::type
-        > type;
+        >;
+};
+
+
+template <typename Linestring, typename NewCoordinateType, typename NewUnits>
+struct helper_geometry<Linestring, NewCoordinateType, NewUnits, linestring_tag>
+{
+    using type = model::linestring
+        <
+            typename helper_geometry
+                <
+                    typename point_type<Linestring>::type, NewCoordinateType, NewUnits
+                >::type
+        >;
+};
+
+template <typename Ring, typename NewCoordinateType, typename NewUnits>
+struct helper_geometry<Ring, NewCoordinateType, NewUnits, ring_tag>
+{
+    using type = model::ring
+        <
+            typename helper_geometry
+                <
+                    typename point_type<Ring>::type, NewCoordinateType, NewUnits
+                >::type,
+            point_order<Ring>::value != counterclockwise,
+            closure<Ring>::value != open
+        >;
 };
 
 
@@ -103,10 +134,10 @@ template
 >
 struct helper_geometry
 {
-    typedef typename detail_dispatch::helper_geometry
+    using type = typename detail_dispatch::helper_geometry
         <
             Geometry, NewCoordinateType, NewUnits
-        >::type type;
+        >::type;
 };
 
 


### PR DESCRIPTION
I decided to use helper geometry using the same coordinate type instead of output ring type to avoid result changes in case different coordinate type was used in the output.

This PR also fixes range emptiness check where member function of a range was called instead of `boost::empty()`.