### PR TITLE
Fix Visual Studio warnings

### DIFF
--- a/include/boost/geometry/algorithms/detail/buffer/piece_border.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/piece_border.hpp
@@ -353,7 +353,7 @@ private :
               TiRStrategy const& strategy,
               geometry::strategy::buffer::place_on_ring_type place_on_ring, State& state) const
     {
-        return strategy.apply(point, p1, p2, place_on_ring, m_is_convex, state, get_full_ring());
+        return strategy.apply(point, p1, p2, place_on_ring, m_is_convex, state);
     }
 
     template <typename It, typename Box, typename Strategy>

--- a/include/boost/geometry/algorithms/detail/convex_hull/interface.hpp
+++ b/include/boost/geometry/algorithms/detail/convex_hull/interface.hpp
@@ -3,6 +3,7 @@
 // Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2014-2021.
 // Modifications copyright (c) 2014-2021 Oracle and/or its affiliates.
@@ -224,7 +225,7 @@ struct convex_hull<Box, box_tag>
     template <typename OutputGeometry, typename Strategy>
     static inline void apply(Box const& box,
                              OutputGeometry& out,
-                             Strategy const& strategy)
+                             Strategy const& )
     {
         static bool const Close
             = geometry::closure<OutputGeometry>::value == closed;

--- a/include/boost/geometry/algorithms/detail/overlay/handle_self_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/handle_self_turns.hpp
@@ -1,7 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2017 Barend Gehrels, Amsterdam, the Netherlands.
-// Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
+// Copyright (c) 2017-2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2019-2022.
 // Modifications copyright (c) 2019-2022 Oracle and/or its affiliates.
@@ -165,8 +165,8 @@ private :
             if (! cinfo.turn_indices.empty()
                 && is_self_cluster(cluster_id, turns, clusters))
             {
-                signed_size_type const index = *cinfo.turn_indices.begin();
-                if (! check_within<OverlayType>::apply(turns[index],
+                signed_size_type const first_index = *cinfo.turn_indices.begin();
+                if (! check_within<OverlayType>::apply(turns[first_index],
                                                        geometry0, geometry1,
                                                        strategy))
                 {

--- a/include/boost/geometry/algorithms/detail/overlay/pointlike_pointlike.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/pointlike_pointlike.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014-2020, Oracle and/or its affiliates.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
+// Copyright (c) 2014-2020, Oracle and/or its affiliates.
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -32,6 +33,8 @@
 #include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/policies/compare.hpp>
+
+#include <boost/geometry/util/condition.hpp>
 
 
 namespace boost { namespace geometry
@@ -256,8 +259,8 @@ struct multipoint_multipoint_point
     {
         typedef geometry::less<void, -1, typename Strategy::cs_tag> less_type;
 
-        if ( OverlayType != overlay_difference
-             && boost::size(multipoint1) > boost::size(multipoint2) )
+        if (BOOST_GEOMETRY_CONDITION(OverlayType != overlay_difference)
+            && boost::size(multipoint1) > boost::size(multipoint2))
         {
             return multipoint_multipoint_point
                 <

--- a/include/boost/geometry/algorithms/detail/relate/implementation_gc.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/implementation_gc.hpp
@@ -1,9 +1,8 @@
 // Boost.Geometry
 
-// Copyright (c) 2022 Adam Wulkiewicz, Lodz, Poland.
+// Copyright (c) 2022-2023 Adam Wulkiewicz, Lodz, Poland.
 
 // Copyright (c) 2022 Oracle and/or its affiliates.
-
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -25,6 +24,7 @@
 #include <boost/geometry/geometries/multi_point.hpp>
 #include <boost/geometry/geometries/multi_polygon.hpp>
 #include <boost/geometry/geometries/polygon.hpp>
+#include <boost/geometry/util/condition.hpp>
 #include <boost/geometry/views/detail/geometry_collection_view.hpp>
 
 
@@ -49,18 +49,17 @@ struct aa_handler_wrapper
 
     explicit aa_handler_wrapper(Handler& handler)
         : m_handler(handler)
-    {
-        m_overwrite_ii = ! handler.template may_update<interior, interior, '2'>();
-        m_overwrite_ie = ! handler.template may_update<interior, exterior, '2'>();
-        m_overwrite_ei = ! handler.template may_update<exterior, interior, '2'>();
-    }
+        , m_overwrite_ii(! handler.template may_update<interior, interior, '2'>())
+        , m_overwrite_ie(! handler.template may_update<interior, exterior, '2'>())
+        , m_overwrite_ei(! handler.template may_update<exterior, interior, '2'>())
+    {}
 
     template <field F1, field F2, char D>
     inline bool may_update() const
     {
-        if ((F1 == interior && F2 == interior && m_overwrite_ii)
-            || (F1 == interior && F2 == exterior && m_overwrite_ie)
-            || (F1 == exterior && F2 == interior && m_overwrite_ei))
+        if ((BOOST_GEOMETRY_CONDITION(F1 == interior && F2 == interior) && m_overwrite_ii)
+            || (BOOST_GEOMETRY_CONDITION(F1 == interior && F2 == exterior) && m_overwrite_ie)
+            || (BOOST_GEOMETRY_CONDITION(F1 == exterior && F2 == interior) && m_overwrite_ei))
         {
             char const c = m_handler.template get<F1, F2>();
             return D > c || c > '9';
@@ -74,9 +73,9 @@ struct aa_handler_wrapper
     template <field F1, field F2, char V>
     inline void update()
     {
-        if ((F1 == interior && F2 == interior && m_overwrite_ii)
-            || (F1 == interior && F2 == exterior && m_overwrite_ie)
-            || (F1 == exterior && F2 == interior && m_overwrite_ei))
+        if ((BOOST_GEOMETRY_CONDITION(F1 == interior && F2 == interior) && m_overwrite_ii)
+            || (BOOST_GEOMETRY_CONDITION(F1 == interior && F2 == exterior) && m_overwrite_ie)
+            || (BOOST_GEOMETRY_CONDITION(F1 == exterior && F2 == interior) && m_overwrite_ei))
         {
             // NOTE: Other handlers first check for potential interruption
             //   and only after that checks update condition.
@@ -97,9 +96,9 @@ struct aa_handler_wrapper
 
 private:
     Handler & m_handler;
-    bool m_overwrite_ii = false;
-    bool m_overwrite_ie = false;
-    bool m_overwrite_ei = false;
+    bool const m_overwrite_ii;
+    bool const m_overwrite_ie;
+    bool const m_overwrite_ei;
 };
 
 

--- a/include/boost/geometry/algorithms/detail/relate/linear_areal.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/linear_areal.hpp
@@ -1,10 +1,10 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2013-2022.
 // Modifications copyright (c) 2013-2022 Oracle and/or its affiliates.
-
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -234,7 +234,7 @@ template
     typename Strategy
 >
 inline bool calculate_from_inside_sides(Pi const& pi, Pj const& pj, Pk const& pk,
-                                        Qi const& qi, Qj const& qj, Qk const& qk,
+                                        Qi const&   , Qj const& qj, Qk const& qk,
                                         Strategy const& strategy)
 {
     auto const side_strategy = strategy.side();

--- a/include/boost/geometry/algorithms/detail/sweep.hpp
+++ b/include/boost/geometry/algorithms/detail/sweep.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2015, Oracle and/or its affiliates.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
+// Copyright (c) 2015, Oracle and/or its affiliates.
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
 // Licensed under the Boost Software License version 1.0.
@@ -9,6 +10,8 @@
 
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_SWEEP_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_SWEEP_HPP
+
+#include <boost/geometry/util/condition.hpp>
 
 #include <boost/core/ignore_unused.hpp>
 
@@ -56,7 +59,7 @@ inline void sweep(Range const& range, PriorityQueue& queue,
         event_type event = queue.top();
         queue.pop();
         event_visitor.apply(event, queue);
-        if (interrupt_policy.enabled && interrupt_policy.apply(event))
+        if (BOOST_GEOMETRY_CONDITION(interrupt_policy.enabled) && interrupt_policy.apply(event))
         {
             break;
         }

--- a/include/boost/geometry/algorithms/detail/within/multi_point.hpp
+++ b/include/boost/geometry/algorithms/detail/within/multi_point.hpp
@@ -1,5 +1,7 @@
 // Boost.Geometry
 
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
+
 // Copyright (c) 2017-2020, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -38,6 +40,7 @@
 #include <boost/geometry/strategies/covered_by.hpp>
 #include <boost/geometry/strategies/disjoint.hpp>
 
+#include <boost/geometry/util/condition.hpp>
 #include <boost/geometry/util/type_traits.hpp>
 
 
@@ -234,7 +237,7 @@ struct multi_point_multi_geometry
 
             if (boundaries > 0)
             {
-                if (is_linear && boundaries % 2 == 0)
+                if (BOOST_GEOMETRY_CONDITION(is_linear) && boundaries % 2 == 0)
                 {
                     found_interior = true;
                 }

--- a/include/boost/geometry/algorithms/simplify.hpp
+++ b/include/boost/geometry/algorithms/simplify.hpp
@@ -3,6 +3,7 @@
 // Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2018-2022.
 // Modifications copyright (c) 2018-2022 Oracle and/or its affiliates.
@@ -482,7 +483,7 @@ public :
             // Do not duplicate the closing point
             auto rot_end = boost::end(ring);
             std::size_t rot_index = index;
-            if (is_closed_in && size > 1)
+            if (BOOST_GEOMETRY_CONDITION(is_closed_in) && size > 1)
             {
                 --rot_end;
                 if (rot_index == size - 1) { rot_index = 0; }
@@ -497,7 +498,7 @@ public :
             simplify_range<0>::apply(rotated, out, max_distance, impl, strategies);
 
             // Open output if needed
-            if (! is_closed_out && boost::size(out) > 1)
+            if (BOOST_GEOMETRY_CONDITION(! is_closed_out) && boost::size(out) > 1)
             {
                 range::pop_back(out);
             }

--- a/include/boost/geometry/formulas/area_formulas.hpp
+++ b/include/boost/geometry/formulas/area_formulas.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry
 
-// Copyright (c) 2015-2022 Oracle and/or its affiliates.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
+// Copyright (c) 2015-2022 Oracle and/or its affiliates.
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -380,7 +381,7 @@ public:
             return pi;
         }
 
-        if (LongSegment && lat1r != lat2r) // not for segments parallel to equator
+        if (BOOST_GEOMETRY_CONDITION(LongSegment) && lat1r != lat2r) // not for segments parallel to equator
         {
             CT const cbet1 = cos(lat1r);
             CT const sbet1 = sin(lat1r);

--- a/include/boost/geometry/formulas/differential_quantities.hpp
+++ b/include/boost/geometry/formulas/differential_quantities.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry
 
-// Copyright (c) 2016-2019 Oracle and/or its affiliates.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
+// Copyright (c) 2016-2019 Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -162,7 +163,7 @@ private:
                            CT const& sin_sig2, CT const& cos_sig2,
                            CT const& cos_alp0_sqr, CT const& f)
     {
-        if (Order == 0)
+        if (BOOST_GEOMETRY_CONDITION(Order == 0))
         {
             return 0;
         }
@@ -176,7 +177,7 @@ private:
         CT const sin_2sig_12 = sin_2sig2 - sin_2sig1;
         CT const L1 = sig_12 - sin_2sig_12 / c2;
 
-        if (Order == 1)
+        if (BOOST_GEOMETRY_CONDITION(Order == 1))
         {
             return cos_alp0_sqr * f * L1;
         }
@@ -195,7 +196,7 @@ private:
                          + (c12 * cos_alp0_sqr - c24) * sig_12)
                        / c16;
 
-        if (Order == 2)
+        if (BOOST_GEOMETRY_CONDITION(Order == 2))
         {
             return cos_alp0_sqr * f * (L1 + f * L2);
         }
@@ -241,7 +242,7 @@ private:
                                 CT const& sin_sig2, CT const& cos_sig2,
                                 CT const& cos_alp0_sqr, CT const& ep_sqr)
     {
-        if (Order == 0)
+        if (BOOST_GEOMETRY_CONDITION(Order == 0))
         {
             return 0;
         }
@@ -259,7 +260,7 @@ private:
 
         CT const L1 = (c2 * sig_12 - sin_2sig_12) / c4;
 
-        if (Order == 1)
+        if (BOOST_GEOMETRY_CONDITION(Order == 1))
         {
             return c2a0ep2 * L1;
         }
@@ -273,7 +274,7 @@ private:
 
         CT const L2 = (sin_4sig_12 - c8 * sin_2sig_12 + 12 * sig_12) / c64;
 
-        if (Order == 2)
+        if (BOOST_GEOMETRY_CONDITION(Order == 2))
         {
             return c2a0ep2 * (L1 + c2a0ep2 * L2);
         }

--- a/include/boost/geometry/formulas/gnomonic_intersection.hpp
+++ b/include/boost/geometry/formulas/gnomonic_intersection.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry
 
-// Copyright (c) 2016 Oracle and/or its affiliates.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
+// Copyright (c) 2016 Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -80,7 +81,7 @@ public:
             CT xa1, ya1, xa2, ya2;
             CT xb1, yb1, xb2, yb2;
             CT x, y;
-            double lat1, lon1;
+            CT lon1, lat1;
 
             bool ok = gnom_t::forward(lon, lat, lona1, lata1, xa1, ya1, spheroid)
                    && gnom_t::forward(lon, lat, lona2, lata2, xa2, ya2, spheroid)

--- a/include/boost/geometry/formulas/karney_inverse.hpp
+++ b/include/boost/geometry/formulas/karney_inverse.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry
 
 // Copyright (c) 2018 Adeel Ahmad, Islamabad, Pakistan.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // Contributed and/or modified by Adeel Ahmad, as part of Google Summer of Code 2018 program.
 
@@ -267,8 +268,8 @@ public:
             CT sin_sigma2 = sin_beta2;
             CT cos_sigma2 = cos_alpha2 * cos_beta2;
 
-            CT sigma12 = std::atan2((std::max)(c0, cos_sigma1 * sin_sigma2 - sin_sigma1 * cos_sigma2),
-                                                   cos_sigma1 * cos_sigma2 + sin_sigma1 * sin_sigma2);
+            sigma12 = std::atan2((std::max)(c0, cos_sigma1 * sin_sigma2 - sin_sigma1 * cos_sigma2),
+                                                cos_sigma1 * cos_sigma2 + sin_sigma1 * sin_sigma2);
 
             CT dummy;
             meridian_length(n, ep2, sigma12, sin_sigma1, cos_sigma1, dn1,
@@ -281,7 +282,7 @@ public:
             {
                 if (sigma12 < c3 * tiny)
                 {
-                    sigma12  = m12x = s12x = c0;
+                    sigma12 = m12x = s12x = c0;
                 }
 
                 m12x *= b;

--- a/include/boost/geometry/formulas/meridian_direct.hpp
+++ b/include/boost/geometry/formulas/meridian_direct.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry
 
-// Copyright (c) 2018 Oracle and/or its affiliates.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
+// Copyright (c) 2018 Oracle and/or its affiliates.
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -127,14 +128,14 @@ public:
         CT mp = formula::quarter_meridian<CT>(spheroid);
         CT mu = geometry::math::pi<CT>()/CT(2) * m / mp;
 
-        if (Order == 0)
+        if (BOOST_GEOMETRY_CONDITION(Order == 0))
         {
             return mu;
         }
 
         CT H2 = 1.5 * n;
 
-        if (Order == 1)
+        if (BOOST_GEOMETRY_CONDITION(Order == 1))
         {
             return mu + H2 * sin(2*mu);
         }
@@ -142,7 +143,7 @@ public:
         CT n2 = n * n;
         CT H4 = 1.3125 * n2;
 
-        if (Order == 2)
+        if (BOOST_GEOMETRY_CONDITION(Order == 2))
         {
             return mu + H2 * sin(2*mu) + H4 * sin(4*mu);
         }
@@ -151,7 +152,7 @@ public:
         H2 -= 0.84375 * n3;
         CT H6 = 1.572916667 * n3;
 
-        if (Order == 3)
+        if (BOOST_GEOMETRY_CONDITION(Order == 3))
         {
             return mu + H2 * sin(2*mu) + H4 * sin(4*mu) + H6 * sin(6*mu);
         }

--- a/include/boost/geometry/formulas/meridian_inverse.hpp
+++ b/include/boost/geometry/formulas/meridian_inverse.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry
 
-// Copyright (c) 2017-2018 Oracle and/or its affiliates.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
+// Copyright (c) 2017-2018 Oracle and/or its affiliates.
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -118,14 +119,14 @@ public :
         CT M = a/(1+n);
         CT C0 = 1;
 
-        if (Order == 0)
+        if (BOOST_GEOMETRY_CONDITION(Order == 0))
         {
            return M * C0 * lat;
         }
 
         CT C2 = -1.5 * n;
 
-        if (Order == 1)
+        if (BOOST_GEOMETRY_CONDITION(Order == 1))
         {
             return M * (C0 * lat + C2 * sin(2*lat));
         }
@@ -134,7 +135,7 @@ public :
         C0 += .25 * n2;
         CT C4 = 0.9375 * n2;
 
-        if (Order == 2)
+        if (BOOST_GEOMETRY_CONDITION(Order == 2))
         {
             return M * (C0 * lat + C2 * sin(2*lat) + C4 * sin(4*lat));
         }
@@ -143,7 +144,7 @@ public :
         C2 += 0.1875 * n3;
         CT C6 = -0.729166667 * n3;
 
-        if (Order == 3)
+        if (BOOST_GEOMETRY_CONDITION(Order == 3))
         {
             return M * (C0 * lat + C2 * sin(2*lat) + C4 * sin(4*lat)
                       + C6 * sin(6*lat));
@@ -153,7 +154,7 @@ public :
         C4 -= 0.234375 * n4;
         CT C8 = 0.615234375 * n4;
 
-        if (Order == 4)
+        if (BOOST_GEOMETRY_CONDITION(Order == 4))
         {
             return M * (C0 * lat + C2 * sin(2*lat) + C4 * sin(4*lat)
                       + C6 * sin(6*lat) + C8 * sin(8*lat));

--- a/include/boost/geometry/formulas/sjoberg_intersection.hpp
+++ b/include/boost/geometry/formulas/sjoberg_intersection.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry
 
-// Copyright (c) 2016-2019 Oracle and/or its affiliates.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
+// Copyright (c) 2016-2019 Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -206,7 +207,7 @@ inline CT sjoberg_d_lambda_e_sqr(CT const& sin_betaj, CT const& sin_beta,
 {
     using math::detail::bounded;
 
-    if (Order == 0)
+    if (BOOST_GEOMETRY_CONDITION(Order == 0))
     {
         return 0;
     }
@@ -218,7 +219,7 @@ inline CT sjoberg_d_lambda_e_sqr(CT const& sin_betaj, CT const& sin_beta,
     CT const asin_Bj = asin(sin_betaj / sqrt_1_Cj_sqr);
     CT const L0 = (asin_B - asin_Bj) / c2;
 
-    if (Order == 1)
+    if (BOOST_GEOMETRY_CONDITION(Order == 1))
     {
         return -Cj * e_sqr * L0;
     }
@@ -237,7 +238,7 @@ inline CT sjoberg_d_lambda_e_sqr(CT const& sin_betaj, CT const& sin_beta,
     CT const sqrt_Yj = math::sqrt(-Xj_sqr + one_minus_Cj_sqr);
     CT const L1 = (Cj_sqr_plus_one * (asin_B - asin_Bj) + X * sqrt_Y - Xj * sqrt_Yj) / c16;
 
-    if (Order == 2)
+    if (BOOST_GEOMETRY_CONDITION(Order == 2))
     {
         return -Cj * e_sqr * (L0 + e_sqr * L1);
     }
@@ -251,7 +252,7 @@ inline CT sjoberg_d_lambda_e_sqr(CT const& sin_betaj, CT const& sin_beta,
     CT const Fj = Xj * (-c2 * Xj_sqr + c3 * Cj_sqr + c5);
     CT const L2 = (E * (asin_B - asin_Bj) + F * sqrt_Y - Fj * sqrt_Yj) / c128;
 
-    if (Order == 3)
+    if (BOOST_GEOMETRY_CONDITION(Order == 3))
     {
         return -Cj * e_sqr * (L0 + e_sqr * (L1 + e_sqr * L2));
     }

--- a/include/boost/geometry/srs/projections/impl/pj_init.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_init.hpp
@@ -58,8 +58,8 @@
 #include <boost/geometry/srs/projections/proj4.hpp>
 #include <boost/geometry/srs/projections/spar.hpp>
 
-#include <boost/geometry/util/math.hpp>
 #include <boost/geometry/util/condition.hpp>
+#include <boost/geometry/util/math.hpp>
 
 
 namespace boost { namespace geometry { namespace projections
@@ -479,14 +479,14 @@ inline void pj_init_axis(Params const& params, parameters<T> & projdef)
 // TODO: implement axis support for other types of parameters
 
 template <typename T>
-inline void pj_init_axis(srs::dpar::parameters<T> const& params, parameters<T> & projdef)
+inline void pj_init_axis(srs::dpar::parameters<T> const& , parameters<T> & )
 {}
 
 template <typename Params>
 struct pj_init_axis_static
 {
     template <typename T>
-    static void apply(Params const& , parameters<T> & projdef)
+    static void apply(Params const& , parameters<T> & )
     {}
 };
 

--- a/include/boost/geometry/srs/projections/impl/pj_transform.hpp
+++ b/include/boost/geometry/srs/projections/impl/pj_transform.hpp
@@ -1,6 +1,8 @@
 // Boost.Geometry
 // This file is manually converted from PROJ4
 
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
+
 // This file was modified by Oracle on 2017, 2018.
 // Modifications copyright (c) 2017-2018, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -49,6 +51,7 @@
 #include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/invalid_point.hpp>
 
+#include <boost/geometry/util/condition.hpp>
 #include <boost/geometry/util/range.hpp>
 
 #include <cstring>
@@ -249,7 +252,7 @@ inline bool pj_transform(SrcPrj const& srcprj, Par const& srcdefn,
 /* -------------------------------------------------------------------- */
 /*      Transform Z to meters if it isn't already.                      */
 /* -------------------------------------------------------------------- */
-    if( srcdefn.vto_meter != 1.0 && dimension > 2 )
+    if( BOOST_GEOMETRY_CONDITION(srcdefn.vto_meter != 1.0 && dimension > 2) )
     {
         for( std::size_t i = 0; i < point_count; i++ )
         {
@@ -261,10 +264,10 @@ inline bool pj_transform(SrcPrj const& srcprj, Par const& srcdefn,
 /* -------------------------------------------------------------------- */
 /*      Transform geocentric source coordinates to lat/long.            */
 /* -------------------------------------------------------------------- */
-    if( srcdefn.is_geocent )
+    if( BOOST_GEOMETRY_CONDITION(srcdefn.is_geocent) )
     {
         // Point should be cartesian 3D (ECEF)
-        if (dimension < 3)
+        if ( BOOST_GEOMETRY_CONDITION(dimension < 3) )
             BOOST_THROW_EXCEPTION( projection_exception(error_geocentric) );
             //return PJD_ERR_GEOCENTRIC;
 
@@ -454,10 +457,10 @@ inline bool pj_transform(SrcPrj const& srcprj, Par const& srcdefn,
 /* -------------------------------------------------------------------- */
 /*      Transform destination latlong to geocentric if required.        */
 /* -------------------------------------------------------------------- */
-    if( dstdefn.is_geocent )
+    if( BOOST_GEOMETRY_CONDITION(dstdefn.is_geocent) )
     {
         // Point should be cartesian 3D (ECEF)
-        if (dimension < 3)
+        if ( BOOST_GEOMETRY_CONDITION(dimension < 3) )
             BOOST_THROW_EXCEPTION( projection_exception(error_geocentric) );
             //return PJD_ERR_GEOCENTRIC;
 

--- a/include/boost/geometry/srs/projections/proj/tmerc.hpp
+++ b/include/boost/geometry/srs/projections/proj/tmerc.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry - gis-projections (based on PROJ4)
 
 // Copyright (c) 2008-2015 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2017, 2018, 2019, 2022.
 // Modifications copyright (c) 2017-2022, Oracle and/or its affiliates.
@@ -41,14 +42,15 @@
 #ifndef BOOST_GEOMETRY_PROJECTIONS_TMERC_HPP
 #define BOOST_GEOMETRY_PROJECTIONS_TMERC_HPP
 
-#include <boost/geometry/util/math.hpp>
-
 #include <boost/geometry/srs/projections/impl/base_static.hpp>
 #include <boost/geometry/srs/projections/impl/base_dynamic.hpp>
 #include <boost/geometry/srs/projections/impl/projects.hpp>
 #include <boost/geometry/srs/projections/impl/factory_entry.hpp>
 #include <boost/geometry/srs/projections/impl/function_overloads.hpp>
 #include <boost/geometry/srs/projections/impl/pj_mlfn.hpp>
+
+#include <boost/geometry/util/condition.hpp>
+#include <boost/geometry/util/math.hpp>
 
 
 namespace boost { namespace geometry
@@ -291,7 +293,7 @@ namespace projections
 
             /* Ellipsoidal, forward */
             //static PJ_XY exact_e_fwd (PJ_LP lp, PJ *P)
-            inline void fwd(Parameters const& par,
+            inline void fwd(Parameters const& /*par*/,
                             T const& lp_lon,
                             T const& lp_lat,
                             T& xy_x, T& xy_y) const
@@ -382,7 +384,7 @@ namespace projections
 
 
             /* Ellipsoidal, inverse */
-            inline void inv(Parameters const& par,
+            inline void inv(Parameters const& /*par*/,
                             T const& xy_x,
                             T const& xy_y,
                             T& lp_lon,

--- a/include/boost/geometry/strategies/cartesian/buffer_join_round.hpp
+++ b/include/boost/geometry/strategies/cartesian/buffer_join_round.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2012-2015 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2015.
 // Modifications copyright (c) 2015, Oracle and/or its affiliates.
@@ -143,6 +144,7 @@ public :
         geometry::equal_to<Point> equals;
         if (equals(perp1, perp2))
         {
+            boost::ignore_unused(ip);
 #ifdef BOOST_GEOMETRY_DEBUG_BUFFER_WARN
             std::cout << "Corner for equal points " << geometry::wkt(ip) << " " << geometry::wkt(perp1) << std::endl;
 #endif

--- a/include/boost/geometry/strategies/cartesian/intersection.hpp
+++ b/include/boost/geometry/strategies/cartesian/intersection.hpp
@@ -1,7 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2007-2014 Barend Gehrels, Amsterdam, the Netherlands.
-// Copyright (c) 2013-2017 Adam Wulkiewicz, Lodz, Poland.
+// Copyright (c) 2013-2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2014-2021.
 // Modifications copyright (c) 2014-2021, Oracle and/or its affiliates.
@@ -249,10 +249,7 @@ struct cartesian_segments
                 assign_b(point, a, b);
             }
 
-#if defined(BOOST_GEOMETRY_USE_RESCALING)
-            return;
-#endif
-
+#ifndef BOOST_GEOMETRY_USE_RESCALING
             // Verify nearly collinear cases (the threshold is arbitrary
             // but influences performance). If the intersection is located
             // outside the segments, then it should be moved.
@@ -267,6 +264,7 @@ struct cartesian_segments
                 assign_if_exceeds(point, a);
                 assign_if_exceeds(point, b);
             }
+#endif
         }
 
         CoordinateType dx_a, dy_a;

--- a/include/boost/geometry/strategies/cartesian/turn_in_ring_winding.hpp
+++ b/include/boost/geometry/strategies/cartesian/turn_in_ring_winding.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2020 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -107,13 +108,12 @@ public:
         return s1y < s2y ? (py >= s1y && py <= s2y) : (py >= s2y && py <= s1y);
     }
 
-    template <typename Point, typename PointOfSegment, typename Ring>
+    template <typename Point, typename PointOfSegment>
     static inline void apply_on_boundary(Point const& point,
                              PointOfSegment const& s1,
                              PointOfSegment const& s2,
                              place_on_ring_type place_on_ring,
-                             counter& the_state,
-                             Ring const& full_ring)
+                             counter& the_state)
     {
         if (place_on_ring == place_on_ring_offsetted)
         {
@@ -149,13 +149,13 @@ public:
         }
     }
 
-    template <typename Point, typename PointOfSegment, typename Ring>
+    template <typename Point, typename PointOfSegment>
     static inline bool apply(Point const& point,
                              PointOfSegment const& s1,
                              PointOfSegment const& s2,
                              place_on_ring_type place_on_ring,
                              bool is_convex,
-                             counter& the_state, Ring const& full_ring)
+                             counter& the_state)
     {
         int const side = strategy::side::side_rounded_input<CalculationType>::apply(s1, s2, point);
 
@@ -179,7 +179,7 @@ public:
         {
             if (side == 0)
             {
-                apply_on_boundary(point, s1, s2, place_on_ring, the_state, full_ring);
+                apply_on_boundary(point, s1, s2, place_on_ring, the_state);
             }
 #if defined(BOOST_GEOMETRY_USE_RESCALING)
             else if (side == -1)

--- a/include/boost/geometry/strategies/geographic/buffer_join_round.hpp
+++ b/include/boost/geometry/strategies/geographic/buffer_join_round.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry
 
 // Copyright (c) 2022 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -55,7 +56,7 @@ public :
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
     //! Fills output_range with a rounded shape around a vertex
     template <typename Point, typename DistanceType, typename RangeOut>
-    inline bool apply(Point const& ip, Point const& vertex,
+    inline bool apply(Point const& /*ip*/, Point const& vertex,
                       Point const& perp1, Point const& perp2,
                       DistanceType const& buffer_distance,
                       RangeOut& range_out) const

--- a/include/boost/geometry/strategies/geographic/distance_cross_track.hpp
+++ b/include/boost/geometry/strategies/geographic/distance_cross_track.hpp
@@ -465,7 +465,7 @@ private:
 
 
     template <typename CT>
-    static inline auto non_iterative_case(CT const& lon1, CT const& lat1, //p1
+    static inline auto non_iterative_case(CT const&     , CT const&     , //p1
                                           CT const& lon2, CT const& lat2, //p2
                                           CT const& distance)
     {

--- a/include/boost/geometry/util/precise_math.hpp
+++ b/include/boost/geometry/util/precise_math.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2019 Tinko Bartels, Berlin, Germany.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // Contributed and/or modified by Tinko Bartels,
 //   as part of Google Summer of Code 2019 program.
@@ -22,6 +23,7 @@
 #include<array>
 
 #include <boost/geometry/core/access.hpp>
+#include <boost/geometry/util/condition.hpp>
 
 // The following code is based on "Adaptive Precision Floating-Point Arithmetic
 // and Fast Robust Geometric Predicates" by Richard Shewchuk,
@@ -294,7 +296,7 @@ inline RealNumber orient2dtail(vec2d<RealNumber> const& p1,
     t6_01[1] = two_product_tail(t3[0], t4[0], t6_01[0]);
     std::array<RealNumber, 4> tA_03 = two_two_expansion_diff(t5_01, t6_01);
     RealNumber det = std::accumulate(tA_03.begin(), tA_03.end(), static_cast<RealNumber>(0));
-    if (Robustness == 1)
+    if (BOOST_GEOMETRY_CONDITION(Robustness == 1))
     {
         return det;
     }
@@ -381,7 +383,7 @@ inline RealNumber orient2d(vec2d<RealNumber> const& p1,
     t6_01[0] = t3[0] * t4[0];
     RealNumber det = t5_01[0] - t6_01[0];
 
-    if (Robustness == 0)
+    if (BOOST_GEOMETRY_CONDITION(Robustness == 0))
     {
         return det;
     }

--- a/include/boost/geometry/util/series_expansion.hpp
+++ b/include/boost/geometry/util/series_expansion.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry
 
 // Copyright (c) 2018 Adeel Ahmad, Islamabad, Pakistan.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // Contributed and/or modified by Adeel Ahmad, as part of Google Summer of Code 2018 program.
 
@@ -60,9 +61,9 @@ namespace boost { namespace geometry { namespace series_expansion {
                s/case\sCT(/case /g; s/):/:/g; s/epsCT(2)/eps2/g;'
     */
     template <size_t SeriesOrder, typename CT>
-    inline CT evaluate_A1(CT eps)
+    inline CT evaluate_A1(CT const& eps)
     {
-        CT eps2 = math::sqr(eps);
+        CT const eps2 = math::sqr(eps);
         CT t;
         switch (SeriesOrder/2)
         {
@@ -78,7 +79,7 @@ namespace boost { namespace geometry { namespace series_expansion {
         case 3:
             t = eps2*(eps2*(eps2+CT(4))+CT(64))/CT(256);
             break;
-        case 4:
+        default:
             t = eps2*(eps2*(eps2*(CT(25)*eps2+CT(64))+CT(256))+CT(4096))/CT(16384);
             break;
         }
@@ -224,7 +225,7 @@ namespace boost { namespace geometry { namespace series_expansion {
     template <typename Coeffs, typename CT>
     inline void evaluate_coeffs_C1(Coeffs &c, CT const& eps)
     {
-        CT eps2 = math::sqr(eps);
+        CT const eps2 = math::sqr(eps);
         CT d = eps;
         switch (int(Coeffs::static_size) - 1)
         {

--- a/test/algorithms/set_operations/difference/test_difference.hpp
+++ b/test/algorithms/set_operations/difference/test_difference.hpp
@@ -2,7 +2,7 @@
 // Unit Test
 
 // Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
-// Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
+// Copyright (c) 2017-2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2016-2020.
 // Modifications copyright (c) 2016-2020, Oracle and/or its affiliates.
@@ -167,6 +167,7 @@ std::string test_difference(std::string const& caseid, G1 const& g1, G2 const& g
 {
     typedef typename bg::coordinate_type<G1>::type coordinate_type;
     boost::ignore_unused<coordinate_type>();
+    boost::ignore_unused(expected_point_count);
 
     bg::model::multi_polygon<OutputType> result;
 

--- a/test/algorithms/set_operations/intersection/test_intersection.hpp
+++ b/test/algorithms/set_operations/intersection/test_intersection.hpp
@@ -1,6 +1,8 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 // Unit Test
 
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
+
 // Copyright (c) 2007-2015 Barend Gehrels, Amsterdam, the Netherlands.
 
 // This file was modified by Oracle on 2016-2021.
@@ -17,6 +19,7 @@
 #include <fstream>
 #include <iomanip>
 
+#include <boost/core/ignore_unused.hpp>
 #include <boost/range/value_type.hpp>
 #include <boost/variant/variant.hpp>
 
@@ -65,6 +68,8 @@ void check_result(IntersectionOutput const& intersection_output,
     int expected_point_count, expectation_limits const& expected_length_or_area,
     ut_settings const& settings)
 {
+    boost::ignore_unused(expected_point_count);
+
     typedef typename boost::range_value<IntersectionOutput>::type OutputType;
     bool const is_line = bg::geometry_id<OutputType>::type::value == 2;
 

--- a/test/algorithms/set_operations/intersection/test_intersection_linear_linear.hpp
+++ b/test/algorithms/set_operations/intersection/test_intersection_linear_linear.hpp
@@ -1,5 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
+
 // Copyright (c) 2014-2021, Oracle and/or its affiliates.
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -55,8 +57,8 @@ struct ut_settings
 
 
 template <typename Geometry1, typename Geometry2, typename MultiLineString>
-inline void check_result(Geometry1 const& geometry1,
-                         Geometry2 const& geometry2,
+inline void check_result(Geometry1 const& ,
+                         Geometry2 const& ,
                          MultiLineString const& mls_output,
                          MultiLineString const& mls_int1,
                          MultiLineString const& mls_int2,

--- a/test/geometries/boost_polygon.cpp
+++ b/test/geometries/boost_polygon.cpp
@@ -2,6 +2,7 @@
 // Unit Test
 
 // Copyright (c) 2010-2012 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -34,14 +35,15 @@
 template <typename T>
 void fill_polygon_with_two_holes(boost::polygon::polygon_with_holes_data<T>& boost_polygon_polygon)
 {
-    std::vector<boost::polygon::point_data<T> > point_vector;
-    point_vector.push_back(boost::polygon::point_data<T>(0, 0));
-    point_vector.push_back(boost::polygon::point_data<T>(0, 10));
-    point_vector.push_back(boost::polygon::point_data<T>(10, 10));
-    point_vector.push_back(boost::polygon::point_data<T>(10, 0));
-    point_vector.push_back(boost::polygon::point_data<T>(0, 0));
-    boost_polygon_polygon.set(point_vector.begin(), point_vector.end());
-
+    {
+        std::vector<boost::polygon::point_data<T> > point_vector;
+        point_vector.push_back(boost::polygon::point_data<T>(0, 0));
+        point_vector.push_back(boost::polygon::point_data<T>(0, 10));
+        point_vector.push_back(boost::polygon::point_data<T>(10, 10));
+        point_vector.push_back(boost::polygon::point_data<T>(10, 0));
+        point_vector.push_back(boost::polygon::point_data<T>(0, 0));
+        boost_polygon_polygon.set(point_vector.begin(), point_vector.end());
+    }
 
     std::vector<boost::polygon::polygon_data<T> > holes;
     holes.resize(2);

--- a/test/geometries/custom_non_copiable/helper_functions.hpp
+++ b/test/geometries/custom_non_copiable/helper_functions.hpp
@@ -1,6 +1,7 @@
 // Boost.Geometry
 
 // Copyright (c) 2023 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -127,6 +128,7 @@ void create_svg(std::ostream& stream, Geometry1 const& a, Geometry2 const& b, Ge
 
 void write_svg(std::ostringstream& svg, std::string const& filename)
 {
+    boost::ignore_unused(svg, filename);
 #if defined(TEST_WITH_SVG_FILE)
     std::ofstream tmp("/tmp/" + filename);
     if (tmp.good())

--- a/test/iterators/test_iterator_common.hpp
+++ b/test/iterators/test_iterator_common.hpp
@@ -114,10 +114,12 @@ inline void test_equality(CombinedIterator first, CombinedIterator beyond,
 {
     typedef typename CombinedContainer::const_iterator iterator;
 
-    iterator it = combined.begin();
-    for (CombinedIterator cit = first; cit != beyond; ++cit, ++it)
     {
-        BOOST_CHECK( *cit == *it );
+        iterator it = combined.begin();
+        for (CombinedIterator cit = first; cit != beyond; ++cit, ++it)
+        {
+            BOOST_CHECK( *cit == *it );
+        }
     }
 
     if ( combined.begin() != combined.end() )

--- a/test/strategies/buffer_join_geo.cpp
+++ b/test/strategies/buffer_join_geo.cpp
@@ -2,6 +2,7 @@
 // Unit Test
 
 // Copyright (c) 2022 Barend Gehrels, Amsterdam, the Netherlands.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // Use, modification and distribution is subject to the Boost Software License,
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -44,6 +45,8 @@ void test_join(std::string const& case_id, JoinStrategy const& join, P const& ve
                T const& buffer_distance, T const& angle1, T const& angle2,
                std::size_t expected_size)
 {
+    boost::ignore_unused(case_id);
+
     // Use a deque to be able to use push_front
     bg::model::ring<P, true, true, std::deque> output_ring;
 

--- a/test/util/select_most_precise.cpp
+++ b/test/util/select_most_precise.cpp
@@ -4,6 +4,7 @@
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2021.
 // Modifications copyright (c) 2021, Oracle and/or its affiliates.
@@ -19,6 +20,7 @@
 
 #include <geometry_test_common.hpp>
 
+#include <boost/geometry/util/condition.hpp>
 #include <boost/geometry/util/select_most_precise.hpp>
 
 
@@ -60,7 +62,7 @@ int test_main(int, char* [])
     test<float, int, float>();
     test<int, float, float>();
 
-    if ( sizeof(long double) > sizeof(double) )
+    if (BOOST_GEOMETRY_CONDITION(sizeof(long double) > sizeof(double)))
     {
         // This cannot be done for MSVC because double/long double is the same
         // This is also true for Android


### PR DESCRIPTION
- C4100 Unreferenced formal parameter
- C4127 Conditional expression is constant
- C4456 Declaration hides previous local declaration
- C4701 Potentially uninitialized local variable used
- C4702 Unreachable code