### PR TITLE
Update release notes for 1.81

### DIFF
--- a/doc/release_notes.qbk
+++ b/doc/release_notes.qbk
@@ -25,8 +25,16 @@
 
 [*Solved issues]
 
+* [@https://github.com/boostorg/geometry/issues/1048 1048] Index: Fix dangling references when Indexable is returned by value by IndexableGetter
 * [@https://github.com/boostorg/geometry/issues/1076 1076] Union: in rare cases it might miss one polygon
 * [@https://github.com/boostorg/geometry/issues/1081 1081] Union: due to precision it might miss interior rings
+
+[*Bugfixes]
+
+* [@https://github.com/boostorg/geometry/issues/1063 1063] Intersection: fix a bug in intersection of simple spherical polygons
+* [@https://github.com/boostorg/geometry/issues/1064 1064] Formulas: fix a consistency issue in geodesic direct formulas
+* [@https://github.com/boostorg/geometry/issues/1088 1088] Point: Fix regression for custom point types
+* Various fixes for missing include files, warnings, C++20 compilation errors and documentation
 
 [/=================]
 [heading Boost 1.80]

--- a/extensions/meta/libraries.json
+++ b/extensions/meta/libraries.json
@@ -9,13 +9,15 @@
       "Bruno Lalande",
       "Mateusz Loskot",
       "Adam Wulkiewicz",
-      "Menelaos Karavelas"
+      "Menelaos Karavelas",
+      "Vissarion Fisikopoulos"
     ],
     "maintainers": [
       "Barend Gehrels <barend -at- xs4all.nl>",
       "Bruno Lalande <bruno.lalande -at- gmail.com>",
       "Mateusz Loskot <mateusz -at- loskot.net>",
-      "Adam Wulkiewicz <adam.wulkiewicz -at- gmail.com>"
+      "Adam Wulkiewicz <adam.wulkiewicz -at- gmail.com>",
+      "Vissarion Fisikopoulos <fisikop -at- gmail.com"
     ],
     "description":
       "The Boost.Geometry library provides geometric algorithms, primitives and spatial index.",

--- a/index/meta/libraries.json
+++ b/index/meta/libraries.json
@@ -9,13 +9,15 @@
       "Bruno Lalande",
       "Mateusz Loskot",
       "Adam Wulkiewicz",
-      "Menelaos Karavelas"
+      "Menelaos Karavelas",
+      "Vissarion Fisikopoulos"
     ],
     "maintainers": [
       "Barend Gehrels <barend -at- xs4all.nl>",
       "Bruno Lalande <bruno.lalande -at- gmail.com>",
       "Mateusz Loskot <mateusz -at- loskot.net>",
-      "Adam Wulkiewicz <adam.wulkiewicz -at- gmail.com>"
+      "Adam Wulkiewicz <adam.wulkiewicz -at- gmail.com>",
+      "Vissarion Fisikopoulos <fisikop -at- gmail.com"
     ],
     "description":
       "The Boost.Geometry library provides geometric algorithms, primitives and spatial index.",

--- a/meta/libraries.json
+++ b/meta/libraries.json
@@ -8,13 +8,15 @@
       "Bruno Lalande",
       "Mateusz Loskot",
       "Adam Wulkiewicz",
-      "Menelaos Karavelas"
+      "Menelaos Karavelas",
+      "Vissarion Fisikopoulos"
     ],
     "maintainers": [
       "Barend Gehrels <barend -at- xs4all.nl>",
       "Bruno Lalande <bruno.lalande -at- gmail.com>",
       "Mateusz Loskot <mateusz -at- loskot.net>",
-      "Adam Wulkiewicz <adam.wulkiewicz -at- gmail.com>"
+      "Adam Wulkiewicz <adam.wulkiewicz -at- gmail.com>",
+      "Vissarion Fisikopoulos <fisikop -at- gmail.com"
     ],
     "description":
       "The Boost.Geometry library provides geometric algorithms, primitives and spatial index.",


### PR DESCRIPTION
This PR tracks the progress of bugfixes to be released in 1.81. Currently including only merged PRs and waiting for https://github.com/boostorg/geometry/pulls?q=is%3Aopen+is%3Apr+milestone%3A1.81. Then this PR will be updated accordingly. 