### PR TITLE
build: Add cxx14 requirements to root Jamfile

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -2,15 +2,21 @@
 #
 # Copyright (c) 2007-2013 Barend Gehrels, Amsterdam, the Netherlands.
 # Copyright (c) 2008-2013 Bruno Lalande, Paris, France.
-# Copyright (c) 2009-2013 Mateusz Loskot, London, UK.
+# Copyright (c) 2009-2022 Mateusz Loskot, London, UK.
 #
 # Use, modification and distribution is subject to the Boost Software License,
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+import ../../config/checks/config : requires ;
+
 project boost-geometry
     :
     requirements
+        [ requires
+            cxx14_constexpr
+            cxx14_return_type_deduction
+        ]
         <toolset>msvc:<asynch-exceptions>on
     ;
 


### PR DESCRIPTION
The library requires C++14 so it should not even be tried to build with any older `cxxstd`

IOW, `b2 cxxstd=11 libs/geometry/test` will build nothing.

Related to discussion in #1012