### PR TITLE
Replace boost math special functions with std equivalents

### DIFF
--- a/include/boost/geometry/formulas/andoyer_inverse.hpp
+++ b/include/boost/geometry/formulas/andoyer_inverse.hpp
@@ -14,8 +14,6 @@
 #define BOOST_GEOMETRY_FORMULAS_ANDOYER_INVERSE_HPP
 
 
-#include <boost/math/constants/constants.hpp>
-
 #include <boost/geometry/core/radius.hpp>
 
 #include <boost/geometry/util/condition.hpp>

--- a/include/boost/geometry/formulas/area_formulas.hpp
+++ b/include/boost/geometry/formulas/area_formulas.hpp
@@ -12,12 +12,13 @@
 #ifndef BOOST_GEOMETRY_FORMULAS_AREA_FORMULAS_HPP
 #define BOOST_GEOMETRY_FORMULAS_AREA_FORMULAS_HPP
 
+#include <cmath>
+
 #include <boost/geometry/core/radian_access.hpp>
 #include <boost/geometry/formulas/flattening.hpp>
 #include <boost/geometry/formulas/mean_radius.hpp>
 #include <boost/geometry/formulas/karney_inverse.hpp>
 #include <boost/geometry/util/math.hpp>
-#include <boost/math/special_functions/hypot.hpp>
 
 namespace boost { namespace geometry { namespace formula
 {
@@ -92,7 +93,7 @@ public:
     template<typename T>
     static inline void normalize(T& x, T& y)
     {
-        T h = boost::math::hypot(x, y);
+        T h = std::hypot(x, y);
         x /= h;
         y /= h;
     }

--- a/include/boost/geometry/formulas/authalic_radius_sqr.hpp
+++ b/include/boost/geometry/formulas/authalic_radius_sqr.hpp
@@ -11,6 +11,8 @@
 #ifndef BOOST_GEOMETRY_FORMULAS_AUTHALIC_RADIUS_SQR_HPP
 #define BOOST_GEOMETRY_FORMULAS_AUTHALIC_RADIUS_SQR_HPP
 
+#include <cmath>
+
 #include <boost/geometry/core/radius.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tags.hpp>
@@ -20,8 +22,6 @@
 #include <boost/geometry/util/math.hpp>
 
 #include <boost/geometry/algorithms/not_implemented.hpp>
-
-#include <boost/math/special_functions/atanh.hpp>
 
 namespace boost { namespace geometry
 {
@@ -71,7 +71,7 @@ struct authalic_radius_sqr<ResultType, Geometry, srs_spheroid_tag>
         //return a2 / c2 + b2 * boost::math::atanh(e) / (c2 * e);
 
         ResultType const c1 = 1;
-        return (a2 / c2) * ( c1 + (c1 - e2) * boost::math::atanh(e) / e );
+        return (a2 / c2) * ( c1 + (c1 - e2) * std::atanh(e) / e );
     }
 };
 

--- a/include/boost/geometry/formulas/karney_direct.hpp
+++ b/include/boost/geometry/formulas/karney_direct.hpp
@@ -29,11 +29,11 @@
 #ifndef BOOST_GEOMETRY_FORMULAS_KARNEY_DIRECT_HPP
 #define BOOST_GEOMETRY_FORMULAS_KARNEY_DIRECT_HPP
 
+#include <cmath>
 
 #include <boost/array.hpp>
 
 #include <boost/math/constants/constants.hpp>
-#include <boost/math/special_functions/hypot.hpp>
 
 #include <boost/geometry/formulas/flattening.hpp>
 #include <boost/geometry/formulas/result_direct.hpp>
@@ -115,7 +115,7 @@ public:
 
         // Obtain alpha 0 by solving the spherical triangle.
         CT const sin_alpha0 = sin_alpha1 * cos_beta1;
-        CT const cos_alpha0 = boost::math::hypot(cos_alpha1, sin_alpha1 * sin_beta1);
+        CT const cos_alpha0 = std::hypot(cos_alpha1, sin_alpha1 * sin_beta1);
 
         CT const k2 = math::sqr(cos_alpha0) * ep2;
 
@@ -178,7 +178,7 @@ public:
         {
             // Find the latitude at the second point.
             CT const sin_beta2 = cos_alpha0 * sin_sigma2;
-            CT const cos_beta2 = boost::math::hypot(sin_alpha0, cos_alpha0 * cos_sigma2);
+            CT const cos_beta2 = std::hypot(sin_alpha0, cos_alpha0 * cos_sigma2);
 
             result.lat2 = atan2(sin_beta2, one_minus_f * cos_beta2);
 

--- a/include/boost/geometry/formulas/karney_direct.hpp
+++ b/include/boost/geometry/formulas/karney_direct.hpp
@@ -33,8 +33,6 @@
 
 #include <boost/array.hpp>
 
-#include <boost/math/constants/constants.hpp>
-
 #include <boost/geometry/formulas/flattening.hpp>
 #include <boost/geometry/formulas/result_direct.hpp>
 

--- a/include/boost/geometry/formulas/karney_inverse.hpp
+++ b/include/boost/geometry/formulas/karney_inverse.hpp
@@ -30,9 +30,9 @@
 #ifndef BOOST_GEOMETRY_FORMULAS_KARNEY_INVERSE_HPP
 #define BOOST_GEOMETRY_FORMULAS_KARNEY_INVERSE_HPP
 
+#include <cmath>
 
 #include <boost/math/constants/constants.hpp>
-#include <boost/math/special_functions/hypot.hpp>
 
 #include <boost/geometry/util/condition.hpp>
 #include <boost/geometry/util/math.hpp>
@@ -641,7 +641,7 @@ public:
             sin_beta12 + cos_beta2 * sin_beta1 * math::sqr(sin_omega12) / (c1 + cos_omega12) :
             sin_beta12a - cos_beta2 * sin_beta1 * math::sqr(sin_omega12) / (c1 - cos_omega12);
 
-        CT sin_sigma12 = boost::math::hypot(sin_alpha1, cos_alpha1);
+        CT sin_sigma12 = std::hypot(sin_alpha1, cos_alpha1);
         CT cos_sigma12 = sin_beta1 * sin_beta2 + cos_beta1 * cos_beta2 * cos_omega12;
 
         if (shortline && sin_sigma12 < etol2)
@@ -864,7 +864,7 @@ public:
 
 
         CT sin_alpha0 = sin_alpha1 * cos_beta1;
-        CT cos_alpha0 = boost::math::hypot(cos_alpha1, sin_alpha1 * sin_beta1);
+        CT cos_alpha0 = std::hypot(cos_alpha1, sin_alpha1 * sin_beta1);
 
         CT sin_omega1, cos_omega1;
         CT sin_omega2, cos_omega2;

--- a/include/boost/geometry/formulas/karney_inverse.hpp
+++ b/include/boost/geometry/formulas/karney_inverse.hpp
@@ -32,8 +32,6 @@
 
 #include <cmath>
 
-#include <boost/math/constants/constants.hpp>
-
 #include <boost/geometry/util/condition.hpp>
 #include <boost/geometry/util/math.hpp>
 #include <boost/geometry/util/precise_math.hpp>

--- a/include/boost/geometry/formulas/meridian_direct.hpp
+++ b/include/boost/geometry/formulas/meridian_direct.hpp
@@ -12,8 +12,6 @@
 #ifndef BOOST_GEOMETRY_FORMULAS_MERIDIAN_DIRECT_HPP
 #define BOOST_GEOMETRY_FORMULAS_MERIDIAN_DIRECT_HPP
 
-#include <boost/math/constants/constants.hpp>
-
 #include <boost/geometry/core/radius.hpp>
 
 #include <boost/geometry/formulas/differential_quantities.hpp>

--- a/include/boost/geometry/formulas/meridian_inverse.hpp
+++ b/include/boost/geometry/formulas/meridian_inverse.hpp
@@ -11,8 +11,6 @@
 #ifndef BOOST_GEOMETRY_FORMULAS_MERIDIAN_INVERSE_HPP
 #define BOOST_GEOMETRY_FORMULAS_MERIDIAN_INVERSE_HPP
 
-#include <boost/math/constants/constants.hpp>
-
 #include <boost/geometry/core/radius.hpp>
 
 #include <boost/geometry/util/condition.hpp>

--- a/include/boost/geometry/formulas/meridian_segment.hpp
+++ b/include/boost/geometry/formulas/meridian_segment.hpp
@@ -12,8 +12,6 @@
 #ifndef BOOST_GEOMETRY_FORMULAS_MERIDIAN_SEGMENT_HPP
 #define BOOST_GEOMETRY_FORMULAS_MERIDIAN_SEGMENT_HPP
 
-#include <boost/math/constants/constants.hpp>
-
 #include <boost/geometry/core/radius.hpp>
 
 #include <boost/geometry/util/condition.hpp>

--- a/include/boost/geometry/formulas/sjoberg_intersection.hpp
+++ b/include/boost/geometry/formulas/sjoberg_intersection.hpp
@@ -12,8 +12,6 @@
 #define BOOST_GEOMETRY_FORMULAS_SJOBERG_INTERSECTION_HPP
 
 
-#include <boost/math/constants/constants.hpp>
-
 #include <boost/geometry/core/radius.hpp>
 
 #include <boost/geometry/util/condition.hpp>

--- a/include/boost/geometry/formulas/thomas_direct.hpp
+++ b/include/boost/geometry/formulas/thomas_direct.hpp
@@ -13,8 +13,6 @@
 #define BOOST_GEOMETRY_FORMULAS_THOMAS_DIRECT_HPP
 
 
-#include <boost/math/constants/constants.hpp>
-
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/radius.hpp>
 

--- a/include/boost/geometry/formulas/thomas_inverse.hpp
+++ b/include/boost/geometry/formulas/thomas_inverse.hpp
@@ -13,8 +13,6 @@
 #define BOOST_GEOMETRY_FORMULAS_THOMAS_INVERSE_HPP
 
 
-#include <boost/math/constants/constants.hpp>
-
 #include <boost/geometry/core/radius.hpp>
 
 #include <boost/geometry/util/condition.hpp>

--- a/include/boost/geometry/formulas/vertex_longitude.hpp
+++ b/include/boost/geometry/formulas/vertex_longitude.hpp
@@ -12,12 +12,11 @@
 #ifndef BOOST_GEOMETRY_FORMULAS_MAXIMUM_LONGITUDE_HPP
 #define BOOST_GEOMETRY_FORMULAS_MAXIMUM_LONGITUDE_HPP
 
+#include <cmath>
 
 #include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/formulas/spherical.hpp>
 #include <boost/geometry/formulas/flattening.hpp>
-
-#include <boost/math/special_functions/hypot.hpp>
 
 namespace boost { namespace geometry { namespace formula
 {
@@ -58,7 +57,7 @@ class vertex_longitude_on_spheroid
     template<typename T>
     static inline void normalize(T& x, T& y)
     {
-        T h = boost::math::hypot(x, y);
+        T h = std::hypot(x, y);
         x /= h;
         y /= h;
     }

--- a/include/boost/geometry/formulas/vincenty_direct.hpp
+++ b/include/boost/geometry/formulas/vincenty_direct.hpp
@@ -15,8 +15,6 @@
 #define BOOST_GEOMETRY_FORMULAS_VINCENTY_DIRECT_HPP
 
 
-#include <boost/math/constants/constants.hpp>
-
 #include <boost/geometry/core/radius.hpp>
 
 #include <boost/geometry/util/condition.hpp>

--- a/include/boost/geometry/formulas/vincenty_inverse.hpp
+++ b/include/boost/geometry/formulas/vincenty_inverse.hpp
@@ -16,8 +16,6 @@
 #define BOOST_GEOMETRY_FORMULAS_VINCENTY_INVERSE_HPP
 
 
-#include <boost/math/constants/constants.hpp>
-
 #include <boost/geometry/core/radius.hpp>
 
 #include <boost/geometry/util/condition.hpp>

--- a/include/boost/geometry/policies/robustness/get_rescale_policy.hpp
+++ b/include/boost/geometry/policies/robustness/get_rescale_policy.hpp
@@ -19,6 +19,7 @@
 #define BOOST_GEOMETRY_POLICIES_ROBUSTNESS_GET_RESCALE_POLICY_HPP
 
 
+#include <cmath>
 #include <cstddef>
 #include <type_traits>
 
@@ -75,7 +76,7 @@ inline void scale_box_to_integer_range(Box const& box,
     num_type const half = 0.5;
     if (math::equals(diff, num_type())
         || diff >= range
-        || ! boost::math::isfinite(diff))
+        || ! std::isfinite(diff))
     {
         factor = 1;
     }

--- a/include/boost/geometry/srs/projections/impl/pj_fwd.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_fwd.hpp
@@ -45,8 +45,6 @@
 #include <boost/geometry/srs/projections/impl/adjlon.hpp>
 #include <boost/geometry/srs/projections/impl/projects.hpp>
 
-#include <boost/math/constants/constants.hpp>
-
 /* general forward projection */
 
 namespace boost { namespace geometry { namespace projections {

--- a/include/boost/geometry/srs/projections/proj/aea.hpp
+++ b/include/boost/geometry/srs/projections/proj/aea.hpp
@@ -47,9 +47,10 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_AEA_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_AEA_HPP
 
+#include <cmath>
+
 #include <boost/core/ignore_unused.hpp>
 #include <boost/geometry/util/math.hpp>
-#include <boost/math/special_functions/hypot.hpp>
 
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
@@ -141,7 +142,7 @@ namespace projections
                     static const T half_pi = detail::half_pi<T>();
 
                     T rho = 0.0;
-                    if( (rho = boost::math::hypot(xy_x, xy_y = this->m_proj_parm.rho0 - xy_y)) != 0.0 ) {
+                    if( (rho = std::hypot(xy_x, xy_y = this->m_proj_parm.rho0 - xy_y)) != 0.0 ) {
                         if (this->m_proj_parm.n < 0.) {
                             rho = -rho;
                             xy_x = -xy_x;

--- a/include/boost/geometry/srs/projections/proj/aeqd.hpp
+++ b/include/boost/geometry/srs/projections/proj/aeqd.hpp
@@ -44,7 +44,7 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_AEQD_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_AEQD_HPP
 
-
+#include <cmath>
 #include <type_traits>
 
 #include <boost/config.hpp>
@@ -61,8 +61,6 @@
 #include <boost/geometry/srs/projections/impl/projects.hpp>
 
 #include <boost/geometry/util/math.hpp>
-
-#include <boost/math/special_functions/hypot.hpp>
 
 
 namespace boost { namespace geometry
@@ -144,7 +142,7 @@ namespace projections
             {
                 T c;
 
-                if ((c = boost::math::hypot(xy_x, xy_y)) < epsilon10) {
+                if ((c = std::hypot(xy_x, xy_y)) < epsilon10) {
                     lp_lat = par.phi0;
                     lp_lon = 0.;
                         return;
@@ -251,7 +249,7 @@ namespace projections
                     
                 T cosc, c_rh, sinc;
 
-                if ((c_rh = boost::math::hypot(xy_x, xy_y)) > pi) {
+                if ((c_rh = std::hypot(xy_x, xy_y)) > pi) {
                     if (c_rh - epsilon10 > pi)
                         BOOST_THROW_EXCEPTION( projection_exception(error_tolerance_condition) );
                     c_rh = pi;

--- a/include/boost/geometry/srs/projections/proj/bipc.hpp
+++ b/include/boost/geometry/srs/projections/proj/bipc.hpp
@@ -40,6 +40,8 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_BIPC_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_BIPC_HPP
 
+#include <cmath>
+
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
@@ -47,8 +49,6 @@
 #include <boost/geometry/srs/projections/impl/projects.hpp>
 
 #include <boost/geometry/util/math.hpp>
-
-#include <boost/math/special_functions/hypot.hpp>
 
 namespace boost { namespace geometry
 {
@@ -186,7 +186,7 @@ namespace projections
                         c = C45;
                         Av = Azba;
                     }
-                    rl = rp = r = boost::math::hypot(xy_x, xy_y);
+                    rl = rp = r = std::hypot(xy_x, xy_y);
                     fAz = fabs(Az = atan2(xy_x, xy_y));
                     for (i = n_iter; i ; --i) {
                         z = 2. * atan(math::pow(r / F,T(1) / n));

--- a/include/boost/geometry/srs/projections/proj/bonne.hpp
+++ b/include/boost/geometry/srs/projections/proj/bonne.hpp
@@ -40,6 +40,8 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_BONNE_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_BONNE_HPP
 
+#include <cmath>
+
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
@@ -48,8 +50,6 @@
 #include <boost/geometry/srs/projections/impl/projects.hpp>
 
 #include <boost/geometry/util/math.hpp>
-
-#include <boost/math/special_functions/hypot.hpp>
 
 namespace boost { namespace geometry
 {
@@ -97,7 +97,7 @@ namespace projections
 
                     T s, rh;
 
-                    rh = boost::math::hypot(xy_x, xy_y = this->m_proj_parm.am1 - xy_y);
+                    rh = std::hypot(xy_x, xy_y = this->m_proj_parm.am1 - xy_y);
                     lp_lat = pj_inv_mlfn(this->m_proj_parm.am1 + this->m_proj_parm.m1 - rh, par.es, this->m_proj_parm.en);
                     if ((s = fabs(lp_lat)) < half_pi) {
                         s = sin(lp_lat);
@@ -143,7 +143,7 @@ namespace projections
 
                     T rh;
 
-                    rh = boost::math::hypot(xy_x, xy_y = this->m_proj_parm.cphi1 - xy_y);
+                    rh = std::hypot(xy_x, xy_y = this->m_proj_parm.cphi1 - xy_y);
                     lp_lat = this->m_proj_parm.cphi1 + this->m_proj_parm.phi1 - rh;
                     if (fabs(lp_lat) > half_pi) {
                         BOOST_THROW_EXCEPTION( projection_exception(error_tolerance_condition) );

--- a/include/boost/geometry/srs/projections/proj/eqdc.hpp
+++ b/include/boost/geometry/srs/projections/proj/eqdc.hpp
@@ -40,6 +40,8 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_EQDC_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_EQDC_HPP
 
+#include <cmath>
+
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
@@ -49,8 +51,6 @@
 #include <boost/geometry/srs/projections/impl/projects.hpp>
 
 #include <boost/geometry/util/math.hpp>
-
-#include <boost/math/special_functions/hypot.hpp>
 
 namespace boost { namespace geometry
 {
@@ -100,7 +100,7 @@ namespace projections
 
                     T rho = 0.0;
 
-                    if ((rho = boost::math::hypot(xy_x, xy_y = this->m_proj_parm.rho0 - xy_y)) != 0.0 ) {
+                    if ((rho = std::hypot(xy_x, xy_y = this->m_proj_parm.rho0 - xy_y)) != 0.0 ) {
                         if (this->m_proj_parm.n < 0.) {
                             rho = -rho;
                             xy_x = -xy_x;

--- a/include/boost/geometry/srs/projections/proj/etmerc.hpp
+++ b/include/boost/geometry/srs/projections/proj/etmerc.hpp
@@ -54,14 +54,14 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_ETMERC_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_ETMERC_HPP
 
+#include <cmath>
+
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
 #include <boost/geometry/srs/projections/impl/function_overloads.hpp>
 #include <boost/geometry/srs/projections/impl/pj_param.hpp>
 #include <boost/geometry/srs/projections/impl/projects.hpp>
-
-#include <boost/math/special_functions/hypot.hpp>
 
 namespace boost { namespace geometry
 {
@@ -100,7 +100,7 @@ namespace projections
             template <typename T>
             inline T asinhy(T const& x) {              /* Compute asinh(x) accurately */
                 T y = fabs(x);         /* Enforce odd parity */
-                y = log1py(y * (1 + y/(boost::math::hypot(1.0, y) + 1)));
+                y = log1py(y * (1 + y/(std::hypot(1.0, y) + 1)));
                 return x < 0 ? -y : y;
             }
 
@@ -184,7 +184,7 @@ namespace projections
                     cos_Ce = cos(Ce);
 
                     Cn     = atan2(sin_Cn, cos_Ce*cos_Cn);
-                    Ce     = atan2(sin_Ce*cos_Cn, boost::math::hypot(sin_Cn, cos_Cn*cos_Ce));
+                    Ce     = atan2(sin_Ce*cos_Cn, std::hypot(sin_Cn, cos_Cn*cos_Ce));
 
                     /* compl. sph. N, E -> ell. norm. N, E */
                     Ce  = asinhy(tan(Ce));     /* Replaces: Ce  = log(tan(fourth_pi + Ce*0.5)); */
@@ -219,7 +219,7 @@ namespace projections
                         sin_Ce = sin(Ce);
                         cos_Ce = cos(Ce);
                         Ce     = atan2(sin_Ce, cos_Ce*cos_Cn);
-                        Cn     = atan2(sin_Cn*cos_Ce, boost::math::hypot(sin_Ce, cos_Ce*cos_Cn));
+                        Cn     = atan2(sin_Cn*cos_Ce, std::hypot(sin_Ce, cos_Ce*cos_Cn));
                         /* Gaussian LAT, LNG -> ell. LAT, LNG */
                         lp_lat = gatg(this->m_proj_parm.cgb,  PROJ_ETMERC_ORDER, Cn);
                         lp_lon = Ce;

--- a/include/boost/geometry/srs/projections/proj/geos.hpp
+++ b/include/boost/geometry/srs/projections/proj/geos.hpp
@@ -46,7 +46,7 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_GEOS_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_GEOS_HPP
 
-#include <boost/math/special_functions/hypot.hpp>
+#include <cmath>
 
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
@@ -91,7 +91,7 @@ namespace projections
                 
                     /* Calculation of the three components of the vector from satellite to
                     ** position on earth surface (lon,lat).*/
-                    r = (this->m_proj_parm.radius_p) / boost::math::hypot(this->m_proj_parm.radius_p * cos (lp_lat), sin (lp_lat));
+                    r = (this->m_proj_parm.radius_p) / std::hypot(this->m_proj_parm.radius_p * cos (lp_lat), sin (lp_lat));
                     Vx = r * cos (lp_lon) * cos (lp_lat);
                     Vy = r * sin (lp_lon) * cos (lp_lat);
                     Vz = r * sin (lp_lat);
@@ -105,11 +105,11 @@ namespace projections
                     tmp = this->m_proj_parm.radius_g - Vx;
 
                     if(this->m_proj_parm.flip_axis) {
-                        xy_x = this->m_proj_parm.radius_g_1 * atan (Vy / boost::math::hypot (Vz, tmp));
+                        xy_x = this->m_proj_parm.radius_g_1 * atan (Vy / std::hypot (Vz, tmp));
                         xy_y = this->m_proj_parm.radius_g_1 * atan (Vz / tmp);
                     } else {
                         xy_x = this->m_proj_parm.radius_g_1 * atan (Vy / tmp);
-                        xy_y = this->m_proj_parm.radius_g_1 * atan (Vz / boost::math::hypot (Vy, tmp));
+                        xy_y = this->m_proj_parm.radius_g_1 * atan (Vz / std::hypot (Vy, tmp));
                     }
                 }
 
@@ -124,10 +124,10 @@ namespace projections
                         
                     if(this->m_proj_parm.flip_axis) {
                         Vz = tan (xy_y / this->m_proj_parm.radius_g_1);
-                        Vy = tan (xy_x / this->m_proj_parm.radius_g_1) * boost::math::hypot(1.0, Vz);
+                        Vy = tan (xy_x / this->m_proj_parm.radius_g_1) * std::hypot(1.0, Vz);
                     } else {
                         Vy = tan (xy_x / this->m_proj_parm.radius_g_1);
-                        Vz = tan (xy_y / this->m_proj_parm.radius_g_1) * boost::math::hypot(1.0, Vy);
+                        Vz = tan (xy_y / this->m_proj_parm.radius_g_1) * std::hypot(1.0, Vy);
                     }
 
                     /* Calculation of terms in cubic equation and determinant.*/
@@ -184,11 +184,11 @@ namespace projections
                     tmp = this->m_proj_parm.radius_g - Vx;
 
                     if(this->m_proj_parm.flip_axis) {
-                        xy_x = this->m_proj_parm.radius_g_1 * atan(Vy / boost::math::hypot(Vz, tmp));
+                        xy_x = this->m_proj_parm.radius_g_1 * atan(Vy / std::hypot(Vz, tmp));
                         xy_y = this->m_proj_parm.radius_g_1 * atan(Vz / tmp);
                     } else {
                         xy_x = this->m_proj_parm.radius_g_1 * atan(Vy / tmp);
-                        xy_y = this->m_proj_parm.radius_g_1 * atan(Vz / boost::math::hypot(Vy, tmp));
+                        xy_y = this->m_proj_parm.radius_g_1 * atan(Vz / std::hypot(Vy, tmp));
                     }
                 }
 

--- a/include/boost/geometry/srs/projections/proj/gnom.hpp
+++ b/include/boost/geometry/srs/projections/proj/gnom.hpp
@@ -40,9 +40,10 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_GNOM_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_GNOM_HPP
 
+#include <cmath>
+
 #include <boost/config.hpp>
 #include <boost/geometry/util/math.hpp>
-#include <boost/math/special_functions/hypot.hpp>
 
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
@@ -133,7 +134,7 @@ namespace projections
 
                     T  rh, cosz, sinz;
 
-                    rh = boost::math::hypot(xy_x, xy_y);
+                    rh = std::hypot(xy_x, xy_y);
                     sinz = sin(lp_lat = atan(rh));
                     cosz = sqrt(1. - sinz * sinz);
 

--- a/include/boost/geometry/srs/projections/proj/laea.hpp
+++ b/include/boost/geometry/srs/projections/proj/laea.hpp
@@ -40,9 +40,10 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_LAEA_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_LAEA_HPP
 
+#include <cmath>
+
 #include <boost/config.hpp>
 #include <boost/geometry/util/math.hpp>
-#include <boost/math/special_functions/hypot.hpp>
 
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
@@ -161,7 +162,7 @@ namespace projections
                     case obliq:
                         xy_x /= this->m_proj_parm.dd;
                         xy_y *=  this->m_proj_parm.dd;
-                        rho = boost::math::hypot(xy_x, xy_y);
+                        rho = std::hypot(xy_x, xy_y);
                         if (rho < epsilon10) {
                             lp_lon = 0.;
                             lp_lat = par.phi0;
@@ -259,7 +260,7 @@ namespace projections
 
                     T  cosz=0.0, rh, sinz=0.0;
 
-                    rh = boost::math::hypot(xy_x, xy_y);
+                    rh = std::hypot(xy_x, xy_y);
                     if ((lp_lat = rh * .5 ) > 1.) {
                         BOOST_THROW_EXCEPTION( projection_exception(error_tolerance_condition) );
                     }

--- a/include/boost/geometry/srs/projections/proj/lcc.hpp
+++ b/include/boost/geometry/srs/projections/proj/lcc.hpp
@@ -40,6 +40,8 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_LCC_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_LCC_HPP
 
+#include <cmath>
+
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
@@ -50,8 +52,6 @@
 #include <boost/geometry/srs/projections/impl/projects.hpp>
 
 #include <boost/geometry/util/math.hpp>
-
-#include <boost/math/special_functions/hypot.hpp>
 
 namespace boost { namespace geometry
 {
@@ -115,7 +115,7 @@ namespace projections
                     xy_y /= par.k0;
 
                     xy_y = this->m_proj_parm.rho0 - xy_y;
-                    rho = boost::math::hypot(xy_x, xy_y);
+                    rho = std::hypot(xy_x, xy_y);
                     if(rho != 0.0) {
                         if (this->m_proj_parm.n < 0.) {
                             rho = -rho;

--- a/include/boost/geometry/srs/projections/proj/mod_ster.hpp
+++ b/include/boost/geometry/srs/projections/proj/mod_ster.hpp
@@ -40,8 +40,9 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_MOD_STER_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_MOD_STER_HPP
 
+#include <cmath>
+
 #include <boost/geometry/util/math.hpp>
-#include <boost/math/special_functions/hypot.hpp>
 
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
@@ -125,7 +126,7 @@ namespace projections
                             break;
                     }
                     if (nn) {
-                        rh = boost::math::hypot(p.r, p.i);
+                        rh = std::hypot(p.r, p.i);
                         z = 2. * atan(.5 * rh);
                         sinz = sin(z);
                         cosz = cos(z);

--- a/include/boost/geometry/srs/projections/proj/nsper.hpp
+++ b/include/boost/geometry/srs/projections/proj/nsper.hpp
@@ -40,6 +40,8 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_NSPER_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_NSPER_HPP
 
+#include <cmath>
+
 #include <boost/config.hpp>
 
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
@@ -49,8 +51,6 @@
 #include <boost/geometry/srs/projections/impl/projects.hpp>
 
 #include <boost/geometry/util/math.hpp>
-
-#include <boost/math/special_functions/hypot.hpp>
 
 namespace boost { namespace geometry
 {
@@ -161,7 +161,7 @@ namespace projections
                         xy_x = bm * this->m_proj_parm.cg + bq * this->m_proj_parm.sg;
                         xy_y = bq * this->m_proj_parm.cg - bm * this->m_proj_parm.sg;
                     }
-                    rh = boost::math::hypot(xy_x, xy_y);
+                    rh = std::hypot(xy_x, xy_y);
                     if ((sinz = 1. - rh * rh * this->m_proj_parm.pfact) < 0.) {
                         BOOST_THROW_EXCEPTION( projection_exception(error_tolerance_condition) );
                     }

--- a/include/boost/geometry/srs/projections/proj/oea.hpp
+++ b/include/boost/geometry/srs/projections/proj/oea.hpp
@@ -40,7 +40,7 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_OEA_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_OEA_HPP
 
-#include <boost/math/special_functions/hypot.hpp>
+#include <cmath>
 
 #include <boost/geometry/srs/projections/impl/aasincos.hpp>
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
@@ -99,7 +99,7 @@ namespace projections
                     xp = 2. * sin(M);
                     yp = 2. * sin(N) * cos(M * this->m_proj_parm.two_r_m) / cos(M);
                     cAz = cos(Az = aatan2(xp, yp) - this->m_proj_parm.theta);
-                    z = 2. * aasin(0.5 * boost::math::hypot(xp, yp));
+                    z = 2. * aasin(0.5 * std::hypot(xp, yp));
                     sz = sin(z);
                     cz = cos(z);
                     lp_lat = aasin(this->m_proj_parm.sp0 * cz + this->m_proj_parm.cp0 * sz * cAz);

--- a/include/boost/geometry/srs/projections/proj/ortho.hpp
+++ b/include/boost/geometry/srs/projections/proj/ortho.hpp
@@ -40,9 +40,10 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_ORTHO_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_ORTHO_HPP
 
+#include <cmath>
+
 #include <boost/config.hpp>
 #include <boost/geometry/util/math.hpp>
-#include <boost/math/special_functions/hypot.hpp>
 
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
@@ -125,7 +126,7 @@ namespace projections
 
                     T rh, cosc, sinc;
 
-                    if ((sinc = (rh = boost::math::hypot(xy_x, xy_y))) > 1.) {
+                    if ((sinc = (rh = std::hypot(xy_x, xy_y))) > 1.) {
                         if ((sinc - 1.) > epsilon10) {
                             BOOST_THROW_EXCEPTION( projection_exception(error_tolerance_condition) );
                         }

--- a/include/boost/geometry/srs/projections/proj/sconics.hpp
+++ b/include/boost/geometry/srs/projections/proj/sconics.hpp
@@ -40,9 +40,9 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_SCONICS_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_SCONICS_HPP
 
+#include <cmath>
 
 #include <boost/geometry/util/math.hpp>
-#include <boost/math/special_functions/hypot.hpp>
 
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
@@ -134,7 +134,7 @@ namespace projections
                 {
                     T rho;
 
-                    rho = boost::math::hypot(xy_x, xy_y = this->m_proj_parm.rho_0 - xy_y);
+                    rho = std::hypot(xy_x, xy_y = this->m_proj_parm.rho_0 - xy_y);
                     if (this->m_proj_parm.n < 0.) {
                         rho = - rho;
                         xy_x = - xy_x;

--- a/include/boost/geometry/srs/projections/proj/stere.hpp
+++ b/include/boost/geometry/srs/projections/proj/stere.hpp
@@ -40,9 +40,10 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_STERE_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_STERE_HPP
 
+#include <cmath>
+
 #include <boost/config.hpp>
 #include <boost/geometry/util/math.hpp>
-#include <boost/math/special_functions/hypot.hpp>
 
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
@@ -169,7 +170,7 @@ namespace projections
                     T mf = 0;
                     int i;
 
-                    rho = boost::math::hypot(xy_x, xy_y);
+                    rho = std::hypot(xy_x, xy_y);
                     switch (this->m_proj_parm.mode) {
                     case obliq:
                     case equit:
@@ -198,7 +199,7 @@ namespace projections
                                               sin(this->m_proj_parm.phits),
                                               par.e);
                             mf = this->m_proj_parm.akm1 * tf;
-                            rho = boost::math::hypot(xy_x, xy_y + mf);
+                            rho = std::hypot(xy_x, xy_y + mf);
                         }
                         phi_l = half_pi - 2. * atan(tp = - rho / this->m_proj_parm.akm1);
                         halfpi = -half_pi;
@@ -277,7 +278,7 @@ namespace projections
                 {
                     T  c, rh, sinc, cosc;
 
-                    sinc = sin(c = 2. * atan((rh = boost::math::hypot(xy_x, xy_y)) / this->m_proj_parm.akm1));
+                    sinc = sin(c = 2. * atan((rh = std::hypot(xy_x, xy_y)) / this->m_proj_parm.akm1));
                     cosc = cos(c);
                     lp_lon = 0.;
 

--- a/include/boost/geometry/srs/projections/proj/sterea.hpp
+++ b/include/boost/geometry/srs/projections/proj/sterea.hpp
@@ -42,7 +42,7 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_STEREA_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_STEREA_HPP
 
-#include <boost/math/special_functions/hypot.hpp>
+#include <cmath>
 
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
@@ -97,7 +97,7 @@ namespace projections
 
                     xy_x /= par.k0;
                     xy_y /= par.k0;
-                    if((rho = boost::math::hypot(xy_x, xy_y)) != 0.0) {
+                    if((rho = std::hypot(xy_x, xy_y)) != 0.0) {
                         c = 2. * atan2(rho, this->m_proj_parm.R2);
                         sinc = sin(c);
                         cosc = cos(c);

--- a/include/boost/geometry/srs/projections/proj/tpeqd.hpp
+++ b/include/boost/geometry/srs/projections/proj/tpeqd.hpp
@@ -40,8 +40,9 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_TPEQD_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_TPEQD_HPP
 
+#include <cmath>
+
 #include <boost/geometry/util/math.hpp>
-#include <boost/math/special_functions/hypot.hpp>
 
 #include <boost/geometry/srs/projections/impl/aasincos.hpp>
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
@@ -96,12 +97,12 @@ namespace projections
                 {
                     T cz1, cz2, s, d, cp, sp;
 
-                    cz1 = cos(boost::math::hypot(xy_y, xy_x + this->m_proj_parm.hz0));
-                    cz2 = cos(boost::math::hypot(xy_y, xy_x - this->m_proj_parm.hz0));
+                    cz1 = cos(std::hypot(xy_y, xy_x + this->m_proj_parm.hz0));
+                    cz2 = cos(std::hypot(xy_y, xy_x - this->m_proj_parm.hz0));
                     s = cz1 + cz2;
                     d = cz1 - cz2;
                     lp_lon = - atan2(d, (s * this->m_proj_parm.thz0));
-                    lp_lat = aacos(boost::math::hypot(this->m_proj_parm.thz0 * s, d) * this->m_proj_parm.rhshz0);
+                    lp_lat = aacos(std::hypot(this->m_proj_parm.thz0 * s, d) * this->m_proj_parm.rhshz0);
                     if ( xy_y < 0. )
                         lp_lat = - lp_lat;
                     /* lam--phi now in system relative to P1--P2 base equator */

--- a/include/boost/geometry/strategies/cartesian/buffer_side_straight.hpp
+++ b/include/boost/geometry/strategies/cartesian/buffer_side_straight.hpp
@@ -7,9 +7,8 @@
 #ifndef BOOST_GEOMETRY_STRATEGIES_CARTESIAN_BUFFER_SIDE_STRAIGHT_HPP
 #define BOOST_GEOMETRY_STRATEGIES_CARTESIAN_BUFFER_SIDE_STRAIGHT_HPP
 
+#include <cmath>
 #include <cstddef>
-
-#include <boost/math/special_functions/fpclassify.hpp>
 
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/access.hpp>
@@ -82,7 +81,7 @@ public :
         // For normalization [0,1] (=dot product d.d, sqrt)
         promoted_type const length = geometry::math::sqrt(dx * dx + dy * dy);
 
-        if (! boost::math::isfinite(length))
+        if (! std::isfinite(length))
         {
             // In case of coordinates differences of e.g. 1e300, length
             // will overflow and we should not generate output

--- a/include/boost/geometry/strategies/cartesian/centroid_bashein_detmer.hpp
+++ b/include/boost/geometry/strategies/cartesian/centroid_bashein_detmer.hpp
@@ -19,9 +19,9 @@
 #define BOOST_GEOMETRY_STRATEGIES_CARTESIAN_CENTROID_BASHEIN_DETMER_HPP
 
 
+#include <cmath>
 #include <cstddef>
 
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 
 #include <boost/geometry/arithmetic/determinant.hpp>
@@ -219,7 +219,7 @@ public :
                 >::type coordinate_type;
 
             // Prevent NaN centroid coordinates
-            if (boost::math::isfinite(a3))
+            if (std::isfinite(a3))
             {
                 // NOTE: above calculation_type is checked, not the centroid coordinate_type
                 // which means that the centroid can still be filled with INF

--- a/include/boost/geometry/strategies/cartesian/centroid_weighted_length.hpp
+++ b/include/boost/geometry/strategies/cartesian/centroid_weighted_length.hpp
@@ -18,7 +18,8 @@
 #ifndef BOOST_GEOMETRY_STRATEGIES_CARTESIAN_CENTROID_WEIGHTED_LENGTH_HPP
 #define BOOST_GEOMETRY_STRATEGIES_CARTESIAN_CENTROID_WEIGHTED_LENGTH_HPP
 
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
+
 #include <boost/numeric/conversion/cast.hpp>
 
 #include <boost/geometry/arithmetic/arithmetic.hpp>
@@ -120,7 +121,7 @@ public :
 
         distance_type const zero = distance_type();
         if (! geometry::math::equals(state.length, zero)
-            && boost::math::isfinite(state.length)) // Prevent NaN centroid coordinates
+            && std::isfinite(state.length)) // Prevent NaN centroid coordinates
         {
             // NOTE: above distance_type is checked, not the centroid coordinate_type
             // which means that the centroid can still be filled with INF

--- a/include/boost/geometry/util/has_infinite_coordinate.hpp
+++ b/include/boost/geometry/util/has_infinite_coordinate.hpp
@@ -12,11 +12,11 @@
 #ifndef BOOST_GEOMETRY_UTIL_HAS_INFINITE_COORDINATE_HPP
 #define BOOST_GEOMETRY_UTIL_HAS_INFINITE_COORDINATE_HPP
 
+#include <cmath>
 #include <type_traits>
 
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/util/has_nan_coordinate.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 
 namespace boost { namespace geometry
 {
@@ -30,7 +30,7 @@ struct isinf
     template <typename T>
     static inline bool apply(T const& t)
     {
-        return boost::math::isinf(t);
+        return std::isinf(t);
     }
 };
 

--- a/include/boost/geometry/util/has_nan_coordinate.hpp
+++ b/include/boost/geometry/util/has_nan_coordinate.hpp
@@ -12,14 +12,13 @@
 #ifndef BOOST_GEOMETRY_UTIL_HAS_NAN_COORDINATE_HPP
 #define BOOST_GEOMETRY_UTIL_HAS_NAN_COORDINATE_HPP
 
+#include <cmath>
 #include <cstddef>
 #include <type_traits>
 
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
-
-#include <boost/math/special_functions/fpclassify.hpp>
 
 
 namespace boost { namespace geometry
@@ -34,7 +33,7 @@ struct isnan
     template <typename T>
     static inline bool apply(T const& t)
     {
-        return boost::math::isnan(t);
+        return std::isnan(t);
     }
 };
 

--- a/include/boost/geometry/util/has_non_finite_coordinate.hpp
+++ b/include/boost/geometry/util/has_non_finite_coordinate.hpp
@@ -12,11 +12,11 @@
 #ifndef BOOST_GEOMETRY_UTIL_HAS_NON_FINITE_COORDINATE_HPP
 #define BOOST_GEOMETRY_UTIL_HAS_NON_FINITE_COORDINATE_HPP
 
+#include <cmath>
 #include <type_traits>
 
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/util/has_nan_coordinate.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 
 namespace boost { namespace geometry
 {
@@ -30,7 +30,7 @@ struct is_not_finite
     template <typename T>
     static inline bool apply(T const& t)
     {
-        return ! boost::math::isfinite(t);
+        return ! std::isfinite(t);
     }
 };
 

--- a/include/boost/geometry/util/math.hpp
+++ b/include/boost/geometry/util/math.hpp
@@ -29,7 +29,6 @@
 #include <boost/core/ignore_unused.hpp>
 
 #include <boost/math/constants/constants.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 //#include <boost/math/special_functions/round.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 
@@ -187,7 +186,7 @@ struct equals<Type, true>
             return true;
         }
 
-        if (boost::math::isfinite(a) && boost::math::isfinite(b))
+        if (std::isfinite(a) && std::isfinite(b))
         {
             // If a is INF and b is e.g. 0, the expression below returns true
             // but the values are obviously not equal, hence the condition
@@ -302,11 +301,11 @@ struct square_root_for_fundamental_fp
         // For those platforms we need to define the macro
         // BOOST_GEOMETRY_SQRT_CHECK_FINITENESS so that the argument
         // to std::sqrt is checked appropriately before passed to std::sqrt
-        if (boost::math::isfinite(value))
+        if (std::isfinite(value))
         {
             return std::sqrt(value);
         }
-        else if (boost::math::isinf(value) && value < 0)
+        else if (std::isinf(value) && value < 0)
         {
             return -std::numeric_limits<FundamentalFP>::quiet_NaN();
         }

--- a/include/boost/geometry/util/normalize_spheroidal_coordinates.hpp
+++ b/include/boost/geometry/util/normalize_spheroidal_coordinates.hpp
@@ -14,6 +14,8 @@
 #ifndef BOOST_GEOMETRY_UTIL_NORMALIZE_SPHEROIDAL_COORDINATES_HPP
 #define BOOST_GEOMETRY_UTIL_NORMALIZE_SPHEROIDAL_COORDINATES_HPP
 
+#include <cmath>
+
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/util/math.hpp>
@@ -414,7 +416,7 @@ formulas/vertex_longitude.hpp
 template<typename ValueType>
 inline void normalize_unit_vector(ValueType& x, ValueType& y)
 {
-    ValueType h = boost::math::hypot(x, y);
+    ValueType h = std::hypot(x, y);
 
     BOOST_GEOMETRY_ASSERT(h > 0);
 


### PR DESCRIPTION
This was motivated after reading issue #1072 . The functionality of boost/math/special_functions/atanh.hpp, hypot.hpp and fpclassify.hpp seems to have become part of the STL with C++11 so the dependency on Math/Special Functions is unnecessary as far as I can see.

This also removes some unused includes of boost/math/constants/constants.hpp but not the dependency on Math/Constants for which I see no trivial replacement if high-precision constants are desired for non-built-in tyes.