### PR TITLE
Add missing headers so that all headers compile independently

### DIFF
--- a/.github/workflows/headers.yml
+++ b/.github/workflows/headers.yml
@@ -66,6 +66,6 @@ jobs:
         b2 -v
 
     - name: Build libs/geometry/test/headers
-        run: |
-          cd $BOOST_ROOT
-          $BOOST_ROOT/b2 libs/geometry/test/headers
+      run: |
+        cd $BOOST_ROOT
+        $BOOST_ROOT/b2 libs/geometry/test/headers

--- a/.github/workflows/headers.yml
+++ b/.github/workflows/headers.yml
@@ -1,0 +1,71 @@
+##############################################################################
+# GitHub Actions Workflow for Boost.Geometry to check if all headers compile
+# independently
+#
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
+#
+# Use, modification and distribution is subject to the Boost Software License,
+# Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+##############################################################################
+name: headers
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Compile headers
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up environment
+      id: setenv
+      run: |
+        if [[ "$GITHUB_REF" == *master ]]; then
+          echo "BOOST_BRANCH=master" >> $GITHUB_ENV
+        else
+          echo "BOOST_BRANCH=develop" >> $GITHUB_ENV
+        fi
+        echo "BOOST_SELF=$(basename $GITHUB_WORKSPACE)" >> $GITHUB_ENV
+        echo "BOOST_ROOT=$GITHUB_WORKSPACE/boost-root" >> $GITHUB_ENV
+        echo "::set-output name=boost_self::$(basename $GITHUB_WORKSPACE)"
+        echo "::set-output name=boost_root::$GITHUB_WORKSPACE/boost-root"
+
+    - name: Clone boostorg/boost
+      run: |
+        git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/boost.git $BOOST_ROOT
+        cd $BOOST_ROOT
+        git submodule update -q --init libs/headers
+        git submodule update -q --init tools/boost_install
+        git submodule update -q --init tools/boostbook
+        git submodule update -q --init tools/boostdep
+        git submodule update -q --init tools/build
+        git submodule update -q --init tools/quickbook
+        mkdir -p libs/$BOOST_SELF
+
+    - uses: actions/checkout@v2
+      with:
+        path: ${{ steps.setenv.outputs.boost_root }}/libs/${{ steps.setenv.outputs.boost_self }}
+
+    - name: Run tools/boostdep/depinst/depinst.py
+      run: |
+        cd $BOOST_ROOT
+        python tools/boostdep/depinst/depinst.py ../tools/quickbook
+        python tools/boostdep/depinst/depinst.py --include benchmark --include example --include examples --include tools $BOOST_SELF
+
+    - name: Bootstrap boostorg/boost
+      run: |
+        gcc --version
+        cd $BOOST_ROOT
+        ./bootstrap.sh --with-toolset=gcc
+        ./b2 headers
+        test -f /usr/local/bin/b2 && rm -rf /usr/local/bin/b2
+        test -f /usr/local/bin/bjam && rm -rf /usr/local/bin/bjam
+        sudo cp $BOOST_ROOT/b2 /usr/local/bin/
+        ls -l /usr/local/bin/b2
+        b2 -v
+
+    - name: Build libs/geometry/test/headers
+        run: |
+          cd $BOOST_ROOT
+          $BOOST_ROOT/b2 libs/geometry/test/headers

--- a/include/boost/geometry/algorithms/append.hpp
+++ b/include/boost/geometry/algorithms/append.hpp
@@ -4,8 +4,9 @@
 // Copyright (c) 2008-2014 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2014 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2014-2021.
-// Modifications copyright (c) 2014-2021, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014-2023.
+// Modifications copyright (c) 2014-2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -27,7 +28,6 @@
 #include <boost/geometry/algorithms/num_interior_rings.hpp>
 #include <boost/geometry/algorithms/detail/convert_point_to_point.hpp>
 #include <boost/geometry/algorithms/detail/signed_size_type.hpp>
-#include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/mutable_range.hpp>
 #include <boost/geometry/core/point_type.hpp>
 #include <boost/geometry/core/tags.hpp>

--- a/include/boost/geometry/algorithms/area.hpp
+++ b/include/boost/geometry/algorithms/area.hpp
@@ -5,8 +5,9 @@
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 // Copyright (c) 2017-2022 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2017-2021.
-// Modifications copyright (c) 2017-2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017-2023.
+// Modifications copyright (c) 2017-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
@@ -52,8 +53,6 @@
 #include <boost/geometry/strategies/area/spherical.hpp>
 #include <boost/geometry/strategies/concepts/area_concept.hpp>
 #include <boost/geometry/strategies/default_strategy.hpp>
-
-#include <boost/geometry/util/math.hpp>
 
 #include <boost/geometry/views/detail/closed_clockwise_view.hpp>
 

--- a/include/boost/geometry/algorithms/area_result.hpp
+++ b/include/boost/geometry/algorithms/area_result.hpp
@@ -2,8 +2,9 @@
 
 // Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2020-2021.
-// Modifications copyright (c) 2020-2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2020-2023.
+// Modifications copyright (c) 2020-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -19,18 +20,12 @@
 #include <boost/geometry/algorithms/detail/select_geometry_type.hpp>
 
 #include <boost/geometry/core/coordinate_type.hpp>
-#include <boost/geometry/core/cs.hpp>
-#include <boost/geometry/core/geometry_types.hpp>
-#include <boost/geometry/core/tag.hpp>
-#include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/strategies/area/services.hpp>
 #include <boost/geometry/strategies/default_strategy.hpp>
 #include <boost/geometry/strategies/detail.hpp>
 
 #include <boost/geometry/util/select_most_precise.hpp>
-#include <boost/geometry/util/sequence.hpp>
-#include <boost/geometry/util/type_traits.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/algorithms/assign.hpp
+++ b/include/boost/geometry/algorithms/assign.hpp
@@ -5,8 +5,9 @@
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 // Copyright (c) 2014 Samuel Debionne, Grenoble, France.
 
-// This file was modified by Oracle on 2020-2021.
-// Modifications copyright (c) 2020-2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2020-2023.
+// Modifications copyright (c) 2020-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
@@ -19,29 +20,18 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_ASSIGN_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_ASSIGN_HPP
 
-
-#include <cstddef>
-
-#include <boost/concept/requires.hpp>
-#include <boost/concept_check.hpp>
-#include <boost/numeric/conversion/bounds.hpp>
-#include <boost/numeric/conversion/cast.hpp>
-
-#include <boost/variant/apply_visitor.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/variant_fwd.hpp>
+
+#include <boost/geometry/algorithms/append.hpp>
+#include <boost/geometry/algorithms/clear.hpp>
+#include <boost/geometry/algorithms/convert.hpp>
 
 #include <boost/geometry/algorithms/detail/assign_box_corners.hpp>
 #include <boost/geometry/algorithms/detail/assign_indexed_point.hpp>
 #include <boost/geometry/algorithms/detail/assign_values.hpp>
-#include <boost/geometry/algorithms/convert.hpp>
-#include <boost/geometry/algorithms/append.hpp>
-#include <boost/geometry/algorithms/clear.hpp>
-#include <boost/geometry/arithmetic/arithmetic.hpp>
-#include <boost/geometry/core/access.hpp>
-#include <boost/geometry/core/exterior_ring.hpp>
+
 #include <boost/geometry/core/static_assert.hpp>
-#include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/geometries/concepts/check.hpp>
 

--- a/include/boost/geometry/algorithms/azimuth.hpp
+++ b/include/boost/geometry/algorithms/azimuth.hpp
@@ -2,8 +2,8 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2014-2021.
-// Modifications copyright (c) 2014-2021, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014-2023.
+// Modifications copyright (c) 2014-2023, Oracle and/or its affiliates.
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -17,11 +17,8 @@
 
 #include <boost/geometry/algorithms/not_implemented.hpp>
 
-#include <boost/geometry/core/cs.hpp>
-#include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/radian_access.hpp>
 #include <boost/geometry/core/tag.hpp>
-#include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/geometries/concepts/check.hpp>
 
@@ -29,9 +26,6 @@
 #include <boost/geometry/strategies/azimuth/cartesian.hpp>
 #include <boost/geometry/strategies/azimuth/geographic.hpp>
 #include <boost/geometry/strategies/azimuth/spherical.hpp>
-
-#include <boost/geometry/util/math.hpp>
-
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/algorithms/centroid.hpp
+++ b/include/boost/geometry/algorithms/centroid.hpp
@@ -5,10 +5,11 @@
 // Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 // Copyright (c) 2014-2017 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2014-2021.
-// Modifications copyright (c) 2014-2021 Oracle and/or its affiliates.
-// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+// This file was modified by Oracle on 2014-2023.
+// Modifications copyright (c) 2014-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
@@ -29,22 +30,16 @@
 #include <boost/range/size.hpp>
 #include <boost/throw_exception.hpp>
 
-#include <boost/geometry/core/closure.hpp>
-#include <boost/geometry/core/cs.hpp>
-#include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/exception.hpp>
 #include <boost/geometry/core/exterior_ring.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
-#include <boost/geometry/core/tag_cast.hpp>
 #include <boost/geometry/core/tags.hpp>
 #include <boost/geometry/core/point_type.hpp>
 #include <boost/geometry/core/visit.hpp>
 
-#include <boost/geometry/algorithms/assign.hpp>
 #include <boost/geometry/algorithms/convert.hpp>
 #include <boost/geometry/algorithms/detail/centroid/translating_transformer.hpp>
 #include <boost/geometry/algorithms/detail/point_on_border.hpp>
-#include <boost/geometry/algorithms/detail/visit.hpp>
 #include <boost/geometry/algorithms/is_empty.hpp>
 #include <boost/geometry/algorithms/not_implemented.hpp>
 

--- a/include/boost/geometry/algorithms/clear.hpp
+++ b/include/boost/geometry/algorithms/clear.hpp
@@ -4,8 +4,9 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2020-2021.
-// Modifications copyright (c) 2020-2021, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2020-2023.
+// Modifications copyright (c) 2020-2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
@@ -22,7 +23,6 @@
 #include <type_traits>
 
 #include <boost/geometry/algorithms/not_implemented.hpp>
-#include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/exterior_ring.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
 #include <boost/geometry/core/mutable_range.hpp>

--- a/include/boost/geometry/algorithms/convert.hpp
+++ b/include/boost/geometry/algorithms/convert.hpp
@@ -5,8 +5,9 @@
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 // Copyright (c) 2014 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2017-2021.
-// Modifications copyright (c) 2017-2021, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017-2023.
+// Modifications copyright (c) 2017-2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
@@ -28,7 +29,6 @@
 #include <boost/range/end.hpp>
 #include <boost/range/size.hpp>
 #include <boost/range/value_type.hpp>
-#include <boost/variant/apply_visitor.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/variant_fwd.hpp>
 
@@ -39,9 +39,6 @@
 #include <boost/geometry/algorithms/detail/convert_indexed_to_indexed.hpp>
 #include <boost/geometry/algorithms/not_implemented.hpp>
 
-#include <boost/geometry/arithmetic/arithmetic.hpp>
-
-#include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/closure.hpp>
 #include <boost/geometry/core/point_order.hpp>
 #include <boost/geometry/core/tags.hpp>

