### PR TITLE
Fix github actions

### DIFF
--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -4,6 +4,9 @@
 # Copyright (c) 2020 Mateusz Loskot <mateusz@loskot.net>
 # Copyright (c) 2020-2021 Adam Wulkiewicz, Lodz, Poland
 #
+# Copyright (c) 2022 Oracle and/or its affiliates.
+# Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
+#
 # Use, modification and distribution is subject to the Boost Software License,
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -19,7 +19,7 @@ jobs:
   ##############################################################################
   clang:
     name: ${{ matrix.b2_toolset }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false
@@ -99,7 +99,9 @@ jobs:
 
       - name: Install
         run: |
-          # Required for compilers not available in ubuntu latest
+          # Required for compilers not available in ubuntu 20.04
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
           sudo add-apt-repository "deb http://dk.archive.ubuntu.com/ubuntu/ xenial main"
           sudo add-apt-repository "deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe"
           sudo add-apt-repository "deb http://dk.archive.ubuntu.com/ubuntu/ bionic main"
@@ -136,7 +138,7 @@ jobs:
   ##############################################################################
   gcc:
     name: ${{ matrix.b2_toolset }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false
@@ -201,7 +203,7 @@ jobs:
 
       - name: Install
         run: |
-          # Required for compilers not available in ubuntu latest
+          # Required for compilers not available in ubuntu 20.04
           sudo add-apt-repository "deb http://dk.archive.ubuntu.com/ubuntu/ xenial main"
           sudo add-apt-repository "deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe"
           sudo add-apt-repository "deb http://dk.archive.ubuntu.com/ubuntu/ bionic main"

--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -72,8 +72,8 @@ jobs:
           fi
           echo "BOOST_SELF=$(basename $GITHUB_WORKSPACE)" >> $GITHUB_ENV
           echo "BOOST_ROOT=$GITHUB_WORKSPACE/boost-root" >> $GITHUB_ENV
-          echo "::set-output name=boost_self::$(basename $GITHUB_WORKSPACE)"
-          echo "::set-output name=boost_root::$GITHUB_WORKSPACE/boost-root"
+          echo "boost_self=$(basename $GITHUB_WORKSPACE)" >> $GITHUB_OUTPUT
+          echo "boost_root=$GITHUB_WORKSPACE/boost-root" >> $GITHUB_OUTPUT
 
       - name: Clone boostorg/boost
         run: |
@@ -174,8 +174,8 @@ jobs:
           fi
           echo "BOOST_SELF=$(basename $GITHUB_WORKSPACE)" >> $GITHUB_ENV
           echo "BOOST_ROOT=$GITHUB_WORKSPACE/boost-root" >> $GITHUB_ENV
-          echo "::set-output name=boost_self::$(basename $GITHUB_WORKSPACE)"
-          echo "::set-output name=boost_root::$GITHUB_WORKSPACE/boost-root"
+          echo "boost_self=$(basename $GITHUB_WORKSPACE)" >> $GITHUB_OUTPUT
+          echo "boost_root=$GITHUB_WORKSPACE/boost-root" >> $GITHUB_OUTPUT
 
       - name: Clone boostorg/boost
         run: |
@@ -252,8 +252,8 @@ jobs:
           }
           echo "BOOST_SELF=$((Get-Item $env:GITHUB_WORKSPACE).BaseName)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "BOOST_ROOT=$env:GITHUB_WORKSPACE\boost-root" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "::set-output name=boost_self::$((Get-Item $env:GITHUB_WORKSPACE).BaseName)"
-          echo "::set-output name=boost_root::$env:GITHUB_WORKSPACE\boost-root"
+          echo "boost_self=$((Get-Item $env:GITHUB_WORKSPACE).BaseName)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+          echo "boost_root=$env:GITHUB_WORKSPACE\boost-root" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
 
       - name: Clone boostorg/boost
         shell: pwsh


### PR DESCRIPTION
Github actions is failing currently. This is due to a change in ubuntu version used by the CI. It used to be 20.04 (see https://github.com/boostorg/geometry/actions/runs/3591991978/jobs/6047189522#step:1:4) but now it is 22.04.1 (see https://github.com/boostorg/geometry/actions/runs/3594906729/jobs/6179253324#step:1:4). This is expected since `ubuntu-latest` can be either 20.04 or 22.04 depending on the runner (see https://github.com/actions/runner-images#ongoing-migrations). 

This PR changes the runner from `ubuntu-latest` to `ubuntu-20.04`. If we want to switch to `22.04` we either a) have to fix issues with some old versions of compilers e.g. `clang-3.9` that cannot be installed in 22.04 (`libc6-dev : Breaks: libgcc-7-dev (< 7.5.0-6~) but 7.3.0-16ubuntu3 is to be installed`) or b) decide to stop testing with those compilers or c) use Ubuntu 20.04 for old compilers and 22.04 for new ones.

This PR also fixes [a deprecation warning for set-output CI command](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands).