### PR TITLE
[wkt] support tabs, newlines and code cleanup

### DIFF
--- a/doc/release_notes.qbk
+++ b/doc/release_notes.qbk
@@ -1,7 +1,7 @@
 [/============================================================================
   Boost.Geometry (aka GGL, Generic Geometry Library)
 
-  Copyright (c) 2009-2022 Barend Gehrels, Geodan, Amsterdam, the Netherlands.
+  Copyright (c) 2009-2023 Barend Gehrels, Geodan, Amsterdam, the Netherlands.
   Copyright (c) 2009-2017 Bruno Lalande, Paris, France.
   Copyright (c) 2009-2017 Mateusz Loskot <mateusz@loskot.net>, London, UK.
   Copyright (c) 2011-2017 Adam Wulkiewicz, Lodz, Poland.
@@ -18,6 +18,22 @@
 =============================================================================/]
 
 [section:release_notes Release Notes]
+
+[/=================]
+[heading Boost 1.82]
+[/=================]
+
+[*Major improvements]
+
+* [@https://github.com/boostorg/geometry/pull/1045 1045] Support geographic buffer for (multi)linestrings and (multi)polygons
+
+[*Solved issues]
+
+* [@https://github.com/boostorg/geometry/issues/705 705] WKT: allow tabs and new lines
+
+[*Breaking changes]
+
+* The WKT output presentation of an empty polygon is now POLYGON() to make it consistent with other geometries
 
 [/=================]
 [heading Boost 1.81]

--- a/include/boost/geometry/io/wkt/detail/prefix.hpp
+++ b/include/boost/geometry/io/wkt/detail/prefix.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2007-2022 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
@@ -56,6 +56,20 @@ struct prefix_multipolygon
 {
     static inline const char* apply() { return "MULTIPOLYGON"; }
 };
+
+struct prefix_segment
+{
+    static inline const char* apply() { return "SEGMENT"; }
+};
+struct prefix_box
+{
+    static inline const char* apply() { return "BOX"; }
+};
+struct prefix_geometrycollection
+{
+    static inline const char* apply() { return "GEOMETRYCOLLECTION"; }
+};
+
 
 }} // namespace wkt::impl
 #endif

--- a/include/boost/geometry/io/wkt/detail/wkt_multi.hpp
+++ b/include/boost/geometry/io/wkt/detail/wkt_multi.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2007-2022 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
@@ -11,46 +11,13 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef BOOST_GEOMETRY_DOMAINS_GIS_IO_WKT_DETAIL_WKT_MULTI_HPP
-#define BOOST_GEOMETRY_DOMAINS_GIS_IO_WKT_DETAIL_WKT_MULTI_HPP
+#ifndef BOOST_GEOMETRY_IO_WKT_MULTI_HPP
+#define BOOST_GEOMETRY_IO_WKT_MULTI_HPP
 
 #include <boost/geometry/core/tags.hpp>
 #include <boost/geometry/domains/gis/io/wkt/write.hpp>
 
+#include <boost/config/pragma_message.hpp>
+BOOST_PRAGMA_MESSAGE("This include file is deprecated and will be removed in the future.")
 
-namespace boost { namespace geometry
-{
-
-#ifndef DOXYGEN_NO_DETAIL
-namespace detail { namespace wkt
-{
-
-struct prefix_null
-{
-    static inline const char* apply() { return ""; }
-};
-
-struct prefix_multipoint
-{
-    static inline const char* apply() { return "MULTIPOINT"; }
-};
-
-struct prefix_multilinestring
-{
-    static inline const char* apply() { return "MULTILINESTRING"; }
-};
-
-struct prefix_multipolygon
-{
-    static inline const char* apply() { return "MULTIPOLYGON"; }
-};
-
-
-
-}} // namespace wkt::impl
-#endif
-
-
-}} // namespace boost::geometry
-
-#endif // BOOST_GEOMETRY_DOMAINS_GIS_IO_WKT_DETAIL_WKT_MULTI_HPP
+#endif // BOOST_GEOMETRY_IO_WKT_MULTI_HPP

--- a/include/boost/geometry/io/wkt/write.hpp
+++ b/include/boost/geometry/io/wkt/write.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2007-2017 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2007-2022 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2008-2017 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2017 Mateusz Loskot, London, UK.
 // Copyright (c) 2014-2017 Adam Wulkiewicz, Lodz, Poland.
@@ -88,32 +88,6 @@ struct stream_coordinate<P, Count, Count>
     {}
 };
 