--- a/include/boost/geometry/algorithms/correct.hpp
+++ b/include/boost/geometry/algorithms/correct.hpp
@@ -5,8 +5,9 @@
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 // Copyright (c) 2014-2017 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2017-2021.
-// Modifications copyright (c) 2017-2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017-2023.
+// Modifications copyright (c) 2017-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
@@ -21,24 +22,18 @@
 
 
 #include <algorithm>
-#include <cstddef>
 #include <functional>
 
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
-#include <boost/range/value_type.hpp>
 
 #include <boost/geometry/algorithms/area.hpp>
 #include <boost/geometry/algorithms/correct_closure.hpp>
 #include <boost/geometry/algorithms/detail/multi_modify.hpp>
 #include <boost/geometry/algorithms/detail/visit.hpp>
 
-#include <boost/geometry/core/closure.hpp>
-#include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/exterior_ring.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
-#include <boost/geometry/core/mutable_range.hpp>
-#include <boost/geometry/core/ring_type.hpp>
 #include <boost/geometry/core/tags.hpp>
 #include <boost/geometry/core/visit.hpp>
 

--- a/include/boost/geometry/algorithms/correct_closure.hpp
+++ b/include/boost/geometry/algorithms/correct_closure.hpp
@@ -2,8 +2,9 @@
 
 // Copyright (c) 2017 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2020-2021.
-// Modifications copyright (c) 2020-2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2020-2023.
+// Modifications copyright (c) 2020-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -13,22 +14,18 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_CORRECT_CLOSURE_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_CORRECT_CLOSURE_HPP
 
-#include <cstddef>
-
 #include <boost/geometry/algorithms/detail/multi_modify.hpp>
 #include <boost/geometry/algorithms/disjoint.hpp>
 
 #include <boost/geometry/core/closure.hpp>
 #include <boost/geometry/core/exterior_ring.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
-#include <boost/geometry/core/ring_type.hpp>
 #include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/geometries/adapted/boost_variant.hpp>
 #include <boost/geometry/geometries/concepts/check.hpp>
 
 #include <boost/geometry/util/range.hpp>
-#include <boost/geometry/util/type_traits.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/algorithms/densify.hpp
+++ b/include/boost/geometry/algorithms/densify.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry
 
-// Copyright (c) 2017-2021, Oracle and/or its affiliates.
+// Copyright (c) 2017-2023, Oracle and/or its affiliates.
 
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Licensed under the Boost Software License version 1.0.
@@ -21,9 +22,7 @@
 #include <boost/geometry/algorithms/detail/visit.hpp>
 #include <boost/geometry/algorithms/not_implemented.hpp>
 #include <boost/geometry/core/closure.hpp>
-#include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/exception.hpp>
-#include <boost/geometry/core/point_type.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tags.hpp>
 #include <boost/geometry/core/visit.hpp>

--- a/include/boost/geometry/algorithms/detail/buffer/turn_in_original_visitor.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/turn_in_original_visitor.hpp
@@ -2,8 +2,9 @@
 
 // Copyright (c) 2014 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2016-2020.
-// Modifications copyright (c) 2016-2020 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2016-2023.
+// Modifications copyright (c) 2016-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -18,6 +19,7 @@
 #include <boost/geometry/core/coordinate_type.hpp>
 
 #include <boost/geometry/algorithms/detail/buffer/buffer_policies.hpp>
+#include <boost/geometry/algorithms/detail/disjoint/interface.hpp>
 #include <boost/geometry/algorithms/expand.hpp>
 #include <boost/geometry/strategies/agnostic/point_in_poly_winding.hpp>
 #include <boost/geometry/strategies/buffer.hpp>

--- a/include/boost/geometry/algorithms/detail/closest_points/point_to_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/closest_points/point_to_geometry.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021-2023, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 
@@ -22,10 +22,12 @@
 #include <boost/geometry/algorithms/assign.hpp>
 #include <boost/geometry/algorithms/detail/closest_feature/geometry_to_range.hpp>
 #include <boost/geometry/algorithms/detail/closest_feature/point_to_range.hpp>
+#include <boost/geometry/algorithms/detail/closest_points/utilities.hpp>
 #include <boost/geometry/algorithms/detail/distance/is_comparable.hpp>
 #include <boost/geometry/algorithms/detail/distance/iterator_selector.hpp>
 #include <boost/geometry/algorithms/detail/distance/strategy_utils.hpp>
 #include <boost/geometry/algorithms/detail/within/point_in_geometry.hpp>
+#include <boost/geometry/algorithms/dispatch/closest_points.hpp>
 #include <boost/geometry/algorithms/dispatch/distance.hpp>
 
 #include <boost/geometry/core/closure.hpp>

--- a/include/boost/geometry/algorithms/detail/closest_points/range_to_geometry_rtree.hpp
+++ b/include/boost/geometry/algorithms/detail/closest_points/range_to_geometry_rtree.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021-2023, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 
@@ -14,9 +14,11 @@
 #include <utility>
 
 #include <boost/geometry/algorithms/detail/closest_feature/range_to_range.hpp>
+#include <boost/geometry/algorithms/detail/closest_points/utilities.hpp>
 #include <boost/geometry/algorithms/detail/distance/is_comparable.hpp>
 #include <boost/geometry/algorithms/detail/distance/iterator_selector.hpp>
 #include <boost/geometry/algorithms/detail/distance/strategy_utils.hpp>
+#include <boost/geometry/algorithms/dispatch/closest_points.hpp>
 
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/point_type.hpp>

--- a/include/boost/geometry/algorithms/detail/closest_points/segment_to_segment.hpp
+++ b/include/boost/geometry/algorithms/detail/closest_points/segment_to_segment.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021-2023, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 
@@ -16,8 +16,10 @@
 #include <boost/core/addressof.hpp>
 
 #include <boost/geometry/algorithms/assign.hpp>
+#include <boost/geometry/algorithms/detail/closest_points/utilities.hpp>
 #include <boost/geometry/algorithms/detail/distance/is_comparable.hpp>
 #include <boost/geometry/algorithms/detail/distance/strategy_utils.hpp>
+#include <boost/geometry/algorithms/dispatch/closest_points.hpp>
 #include <boost/geometry/algorithms/dispatch/distance.hpp>
 #include <boost/geometry/algorithms/intersects.hpp>
 

--- a/include/boost/geometry/algorithms/detail/closest_points/utilities.hpp
+++ b/include/boost/geometry/algorithms/detail/closest_points/utilities.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021-2023, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 
@@ -9,6 +9,9 @@
 
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_CLOSEST_POINTS_UTILITIES_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_CLOSEST_POINTS_UTILITIES_HPP
+
+#include <boost/geometry/algorithms/detail/assign_indexed_point.hpp>
+#include <boost/geometry/util/algorithm.hpp>
 
 #include <boost/geometry/strategies/distance.hpp>
 

--- a/include/boost/geometry/algorithms/detail/disjoint/multirange_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/multirange_geometry.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014-2021, Oracle and/or its affiliates.
+// Copyright (c) 2014-2023, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
@@ -12,6 +12,7 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_DISJOINT_MULTIRANGE_GEOMETRY_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_DISJOINT_MULTIRANGE_GEOMETRY_HPP
 
+#include <algorithm>
 
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>

