### PR TITLE
Drop dependencies, replace boost with std, remove includes

### DIFF
--- a/include/boost/geometry/algorithms/detail/buffer/piece_border.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/piece_border.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2020-2021 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2020-2022.
 // Modifications copyright (c) 2020-2022, Oracle and/or its affiliates.
@@ -14,7 +15,8 @@
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_BUFFER_PIECE_BORDER_HPP
 
 
-#include <boost/array.hpp>
+#include <array>
+
 #include <boost/core/addressof.hpp>
 
 #include <boost/geometry/core/assert.hpp>
@@ -115,7 +117,7 @@ struct piece_border
     // Points from the original (one or two, depending on piece shape)
     // Note, if there are 2 points, they are REVERSED w.r.t. the original
     // Therefore here we can walk in its order.
-    boost::array<Point, 2> m_originals;
+    std::array<Point, 2> m_originals;
     std::size_t m_original_size;
 
     geometry::model::box<Point> m_envelope;

--- a/include/boost/geometry/algorithms/detail/overlay/copy_segment_point.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/copy_segment_point.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2020-2021.
 // Modifications copyright (c) 2020-2021, Oracle and/or its affiliates.
@@ -14,7 +15,8 @@
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_COPY_SEGMENT_POINT_HPP
 
 
-#include <boost/array.hpp>
+#include <array>
+
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 #include <boost/range/size.hpp>
@@ -113,7 +115,7 @@ struct copy_segment_point_box
             SegmentIdentifier const& seg_id, signed_size_type offset,
             PointOut& point)
     {
-        boost::array<typename point_type<Box>::type, 4> bp;
+        std::array<typename point_type<Box>::type, 4> bp;
         assign_box_corners_oriented<Reverse>(box, bp);
 
         signed_size_type const target = circular_offset(4, seg_id.segment_index, offset);

--- a/include/boost/geometry/algorithms/detail/overlay/copy_segments.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/copy_segments.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2007-2014 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2014-2021.
 // Modifications copyright (c) 2014-2021 Oracle and/or its affiliates.
@@ -15,10 +16,10 @@
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_COPY_SEGMENTS_HPP
 
 
+#include <array>
 #include <type_traits>
 #include <vector>
 
-#include <boost/array.hpp>
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 #include <boost/range/size.hpp>
@@ -238,7 +239,7 @@ struct copy_segments_box
             : 5 - index + to_index + 1;
 
         // Create array of points, the fifth one closes it
-        boost::array<typename point_type<Box>::type, 5> bp;
+        std::array<typename point_type<Box>::type, 5> bp;
         assign_box_corners_oriented<Reverse>(box, bp);
         bp[4] = bp[0];
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
@@ -1,11 +1,10 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
-// Copyright (c) 2014-2017 Adam Wulkiewicz, Lodz, Poland.
+// Copyright (c) 2014-2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2014-2021.
 // Modifications copyright (c) 2014-2021 Oracle and/or its affiliates.
-
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -16,10 +15,10 @@
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_TURNS_HPP
 
 
+#include <array>
 #include <cstddef>
 #include <map>
 
-#include <boost/array.hpp>
 #include <boost/concept_check.hpp>
 #include <boost/core/ignore_unused.hpp>
 #include <boost/range/begin.hpp>
@@ -570,7 +569,7 @@ struct get_turns_cs
 {
     typedef typename geometry::point_type<Range>::type range_point_type;
     typedef typename geometry::point_type<Box>::type box_point_type;
-    typedef boost::array<box_point_type, 4> box_array;
+    typedef std::array<box_point_type, 4> box_array;
 
     using view_type = detail::closed_clockwise_view
         <

--- a/include/boost/geometry/algorithms/detail/overlay/turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/turn_info.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -10,7 +11,7 @@
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_TURN_INFO_HPP
 
 
-#include <boost/array.hpp>
+#include <array>
 
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/algorithms/detail/signed_size_type.hpp>
@@ -80,7 +81,7 @@ template
     typename Point,
     typename SegmentRatio = geometry::segment_ratio<typename coordinate_type<Point>::type>,
     typename Operation = turn_operation<Point, SegmentRatio>,
-    typename Container = boost::array<Operation, 2>
+    typename Container = std::array<Operation, 2>
 >
 struct turn_info
 {

--- a/include/boost/geometry/algorithms/detail/relate/result.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/result.hpp
@@ -1,11 +1,10 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
-// Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
+// Copyright (c) 2017-2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2013-2022.
 // Modifications copyright (c) 2013-2022 Oracle and/or its affiliates.
-
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -19,10 +18,10 @@
 #include <cstddef>
 #include <cstring>
 #include <string>
+#include <tuple>
 #include <type_traits>
 
 #include <boost/throw_exception.hpp>
-#include <boost/tuple/tuple.hpp>
 
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>

--- a/include/boost/geometry/arithmetic/arithmetic.hpp
+++ b/include/boost/geometry/arithmetic/arithmetic.hpp
@@ -3,6 +3,7 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2008-2012 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2021.
 // Modifications copyright (c) 2021 Oracle and/or its affiliates.
@@ -20,7 +21,6 @@
 
 #include <functional>
 
-#include <boost/call_traits.hpp>
 #include <boost/concept/requires.hpp>
 
 #include <boost/geometry/core/coordinate_type.hpp>
@@ -32,24 +32,6 @@
 namespace boost { namespace geometry
 {
 
-#ifndef DOXYGEN_NO_DETAIL
-namespace detail
-{
-
-
-template <typename Point>
-struct param
-{
-    typedef typename boost::call_traits
-        <
-            typename coordinate_type<Point>::type
-        >::param_type type;
-};
-
-
-} // namespace detail
-#endif // DOXYGEN_NO_DETAIL
-
 /*!
     \brief Adds the same value to each coordinate of a point
     \ingroup arithmetic
@@ -59,7 +41,7 @@ struct param
     \param value value to add
  */
 template <typename Point>
-inline void add_value(Point& p, typename detail::param<Point>::type value)
+inline void add_value(Point& p, typename coordinate_type<Point>::type const& value)
 {
     BOOST_CONCEPT_ASSERT( (concepts::Point<Point>) );
 
@@ -101,7 +83,7 @@ inline void add_point(Point1& p1, Point2 const& p2)
     \param value value to subtract
  */
 template <typename Point>
-inline void subtract_value(Point& p, typename detail::param<Point>::type value)
+inline void subtract_value(Point& p, typename coordinate_type<Point>::type const& value)
 {
     BOOST_CONCEPT_ASSERT( (concepts::Point<Point>) );
 
@@ -143,7 +125,7 @@ inline void subtract_point(Point1& p1, Point2 const& p2)
     \param value value to multiply by
  */
 template <typename Point>
-inline void multiply_value(Point& p, typename detail::param<Point>::type value)
+inline void multiply_value(Point& p, typename coordinate_type<Point>::type const& value)
 {
     BOOST_CONCEPT_ASSERT( (concepts::Point<Point>) );
 
@@ -186,7 +168,7 @@ inline void multiply_point(Point1& p1, Point2 const& p2)
     \param value value to divide by
  */
 template <typename Point>
-inline void divide_value(Point& p, typename detail::param<Point>::type value)
+inline void divide_value(Point& p, typename coordinate_type<Point>::type const& value)
 {
     BOOST_CONCEPT_ASSERT( (concepts::Point<Point>) );
 
@@ -228,7 +210,7 @@ inline void divide_point(Point1& p1, Point2 const& p2)
     \param value value to assign
  */
 template <typename Point>
-inline void assign_value(Point& p, typename detail::param<Point>::type value)
+inline void assign_value(Point& p, typename coordinate_type<Point>::type const& value)
 {
     BOOST_CONCEPT_ASSERT( (concepts::Point<Point>) );
 

--- a/include/boost/geometry/extensions/gis/io/shapelib/shp_create_object.hpp
+++ b/include/boost/geometry/extensions/gis/io/shapelib/shp_create_object.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2020.
 // Modifications copyright (c) 2020 Oracle and/or its affiliates.
@@ -14,10 +15,11 @@
 #define BOOST_GEOMETRY_EXT_GIS_IO_SHAPELIB_SHP_CREATE_OBJECT_HPP
 
 
+#include <memory>
+
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 #include <boost/range/size.hpp>
-#include <boost/scoped_array.hpp>
 
 #include <boost/geometry/core/exterior_ring.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
@@ -83,8 +85,8 @@ struct shape_create_range
     {
         int const n = boost::size(range);
 
-        boost::scoped_array<double> x(new double[n]);
-        boost::scoped_array<double> y(new double[n]);
+        std::unique_ptr<double[]> x(new double[n]);
+        std::unique_ptr<double[]> y(new double[n]);
 
         range_to_part(range, x.get(), y.get());
 
@@ -126,9 +128,9 @@ struct shape_create_polygon
         int const n = geometry::num_points(polygon);
         int const ring_count = 1 + geometry::num_interior_rings(polygon);
 
-        boost::scoped_array<double> x(new double[n]);
-        boost::scoped_array<double> y(new double[n]);
-        boost::scoped_array<int> parts(new int[ring_count]);
+        std::unique_ptr<double[]> x(new double[n]);
+        std::unique_ptr<double[]> y(new double[n]);
+        std::unique_ptr<int[]> parts(new int[ring_count]);
 
         int ring = 0;
         int offset = 0;

--- a/include/boost/geometry/extensions/gis/io/shapelib/shp_create_object_multi.hpp
+++ b/include/boost/geometry/extensions/gis/io/shapelib/shp_create_object_multi.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2020.
 // Modifications copyright (c) 2020 Oracle and/or its affiliates.
@@ -14,11 +15,11 @@
 #define BOOST_GEOMETRY_EXT_GIS_IO_SHAPELIB_SHP_CREATE_OBJECT_MULTI_HPP
 
 
+#include <memory>
+
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 #include <boost/range/size.hpp>
-
-#include <boost/scoped_array.hpp>
 
 #include <boost/geometry/core/tags.hpp>
 #include <boost/geometry/core/point_type.hpp>
@@ -43,8 +44,8 @@ struct shape_create_multi_point
     static inline SHPObject* apply(MultiPoint const& multi)
     {
         int const n = boost::size(multi);
-        boost::scoped_array<double> x(new double[n]);
-        boost::scoped_array<double> y(new double[n]);
+        std::unique_ptr<double[]> x(new double[n]);
+        std::unique_ptr<double[]> y(new double[n]);
 
         range_to_part(multi, x.get(), y.get());
 
@@ -64,9 +65,9 @@ struct shape_create_multi_linestring
         int const n = geometry::num_points(multi);
         int const part_count = boost::size(multi);
 
-        boost::scoped_array<double> x(new double[n]);
-        boost::scoped_array<double> y(new double[n]);
-        boost::scoped_array<int> parts(new int[part_count]);
+        std::unique_ptr<double[]> x(new double[n]);
+        std::unique_ptr<double[]> y(new double[n]);
+        std::unique_ptr<int[]> parts(new int[part_count]);
 
         int ring = 0;
         int offset = 0;
@@ -94,9 +95,9 @@ struct shape_create_multi_polygon
         int const n = geometry::num_points(multi);
         int const ring_count = boost::size(multi) + geometry::num_interior_rings(multi);
 
-        boost::scoped_array<double> x(new double[n]);
-        boost::scoped_array<double> y(new double[n]);
-        boost::scoped_array<int> parts(new int[ring_count]);
+        std::unique_ptr<double[]> x(new double[n]);
+        std::unique_ptr<double[]> y(new double[n]);
+        std::unique_ptr<int[]> parts(new int[ring_count]);
 
         int ring = 0;
         int offset = 0;

--- a/include/boost/geometry/extensions/gis/io/shapelib/shp_read_object.hpp
+++ b/include/boost/geometry/extensions/gis/io/shapelib/shp_read_object.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2020.
 // Modifications copyright (c) 2020 Oracle and/or its affiliates.
@@ -14,13 +15,11 @@
 #define BOOST_GEOMETRY_EXT_GIS_IO_SHAPELIB_SHP_READ_OBJECT_HPP
 
 
-#include <boost/scoped_array.hpp>
-
+#include <boost/geometry/algorithms/num_points.hpp>
 #include <boost/geometry/core/exterior_ring.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
 #include <boost/geometry/core/ring_type.hpp>
 #include <boost/geometry/core/static_assert.hpp>
-#include <boost/geometry/algorithms/num_points.hpp>
 
 
 // Should be somewhere in your include path

--- a/include/boost/geometry/extensions/index/rtree/rtree.hpp
+++ b/include/boost/geometry/extensions/index/rtree/rtree.hpp
@@ -3,6 +3,7 @@
 // Boost.SpatialIndex - rtree implementation
 //
 // Copyright 2008 Federico J. Fernandez.
+// Copyright 2023 Adam Wulkiewicz.
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -12,13 +13,13 @@
 
 #include <cstddef>
 #include <iostream> // TODO: Remove if print() is removed
+#include <memory>
 #include <stdexcept>
 #include <utility>
 #include <vector>
 
 #include <boost/concept_check.hpp>
 #include <boost/core/ignore_unused.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include <boost/geometry/algorithms/area.hpp>
 
@@ -33,8 +34,8 @@ class rtree
 {
 public:
 
-    typedef boost::shared_ptr<rtree_node<Box, Value> > node_pointer;
-    typedef boost::shared_ptr<rtree_leaf<Box, Value> > leaf_pointer;
+    typedef std::shared_ptr<rtree_node<Box, Value> > node_pointer;
+    typedef std::shared_ptr<rtree_leaf<Box, Value> > leaf_pointer;
 
     /**
      * \brief Creates a rtree with 'maximum' elements per node and 'minimum'.

--- a/include/boost/geometry/extensions/index/rtree/rtree_leaf.hpp
+++ b/include/boost/geometry/extensions/index/rtree/rtree_leaf.hpp
@@ -3,6 +3,7 @@
 // Boost.SpatialIndex - rtree leaf implementation
 //
 // Copyright 2008 Federico J. Fernandez.
+// Copyright 2023 Adam Wulkiewicz.
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -12,11 +13,10 @@
 
 #include <deque>
 #include <iostream> // TODO: Remove if print() is removed
+#include <memory>
 #include <stdexcept>
 #include <utility>
 #include <vector>
-
-#include <boost/shared_ptr.hpp>
 
 #include <boost/geometry/algorithms/area.hpp>
 #include <boost/geometry/algorithms/assign.hpp>
@@ -33,7 +33,7 @@ class rtree_leaf : public rtree_node<Box, Value>
 public:
 
     /// container type for the leaves
-    typedef boost::shared_ptr<rtree_node<Box, Value> > node_pointer;
+    typedef std::shared_ptr<rtree_node<Box, Value> > node_pointer;
     typedef std::vector<std::pair<Box, Value> > leaf_map;
 
     /**

--- a/include/boost/geometry/extensions/index/rtree/rtree_node.hpp
+++ b/include/boost/geometry/extensions/index/rtree/rtree_node.hpp
@@ -3,6 +3,7 @@
 // Boost.SpatialIndex - rtree node implementation
 //
 // Copyright 2008 Federico J. Fernandez.
+// Copyright 2023 Adam Wulkiewicz.
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -12,11 +13,10 @@
 
 #include <deque>
 #include <iostream> // TODO: Remove if print() is removed
+#include <memory>
 #include <stdexcept>
 #include <utility>
 #include <vector>
-
-#include <boost/shared_ptr.hpp>
 
 #include <boost/geometry/algorithms/area.hpp>
 #include <boost/geometry/algorithms/assign.hpp>
@@ -37,8 +37,8 @@ class rtree_node
 {
 public:
 
-    typedef boost::shared_ptr<rtree_node<Box, Value> > node_pointer;
-    typedef boost::shared_ptr<rtree_leaf<Box, Value> > leaf_pointer;
+    typedef std::shared_ptr<rtree_node<Box, Value> > node_pointer;
+    typedef std::shared_ptr<rtree_leaf<Box, Value> > leaf_pointer;
 
     /// type for the node map
     typedef std::vector<std::pair<Box, node_pointer > > node_map;

--- a/include/boost/geometry/formulas/karney_direct.hpp
+++ b/include/boost/geometry/formulas/karney_direct.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry
 
 // Copyright (c) 2018 Adeel Ahmad, Islamabad, Pakistan.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // Contributed and/or modified by Adeel Ahmad,
 //   as part of Google Summer of Code 2018 program.
@@ -30,8 +31,6 @@
 #ifndef BOOST_GEOMETRY_FORMULAS_KARNEY_DIRECT_HPP
 #define BOOST_GEOMETRY_FORMULAS_KARNEY_DIRECT_HPP
 
-
-#include <boost/array.hpp>
 
 #include <boost/math/constants/constants.hpp>
 #include <boost/math/special_functions/hypot.hpp>

--- a/include/boost/geometry/index/detail/rtree/query_iterators.hpp
+++ b/include/boost/geometry/index/detail/rtree/query_iterators.hpp
@@ -2,7 +2,7 @@
 //
 // R-tree query iterators
 //
-// Copyright (c) 2011-2015 Adam Wulkiewicz, Lodz, Poland.
+// Copyright (c) 2011-2023 Adam Wulkiewicz, Lodz, Poland.
 //
 // This file was modified by Oracle on 2019-2021.
 // Modifications copyright (c) 2019-2021 Oracle and/or its affiliates.
@@ -15,7 +15,7 @@
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_RTREE_QUERY_ITERATORS_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_RTREE_QUERY_ITERATORS_HPP
 
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 
 #include <boost/geometry/index/detail/rtree/node/node_elements.hpp>
 #include <boost/geometry/index/detail/rtree/visitors/distance_query.hpp>
@@ -261,7 +261,7 @@ template <typename Value, typename Allocators>
 class query_iterator
 {
     typedef query_iterator_base<Value, Allocators> iterator_base;
-    typedef boost::scoped_ptr<iterator_base> iterator_ptr;
+    typedef std::unique_ptr<iterator_base> iterator_ptr;
 
 public:
     typedef std::forward_iterator_tag iterator_category;

--- a/include/boost/geometry/io/svg/svg_mapper.hpp
+++ b/include/boost/geometry/io/svg/svg_mapper.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2009-2015 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2015-2021.
 // Modifications copyright (c) 2015-2020, Oracle and/or its affiliates.
@@ -18,6 +19,7 @@
 #define BOOST_GEOMETRY_IO_SVG_MAPPER_HPP
 
 #include <cstdio>
+#include <memory>
 #include <type_traits>
 #include <vector>
 
@@ -25,7 +27,6 @@
 #include <boost/algorithm/string/split.hpp>
 #include <boost/config.hpp>
 #include <boost/noncopyable.hpp>
-#include <boost/scoped_ptr.hpp>
 
 #include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tags.hpp>
@@ -290,7 +291,7 @@ class svg_mapper : boost::noncopyable
         > transformer_type;
 
     model::box<Point> m_bounding_box;
-    boost::scoped_ptr<transformer_type> m_matrix;
+    std::unique_ptr<transformer_type> m_matrix;
     std::ostream& m_stream;
 
     SvgCoordinateType const m_width;

--- a/include/boost/geometry/io/wkt/read.hpp
+++ b/include/boost/geometry/io/wkt/read.hpp
@@ -3,12 +3,11 @@
 // Copyright (c) 2007-2022 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
-// Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
+// Copyright (c) 2017-2023 Adam Wulkiewicz, Lodz, Poland.
 // Copyright (c) 2020 Baidyanath Kundu, Haldia, India
 
 // This file was modified by Oracle on 2014-2021.
 // Modifications copyright (c) 2014-2021 Oracle and/or its affiliates.
-
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
@@ -24,14 +23,13 @@
 #include <cstddef>
 #include <string>
 
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/tokenizer.hpp>
-
-#include <boost/algorithm/string.hpp>
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 #include <boost/range/size.hpp>
 #include <boost/range/value_type.hpp>
+#include <boost/tokenizer.hpp>
 #include <boost/throw_exception.hpp>
 
 #include <boost/geometry/algorithms/assign.hpp>

--- a/include/boost/geometry/io/wkt/write.hpp
+++ b/include/boost/geometry/io/wkt/write.hpp
@@ -3,12 +3,11 @@
 // Copyright (c) 2007-2022 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2008-2017 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2017 Mateusz Loskot, London, UK.
-// Copyright (c) 2014-2017 Adam Wulkiewicz, Lodz, Poland.
+// Copyright (c) 2014-2023 Adam Wulkiewicz, Lodz, Poland.
 // Copyright (c) 2020 Baidyanath Kundu, Haldia, India.
 
 // This file was modified by Oracle on 2015-2021.
 // Modifications copyright (c) 2015-2021, Oracle and/or its affiliates.
-
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -22,10 +21,10 @@
 #ifndef BOOST_GEOMETRY_IO_WKT_WRITE_HPP
 #define BOOST_GEOMETRY_IO_WKT_WRITE_HPP
 
+#include <array>
 #include <ostream>
 #include <string>
 
-#include <boost/array.hpp>
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 #include <boost/range/size.hpp>
@@ -305,7 +304,7 @@ struct wkt_segment
                 Segment const& segment, bool)
     {
         // Convert to two points, then stream
-        using sequence = boost::array<point_type, 2>;
+        using sequence = std::array<point_type, 2>;
 
         sequence points;
         geometry::detail::assign_point_from_index<0>(segment, points[0]);

--- a/include/boost/geometry/srs/projection.hpp
+++ b/include/boost/geometry/srs/projection.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2008-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2017-2020.
 // Modifications copyright (c) 2017-2020, Oracle and/or its affiliates.
@@ -14,10 +15,10 @@
 #define BOOST_GEOMETRY_SRS_PROJECTION_HPP
 
 
+#include <memory>
 #include <string>
 #include <type_traits>
 
-#include <boost/smart_ptr/shared_ptr.hpp>
 #include <boost/throw_exception.hpp>
 
 #include <boost/geometry/algorithms/convert.hpp>
@@ -378,7 +379,7 @@ private:
         return result;
     }
 
-    boost::shared_ptr<vprj_t> m_ptr;
+    std::shared_ptr<vprj_t> m_ptr;
 };
 
 template <typename StaticParameters, typename CT>

--- a/include/boost/geometry/srs/projections/dpar.hpp
+++ b/include/boost/geometry/srs/projections/dpar.hpp
@@ -1,5 +1,7 @@
 // Boost.Geometry
 
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
+
 // Copyright (c) 2017-2022, Oracle and/or its affiliates.
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -31,7 +33,6 @@
 #include <boost/range/end.hpp>
 #include <boost/range/size.hpp>
 #include <boost/range/value_type.hpp>
-#include <boost/tuple/tuple.hpp>
 #include <boost/variant/variant.hpp>
 
 

--- a/include/boost/geometry/srs/projections/factory.hpp
+++ b/include/boost/geometry/srs/projections/factory.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2008-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2017-2022.
 // Modifications copyright (c) 2017-2022, Oracle and/or its affiliates.
@@ -15,9 +16,8 @@
 #define BOOST_GEOMETRY_PROJECTIONS_FACTORY_HPP
 
 #include <map>
+#include <memory>
 #include <string>
-
-#include <boost/shared_ptr.hpp>
 
 #include <boost/geometry/core/static_assert.hpp>
 
@@ -182,7 +182,7 @@ private:
 
     typedef factory_key<Params> key;
     typedef typename key::type key_type;
-    typedef boost::shared_ptr<entry_base> entry_ptr;
+    typedef std::shared_ptr<entry_base> entry_ptr;
 
     typedef std::map<key_type, entry_ptr> entries_map;
 

--- a/include/boost/geometry/srs/projections/impl/dms_parser.hpp
+++ b/include/boost/geometry/srs/projections/impl/dms_parser.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2017, 2018.
 // Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
@@ -39,9 +40,10 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+#include <algorithm>
 #include <string>
+#include <ostream>
 
-#include <boost/algorithm/string.hpp>
 #include <boost/static_assert.hpp>
 
 #include <boost/geometry/core/config.hpp>

--- a/include/boost/geometry/srs/projections/impl/pj_datum_set.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_datum_set.hpp
@@ -2,6 +2,7 @@
 // This file is manually converted from PROJ4
 
 // Copyright (c) 2008-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2017-2020.
 // Modifications copyright (c) 2017-2020, Oracle and/or its affiliates.
@@ -43,7 +44,8 @@
 #include <string>
 #include <vector>
 
-#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
 
 #include <boost/geometry/srs/projections/dpar.hpp>
 #include <boost/geometry/srs/projections/exception.hpp>

--- a/include/boost/geometry/srs/projections/impl/pj_gridinfo.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_gridinfo.hpp
@@ -1,6 +1,8 @@
 // Boost.Geometry
 // This file is manually converted from PROJ4
 
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
+
 // This file was modified by Oracle on 2018, 2019.
 // Modifications copyright (c) 2018-2019, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -41,11 +43,11 @@
 #define BOOST_GEOMETRY_SRS_PROJECTIONS_IMPL_PJ_GRIDINFO_HPP
 
 
-#include <boost/algorithm/string.hpp>
-
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/util/math.hpp>
 
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string/trim.hpp>
 #include <boost/cstdint.hpp>
 
 #include <algorithm>

--- a/include/boost/geometry/srs/projections/impl/pj_init.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_init.hpp
@@ -2,6 +2,7 @@
 // This file is manually converted from PROJ4
 
 // Copyright (c) 2008-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2017-2020.
 // Modifications copyright (c) 2017-2020, Oracle and/or its affiliates.
@@ -43,9 +44,6 @@
 #include <string>
 #include <type_traits>
 #include <vector>
-
-#include <boost/algorithm/string.hpp>
-#include <boost/tuple/tuple.hpp>
 
 #include <boost/geometry/core/static_assert.hpp>
 

--- a/include/boost/geometry/srs/projections/proj/igh.hpp
+++ b/include/boost/geometry/srs/projections/proj/igh.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry - gis-projections (based on PROJ4)
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2017-2021.
 // Modifications copyright (c) 2017-2021, Oracle and/or its affiliates.
@@ -48,8 +49,6 @@
 #include <boost/geometry/srs/projections/proj/moll.hpp>
 
 #include <boost/geometry/util/math.hpp>
-
-#include <boost/shared_ptr.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/proj/ob_tran.hpp
+++ b/include/boost/geometry/srs/projections/proj/ob_tran.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry - gis-projections (based on PROJ4)
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2017-2020.
 // Modifications copyright (c) 2017-2020, Oracle and/or its affiliates.
@@ -40,19 +41,17 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_OB_TRAN_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_OB_TRAN_HPP
 
+#include <memory>
 #include <type_traits>
 
-#include <boost/geometry/util/math.hpp>
-#include <boost/shared_ptr.hpp>
-
 #include <boost/geometry/core/static_assert.hpp>
-
 #include <boost/geometry/srs/projections/impl/aasincos.hpp>
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
 #include <boost/geometry/srs/projections/impl/pj_ell_set.hpp>
 #include <boost/geometry/srs/projections/impl/projects.hpp>
+#include <boost/geometry/util/math.hpp>
 
 namespace boost { namespace geometry
 {
@@ -199,7 +198,7 @@ namespace projections
                     link->inv(link->params(), xy_x, xy_y, lp_lon, lp_lat);
                 }
 
-                boost::shared_ptr<dynamic_wrapper_b<T, Parameters> > link;
+                std::shared_ptr<dynamic_wrapper_b<T, Parameters> > link;
                 T lamp;
                 T cphip, sphip;
             };

--- a/include/boost/geometry/srs/shared_grids_boost.hpp
+++ b/include/boost/geometry/srs/shared_grids_boost.hpp
@@ -14,7 +14,8 @@
 #include <boost/geometry/srs/projections/grids.hpp>
 
 
-#include <boost/thread.hpp>
+#include <boost/thread/lock_types.hpp>
+#include <boost/thread/shared_mutex.hpp>
 
 
 namespace boost { namespace geometry

--- a/include/boost/geometry/strategies/agnostic/point_in_box_by_side.hpp
+++ b/include/boost/geometry/strategies/agnostic/point_in_box_by_side.hpp
@@ -3,6 +3,7 @@
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2018-2020.
 // Modifications copyright (c) 2018-2020 Oracle and/or its affiliates.
@@ -18,20 +19,18 @@
 #ifndef BOOST_GEOMETRY_STRATEGIES_AGNOSTIC_POINT_IN_BOX_BY_SIDE_HPP
 #define BOOST_GEOMETRY_STRATEGIES_AGNOSTIC_POINT_IN_BOX_BY_SIDE_HPP
 
-#include <boost/array.hpp>
+#include <array>
+
 #include <boost/core/ignore_unused.hpp>
 
+#include <boost/geometry/algorithms/assign.hpp>
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
-
-#include <boost/geometry/algorithms/assign.hpp>
-
-#include <boost/geometry/strategies/side.hpp>
-
 #include <boost/geometry/strategies/covered_by.hpp>
-#include <boost/geometry/strategies/within.hpp>
 #include <boost/geometry/strategies/geographic/side.hpp>
+#include <boost/geometry/strategies/side.hpp>
 #include <boost/geometry/strategies/spherical/ssf.hpp>
+#include <boost/geometry/strategies/within.hpp>
 
 
 namespace boost { namespace geometry { namespace strategy
@@ -86,7 +85,7 @@ inline bool point_in_box_by_side(Point const& point, Box const& box,
     // Create (counterclockwise) array of points, the fifth one closes it
     // Every point should be on the LEFT side (=1), or ON the border (=0),
     // So >= 1 or >= 0
-    boost::array<typename point_type<Box>::type, 5> bp;
+    std::array<typename point_type<Box>::type, 5> bp;
     geometry::detail::assign_box_corners_oriented<true>(box, bp);
     bp[4] = bp[0];
 

--- a/include/boost/geometry/strategies/geographic/closest_points_pt_seg.hpp
+++ b/include/boost/geometry/strategies/geographic/closest_points_pt_seg.hpp
@@ -1,5 +1,7 @@
 // Boost.Geometry
 
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
+
 // Copyright (c) 2021, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
@@ -10,50 +12,14 @@
 #ifndef BOOST_GEOMETRY_STRATEGIES_GEOGRAPHIC_CLOSEST_POINTS_CROSS_TRACK_HPP
 #define BOOST_GEOMETRY_STRATEGIES_GEOGRAPHIC_CLOSEST_POINTS_CROSS_TRACK_HPP
 
-#include <algorithm>
-
-#include <boost/tuple/tuple.hpp>
-#include <boost/algorithm/minmax.hpp>
-#include <boost/config.hpp>
-#include <boost/concept_check.hpp>
-
-#include <boost/geometry/core/cs.hpp>
-#include <boost/geometry/core/access.hpp>
+#include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/coordinate_promotion.hpp>
+#include <boost/geometry/core/coordinate_system.hpp>
 #include <boost/geometry/core/radian_access.hpp>
-#include <boost/geometry/core/tags.hpp>
-
-#include <boost/geometry/strategies/distance.hpp>
-#include <boost/geometry/strategies/concepts/distance_concept.hpp>
-#include <boost/geometry/strategies/spherical/distance_cross_track.hpp>
-#include <boost/geometry/strategies/spherical/distance_haversine.hpp>
-#include <boost/geometry/strategies/spherical/point_in_point.hpp>
-#include <boost/geometry/strategies/geographic/azimuth.hpp>
-#include <boost/geometry/strategies/geographic/distance.hpp>
+#include <boost/geometry/geometries/point.hpp>
+#include <boost/geometry/srs/spheroid.hpp>
 #include <boost/geometry/strategies/geographic/distance_cross_track.hpp>
-#include <boost/geometry/strategies/geographic/parameters.hpp>
-#include <boost/geometry/strategies/geographic/intersection.hpp>
-
-#include <boost/geometry/util/math.hpp>
 #include <boost/geometry/util/select_calculation_type.hpp>
-#include <boost/geometry/util/normalize_spheroidal_coordinates.hpp>
-
-#include <boost/geometry/formulas/mean_radius.hpp>
-#include <boost/geometry/formulas/result_direct.hpp>
-#include <boost/geometry/formulas/spherical.hpp>
-#include <boost/geometry/formulas/vincenty_direct.hpp>
-
-#ifdef BOOST_GEOMETRY_DEBUG_GEOGRAPHIC_CROSS_TRACK
-#include <boost/geometry/io/dsv/write.hpp>
-#endif
-
-#ifndef BOOST_GEOMETRY_DETAIL_POINT_SEGMENT_DISTANCE_MAX_STEPS
-#define BOOST_GEOMETRY_DETAIL_POINT_SEGMENT_DISTANCE_MAX_STEPS 100
-#endif
-
-#ifdef BOOST_GEOMETRY_DEBUG_GEOGRAPHIC_CROSS_TRACK
-#include <iostream>
-#endif
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/strategies/geographic/distance_cross_track.hpp
+++ b/include/boost/geometry/strategies/geographic/distance_cross_track.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2016-2022, Oracle and/or its affiliates.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
+// Copyright (c) 2016-2022, Oracle and/or its affiliates.
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -14,8 +15,6 @@
 
 #include <algorithm>
 
-#include <boost/tuple/tuple.hpp>
-#include <boost/algorithm/minmax.hpp>
 #include <boost/config.hpp>
 #include <boost/concept_check.hpp>
 

--- a/include/boost/geometry/strategy/spherical/envelope_multipoint.hpp
+++ b/include/boost/geometry/strategy/spherical/envelope_multipoint.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2015-2020, Oracle and/or its affiliates.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
+// Copyright (c) 2015-2020, Oracle and/or its affiliates.
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -13,12 +14,11 @@
 #ifndef BOOST_GEOMETRY_STRATEGY_SPHERICAL_ENVELOPE_MULTIPOINT_HPP
 #define BOOST_GEOMETRY_STRATEGY_SPHERICAL_ENVELOPE_MULTIPOINT_HPP
 
-#include <cstddef>
 #include <algorithm>
+#include <cstddef>
 #include <utility>
 #include <vector>
 
-#include <boost/algorithm/minmax_element.hpp>
 #include <boost/range/begin.hpp>
 #include <boost/range/empty.hpp>
 #include <boost/range/end.hpp>
@@ -62,8 +62,7 @@ private:
         template <typename Point>
         inline bool operator()(Point const& point1, Point const& point2) const
         {
-            return math::smaller(geometry::get<Dim>(point1),
-                                 geometry::get<Dim>(point2));
+            return math::smaller(geometry::get<Dim>(point1), geometry::get<Dim>(point2));
         }
     };
 
@@ -73,12 +72,6 @@ private:
                                                  bool& has_north_pole,
                                                  OutputIterator oit)
     {
-        typedef typename boost::range_value<MultiPoint>::type point_type;
-        typedef typename boost::range_iterator
-            <
-                MultiPoint const
-            >::type iterator_type;
-
         // analyze point coordinates:
         // (1) normalize point coordinates
         // (2) check if any point is the north or the south pole
@@ -89,20 +82,16 @@ private:
         has_south_pole = false;
         has_north_pole = false;
 
-        for (iterator_type it = boost::begin(multipoint);
-             it != boost::end(multipoint);
-             ++it)
+        for (auto it = boost::begin(multipoint); it != boost::end(multipoint); ++it)
         {
-            point_type point;
+            typename boost::range_value<MultiPoint>::type point;
             normalize::spherical_point::apply(*it, point);
 
-            if (math::equals(geometry::get<1>(point),
-                             Constants::min_latitude()))
+            if (math::equals(geometry::get<1>(point), Constants::min_latitude()))
             {
                 has_south_pole = true;
             }
-            else if (math::equals(geometry::get<1>(point),
-                                  Constants::max_latitude()))
+            else if (math::equals(geometry::get<1>(point), Constants::max_latitude()))
             {
                 has_north_pole = true;
             }
@@ -118,12 +107,8 @@ private:
                                     Value& max_gap_left,
                                     Value& max_gap_right)
     {
-        typedef typename boost::range_iterator
-            <
-                SortedRange const
-            >::type iterator_type;
-
-        iterator_type it1 = boost::begin(sorted_range), it2 = it1;
+        auto it1 = boost::begin(sorted_range);
+        auto it2 = it1;
         ++it2;
         max_gap_left = geometry::get<0>(*it1);
         max_gap_right = geometry::get<0>(*it2);
@@ -155,16 +140,9 @@ private:
                                               CoordinateType& lon_min,
                                               CoordinateType& lon_max)
     {
-        typedef typename boost::range_iterator
-            <
-                PointRange const
-            >::type iterator_type;
-
         // compute min and max longitude values
-        std::pair<iterator_type, iterator_type> min_max_longitudes
-            = boost::minmax_element(boost::begin(range),
-                                    boost::end(range),
-                                    lon_less);
+        auto const min_max_longitudes
+            = std::minmax_element(boost::begin(range), boost::end(range), lon_less);
 
         lon_min = geometry::get<0>(*min_max_longitudes.first);
         lon_max = geometry::get<0>(*min_max_longitudes.second);
@@ -212,20 +190,16 @@ private:
         else if (has_south_pole)
         {
             lat_min = Constants::min_latitude();
-            lat_max
-                = geometry::get<1>(*std::max_element(first, last, lat_less));
+            lat_max = geometry::get<1>(*std::max_element(first, last, lat_less));
         }
         else if (has_north_pole)
         {
-            lat_min
-                = geometry::get<1>(*std::min_element(first, last, lat_less));
+            lat_min = geometry::get<1>(*std::min_element(first, last, lat_less));
             lat_max = Constants::max_latitude();
         }
         else
         {
-            std::pair<Iterator, Iterator> min_max_latitudes
-                = boost::minmax_element(first, last, lat_less);
-
+            auto const min_max_latitudes = std::minmax_element(first, last, lat_less);
             lat_min = geometry::get<1>(*min_max_latitudes.first);
             lat_max = geometry::get<1>(*min_max_latitudes.second);
         }
@@ -237,11 +211,6 @@ public:
     {
         typedef typename point_type<MultiPoint>::type point_type;
         typedef typename coordinate_type<MultiPoint>::type coordinate_type;
-        typedef typename boost::range_iterator
-            <
-                MultiPoint const
-            >::type iterator_type;
-
         typedef math::detail::constants_on_spheroid
             <
                 coordinate_type,
@@ -332,7 +301,7 @@ public:
         geometry::detail::envelope::envelope_indexed_box_on_spheroid<max_corner, 2>::apply(helper_mbr, mbr);
 
         // compute envelope for higher coordinates
-        iterator_type it = boost::begin(multipoint);
+        auto it = boost::begin(multipoint);
         geometry::detail::envelope::envelope_one_point<2, dimension<Box>::value>::apply(*it, mbr);
 
         for (++it; it != boost::end(multipoint); ++it)


### PR DESCRIPTION
Drop Boost.SmartPtr dependency
Drop Boost.Utility (Call Traits) dependency
Replace `boost::array` with `std::array`
Replace `boost::minmax_element` with `std::minmax_element` Remove unneeded headers of Boost.Tuple and Boost.Algorithm Include specific headers from Boost.StringAlgo and Boost.Thread
Use auto for iterator types