### PR TITLE
Fix compilation of touches for geometry collections with gcc-10

### DIFF
--- a/include/boost/geometry/algorithms/detail/relate/de9im.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/de9im.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2022 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2013-2022.
 // Modifications copyright (c) 2013-2022 Oracle and/or its affiliates.
@@ -273,6 +274,11 @@ struct static_mask_touches_impl<Geometry1, Geometry2, 0, 0>
 {
     typedef geometry::detail::relate::false_mask type;
 };
+
+template <typename Geometry1, typename Geometry2>
+struct static_mask_touches_not_pp_type
+    : static_mask_touches_impl<Geometry1, Geometry2, 2, 2> // dummy dimensions
+{};
 
 template <typename Geometry1, typename Geometry2>
 struct static_mask_touches_type

--- a/include/boost/geometry/algorithms/detail/relate/implementation_gc.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/implementation_gc.hpp
@@ -1,5 +1,7 @@
 // Boost.Geometry
 
+// Copyright (c) 2022 Adam Wulkiewicz, Lodz, Poland.
+
 // Copyright (c) 2022 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -200,7 +202,6 @@ struct gc_gc
         bool disjoint_found[2][3] = {{false, false, false}, {false, false, false}};
         bool disjoint_linear_boundary_found[2] = {false, false};
         bool has_disjoint = false;
-        bool has_disjoint_linear = false;
 
         gc_group_elements(gc1_view, gc2_view, strategy,
             [&](auto const& inters_group)

--- a/test/algorithms/touches/touches_gc.cpp
+++ b/test/algorithms/touches/touches_gc.cpp
@@ -1,5 +1,7 @@
 // Boost.Geometry
 
+// Copyright (c) 2022 Adam Wulkiewicz, Lodz, Poland.
+
 // Copyright (c) 2022 Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -41,6 +43,13 @@ void test_gc()
                                                 " POLYGON((20 10,20 20,30 20,30 10,20 10)), POLYGON((10 20,10 30,20 30,20 20,10 20)))",
                               "GEOMETRYCOLLECTION(POLYGON((10 10,10 20,20 20,20 10,10 10)), LINESTRING(11 11,19 19))",
                               true);
+
+    test_geometry<gc_t, gc_t>("GEOMETRYCOLLECTION(POINT(0 0), POINT(2 2))",
+                              "GEOMETRYCOLLECTION(POINT(0 0), POINT(1 1))",
+                              false);
+    test_geometry<gc_t, gc_t>("GEOMETRYCOLLECTION(POINT(0 0))",
+                              "GEOMETRYCOLLECTION(POINT(0 0))",
+                              false);
 
     test_geometry<gc_t, gc_t>("GEOMETRYCOLLECTION(POINT(2 2))",
                               "GEOMETRYCOLLECTION(LINESTRING(0 0, 1 1), LINESTRING(1 1, 2 2))",


### PR DESCRIPTION
Avoid -1 to size_t conversion while instantiating static mask. Relate is now called with proper mask based on run-time topological dimension of GCs just like it's done with other relational operations which masks depend on dimensions of arguments.

Also fix warning in relate.