### PR TITLE
Update circleCI scripts and image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,10 @@
 # Copyright (c) 2018 Mateusz Loskot <mateusz@loskot.net>
 # Copyright (c) 2018-2021 Adam Wulkiewicz, Lodz, Poland
 #
+# This file was modified by Oracle on 2023.
+# Modifications copyright (c) 2023 Oracle and/or its affiliates.
+# Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
+#
 # Use, modification and distribution is subject to the Boost Software License,
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
@@ -19,8 +23,8 @@ environment: &environment
 # Docker image
 docker: &docker
   docker:
-      # gcc-6.0, ruby-2.3, sudo, curl
-    - image: circleci/ruby:2.3
+      # gcc-9.3, ruby-2.3, sudo, curl
+    - image: cimg/base:stable-20.04
 
 # Build configuration
 config: &config
@@ -60,7 +64,7 @@ jobs:
             git submodule update --init tools/build
             git submodule update --init libs/config
             git submodule update --init tools/boostdep
-            python tools/boostdep/depinst/depinst.py geometry -I index/test
+            python3 tools/boostdep/depinst/depinst.py geometry -I index/test
             ./bootstrap.sh
             ./b2 headers
       - run: mkdir $COVERAGE_DIR

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,24 @@ jobs:
           root: ~/project
           paths:
             - shared-coverage/algorithms_buffer
+  algorithms_closest_points:
+    <<: *config
+    steps:
+      - *attach_workspace
+      - run: ./$BOOST_DIR/libs/geometry/.circleci/run_test.sh algorithms_closest_points test/algorithms/closest_points 1
+      - persist_to_workspace:
+          root: ~/project
+          paths:
+            - shared-coverage/algorithms_closest_points
+  algorithms_convex_hull:
+    <<: *config
+    steps:
+      - *attach_workspace
+      - run: ./$BOOST_DIR/libs/geometry/.circleci/run_test.sh algorithms_convex_hull test/algorithms/convex_hull
+      - persist_to_workspace:
+          root: ~/project
+          paths:
+            - shared-coverage/algorithms_convex_hull
   algorithms_covered_by:
     <<: *config
     steps:
@@ -335,6 +353,15 @@ jobs:
           root: ~/project
           paths:
             - shared-coverage/policies
+  robustness:
+    <<: *config
+    steps:
+      - *attach_workspace
+      - run: ./$BOOST_DIR/libs/geometry/.circleci/run_test.sh robustness test/robustness
+      - persist_to_workspace:
+          root: ~/project
+          paths:
+            - shared-coverage/robustness
   srs:
     <<: *config
     steps:
@@ -426,12 +453,14 @@ jobs:
     steps:
       - *attach_workspace
       - run: ls -lah $COVERAGE_DIR
+      - run: sudo apt-get update
       - run: sudo apt-get install lcov
       - run: lcov --directory $COVERAGE_DIR --base-directory $BOOST_DIR --capture --output-file $COVERAGE_DIR/coverage.info
       - run: lcov --extract $COVERAGE_DIR/coverage.info "*/boost/geometry/*" "*/libs/geometry/include/*" --output-file $COVERAGE_DIR/coverage.info
       - run: sed -i 's/SF:.*boost\/geometry/SF:boost\/geometry/g' $COVERAGE_DIR/coverage.info
 #Coveralls
-      - run: gem install coveralls-lcov
+      - run: sudo apt-get install rubygems
+      - run: sudo gem install coveralls-lcov
       - run: sudo apt-get install jq
       - run: cd $BOOST_DIR/libs/geometry/include && coveralls-lcov --repo-token=$COVERALLS_REPO_TOKEN -v -n ../../../../$COVERAGE_DIR/coverage.info > ../../../../$COVERAGE_DIR/coverage.json
       - run: jq -c ".service_name = \"circle-ci\" | .service_number = \"$CIRCLE_BUILD_NUM\" | .git .branch =\"$CIRCLE_BRANCH\"" $COVERAGE_DIR/coverage.json > $COVERAGE_DIR/processed.json
@@ -466,6 +495,7 @@ requires_2: &requires_2
     - io
     - iterators
     - policies
+    - robustness
     - strategies
     - views
 
@@ -474,6 +504,8 @@ requires_3: &requires_3
     - algorithms
     - algorithms_area
     - algorithms_buffer
+    - algorithms_closest_points
+    - algorithms_convex_hull
     - algorithms_covered_by
     - algorithms_crosses
     - algorithms_disjoint
@@ -554,6 +586,9 @@ workflows:
       - policies:
           <<: *requires_1
           <<: *only_master_develop
+      - robustness:
+          <<: *requires_1
+          <<: *only_master_develop
       - strategies:
           <<: *requires_1
           <<: *only_master_develop
@@ -568,6 +603,12 @@ workflows:
           <<: *requires_2
           <<: *only_master_develop
       - algorithms_buffer:
+          <<: *requires_2
+          <<: *only_master_develop
+      - algorithms_closest_points:
+          <<: *requires_2
+          <<: *only_master_develop
+      - algorithms_convex_hull:
           <<: *requires_2
           <<: *only_master_develop
       - algorithms_covered_by:

--- a/.circleci/run_test.sh
+++ b/.circleci/run_test.sh
@@ -18,7 +18,7 @@ fi
 
 cd $BOOST_DIR
 
-./b2 -j$TEST_NPARALLEL cxxflags="--coverage" linkflags="--coverage" libs/geometry/$TEST_DIR
+./b2 -j$TEST_NPARALLEL toolset=gcc cxxflags="--coverage" linkflags="--coverage" libs/geometry/$TEST_DIR
 
 EXIT_STATUS=$?
 


### PR DESCRIPTION
Following the discussion [here](https://github.com/boostorg/geometry/discussions/1155) this PR proposes:

- to update the circleCI image to a next-gen convenience image (read [this](https://circleci.com/docs/next-gen-migration-guide/) for the advantages of this change). Moreover, following the discussion [here](https://github.com/boostorg/geometry/pull/1147) the compiler is set to gcc-6 to possible catch library issues,
- add ~~a closing job to circleCI to cover~~ missing tests.