--- a/include/boost/geometry/algorithms/detail/num_distinct_consecutive_points.hpp
+++ b/include/boost/geometry/algorithms/detail/num_distinct_consecutive_points.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014-2020, Oracle and/or its affiliates.
+// Copyright (c) 2014-2023, Oracle and/or its affiliates.
 
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -18,6 +19,8 @@
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 #include <boost/range/size.hpp>
+
+#include <boost/geometry/algorithms/detail/equals/point_point.hpp>
 
 
 namespace boost { namespace geometry

--- a/include/boost/geometry/algorithms/detail/overlay/assign_parents.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/assign_parents.hpp
@@ -3,8 +3,9 @@
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2017-2022.
-// Modifications copyright (c) 2017-2022 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017-2023.
+// Modifications copyright (c) 2017-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -18,6 +19,8 @@
 #include <boost/range/end.hpp>
 
 #include <boost/geometry/core/coordinate_type.hpp>
+
+#include <boost/geometry/algorithms/area_result.hpp>
 #include <boost/geometry/algorithms/envelope.hpp>
 #include <boost/geometry/algorithms/expand.hpp>
 #include <boost/geometry/algorithms/detail/covered_by/implementation.hpp>
@@ -26,6 +29,7 @@
 #include <boost/geometry/algorithms/detail/overlay/range_in_geometry.hpp>
 
 #include <boost/geometry/geometries/box.hpp>
+
 #include <boost/geometry/util/for_each_with_index.hpp>
 
 namespace boost { namespace geometry

--- a/include/boost/geometry/algorithms/detail/overlay/cluster_exits.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/cluster_exits.hpp
@@ -2,8 +2,9 @@
 
 // Copyright (c) 2020 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2020.
-// Modifications copyright (c) 2020 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2020-2023.
+// Modifications copyright (c) 2020-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -22,6 +23,7 @@
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/algorithms/detail/overlay/overlay_type.hpp>
+#include <boost/geometry/algorithms/detail/overlay/sort_by_side.hpp>
 #include <boost/geometry/algorithms/detail/signed_size_type.hpp>
 #include <boost/geometry/util/condition.hpp>
 

--- a/include/boost/geometry/algorithms/detail/overlay/discard_duplicate_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/discard_duplicate_turns.hpp
@@ -2,12 +2,18 @@
 
 // Copyright (c) 2021 Barend Gehrels, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2023.
+// Modifications copyright (c) 2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_DISCARD_DUPLICATE_TURNS_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_DISCARD_DUPLICATE_TURNS_HPP
+
+#include <map>
 
 #include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>
 #include <boost/geometry/algorithms/detail/overlay/get_ring.hpp>

--- a/include/boost/geometry/algorithms/detail/overlay/sort_by_side.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/sort_by_side.hpp
@@ -3,9 +3,10 @@
 // Copyright (c) 2015 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2017, 2019.
-// Modifications copyright (c) 2017, 2019 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017-2023.
+// Modifications copyright (c) 2017-2023 Oracle and/or its affiliates.
 
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -17,6 +18,7 @@
 
 #include <algorithm>
 #include <map>
+#include <set>
 #include <vector>
 
 #include <boost/geometry/algorithms/detail/overlay/approximately_equals.hpp>

--- a/include/boost/geometry/algorithms/detail/within/within_no_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/within/within_no_turns.hpp
@@ -4,8 +4,9 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2013.
-// Modifications copyright (c) 2013, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013-2023.
+// Modifications copyright (c) 2013-2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
@@ -106,7 +107,7 @@ struct within_no_turns<Geometry1, Geometry2, polygon_tag, polygon_tag>
         }
         // Now check if holes of G2 aren't inside G1
         auto const& rings2 = geometry::interior_rings(geometry2);
-        for (auto it2 = boost::begin(rings2); it != boost::end(rings2); ++it)
+        for (auto it2 = boost::begin(rings2); it2 != boost::end(rings2); ++it2)
         {
             point2_type p2;
             if (! geometry::point_on_border(p2, *it2))

--- a/include/boost/geometry/algorithms/difference.hpp
+++ b/include/boost/geometry/algorithms/difference.hpp
@@ -2,9 +2,9 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017-2022.
-// Modifications copyright (c) 2017-2022, Oracle and/or its affiliates.
-
+// This file was modified by Oracle on 2017-2023.
+// Modifications copyright (c) 2017-2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -21,14 +21,13 @@
 #include <boost/geometry/algorithms/detail/overlay/intersection_insert.hpp>
 #include <boost/geometry/algorithms/detail/visit.hpp>
 #include <boost/geometry/core/geometry_types.hpp>
-#include <boost/geometry/geometries/adapted/boost_variant.hpp>
+#include <boost/geometry/geometries/adapted/boost_variant.hpp> // For backward compatibility
 #include <boost/geometry/policies/robustness/get_rescale_policy.hpp>
 #include <boost/geometry/strategies/default_strategy.hpp>
 #include <boost/geometry/strategies/detail.hpp>
 #include <boost/geometry/strategies/relate/cartesian.hpp>
 #include <boost/geometry/strategies/relate/geographic.hpp>
 #include <boost/geometry/strategies/relate/spherical.hpp>
-#include <boost/geometry/util/range.hpp>
 #include <boost/geometry/util/sequence.hpp>
 #include <boost/geometry/views/detail/geometry_collection_view.hpp>
 

--- a/include/boost/geometry/algorithms/discrete_frechet_distance.hpp
+++ b/include/boost/geometry/algorithms/discrete_frechet_distance.hpp
@@ -4,8 +4,9 @@
 // Contributed and/or modified by Yaghyavardhan Singh Khangarot,
 //   as part of Google Summer of Code 2018 program.
 
-// This file was modified by Oracle on 2018-2021.
-// Modifications copyright (c) 2018-2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2018-2023.
+// Modifications copyright (c) 2018-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -15,16 +16,11 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DISCRETE_FRECHET_DISTANCE_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DISCRETE_FRECHET_DISTANCE_HPP
 
-#include <algorithm>
-
 #ifdef BOOST_GEOMETRY_DEBUG_FRECHET_DISTANCE
 #include <iostream>
 #endif
 
-#include <iterator>
-#include <utility>
 #include <vector>
-#include <limits>
 
 #include <boost/geometry/algorithms/detail/dummy_geometries.hpp>
 #include <boost/geometry/algorithms/detail/throw_on_empty_input.hpp>

--- a/include/boost/geometry/algorithms/for_each.hpp
+++ b/include/boost/geometry/algorithms/for_each.hpp
@@ -5,9 +5,9 @@
 // Copyright (c) 2009-2014 Mateusz Loskot, London, UK.
 // Copyright (c) 2014 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2014-2020.
-// Modifications copyright (c) 2014-2020, Oracle and/or its affiliates.
-
+// This file was modified by Oracle on 2014-2023.
+// Modifications copyright (c) 2014-2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -21,8 +21,6 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_FOR_EACH_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_FOR_EACH_HPP
 
-
-#include <algorithm>
 
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
@@ -40,9 +38,6 @@
 #include <boost/geometry/geometries/concepts/check.hpp>
 
 #include <boost/geometry/geometries/segment.hpp>
-
-#include <boost/geometry/util/range.hpp>
-#include <boost/geometry/util/type_traits.hpp>
 
 #include <boost/geometry/views/detail/indexed_point_view.hpp>
 

--- a/include/boost/geometry/algorithms/is_convex.hpp
+++ b/include/boost/geometry/algorithms/is_convex.hpp
@@ -2,9 +2,9 @@
 
 // Copyright (c) 2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017-2021.
-// Modifications copyright (c) 2017-2021 Oracle and/or its affiliates.
-
+// This file was modified by Oracle on 2017-2023.
+// Modifications copyright (c) 2017-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -20,12 +20,8 @@
 #include <boost/geometry/algorithms/detail/equals/point_point.hpp>
 #include <boost/geometry/algorithms/detail/dummy_geometries.hpp>
 #include <boost/geometry/algorithms/detail/visit.hpp>
-#include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/closure.hpp>
-#include <boost/geometry/core/cs.hpp>
-#include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/exterior_ring.hpp>
-#include <boost/geometry/core/point_type.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
 #include <boost/geometry/core/visit.hpp>
 #include <boost/geometry/geometries/adapted/boost_variant.hpp> // For backward compatibility

--- a/include/boost/geometry/algorithms/is_empty.hpp
+++ b/include/boost/geometry/algorithms/is_empty.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2015-2021, Oracle and/or its affiliates.
+// Copyright (c) 2015-2023, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
@@ -20,7 +20,6 @@
 #include <boost/geometry/algorithms/detail/visit.hpp>
 
 #include <boost/geometry/core/exterior_ring.hpp>
-#include <boost/geometry/core/geometry_types.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tags.hpp>

--- a/include/boost/geometry/algorithms/length.hpp
+++ b/include/boost/geometry/algorithms/length.hpp
@@ -4,9 +4,9 @@
 // Copyright (c) 2008-2014 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2014 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2014-2021.
-// Modifications copyright (c) 2014-2021, Oracle and/or its affiliates.
-
+// This file was modified by Oracle on 2014-2023.
+// Modifications copyright (c) 2014-2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -20,22 +20,17 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_LENGTH_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_LENGTH_HPP
 
-#include <iterator>
-
-#include <boost/core/ignore_unused.hpp>
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
-#include <boost/range/iterator.hpp>
 #include <boost/range/value_type.hpp>
 
-#include <boost/geometry/algorithms/assign.hpp>
+#include "boost/geometry/algorithms/detail/assign_indexed_point.hpp"
 #include <boost/geometry/algorithms/detail/calculate_null.hpp>
 #include <boost/geometry/algorithms/detail/dummy_geometries.hpp>
 #include <boost/geometry/algorithms/detail/multi_sum.hpp>
 // #include <boost/geometry/algorithms/detail/throw_on_empty_input.hpp>
 #include <boost/geometry/algorithms/detail/visit.hpp>
 
-#include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/closure.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tags.hpp>

--- a/include/boost/geometry/algorithms/line_interpolate.hpp
+++ b/include/boost/geometry/algorithms/line_interpolate.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2018-2021 Oracle and/or its affiliates.
+// Copyright (c) 2018-2023 Oracle and/or its affiliates.
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -18,6 +18,7 @@
 #include <boost/range/end.hpp>
 #include <boost/range/iterator.hpp>
 #include <boost/range/value_type.hpp>
+#include <boost/variant/apply_visitor.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/variant_fwd.hpp>
 
@@ -26,6 +27,7 @@
 
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/closure.hpp>
+#include <boost/geometry/core/exception.hpp>
 #include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tags.hpp>
 
@@ -38,7 +40,10 @@
 #include <boost/geometry/strategies/line_interpolate/spherical.hpp>
 
 #include <boost/geometry/util/condition.hpp>
+#include <boost/geometry/util/range.hpp>
 #include <boost/geometry/util/type_traits.hpp>
+
+#include <boost/geometry/views/segment_view.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/algorithms/line_interpolate.hpp
+++ b/include/boost/geometry/algorithms/line_interpolate.hpp
@@ -11,12 +11,10 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_LINE_INTERPOLATE_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_LINE_INTERPOLATE_HPP
 
-#include <iterator>
 #include <type_traits>
 
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
-#include <boost/range/iterator.hpp>
 #include <boost/range/value_type.hpp>
 #include <boost/variant/apply_visitor.hpp>
 #include <boost/variant/static_visitor.hpp>
@@ -25,8 +23,6 @@
 #include <boost/geometry/algorithms/detail/convert_point_to_point.hpp>
 #include <boost/geometry/algorithms/detail/dummy_geometries.hpp>
 
-#include <boost/geometry/core/cs.hpp>
-#include <boost/geometry/core/closure.hpp>
 #include <boost/geometry/core/exception.hpp>
 #include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tags.hpp>

--- a/include/boost/geometry/algorithms/make.hpp
+++ b/include/boost/geometry/algorithms/make.hpp
@@ -4,7 +4,8 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
-// Copyright (c) 2020, Oracle and/or its affiliates.
+// Copyright (c) 2020-2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
@@ -19,7 +20,7 @@
 
 #include <type_traits>
 
-#include <boost/geometry/algorithms/assign.hpp>
+#include "boost/geometry/algorithms/detail/assign_values.hpp"
 
 #include <boost/geometry/core/make.hpp>
 

--- a/include/boost/geometry/algorithms/merge_elements.hpp
+++ b/include/boost/geometry/algorithms/merge_elements.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry
 
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022-2023, Oracle and/or its affiliates.
 
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Licensed under the Boost Software License version 1.0.
@@ -29,7 +30,6 @@
 #include <boost/geometry/strategies/relate/cartesian.hpp>
 #include <boost/geometry/strategies/relate/geographic.hpp>
 #include <boost/geometry/strategies/relate/spherical.hpp>
-#include <boost/geometry/strategies/spherical/compare.hpp>
 
 
 namespace boost { namespace geometry

--- a/include/boost/geometry/algorithms/num_segments.hpp
+++ b/include/boost/geometry/algorithms/num_segments.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014-2021, Oracle and/or its affiliates.
+// Copyright (c) 2014-2023, Oracle and/or its affiliates.
 
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -27,8 +28,6 @@
 
 #include <boost/geometry/geometries/adapted/boost_variant.hpp> // For backward compatibility
 #include <boost/geometry/geometries/concepts/check.hpp>
-
-#include <boost/geometry/util/range.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/algorithms/perimeter.hpp
+++ b/include/boost/geometry/algorithms/perimeter.hpp
@@ -4,8 +4,9 @@
 // Copyright (c) 2008-2014 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2014 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2014-2021.
-// Modifications copyright (c) 2014-2021, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014-2023.
+// Modifications copyright (c) 2014-2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -28,7 +29,6 @@
 // #include <boost/geometry/algorithms/detail/throw_on_empty_input.hpp>
 #include <boost/geometry/algorithms/detail/visit.hpp>
 
-#include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/closure.hpp>
 #include <boost/geometry/core/tags.hpp>
 #include <boost/geometry/core/visit.hpp>

--- a/include/boost/geometry/algorithms/point_on_surface.hpp
+++ b/include/boost/geometry/algorithms/point_on_surface.hpp
@@ -5,8 +5,9 @@
 // Copyright (c) 2009-2013 Mateusz Loskot, London, UK.
 // Copyright (c) 2013-2017 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2014-2020.
-// Modifications copyright (c) 2014-2020 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014-2023.
+// Modifications copyright (c) 2014-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -16,23 +17,16 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_POINT_ON_SURFACE_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_POINT_ON_SURFACE_HPP
 
-
-#include <cstddef>
-#include <numeric>
-
-#include <boost/concept_check.hpp>
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 
 #include <boost/geometry/core/point_type.hpp>
-#include <boost/geometry/core/ring_type.hpp>
 
 #include <boost/geometry/geometries/concepts/check.hpp>
 
 #include <boost/geometry/algorithms/detail/extreme_points.hpp>
 #include <boost/geometry/algorithms/detail/signed_size_type.hpp>
 
-#include <boost/geometry/strategies/cartesian/centroid_bashein_detmer.hpp>
 #include <boost/geometry/strategies/side.hpp>
 
 

--- a/include/boost/geometry/algorithms/remove_spikes.hpp
+++ b/include/boost/geometry/algorithms/remove_spikes.hpp
@@ -5,9 +5,9 @@
 // Copyright (c) 2009-2013 Mateusz Loskot, London, UK.
 // Copyright (c) 2013-2014 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2017-2020.
-// Modifications copyright (c) 2017-2020 Oracle and/or its affiliates.
-
+// This file was modified by Oracle on 2017-2023.
+// Modifications copyright (c) 2017-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -16,8 +16,6 @@
 
 #ifndef BOOST_GEOMETRY_ALGORITHMS_REMOVE_SPIKES_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_REMOVE_SPIKES_HPP
-
-#include <deque>
 
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
@@ -28,10 +26,8 @@
 #include <boost/variant/variant_fwd.hpp>
 
 #include <boost/geometry/core/closure.hpp>
-#include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
-#include <boost/geometry/core/point_order.hpp>
 #include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/geometries/concepts/check.hpp>

--- a/include/boost/geometry/algorithms/reverse.hpp
+++ b/include/boost/geometry/algorithms/reverse.hpp
@@ -5,8 +5,9 @@
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 // Copyright (c) 2014 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2020-2021.
-// Modifications copyright (c) 2020-2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2020-2023.
+// Modifications copyright (c) 2020-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
@@ -31,7 +32,6 @@
 #include <boost/geometry/core/visit.hpp>
 #include <boost/geometry/geometries/adapted/boost_variant.hpp> // For backward compatibility
 #include <boost/geometry/geometries/concepts/check.hpp>
-#include <boost/geometry/util/type_traits.hpp>
 
 
 namespace boost { namespace geometry

--- a/include/boost/geometry/algorithms/simplify.hpp
+++ b/include/boost/geometry/algorithms/simplify.hpp
@@ -4,8 +4,9 @@
 // Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2018-2022.
-// Modifications copyright (c) 2018-2022 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2018-2023.
+// Modifications copyright (c) 2018-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
@@ -26,7 +27,6 @@
 #include <vector>
 
 #include <boost/core/addressof.hpp>
-#include <boost/core/ignore_unused.hpp>
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 #include <boost/range/size.hpp>
@@ -53,7 +53,6 @@
 #include <boost/geometry/geometries/adapted/boost_variant.hpp> // For backward compatibility
 #include <boost/geometry/geometries/concepts/check.hpp>
 
-#include <boost/geometry/strategies/concepts/simplify_concept.hpp>
 #include <boost/geometry/strategies/default_strategy.hpp>
 #include <boost/geometry/strategies/detail.hpp>
 #include <boost/geometry/strategies/distance/comparable.hpp>

--- a/include/boost/geometry/algorithms/sym_difference.hpp
+++ b/include/boost/geometry/algorithms/sym_difference.hpp
@@ -2,9 +2,9 @@
 
 // Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2015-2022.
-// Modifications copyright (c) 2015-2022 Oracle and/or its affiliates.
-
+// This file was modified by Oracle on 2015-2023.
+// Modifications copyright (c) 2015-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -16,12 +16,9 @@
 #define BOOST_GEOMETRY_ALGORITHMS_SYM_DIFFERENCE_HPP
 
 
-#include <algorithm>
 #include <iterator>
-#include <vector>
 
 #include <boost/geometry/algorithms/difference.hpp>
-#include <boost/geometry/algorithms/intersection.hpp>
 #include <boost/geometry/algorithms/union.hpp>
 #include <boost/geometry/geometries/adapted/boost_variant.hpp>
 #include <boost/geometry/geometries/multi_polygon.hpp>
@@ -31,7 +28,6 @@
 #include <boost/geometry/strategies/relate/cartesian.hpp>
 #include <boost/geometry/strategies/relate/geographic.hpp>
 #include <boost/geometry/strategies/relate/spherical.hpp>
-#include <boost/geometry/util/range.hpp>
 
 
 namespace boost { namespace geometry

--- a/include/boost/geometry/algorithms/transform.hpp
+++ b/include/boost/geometry/algorithms/transform.hpp
@@ -5,8 +5,9 @@
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 // Copyright (c) 2014 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2020.
-// Modifications copyright (c) 2020 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2020-2023.
+// Modifications copyright (c) 2020-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
@@ -19,8 +20,6 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_TRANSFORM_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_TRANSFORM_HPP
 
-#include <cmath>
-#include <iterator>
 #include <type_traits>
 
 #include <boost/range/begin.hpp>
@@ -28,19 +27,18 @@
 #include <boost/range/size.hpp>
 #include <boost/range/value_type.hpp>
 
-#include <boost/variant/apply_visitor.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/variant_fwd.hpp>
 
-#include <boost/geometry/algorithms/assign.hpp>
 #include <boost/geometry/algorithms/clear.hpp>
+#include "boost/geometry/algorithms/detail/assign_indexed_point.hpp"
+#include "boost/geometry/algorithms/detail/assign_values.hpp"
 #include <boost/geometry/algorithms/num_interior_rings.hpp>
 
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/exterior_ring.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
 #include <boost/geometry/core/mutable_range.hpp>
-#include <boost/geometry/core/ring_type.hpp>
 #include <boost/geometry/core/tag_cast.hpp>
 #include <boost/geometry/core/tags.hpp>
 #include <boost/geometry/geometries/concepts/check.hpp>

--- a/include/boost/geometry/algorithms/union.hpp
+++ b/include/boost/geometry/algorithms/union.hpp
@@ -2,9 +2,9 @@
 
 // Copyright (c) 2007-2014 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2014-2022.
-// Modifications copyright (c) 2014-2022 Oracle and/or its affiliates.
-
+// This file was modified by Oracle on 2014-2023.
+// Modifications copyright (c) 2014-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -16,11 +16,8 @@
 #define BOOST_GEOMETRY_ALGORITHMS_UNION_HPP
 
 
-#include <boost/range/value_type.hpp>
-
 #include <boost/geometry/algorithms/detail/gc_group_elements.hpp>
 #include <boost/geometry/algorithms/detail/intersection/gc.hpp>
-#include <boost/geometry/algorithms/detail/intersection/multi.hpp>
 #include <boost/geometry/algorithms/detail/overlay/intersection_insert.hpp>
 #include <boost/geometry/algorithms/detail/overlay/linear_linear.hpp>
 #include <boost/geometry/algorithms/detail/overlay/overlay.hpp>
@@ -36,7 +33,6 @@
 #include <boost/geometry/strategies/relate/cartesian.hpp>
 #include <boost/geometry/strategies/relate/geographic.hpp>
 #include <boost/geometry/strategies/relate/spherical.hpp>
-#include <boost/geometry/util/range.hpp>
 #include <boost/geometry/util/type_traits_std.hpp>
 #include <boost/geometry/views/detail/geometry_collection_view.hpp>
 #include <boost/geometry/views/detail/random_access_view.hpp>

--- a/include/boost/geometry/core/interior_rings.hpp
+++ b/include/boost/geometry/core/interior_rings.hpp
@@ -4,8 +4,9 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2020.
-// Modifications copyright (c) 2020, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2020-2023.
+// Modifications copyright (c) 2020-2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
@@ -18,7 +19,6 @@
 #ifndef BOOST_GEOMETRY_CORE_INTERIOR_RINGS_HPP
 #define BOOST_GEOMETRY_CORE_INTERIOR_RINGS_HPP
 
-#include <cstddef>
 #include <type_traits>
 
 #include <boost/range/value_type.hpp>

--- a/include/boost/geometry/core/mutable_range.hpp
+++ b/include/boost/geometry/core/mutable_range.hpp
@@ -4,8 +4,9 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2020-2021.
-// Modifications copyright (c) 2020-2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2020-2023.
+// Modifications copyright (c) 2020-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
@@ -19,7 +20,6 @@
 #define BOOST_GEOMETRY_CORE_MUTABLE_RANGE_HPP
 
 
-#include <cstddef>
 #include <type_traits>
 
 #include <boost/range/size_type.hpp>

--- a/include/boost/geometry/formulas/interpolate_point_spherical.hpp
+++ b/include/boost/geometry/formulas/interpolate_point_spherical.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2019-2021 Oracle and/or its affiliates.
+// Copyright (c) 2019-2023 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -12,6 +12,7 @@
 #ifndef BOOST_GEOMETRY_FORMULAS_INTERPOLATE_POINT_SPHERICAL_HPP
 #define BOOST_GEOMETRY_FORMULAS_INTERPOLATE_POINT_SPHERICAL_HPP
 
+#include <boost/geometry/arithmetic/normalize.hpp>
 #include <boost/geometry/formulas/spherical.hpp>
 #include <boost/geometry/geometries/point.hpp>
 

--- a/include/boost/geometry/index/detail/algorithms/content.hpp
+++ b/include/boost/geometry/index/detail/algorithms/content.hpp
@@ -4,8 +4,9 @@
 //
 // Copyright (c) 2011-2014 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2020-2022.
-// Modifications copyright (c) 2020-2022 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2020-2023.
+// Modifications copyright (c) 2020-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -15,6 +16,7 @@
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_ALGORITHMS_CONTENT_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_ALGORITHMS_CONTENT_HPP
 
+#include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/static_assert.hpp>

--- a/include/boost/geometry/index/detail/algorithms/diff_abs.hpp
+++ b/include/boost/geometry/index/detail/algorithms/diff_abs.hpp
@@ -4,8 +4,9 @@
 //
 // Copyright (c) 2011-2013 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2020.
-// Modifications copyright (c) 2020, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2020-2023.
+// Modifications copyright (c) 2020-2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -15,6 +16,7 @@
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_ALGORITHMS_DIFF_ABS_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_ALGORITHMS_DIFF_ABS_HPP
 
+#include <cmath>
 #include <type_traits>
 
 namespace boost { namespace geometry { namespace index { namespace detail

--- a/include/boost/geometry/index/detail/algorithms/margin.hpp
+++ b/include/boost/geometry/index/detail/algorithms/margin.hpp
@@ -4,8 +4,9 @@
 //
 // Copyright (c) 2011-2014 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2020-2022.
-// Modifications copyright (c) 2020-2022 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2020-2023.
+// Modifications copyright (c) 2020-2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -15,6 +16,7 @@
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_ALGORITHMS_MARGIN_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_ALGORITHMS_MARGIN_HPP
 
+#include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/static_assert.hpp>

--- a/include/boost/geometry/index/detail/algorithms/path_intersection.hpp
+++ b/include/boost/geometry/index/detail/algorithms/path_intersection.hpp
@@ -4,8 +4,9 @@
 //
 // Copyright (c) 2011-2017 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2020-2021.
-// Modifications copyright (c) 2020-2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2020-2023.
+// Modifications copyright (c) 2020-2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -15,6 +16,9 @@
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_ALGORITHMS_PATH_INTERSECTION_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_ALGORITHMS_PATH_INTERSECTION_HPP
 
+
+#include <boost/geometry/algorithms/detail/assign_indexed_point.hpp>
+#include <boost/geometry/algorithms/detail/distance/interface.hpp>
 
 #include <boost/geometry/core/static_assert.hpp>
 

--- a/include/boost/geometry/index/detail/distance_predicates.hpp
+++ b/include/boost/geometry/index/detail/distance_predicates.hpp
@@ -5,8 +5,9 @@
 //
 // Copyright (c) 2011-2015 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2019-2021.
-// Modifications copyright (c) 2019-2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2019-2023.
+// Modifications copyright (c) 2019-2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -17,6 +18,13 @@
 #define BOOST_GEOMETRY_INDEX_DETAIL_DISTANCE_PREDICATES_HPP
 
 #include <boost/geometry/core/static_assert.hpp>
+
+#include <boost/geometry/algorithms/detail/covered_by/interface.hpp>
+#include <boost/geometry/algorithms/detail/disjoint/interface.hpp>
+#include <boost/geometry/algorithms/detail/intersects/interface.hpp>
+#include <boost/geometry/algorithms/detail/overlaps/interface.hpp>
+#include <boost/geometry/algorithms/detail/touches/interface.hpp>
+#include <boost/geometry/algorithms/detail/within/interface.hpp>
 
 #include <boost/geometry/index/detail/algorithms/comparable_distance_near.hpp>
 #include <boost/geometry/index/detail/algorithms/comparable_distance_far.hpp>

--- a/include/boost/geometry/index/detail/minmax_heap.hpp
+++ b/include/boost/geometry/index/detail/minmax_heap.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry
 
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021-2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Licensed under the Boost Software License version 1.0.
@@ -10,6 +11,7 @@
 #define BOOST_GEOMETRY_INDEX_DETAIL_MINMAX_HEAP_HPP
 
 #include <iterator>
+#include <limits.h>
 #include <type_traits>
 #include <utility>
 

--- a/include/boost/geometry/index/detail/predicates.hpp
+++ b/include/boost/geometry/index/detail/predicates.hpp
@@ -4,8 +4,9 @@
 //
 // Copyright (c) 2011-2015 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2019-2021.
-// Modifications copyright (c) 2019-2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2019-2023.
+// Modifications copyright (c) 2019-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -18,6 +19,13 @@
 #include <tuple>
 #include <type_traits>
 //#include <utility>
+
+#include <boost/geometry/algorithms/detail/covered_by/interface.hpp>
+#include <boost/geometry/algorithms/detail/disjoint/interface.hpp>
+#include <boost/geometry/algorithms/detail/intersects/interface.hpp>
+#include <boost/geometry/algorithms/detail/overlaps/interface.hpp>
+#include <boost/geometry/algorithms/detail/touches/interface.hpp>
+#include <boost/geometry/algorithms/detail/within/interface.hpp>
 
 #include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tag.hpp>

--- a/include/boost/geometry/index/detail/rtree/node/variant_dynamic.hpp
+++ b/include/boost/geometry/index/detail/rtree/node/variant_dynamic.hpp
@@ -4,8 +4,9 @@
 //
 // Copyright (c) 2011-2023 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2021.
-// Modifications copyright (c) 2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2021-2023.
+// Modifications copyright (c) 2021-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -24,6 +25,7 @@
 #include <boost/geometry/index/detail/rtree/options.hpp>
 #include <boost/geometry/index/detail/rtree/node/concept.hpp>
 #include <boost/geometry/index/detail/rtree/node/pairs.hpp>
+#include <boost/geometry/index/detail/rtree/node/scoped_deallocator.hpp>
 
 namespace boost { namespace geometry { namespace index {
 

--- a/include/boost/geometry/index/detail/rtree/node/weak_dynamic.hpp
+++ b/include/boost/geometry/index/detail/rtree/node/weak_dynamic.hpp
@@ -4,8 +4,9 @@
 //
 // Copyright (c) 2011-2023 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2021.
-// Modifications copyright (c) 2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2021-2023.
+// Modifications copyright (c) 2021-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -18,10 +19,12 @@
 #include <boost/container/allocator_traits.hpp>
 #include <boost/container/vector.hpp>
 #include <boost/core/pointer_traits.hpp>
+#include <boost/core/swap.hpp>
 
 #include <boost/geometry/index/detail/rtree/options.hpp>
 #include <boost/geometry/index/detail/rtree/node/concept.hpp>
 #include <boost/geometry/index/detail/rtree/node/pairs.hpp>
+#include <boost/geometry/index/detail/rtree/node/scoped_deallocator.hpp>
 #include <boost/geometry/index/detail/rtree/node/weak_visitor.hpp>
 
 namespace boost { namespace geometry { namespace index {

--- a/include/boost/geometry/index/detail/rtree/pack_create.hpp
+++ b/include/boost/geometry/index/detail/rtree/pack_create.hpp
@@ -5,8 +5,9 @@
 // Copyright (c) 2011-2023 Adam Wulkiewicz, Lodz, Poland.
 // Copyright (c) 2020 Caian Benedicto, Campinas, Brazil.
 //
-// This file was modified by Oracle on 2019-2021.
-// Modifications copyright (c) 2019-2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2019-2023.
+// Modifications copyright (c) 2019-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -18,11 +19,13 @@
 
 #include <boost/core/ignore_unused.hpp>
 
+#include <boost/geometry/algorithms/centroid.hpp>
 #include <boost/geometry/algorithms/detail/expand_by_epsilon.hpp>
 #include <boost/geometry/algorithms/expand.hpp>
 
-#include <boost/geometry/index/detail/algorithms/content.hpp>
 #include <boost/geometry/index/detail/algorithms/bounds.hpp>
+#include <boost/geometry/index/detail/algorithms/content.hpp>
+#include <boost/geometry/index/detail/algorithms/is_valid.hpp>
 #include <boost/geometry/index/detail/algorithms/nth_element.hpp>
 #include <boost/geometry/index/detail/rtree/node/node_elements.hpp>
 #include <boost/geometry/index/detail/rtree/node/subtree_destroyer.hpp>

--- a/include/boost/geometry/index/detail/rtree/rstar/insert.hpp
+++ b/include/boost/geometry/index/detail/rtree/rstar/insert.hpp
@@ -4,8 +4,9 @@
 //
 // Copyright (c) 2011-2015 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2019-2021.
-// Modifications copyright (c) 2019-2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2019-2023.
+// Modifications copyright (c) 2019-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -19,6 +20,7 @@
 
 #include <boost/core/ignore_unused.hpp>
 
+#include <boost/geometry/algorithms/centroid.hpp>
 #include <boost/geometry/algorithms/detail/comparable_distance/interface.hpp>
 
 #include <boost/geometry/index/detail/algorithms/content.hpp>

--- a/include/boost/geometry/index/detail/rtree/utilities/are_counts_ok.hpp
+++ b/include/boost/geometry/index/detail/rtree/utilities/are_counts_ok.hpp
@@ -4,8 +4,9 @@
 //
 // Copyright (c) 2011-2015 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2019.
-// Modifications copyright (c) 2019 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2019-2023.
+// Modifications copyright (c) 2019-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -16,6 +17,7 @@
 #define BOOST_GEOMETRY_INDEX_DETAIL_RTREE_UTILITIES_ARE_COUNTS_OK_HPP
 
 #include <boost/geometry/index/detail/rtree/node/node.hpp>
+#include <boost/geometry/index/detail/rtree/utilities/view.hpp>
 
 namespace boost { namespace geometry { namespace index { namespace detail { namespace rtree { namespace utilities {
 

--- a/include/boost/geometry/index/detail/rtree/utilities/are_levels_ok.hpp
+++ b/include/boost/geometry/index/detail/rtree/utilities/are_levels_ok.hpp
@@ -4,8 +4,9 @@
 //
 // Copyright (c) 2011-2013 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2019.
-// Modifications copyright (c) 2019 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2019-2023.
+// Modifications copyright (c) 2019-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -16,6 +17,7 @@
 #define BOOST_GEOMETRY_INDEX_DETAIL_RTREE_UTILITIES_ARE_LEVELS_OK_HPP
 
 #include <boost/geometry/index/detail/rtree/node/node.hpp>
+#include <boost/geometry/index/detail/rtree/utilities/view.hpp>
 
 namespace boost { namespace geometry { namespace index { namespace detail { namespace rtree { namespace utilities {
 

--- a/include/boost/geometry/index/detail/rtree/utilities/print.hpp
+++ b/include/boost/geometry/index/detail/rtree/utilities/print.hpp
@@ -4,8 +4,9 @@
 //
 // Copyright (c) 2011-2013 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2019-2021.
-// Modifications copyright (c) 2019-2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2019-2023.
+// Modifications copyright (c) 2019-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -22,6 +23,10 @@
 #include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/core/tags.hpp>
+
+#include <boost/geometry/index/detail/rtree/node/node_elements.hpp>
+#include <boost/geometry/index/detail/rtree/node/variant_visitor.hpp>
+#include <boost/geometry/index/detail/rtree/utilities/view.hpp>
 
 namespace boost { namespace geometry { namespace index { namespace detail {
 

--- a/include/boost/geometry/index/detail/rtree/utilities/statistics.hpp
+++ b/include/boost/geometry/index/detail/rtree/utilities/statistics.hpp
@@ -5,8 +5,9 @@
 // Copyright (c) 2011-2013 Adam Wulkiewicz, Lodz, Poland.
 // Copyright (c) 2013 Mateusz Loskot, London, UK.
 //
-// This file was modified by Oracle on 2019-2020.
-// Modifications copyright (c) 2019-2020 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2019-2023.
+// Modifications copyright (c) 2019-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -18,6 +19,10 @@
 
 #include <algorithm>
 #include <tuple>
+
+#include <boost/geometry/index/detail/rtree/node/node_elements.hpp>
+#include <boost/geometry/index/detail/rtree/node/variant_visitor.hpp>
+#include <boost/geometry/index/detail/rtree/utilities/view.hpp>
 
 namespace boost { namespace geometry { namespace index { namespace detail { namespace rtree { namespace utilities {
 

--- a/include/boost/geometry/index/detail/rtree/visitors/children_box.hpp
+++ b/include/boost/geometry/index/detail/rtree/visitors/children_box.hpp
@@ -4,8 +4,9 @@
 //
 // Copyright (c) 2011-2015 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2019.
-// Modifications copyright (c) 2019 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2019-2023.
+// Modifications copyright (c) 2019-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -14,6 +15,9 @@
 
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_RTREE_VISITORS_CHILDREN_BOX_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_RTREE_VISITORS_CHILDREN_BOX_HPP
+
+#include <boost/geometry/index/detail/rtree/node/node.hpp>
+#include <boost/geometry/index/detail/rtree/node/node_elements.hpp>
 
 namespace boost { namespace geometry { namespace index {
 

--- a/include/boost/geometry/index/detail/rtree/visitors/count.hpp
+++ b/include/boost/geometry/index/detail/rtree/visitors/count.hpp
@@ -4,8 +4,9 @@
 //
 // Copyright (c) 2011-2014 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2019.
-// Modifications copyright (c) 2019 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2019-2023.
+// Modifications copyright (c) 2019-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -14,6 +15,12 @@
 
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_RTREE_VISITORS_COUNT_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_RTREE_VISITORS_COUNT_HPP
+
+#include <boost/geometry/index/equal_to.hpp>
+#include <boost/geometry/index/detail/algorithms/bounds.hpp>
+#include <boost/geometry/index/detail/rtree/node/node_elements.hpp>
+#include <boost/geometry/index/detail/rtree/node/variant_visitor.hpp>
+#include <boost/geometry/index/parameters.hpp>
 
 namespace boost { namespace geometry { namespace index {
 

--- a/include/boost/geometry/index/detail/rtree/visitors/destroy.hpp
+++ b/include/boost/geometry/index/detail/rtree/visitors/destroy.hpp
@@ -4,8 +4,9 @@
 //
 // Copyright (c) 2011-2014 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2019.
-// Modifications copyright (c) 2019 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2019-2023.
+// Modifications copyright (c) 2019-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -14,6 +15,10 @@
 
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_RTREE_VISITORS_DELETE_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_RTREE_VISITORS_DELETE_HPP
+
+#include <boost/geometry/index/detail/rtree/node/concept.hpp>
+#include <boost/geometry/index/detail/rtree/node/node_elements.hpp>
+#include <boost/geometry/index/detail/rtree/node/weak_visitor.hpp>
 
 namespace boost { namespace geometry { namespace index {
 

--- a/include/boost/geometry/index/detail/rtree/visitors/distance_query.hpp
+++ b/include/boost/geometry/index/detail/rtree/visitors/distance_query.hpp
@@ -4,8 +4,9 @@
 //
 // Copyright (c) 2011-2014 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2019-2021.
-// Modifications copyright (c) 2019-2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2019-2023.
+// Modifications copyright (c) 2019-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -20,6 +21,7 @@
 #include <boost/geometry/index/detail/distance_predicates.hpp>
 #include <boost/geometry/index/detail/predicates.hpp>
 #include <boost/geometry/index/detail/priority_dequeue.hpp>
+#include <boost/geometry/index/detail/rtree/node/weak_visitor.hpp>
 #include <boost/geometry/index/detail/rtree/node/node_elements.hpp>
 #include <boost/geometry/index/detail/translator.hpp>
 #include <boost/geometry/index/parameters.hpp>

--- a/include/boost/geometry/index/detail/rtree/visitors/insert.hpp
+++ b/include/boost/geometry/index/detail/rtree/visitors/insert.hpp
@@ -4,8 +4,9 @@
 //
 // Copyright (c) 2011-2023 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2019-2021.
-// Modifications copyright (c) 2019-2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2019-2023.
+// Modifications copyright (c) 2019-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -24,6 +25,7 @@
 
 #include <boost/geometry/index/detail/algorithms/bounds.hpp>
 #include <boost/geometry/index/detail/algorithms/content.hpp>
+#include <boost/geometry/index/detail/rtree/node/node.hpp>
 #include <boost/geometry/index/detail/rtree/node/node_elements.hpp>
 #include <boost/geometry/index/detail/rtree/node/subtree_destroyer.hpp>
 #include <boost/geometry/index/detail/rtree/options.hpp>

--- a/include/boost/geometry/index/detail/rtree/visitors/iterator.hpp
+++ b/include/boost/geometry/index/detail/rtree/visitors/iterator.hpp
@@ -4,8 +4,9 @@
 //
 // Copyright (c) 2011-2015 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2021.
-// Modifications copyright (c) 2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2021-2023.
+// Modifications copyright (c) 2021-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -17,6 +18,7 @@
 
 #include <boost/geometry/index/detail/rtree/node/concept.hpp>
 #include <boost/geometry/index/detail/rtree/node/node_elements.hpp>
+#include <boost/geometry/index/detail/rtree/node/variant_visitor.hpp>
 
 namespace boost { namespace geometry { namespace index {
 

--- a/include/boost/geometry/index/detail/rtree/visitors/remove.hpp
+++ b/include/boost/geometry/index/detail/rtree/visitors/remove.hpp
@@ -4,8 +4,9 @@
 //
 // Copyright (c) 2011-2017 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2019-2021.
-// Modifications copyright (c) 2019-2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2019-2023.
+// Modifications copyright (c) 2019-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -17,9 +18,13 @@
 
 #include <boost/geometry/algorithms/detail/covered_by/interface.hpp>
 
+#include <boost/geometry/index/parameters.hpp>
+#include <boost/geometry/index/detail/algorithms/bounds.hpp>
+#include <boost/geometry/index/detail/rtree/node/node.hpp>
 #include <boost/geometry/index/detail/rtree/node/node_elements.hpp>
 #include <boost/geometry/index/detail/rtree/node/subtree_destroyer.hpp>
 #include <boost/geometry/index/detail/rtree/visitors/destroy.hpp>
+#include <boost/geometry/index/detail/rtree/visitors/insert.hpp>
 #include <boost/geometry/index/detail/rtree/visitors/is_leaf.hpp>
 
 namespace boost { namespace geometry { namespace index {

--- a/include/boost/geometry/index/detail/rtree/visitors/spatial_query.hpp
+++ b/include/boost/geometry/index/detail/rtree/visitors/spatial_query.hpp
@@ -4,8 +4,9 @@
 //
 // Copyright (c) 2011-2014 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2019-2021.
-// Modifications copyright (c) 2019-2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2019-2023.
+// Modifications copyright (c) 2019-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -16,6 +17,7 @@
 #define BOOST_GEOMETRY_INDEX_DETAIL_RTREE_VISITORS_SPATIAL_QUERY_HPP
 
 #include <boost/geometry/index/detail/rtree/node/node_elements.hpp>
+#include <boost/geometry/index/detail/rtree/node/weak_visitor.hpp>
 #include <boost/geometry/index/detail/predicates.hpp>
 #include <boost/geometry/index/parameters.hpp>
 

--- a/include/boost/geometry/index/detail/serialization.hpp
+++ b/include/boost/geometry/index/detail/serialization.hpp
@@ -2,8 +2,9 @@
 //
 // Copyright (c) 2011-2023 Adam Wulkiewicz, Lodz, Poland.
 //
-// This file was modified by Oracle on 2021.
-// Modifications copyright (c) 2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2021-2023.
+// Modifications copyright (c) 2021-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 //
 // Use, modification and distribution is subject to the Boost Software License,
@@ -16,10 +17,10 @@
 #include <boost/type_traits/alignment_of.hpp>
 #include <boost/type_traits/aligned_storage.hpp>
 
-//#include <boost/serialization/serialization.hpp>
+#include <boost/serialization/serialization.hpp>
 #include <boost/serialization/split_member.hpp>
 #include <boost/serialization/version.hpp>
-//#include <boost/serialization/nvp.hpp>
+#include <boost/serialization/nvp.hpp>
 
 #include <boost/geometry/geometries/point.hpp>
 #include <boost/geometry/geometries/box.hpp>

--- a/include/boost/geometry/policies/predicate_based_interrupt_policy.hpp
+++ b/include/boost/geometry/policies/predicate_based_interrupt_policy.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014-2021, Oracle and/or its affiliates.
+// Copyright (c) 2014-2023, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
@@ -12,7 +12,10 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_POLICIES_PREDICATE_BASED_INTERRUPT_POLICY_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_POLICIES_PREDICATE_BASED_INTERRUPT_POLICY_HPP
 
+#include <algorithm>
+
 #include <boost/range/begin.hpp>
+#include <boost/range/empty.hpp>
 #include <boost/range/end.hpp>
 
 

--- a/include/boost/geometry/srs/projections/dpar.hpp
+++ b/include/boost/geometry/srs/projections/dpar.hpp
@@ -2,7 +2,7 @@
 
 // Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
-// Copyright (c) 2017-2022, Oracle and/or its affiliates.
+// Copyright (c) 2017-2023, Oracle and/or its affiliates.
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -33,6 +33,8 @@
 #include <boost/range/end.hpp>
 #include <boost/range/size.hpp>
 #include <boost/range/value_type.hpp>
+
+#include <boost/variant/get.hpp>
 #include <boost/variant/variant.hpp>
 
 

--- a/include/boost/geometry/srs/projections/proj/cass.hpp
+++ b/include/boost/geometry/srs/projections/proj/cass.hpp
@@ -47,6 +47,7 @@
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
 #include <boost/geometry/srs/projections/impl/pj_generic_inverse.hpp>
 #include <boost/geometry/srs/projections/impl/pj_mlfn.hpp>
+#include <boost/geometry/srs/projections/impl/pj_param.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/srs/projections/str_cast.hpp
+++ b/include/boost/geometry/srs/projections/str_cast.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry
 
-// Copyright (c) 2018-2020, Oracle and/or its affiliates.
+// Copyright (c) 2018-2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -10,13 +11,10 @@
 #ifndef BOOST_GEOMETRY_SRS_PROJECTIONS_STR_CAST_HPP
 #define BOOST_GEOMETRY_SRS_PROJECTIONS_STR_CAST_HPP
 
-#include <cstdlib>
-#include <string>
-#include <type_traits>
-
 #include <boost/config.hpp>
 #include <boost/geometry/core/exception.hpp>
 #include <boost/throw_exception.hpp>
+#include <boost/type_traits/remove_cv.hpp>
 
 namespace boost { namespace geometry
 {

--- a/include/boost/geometry/strategies/cartesian/buffer_end_round.hpp
+++ b/include/boost/geometry/strategies/cartesian/buffer_end_round.hpp
@@ -2,9 +2,9 @@
 
 // Copyright (c) 2012-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2015.
-// Modifications copyright (c) 2015, Oracle and/or its affiliates.
-
+// This file was modified by Oracle on 2015-2023.
+// Modifications copyright (c) 2015-2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -16,7 +16,9 @@
 
 #include <boost/core/ignore_unused.hpp>
 
+#include <boost/geometry/arithmetic/arithmetic.hpp>
 #include <boost/geometry/core/cs.hpp>
+#include <boost/geometry/core/access.hpp>
 #include <boost/geometry/strategies/tags.hpp>
 #include <boost/geometry/util/math.hpp>
 #include <boost/geometry/util/select_most_precise.hpp>
@@ -80,8 +82,8 @@ private :
         for (std::size_t i = 0; i < point_buffer_count; i++, alpha -= diff)
         {
             typename boost::range_value<RangeOut>::type p;
-            set<0>(p, get<0>(point) + buffer_distance * cos(alpha));
-            set<1>(p, get<1>(point) + buffer_distance * sin(alpha));
+            geometry::set<0>(p, geometry::get<0>(point) + buffer_distance * cos(alpha));
+            geometry::set<1>(p, geometry::get<1>(point) + buffer_distance * sin(alpha));
             range_out.push_back(p);
         }
     }
@@ -144,8 +146,8 @@ public :
                     : (dist_left - dist_right)) / two;
 
             Point shifted_point;
-            set<0>(shifted_point, get<0>(ultimate_point) + dist_half * cos(alpha));
-            set<1>(shifted_point, get<1>(ultimate_point) + dist_half * sin(alpha));
+            geometry::set<0>(shifted_point, geometry::get<0>(ultimate_point) + dist_half * cos(alpha));
+            geometry::set<1>(shifted_point, geometry::get<1>(ultimate_point) + dist_half * sin(alpha));
             generate_points(shifted_point, alpha, dist_average, range_out);
         }
 

--- a/include/boost/geometry/strategies/cartesian/centroid_weighted_length.hpp
+++ b/include/boost/geometry/strategies/cartesian/centroid_weighted_length.hpp
@@ -3,9 +3,9 @@
 // Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 // Copyright (c) 2009-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2015-2021.
-// Modifications copyright (c) 2015-2021, Oracle and/or its affiliates.
-
+// This file was modified by Oracle on 2015-2023.
+// Modifications copyright (c) 2015-2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
@@ -20,6 +20,8 @@
 
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/numeric/conversion/cast.hpp>
+
+#include <boost/geometry/algorithms/assign.hpp>
 
 #include <boost/geometry/arithmetic/arithmetic.hpp>
 

--- a/include/boost/geometry/strategies/cartesian/closest_points_pt_seg.hpp
+++ b/include/boost/geometry/strategies/cartesian/closest_points_pt_seg.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021-2023, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 
@@ -9,6 +9,8 @@
 
 #ifndef BOOST_GEOMETRY_STRATEGIES_CARTESIAN_CLOSEST_POINTS_PT_SEG_HPP
 #define BOOST_GEOMETRY_STRATEGIES_CARTESIAN_CLOSEST_POINTS_PT_SEG_HPP
+
+#include <boost/geometry/algorithms/convert.hpp>
 
 #include <boost/geometry/core/coordinate_promotion.hpp>
 

--- a/include/boost/geometry/strategies/cartesian/side_rounded_input.hpp
+++ b/include/boost/geometry/strategies/cartesian/side_rounded_input.hpp
@@ -2,6 +2,10 @@
 
 // Copyright (c) 2021 Tinko Bartels, Berlin, Germany.
 
+// This file was modified by Oracle on 2023.
+// Modifications copyright (c) 2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -9,8 +13,12 @@
 #ifndef BOOST_GEOMETRY_STRATEGY_CARTESIAN_SIDE_ROUNDED_INPUT_HPP
 #define BOOST_GEOMETRY_STRATEGY_CARTESIAN_SIDE_ROUNDED_INPUT_HPP
 
+#include <limits>
 
+#include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/config.hpp>
+
+#include <boost/geometry/util/math.hpp>
 
 #include <boost/geometry/strategies/side.hpp>
 

--- a/include/boost/geometry/strategies/cartesian/turn_in_ring_winding.hpp
+++ b/include/boost/geometry/strategies/cartesian/turn_in_ring_winding.hpp
@@ -2,6 +2,10 @@
 
 // Copyright (c) 2020 Barend Gehrels, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2023.
+// Modifications copyright (c) 2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -9,6 +13,7 @@
 #ifndef BOOST_GEOMETRY_STRATEGIES_CARTESIAN_TURN_IN_RING_WINDING_HPP
 #define BOOST_GEOMETRY_STRATEGIES_CARTESIAN_TURN_IN_RING_WINDING_HPP
 
+#include <boost/geometry/arithmetic/infinite_line_functions.hpp>
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/config.hpp>
 #include <boost/geometry/algorithms/detail/make/make.hpp>

--- a/include/boost/geometry/strategy/spherical/envelope_multipoint.hpp
+++ b/include/boost/geometry/strategy/spherical/envelope_multipoint.hpp
@@ -2,7 +2,7 @@
 
 // Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
-// Copyright (c) 2015-2020, Oracle and/or its affiliates.
+// Copyright (c) 2015-2023, Oracle and/or its affiliates.
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -42,6 +42,7 @@
 #include <boost/geometry/algorithms/detail/expand/point.hpp>
 
 #include <boost/geometry/strategy/cartesian/envelope_point.hpp>
+#include <boost/geometry/strategy/cartesian/expand_point.hpp>
 #include <boost/geometry/strategies/normalize.hpp>
 #include <boost/geometry/strategy/spherical/envelope_box.hpp>
 #include <boost/geometry/strategy/spherical/envelope_point.hpp>

--- a/include/boost/geometry/util/sequence.hpp
+++ b/include/boost/geometry/util/sequence.hpp
@@ -1,7 +1,7 @@
 // Boost.Geometry
 
-// Copyright (c) 2020-2021, Oracle and/or its affiliates.
-
+// Copyright (c) 2020-2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Licensed under the Boost Software License version 1.0.
@@ -10,7 +10,7 @@
 #ifndef BOOST_GEOMETRY_UTIL_SEQUENCE_HPP
 #define BOOST_GEOMETRY_UTIL_SEQUENCE_HPP
 
-
+#include <utility>
 #include <type_traits>
 
 

--- a/include/boost/geometry/views/closeable_view.hpp
+++ b/include/boost/geometry/views/closeable_view.hpp
@@ -4,8 +4,9 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2020-2021.
-// Modifications copyright (c) 2020-2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2020-2023.
+// Modifications copyright (c) 2020-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
@@ -124,17 +125,17 @@ namespace traits
 
 
 template <typename Range, closure_selector Close>
-struct tag<detail::closed_view<Range, Close> >
+struct tag<geometry::detail::closed_view<Range, Close> >
     : geometry::tag<Range>
 {};
 
 template <typename Range, closure_selector Close>
-struct point_order<detail::closed_view<Range, Close> >
+struct point_order<geometry::detail::closed_view<Range, Close> >
     : geometry::point_order<Range>
 {};
 
 template <typename Range, closure_selector Close>
-struct closure<detail::closed_view<Range, Close> >
+struct closure<geometry::detail::closed_view<Range, Close> >
 {
     static const closure_selector value = closed;
 };

--- a/include/boost/geometry/views/detail/closed_clockwise_view.hpp
+++ b/include/boost/geometry/views/detail/closed_clockwise_view.hpp
@@ -5,7 +5,8 @@
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
 // This file was modified by Oracle on 2014-2021.
-// Modifications copyright (c) 2014-2021 Oracle and/or its affiliates.
+// Modifications copyright (c) 2014-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
@@ -72,18 +73,18 @@ namespace traits
 {
 
 template <typename Range, closure_selector Closure, order_selector Order>
-struct tag<detail::closed_clockwise_view<Range, Closure, Order> >
+struct tag<geometry::detail::closed_clockwise_view<Range, Closure, Order> >
     : geometry::tag<Range>
 {};
 
 template <typename Range, closure_selector Closure, order_selector Order>
-struct point_order<detail::closed_clockwise_view<Range, Closure, Order> >
+struct point_order<geometry::detail::closed_clockwise_view<Range, Closure, Order> >
 {
     static const order_selector value = clockwise;
 };
 
 template <typename Range, closure_selector Closure, order_selector Order>
-struct closure<detail::closed_clockwise_view<Range, Closure, Order> >
+struct closure<geometry::detail::closed_clockwise_view<Range, Closure, Order> >
 {
     static const closure_selector value = closed;
 };

--- a/include/boost/geometry/views/detail/random_access_view.hpp
+++ b/include/boost/geometry/views/detail/random_access_view.hpp
@@ -1,7 +1,7 @@
 // Boost.Geometry
 
-// Copyright (c) 2022, Oracle and/or its affiliates.
-
+// Copyright (c) 2022-2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Licensed under the Boost Software License version 1.0.
@@ -9,6 +9,8 @@
 
 #ifndef BOOST_GEOMETRY_VIEWS_DETAIL_RANDOM_ACCESS_VIEW_HPP
 #define BOOST_GEOMETRY_VIEWS_DETAIL_RANDOM_ACCESS_VIEW_HPP
+
+#include <vector>
 
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>

--- a/include/boost/geometry/views/reversible_view.hpp
+++ b/include/boost/geometry/views/reversible_view.hpp
@@ -4,8 +4,9 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2020-2021.
-// Modifications copyright (c) 2020-2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2020-2023.
+// Modifications copyright (c) 2020-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
@@ -102,18 +103,18 @@ namespace traits
 
 
 template <typename Range, order_selector Order>
-struct tag<detail::clockwise_view<Range, Order> >
+struct tag<geometry::detail::clockwise_view<Range, Order> >
     : geometry::tag<Range>
 {};
 
 template <typename Range, order_selector Order>
-struct point_order<detail::clockwise_view<Range, Order> >
+struct point_order<geometry::detail::clockwise_view<Range, Order> >
 {
     static const order_selector value = clockwise;
 };
 
 template <typename Range, order_selector Order>
-struct closure<detail::clockwise_view<Range, Order> >
+struct closure<geometry::detail::clockwise_view<Range, Order> >
     : geometry::closure<Range>
 {};
 

--- a/test/algorithms/merge_elements.cpp
+++ b/test/algorithms/merge_elements.cpp
@@ -1,8 +1,9 @@
 // Boost.Geometry
 // Unit Test
 
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022-2023, Oracle and/or its affiliates.
 
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Licensed under the Boost Software License version 1.0.
@@ -62,7 +63,7 @@ void test_all(std::size_t points_count, std::size_t linestrings_count, std::size
     decltype(a) a_expected = area;
     BOOST_CHECK_CLOSE(l, l_expected, 0.000001);
     BOOST_CHECK_CLOSE(p, p_expected, 0.000001);
-    BOOST_CHECK_CLOSE(a, a_expected, 0.000001);    
+    BOOST_CHECK_CLOSE(a, a_expected, 0.000001);
 }
 
 int test_main(int, char* [])
@@ -72,6 +73,6 @@ int test_main(int, char* [])
     //       only different geometries stored in a GC. Hence duplicated point in the result.
     test_all<bg::model::point<double, 2, bg::cs::spherical_equatorial<bg::degree>>>(4, 6, 2, 0.48141804683843953, 1.2506937915396685, 0.029392562222852522);
     test_all<bg::model::point<double, 2, bg::cs::geographic<bg::degree>>>(4, 6, 2, 3058383.6297531724, 7951118.1434133006, 1187967114570.5911);
-    
+
     return 0;
 }

--- a/test/algorithms/test_simplify.hpp
+++ b/test/algorithms/test_simplify.hpp
@@ -3,8 +3,9 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2021.
-// Modifications copyright (c) 2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2021-2023.
+// Modifications copyright (c) 2021-2023 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -24,6 +25,7 @@
 #include <boost/geometry/algorithms/simplify.hpp>
 #include <boost/geometry/algorithms/distance.hpp>
 #include <boost/geometry/geometries/geometry_collection.hpp>
+#include <boost/geometry/strategies/concepts/simplify_concept.hpp>
 #include <boost/geometry/strategies/strategies.hpp>
 #include <boost/geometry/io/wkt/wkt.hpp>
 #include <boost/variant/variant.hpp>
@@ -178,7 +180,7 @@ void test_geometry(std::string const& wkt,
 
     using variant_t = typename boost_variant_type<Geometry>::type;
     variant_t v(geometry);
-    
+
     // Define default strategy for testing
     typedef bg::strategy::simplify::douglas_peucker
         <
@@ -190,7 +192,7 @@ void test_geometry(std::string const& wkt,
 
     check_geometry(geometry, expected, distance);
     check_geometry(v, expected, distance);
-    
+
     check_geometry(geometry, expected, distance, dp());
     check_geometry(v, expected, distance, dp());
 

--- a/test/geometries/box.cpp
+++ b/test/geometries/box.cpp
@@ -5,8 +5,9 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2020.
-// Modifications copyright (c) 2020, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2020-2023.
+// Modifications copyright (c) 2020-2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
@@ -19,13 +20,14 @@
 
 #include <geometry_test_common.hpp>
 
+#include <boost/geometry/algorithms/assign.hpp>
 #include <boost/geometry/algorithms/make.hpp>
-
 
 #include <boost/geometry/geometries/point.hpp>
 #include <boost/geometry/geometries/box.hpp>
 #include <boost/geometry/geometries/adapted/c_array.hpp>
 #include <boost/geometry/geometries/adapted/boost_tuple.hpp>
+
 #include <test_common/test_point.hpp>
 
 BOOST_GEOMETRY_REGISTER_C_ARRAY_CS(cs::cartesian)

--- a/test/geometries/linestring.cpp
+++ b/test/geometries/linestring.cpp
@@ -3,6 +3,10 @@
 
 // Copyright (c) 2020 Digvijay Janartha, Hamirpur, India.
 
+// This file was modified by Oracle on 2023.
+// Modifications copyright (c) 2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -12,6 +16,7 @@
 #include <geometry_test_common.hpp>
 
 #include <boost/core/ignore_unused.hpp>
+#include <boost/geometry/algorithms/assign.hpp>
 #include <boost/geometry/algorithms/make.hpp>
 #include <boost/geometry/algorithms/append.hpp>
 #include <boost/geometry/geometries/point.hpp>

--- a/test/geometries/multi_point.cpp
+++ b/test/geometries/multi_point.cpp
@@ -3,6 +3,10 @@
 
 // Copyright (c) 2020 Digvijay Janartha, Hamirpur, India.
 
+// This file was modified by Oracle on 2023.
+// Modifications copyright (c) 2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -14,6 +18,7 @@
 #include <boost/core/ignore_unused.hpp>
 #include <boost/geometry/algorithms/make.hpp>
 #include <boost/geometry/algorithms/append.hpp>
+#include <boost/geometry/algorithms/assign.hpp>
 #include <boost/geometry/geometries/point.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/multi_point.hpp>

--- a/test/geometries/multi_polygon.cpp
+++ b/test/geometries/multi_polygon.cpp
@@ -3,6 +3,10 @@
 
 // Copyright (c) 2020 Digvijay Janartha, Hamirpur, India.
 
+// This file was modified by Oracle on 2023.
+// Modifications copyright (c) 2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -14,6 +18,7 @@
 #include <boost/core/ignore_unused.hpp>
 #include <boost/geometry/algorithms/make.hpp>
 #include <boost/geometry/algorithms/append.hpp>
+#include <boost/geometry/algorithms/assign.hpp>
 #include <boost/geometry/geometries/point.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/polygon.hpp>
@@ -40,6 +45,7 @@ bg::model::polygon<P> create_polygon()
     bg::assign_values(p1, 1, 2);
     bg::assign_values(p2, 2, 0);
     bg::assign_values(p3, 0, 0);
+
 
     bg::append(pl1, p1);
     bg::append(pl1, p2);

--- a/test/geometries/polygon.cpp
+++ b/test/geometries/polygon.cpp
@@ -3,8 +3,9 @@
 
 // Copyright (c) 2020 Digvijay Janartha, Hamirpur, India.
 
-// This file was modified by Oracle on 2021.
-// Modifications copyright (c) 2021, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2021-2023.
+// Modifications copyright (c) 2021-2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -16,6 +17,7 @@
 #include <geometry_test_common.hpp>
 
 #include <boost/core/ignore_unused.hpp>
+#include <boost/geometry/algorithms/assign.hpp>
 #include <boost/geometry/algorithms/make.hpp>
 #include <boost/geometry/algorithms/append.hpp>
 #include <boost/geometry/geometries/point.hpp>
@@ -33,7 +35,7 @@ BOOST_GEOMETRY_REGISTER_BOOST_TUPLE_CS(cs::cartesian)
 
 template <typename P>
 bg::model::polygon<P> create_polygon()
-{   
+{
     bg::model::polygon<P> pl1;
     P p1;
     P p2;
@@ -41,7 +43,7 @@ bg::model::polygon<P> create_polygon()
     bg::assign_values(p1, 1, 2);
     bg::assign_values(p2, 2, 0);
     bg::assign_values(p3, 0, 0);
-    
+
     bg::append(pl1, p1);
     bg::append(pl1, p2);
     bg::append(pl1, p3);
@@ -51,7 +53,7 @@ bg::model::polygon<P> create_polygon()
 
 template <typename PL, typename P>
 void check_polygon(PL& to_check, P p1, P p2, P p3)
-{   
+{
     PL cur;
     bg::append(cur, p1);
     bg::append(cur, p2);
@@ -88,7 +90,7 @@ void test_copy_assignment()
 
 template <typename P>
 void test_concept()
-{   
+{
     typedef bg::model::polygon<P> PL;
 
     BOOST_CONCEPT_ASSERT( (bg::concepts::ConstPolygon<PL>) );
@@ -101,7 +103,7 @@ void test_concept()
 
 template <typename P>
 void test_all()
-{   
+{
     test_default_constructor<P>();
     test_copy_constructor<P>();
     test_copy_assignment<P>();
@@ -110,7 +112,7 @@ void test_all()
 
 template <typename P>
 void test_custom_polygon(bg::model::ring<P> IL)
-{   
+{
     std::initializer_list<bg::model::ring<P> > RIL = {IL};
     bg::model::polygon<P> pl1(RIL);
     std::ostringstream out;
@@ -120,7 +122,7 @@ void test_custom_polygon(bg::model::ring<P> IL)
 
 template <typename P>
 void test_custom()
-{   
+{
     std::initializer_list<P> IL = {P(3, 3), P(3, 0), P(0, 0), P(0, 3), P(3, 3)};
     bg::model::ring<P> r1(IL);
     test_custom_polygon<P>(r1);
@@ -138,7 +140,7 @@ void test_cs()
 
 
 int test_main(int, char* [])
-{   
+{
     test_cs<bg::cs::cartesian>();
     test_cs<bg::cs::spherical<bg::degree> >();
     test_cs<bg::cs::spherical_equatorial<bg::degree> >();

--- a/test/geometries/ring.cpp
+++ b/test/geometries/ring.cpp
@@ -3,6 +3,10 @@
 
 // Copyright (c) 2020 Digvijay Janartha, Hamirpur, India.
 
+// This file was modified by Oracle on 2023.
+// Modifications copyright (c) 2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -12,6 +16,7 @@
 #include <geometry_test_common.hpp>
 
 #include <boost/core/ignore_unused.hpp>
+#include <boost/geometry/algorithms/assign.hpp>
 #include <boost/geometry/algorithms/make.hpp>
 #include <boost/geometry/algorithms/append.hpp>
 #include <boost/geometry/geometries/point.hpp>
@@ -41,6 +46,7 @@ bg::model::ring<P> create_ring()
     bg::assign_values(p2, 2, 0);
     bg::assign_values(p3, 0, 0);
     bg::assign_values(p4, 0, 2);
+
 
     bg::append(r1, p1);
     bg::append(r1, p2);

--- a/test/headers/Jamfile
+++ b/test/headers/Jamfile
@@ -2,6 +2,10 @@
 #
 # Copyright (c) 2018 Mateusz Loskot <mateusz@loskot.net>
 #
+# This file was modified by Oracle on 2023.
+# Modifications copyright (c) 2023 Oracle and/or its affiliates.
+# Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
+#
 # Use, modification and distribution is subject to the Boost Software License,
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
@@ -27,7 +31,8 @@ rule generate_self_contained_headers ( headers_subpath )
 
     local top_headers_path = [ path.make $(BOOST_ROOT)/libs/geometry/include/boost/geometry ] ;
 
-    for local file in [ path.glob-tree $(top_headers_path)/$(headers_subpath) : *.hpp ]
+    # Skip the OpenGL visualization related header
+    for local file in [ path.glob-tree $(top_headers_path)/$(headers_subpath) : *.hpp : gl_draw.hpp  ]
     {
         local rel_file = [ path.relative-to $(top_headers_path) $(file) ] ;
         local target_name = [ regex.replace h/$(rel_file) "/" "-" ] ;

--- a/test/strategies/matrix_transformer.cpp
+++ b/test/strategies/matrix_transformer.cpp
@@ -3,6 +3,10 @@
 
 // Copyright (c) 2019 Tinko Bartels
 
+// This file was modified by Oracle on 2023.
+// Modifications copyright (c) 2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -13,9 +17,10 @@
 
 #include <geometry_test_common.hpp>
 
-#include <boost/geometry/strategies/transform/matrix_transformers.hpp>
+#include <boost/geometry/algorithms/assign.hpp>
 #include <boost/geometry/algorithms/transform.hpp>
 #include <boost/geometry/geometries/point.hpp>
+#include <boost/geometry/strategies/transform/matrix_transformers.hpp>
 
 template <typename coordinate_type>
 void test_all()

--- a/test/strategies/transformer.cpp
+++ b/test/strategies/transformer.cpp
@@ -8,6 +8,10 @@
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
+// This file was modified by Oracle on 2023.
+// Modifications copyright (c) 2023, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
+
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -15,17 +19,17 @@
 
 #include <geometry_test_common.hpp>
 
-#include <boost/geometry/strategies/transform/inverse_transformer.hpp>
-#include <boost/geometry/strategies/transform/map_transformer.hpp>
-#include <boost/geometry/strategies/transform/matrix_transformers.hpp>
-
-
+#include <boost/geometry/algorithms/assign.hpp>
 #include <boost/geometry/algorithms/make.hpp>
 #include <boost/geometry/algorithms/transform.hpp>
 
 #include <boost/geometry/geometries/point.hpp>
 #include <boost/geometry/geometries/adapted/c_array.hpp>
 #include <boost/geometry/geometries/adapted/boost_tuple.hpp>
+
+#include <boost/geometry/strategies/transform/inverse_transformer.hpp>
+#include <boost/geometry/strategies/transform/map_transformer.hpp>
+#include <boost/geometry/strategies/transform/matrix_transformers.hpp>
 
 BOOST_GEOMETRY_REGISTER_C_ARRAY_CS(cs::cartesian)
 BOOST_GEOMETRY_REGISTER_BOOST_TUPLE_CS(cs::cartesian)

--- a/test/util/algorithm.cpp
+++ b/test/util/algorithm.cpp
@@ -1,7 +1,8 @@
 // Boost.Geometry
 
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021-2023, Oracle and/or its affiliates.
 
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Licensed under the Boost Software License version 1.0.
@@ -11,6 +12,8 @@
 #include <geometry_test_common.hpp>
 
 #include <boost/geometry/algorithms/assign.hpp>
+
+#include <boost/geometry/arithmetic/arithmetic.hpp>
 
 #include <boost/geometry/core/cs.hpp>
 


### PR DESCRIPTION
Fixes https://github.com/boostorg/geometry/issues/523

Also adds a github actions script to test that all headers compile independently.