### PR TITLE
Add bin/ pattern to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Boost.Build
 stdcerr
+bin/
 
 # Visual Studio (Code)
 /.vs


### PR DESCRIPTION
This adds a pattern to the .gitignore that matches all the bin/ directories in the main directory or any of the test (or possibly example) subdirectories. They are created when building the tests ~~as instructed by the contribution tutorial~~ within a cloned copy of only BG rather than the full Boost checkout so that they are not listed as modified files by e.g. `git status` or in shell autocomplete for e.g. `git add`.

The motivation for this PR is increased convenience. I might have overlooked a reason against this change but I didn't find anything on the matter in docs/wiki/rejected PRs and couldn't think of anything.