-struct prefix_linestring_par
-{
-    static inline const char* apply() { return "LINESTRING("; }
-};
-
-struct prefix_ring_par_par
-{
-    // Note, double parentheses are intentional, indicating WKT ring begin/end
-    static inline const char* apply() { return "POLYGON(("; }
-};
-
-struct opening_parenthesis
-{
-    static inline const char* apply() { return "("; }
-};
-
-struct closing_parenthesis
-{
-    static inline const char* apply() { return ")"; }
-};
-
-struct double_closing_parenthesis
-{
-    static inline const char* apply() { return "))"; }
-};
-
 /*!
 \brief Stream points as \ref WKT
 */
@@ -131,14 +105,13 @@ struct wkt_point
 
 /*!
 \brief Stream ranges as WKT
-\note policy is used to stream prefix/postfix, enabling derived classes to override this
 */
 template
 <
     typename Range,
-    bool ForceClosurePossible,
     typename PrefixPolicy,
-    typename SuffixPolicy
+    bool ForceClosurePossible = false,
+    bool WriteDoubleBrackets = false
 >
 struct wkt_range
 {
@@ -146,52 +119,60 @@ struct wkt_range
     static inline void apply(std::basic_ostream<Char, Traits>& os,
                 Range const& range, bool force_closure = ForceClosurePossible)
     {
-        typedef typename boost::range_iterator<Range const>::type iterator_type;
-
-        typedef stream_coordinate
+        using stream_type = stream_coordinate
             <
                 point_type, 0, dimension<point_type>::type::value
-            > stream_type;
+            >;
 
         bool first = true;
 
         os << PrefixPolicy::apply();
+        os << "(";
 
-        // TODO: check EMPTY here
-
-        iterator_type begin = boost::begin(range);
-        iterator_type end = boost::end(range);
-        for (iterator_type it = begin; it != end; ++it)
+        if (boost::size(range) > 0)
         {
-            os << (first ? "" : ",");
-            stream_type::apply(os, *it);
-            first = false;
+            if (WriteDoubleBrackets)
+            {
+                os << "(";
+            }
+            auto begin = boost::begin(range);
+            auto end = boost::end(range);
+            for (auto it = begin; it != end; ++it)
+            {
+                os << (first ? "" : ",");
+                stream_type::apply(os, *it);
+                first = false;
+            }
+
+            // optionally, close range to ring by repeating the first point
+            if (BOOST_GEOMETRY_CONDITION(ForceClosurePossible)
+                && force_closure
+                && boost::size(range) > 1
+                && wkt_range::disjoint(*begin, *(end - 1)))
+            {
+                os << ",";
+                stream_type::apply(os, *begin);
+            }
+            if (WriteDoubleBrackets)
+            {
+                os << ")";
+            }
         }
 
-        // optionally, close range to ring by repeating the first point
-        if (BOOST_GEOMETRY_CONDITION(ForceClosurePossible)
-            && force_closure
-            && boost::size(range) > 1
-            && wkt_range::disjoint(*begin, *(end - 1)))
-        {
-            os << ",";
-            stream_type::apply(os, *begin);
-        }
-
-        os << SuffixPolicy::apply();
+        os << ")";
     }
 
 
 private:
-    typedef typename boost::range_value<Range>::type point_type;
+    using point_type = typename boost::range_value<Range>::type;
 
     static inline bool disjoint(point_type const& p1, point_type const& p2)
     {
         // TODO: pass strategy
-        typedef typename strategies::io::services::default_strategy
+        using strategy_type = typename strategies::io::services::default_strategy
             <
                 point_type
-            >::type strategy_type;
+            >::type;
 
         return detail::disjoint::disjoint_point_point(p1, p2, strategy_type());
     }
@@ -206,9 +187,8 @@ struct wkt_sequence
     : wkt_range
         <
             Range,
-            ForceClosurePossible,
-            opening_parenthesis,
-            closing_parenthesis
+            prefix_null,
+            ForceClosurePossible
         >
 {};
 
@@ -219,20 +199,29 @@ struct wkt_poly
     static inline void apply(std::basic_ostream<Char, Traits>& os,
                 Polygon const& poly, bool force_closure)
     {
-        typedef typename ring_type<Polygon const>::type ring;
+        using ring = typename ring_type<Polygon const>::type;
+
+        auto const exterior = exterior_ring(poly);
+        auto const rings = interior_rings(poly);
+
+        std::size_t point_count = boost::size(exterior);
+        for (auto it = boost::begin(rings); it != boost::end(rings); ++it)
+        {
+            point_count += boost::size(*it);
+        }
 
         os << PrefixPolicy::apply();
-        // TODO: check EMPTY here
-        os << "(";
-        wkt_sequence<ring>::apply(os, exterior_ring(poly), force_closure);
 
-        typename interior_return_type<Polygon const>::type
-            rings = interior_rings(poly);
-        for (typename detail::interior_iterator<Polygon const>::type
-                it = boost::begin(rings); it != boost::end(rings); ++it)
+        os << "(";
+        if (point_count > 0)
         {
-            os << ",";
-            wkt_sequence<ring>::apply(os, *it, force_closure);
+            wkt_sequence<ring>::apply(os, exterior, force_closure);
+
+            for (auto it = boost::begin(rings); it != boost::end(rings); ++it)
+            {
+                os << ",";
+                wkt_sequence<ring>::apply(os, *it, force_closure);
+            }
         }
         os << ")";
     }
@@ -247,13 +236,9 @@ struct wkt_multi
                 Multi const& geometry, bool force_closure)
     {
         os << PrefixPolicy::apply();
-        // TODO: check EMPTY here
         os << "(";
 
-        for (typename boost::range_iterator<Multi const>::type
-                    it = boost::begin(geometry);
-            it != boost::end(geometry);
-            ++it)
+        for (auto it = boost::begin(geometry); it != boost::end(geometry); ++it)
         {
             if (it != boost::begin(geometry))
             {
@@ -269,7 +254,7 @@ struct wkt_multi
 template <typename Box>
 struct wkt_box
 {
-    typedef typename point_type<Box>::type point_type;
+    using point_type = typename point_type<Box>::type;
 
     template <typename Char, typename Traits>
     static inline void apply(std::basic_ostream<Char, Traits>& os,
@@ -313,14 +298,14 @@ struct wkt_box
 template <typename Segment>
 struct wkt_segment
 {
-    typedef typename point_type<Segment>::type point_type;
+    using point_type = typename point_type<Segment>::type;
 
     template <typename Char, typename Traits>
     static inline void apply(std::basic_ostream<Char, Traits>& os,
                 Segment const& segment, bool)
     {
         // Convert to two points, then stream
-        typedef boost::array<point_type, 2> sequence;
+        using sequence = boost::array<point_type, 2>;
 
         sequence points;
         geometry::detail::assign_point_from_index<0>(segment, points[0]);
@@ -363,9 +348,7 @@ struct wkt<Linestring, linestring_tag>
     : detail::wkt::wkt_range
         <
             Linestring,
-            false,
-            detail::wkt::prefix_linestring_par,
-            detail::wkt::closing_parenthesis
+            detail::wkt::prefix_linestring
         >
 {};
 
@@ -395,9 +378,9 @@ struct wkt<Ring, ring_tag>
     : detail::wkt::wkt_range
         <
             Ring,
+            detail::wkt::prefix_polygon,
             true,
-            detail::wkt::prefix_ring_par_par,
-            detail::wkt::double_closing_parenthesis
+            true
         >
 {};
 

--- a/include/boost/geometry/multi/io/wkt/detail/prefix.hpp
+++ b/include/boost/geometry/multi/io/wkt/detail/prefix.hpp
@@ -14,8 +14,7 @@
 #ifndef BOOST_GEOMETRY_MULTI_IO_WKT_DETAIL_PREFIX_HPP
 #define BOOST_GEOMETRY_MULTI_IO_WKT_DETAIL_PREFIX_HPP
 
-
-#include <boost/geometry/io/wkt/detail/prefix.hpp>
-
+#include <boost/config/pragma_message.hpp>
+BOOST_PRAGMA_MESSAGE("This include file is deprecated and will be removed in the future.")
 
 #endif // BOOST_GEOMETRY_MULTI_IO_WKT_DETAIL_PREFIX_HPP

--- a/test/algorithms/for_each.cpp
+++ b/test/algorithms/for_each.cpp
@@ -87,12 +87,12 @@ void test_all()
             "POLYGON EMPTY"
 
             , 0
-            , "POLYGON(())"
-            , "POLYGON(())"
+            , "POLYGON()"
+            , "POLYGON()"
 
             , ""
             , 0
-            , "POLYGON(())"
+            , "POLYGON()"
         );
     test_geometry<bg::model::ring<P, true, false> > // open ring
         (

--- a/test/io/wkt/wkt_multi.cpp
+++ b/test/io/wkt/wkt_multi.cpp
@@ -1,7 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 // Unit Test
 
-// Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2007-2022 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 
@@ -76,6 +76,18 @@ void test_all()
     test_wkt<bg::model::multi_linestring<bg::model::linestring<P> > >("multilinestring((1 1,2 2,3 3),(4 4,5 5,6 6))", 6, 4 * sqrt(2.0));
     test_wkt<bg::model::multi_polygon<bg::model::polygon<P> > >("multipolygon(((0 0,0 2,2 2,2 0,0 0),(1 1,1 2,2 2,2 1,1 1)),((0 0,0 4,4 4,4 0,0 0)))", 15, 0, 21, 28);
 
+    // Support tabs, and new lines.
+    test_relaxed_wkt<bg::model::multi_point<P> >("multipoint((1\t2),\n(3\r4))", "multipoint((1 2),(3 4))");
+
+    // Verify empty multi geometries
+    test_relaxed_wkt<bg::model::multi_point<P> >("multipoint()", "multipoint()");
+    test_relaxed_wkt<bg::model::multi_linestring<bg::model::linestring<P> >>("multilinestring()", "multilinestring()");
+    test_relaxed_wkt<bg::model::multi_polygon<bg::model::polygon<P> > >("multipolygon()", "multipolygon()");
+
+    test_relaxed_wkt<bg::model::multi_point<P> >("multipoint empty", "multipoint()");
+    test_relaxed_wkt<bg::model::multi_linestring<bg::model::linestring<P> >>("multilinestring empty", "multilinestring()");
+    test_relaxed_wkt<bg::model::multi_polygon<bg::model::polygon<P> > >("multipolygon empty", "multipolygon()");
+
     // Support for the official alternative syntax for multipoint
     // (provided by Aleksey Tulinov):
     test_relaxed_wkt<bg::model::multi_point<P> >("multipoint(1 2,3 4)", "multipoint((1 2),(3 4))");
@@ -103,24 +115,3 @@ void test_all()
 
     test_order_closure<T>();
 }
-
-/*
-
-... see comments in "wkt.cpp"
-
-union select 13,'# mpoint',npoints(geomfromtext('MULTIPOINT((1 2),(3 4))'))
-union select 14,'length mpoint',length(geomfromtext('MULTIPOINT((1 2),(3 4))'))
-union select 15,'peri mpoint',perimeter(geomfromtext('MULTIPOINT((1 2),(3 4))'))
-union select 16,'area mpoint',area(geomfromtext('MULTIPOINT((1 2),(3 4))'))
-
-union select 17,'# mls',npoints(geomfromtext('MULTILINESTRING((1 1,2 2,3 3),(4 4,5 5,6 6))'))
-union select 18,'length mls',length(geomfromtext('MULTILINESTRING((1 1,2 2,3 3),(4 4,5 5,6 6))'))
-union select 19,'peri mls',perimeter(geomfromtext('MULTILINESTRING((1 1,2 2,3 3),(4 4,5 5,6 6))'))
-union select 20,'area mls',area(geomfromtext('MULTILINESTRING((1 1,2 2,3 3),(4 4,5 5,6 6))'))
-
-union select 21,'# mpoly',npoints(geomfromtext('MULTIPOLYGON(((0 0,0 2,2 2,2 0,0 0),(1 1,1 2,2 2,2 1,1 1)),((0 0,0 4,4 4,4 0,0 0)))'))
-union select 22,'length mpoly',length(geomfromtext('MULTIPOLYGON(((0 0,0 2,2 2,2 0,0 0),(1 1,1 2,2 2,2 1,1 1)),((0 0,0 4,4 4,4 0,0 0)))'))
-union select 23,'peri mpoly',perimeter(geomfromtext('MULTIPOLYGON(((0 0,0 2,2 2,2 0,0 0),(1 1,1 2,2 2,2 1,1 1)),((0 0,0 4,4 4,4 0,0 0)))'))
-union select 24,'area mpoly',area(geomfromtext('MULTIPOLYGON(((0 0,0 2,2 2,2 0,0 0),(1 1,1 2,2 2,2 1,1 1)),((0 0,0 4,4 4,4 0,0 0)))'))
-
-*/


### PR DESCRIPTION
This PR does the following:
- it supports tabs and newlines in WKT (see #705, that is how I noticed it - but i/o warning we better just support it)
- there were some todo's about EMPTY, they are now checked
- doing that, the inconsistency of writing empty polygons (`(())` vs `()`) is removed
- fixing that, it removes the need of specific prefixes with opening brackets
- fixing that, the existing prefixes are now used throughout such that for example `"POINT"` is defined only once
- fixing that, I noticed a copy of the prefixes in an old unused headerfile, the multi headerfiles are now marked as deprecated

It's a small breaking change because an empty polygon is now streamed as `POLYGON()` but I think that will be no problem.