### PR TITLE
Fix convex hull issue by passing compare strategies

### DIFF
--- a/include/boost/geometry/algorithms/detail/convex_hull/graham_andrew.hpp
+++ b/include/boost/geometry/algorithms/detail/convex_hull/graham_andrew.hpp
@@ -224,7 +224,6 @@ private:
             point_type const& left, point_type const& right,
             SideStrategy const& side)
     {
-        //std::cout << "add to hull" << std::endl;
         output.push_back(left);
         for (auto const& i : input)
         {

--- a/include/boost/geometry/algorithms/detail/convex_hull/graham_andrew.hpp
+++ b/include/boost/geometry/algorithms/detail/convex_hull/graham_andrew.hpp
@@ -190,7 +190,7 @@ private:
 
         point_type most_left, most_right;
 
-        geometry::less<point_type, -1, Strategy> less;
+        geometry::less_exact<point_type, -1, Strategy> less;
 
         detail::convex_hull::get_extremes(in_proxy, most_left, most_right, less);
 

--- a/include/boost/geometry/algorithms/detail/convex_hull/graham_andrew.hpp
+++ b/include/boost/geometry/algorithms/detail/convex_hull/graham_andrew.hpp
@@ -2,8 +2,8 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2014-2021.
-// Modifications copyright (c) 2014-2021 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2014-2023.
+// Modifications copyright (c) 2014-2023 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -190,8 +190,7 @@ private:
 
         point_type most_left, most_right;
 
-        // TODO: User-defined CS-specific less-compare
-        geometry::less<point_type> less;
+        geometry::less<point_type, -1, Strategy> less;
 
         detail::convex_hull::get_extremes(in_proxy, most_left, most_right, less);
 
@@ -225,6 +224,7 @@ private:
             point_type const& left, point_type const& right,
             SideStrategy const& side)
     {
+        //std::cout << "add to hull" << std::endl;
         output.push_back(left);
         for (auto const& i : input)
         {

--- a/include/boost/geometry/algorithms/detail/disjoint/multipoint_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/multipoint_geometry.hpp
@@ -2,7 +2,7 @@
 
 // Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
-// Copyright (c) 2014-2021, Oracle and/or its affiliates.
+// Copyright (c) 2014-2023, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
@@ -63,12 +63,13 @@ namespace detail { namespace disjoint
 class multipoint_multipoint
 {
 private:
-    template <typename Iterator, typename CSTag>
+    template <typename Iterator, typename Strategy>
     class unary_not_disjoint_predicate
-        : geometry::less<void, -1, CSTag>
+        : geometry::less<void, -1, Strategy>
     {
     private:
-        typedef geometry::less<void, -1, CSTag> base_type;
+        //TODO: pass strategy
+        typedef geometry::less<void, -1, Strategy> base_type;
 
     public:
         unary_not_disjoint_predicate(Iterator first, Iterator last)
@@ -96,8 +97,8 @@ public:
     {
         BOOST_GEOMETRY_ASSERT( boost::size(multipoint1) <= boost::size(multipoint2) );
 
-        using cs_tag = typename Strategy::cs_tag;
-        using less_type = geometry::less<void, -1, cs_tag>;
+        //TODO: pass strategy
+        using less_type = geometry::less<void, -1, Strategy>;
         using point1_type = typename boost::range_value<MultiPoint1>::type;
 
         std::vector<point1_type> points1(boost::begin(multipoint1),
@@ -108,7 +109,7 @@ public:
         using predicate_type = unary_not_disjoint_predicate
             <
                 typename std::vector<point1_type>::const_iterator,
-                cs_tag
+                Strategy
             >;
 
         return none_of(boost::begin(multipoint2),

--- a/include/boost/geometry/algorithms/detail/disjoint/multipoint_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/multipoint_geometry.hpp
@@ -68,12 +68,11 @@ private:
         : geometry::less<void, -1, Strategy>
     {
     private:
-        //TODO: pass strategy
-        typedef geometry::less<void, -1, Strategy> base_type;
+        using less_type = geometry::less<void, -1, Strategy>;
 
     public:
         unary_not_disjoint_predicate(Iterator first, Iterator last)
-            : base_type(), m_first(first), m_last(last)
+            : less_type(), m_first(first), m_last(last)
         {}
 
         template <typename Point>
@@ -82,7 +81,7 @@ private:
             return std::binary_search(m_first,
                                       m_last,
                                       point,
-                                      static_cast<base_type const&>(*this));
+                                      static_cast<less_type const&>(*this));
         }
 
     private:
@@ -97,7 +96,6 @@ public:
     {
         BOOST_GEOMETRY_ASSERT( boost::size(multipoint1) <= boost::size(multipoint2) );
 
-        //TODO: pass strategy
         using less_type = geometry::less<void, -1, Strategy>;
         using point1_type = typename boost::range_value<MultiPoint1>::type;
 

--- a/include/boost/geometry/algorithms/detail/distance/segment_to_box.hpp
+++ b/include/boost/geometry/algorithms/detail/distance/segment_to_box.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014-2021 Oracle and/or its affiliates.
+// Copyright (c) 2014-2023 Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
@@ -658,7 +658,8 @@ public:
                                    BoxPoint const& bottom_right,
                                    Strategies const& strategies)
     {
-        BOOST_GEOMETRY_ASSERT( (geometry::less<SegmentPoint, -1, typename Strategies::cs_tag>()(p0, p1))
+        //TODO: pass strategy
+        BOOST_GEOMETRY_ASSERT( (geometry::less<SegmentPoint, -1, Strategies>()(p0, p1))
                             || geometry::has_nan_coordinate(p0)
                             || geometry::has_nan_coordinate(p1) );
 
@@ -753,7 +754,8 @@ public:
                               bottom_left, bottom_right,
                               top_left, top_right);
 
-        typedef geometry::less<segment_point, -1, typename Strategies::cs_tag> less_type;
+        //TODO: pass strategy
+        typedef geometry::less<segment_point, -1, Strategies> less_type;
         if (less_type()(p[0], p[1]))
         {
             return segment_to_box_2D

--- a/include/boost/geometry/algorithms/detail/distance/segment_to_box.hpp
+++ b/include/boost/geometry/algorithms/detail/distance/segment_to_box.hpp
@@ -658,7 +658,6 @@ public:
                                    BoxPoint const& bottom_right,
                                    Strategies const& strategies)
     {
-        //TODO: pass strategy
         BOOST_GEOMETRY_ASSERT( (geometry::less<SegmentPoint, -1, Strategies>()(p0, p1))
                             || geometry::has_nan_coordinate(p0)
                             || geometry::has_nan_coordinate(p1) );
@@ -754,7 +753,6 @@ public:
                               bottom_left, bottom_right,
                               top_left, top_right);
 
-        //TODO: pass strategy
         typedef geometry::less<segment_point, -1, Strategies> less_type;
         if (less_type()(p[0], p[1]))
         {

--- a/include/boost/geometry/algorithms/detail/is_simple/multipoint.hpp
+++ b/include/boost/geometry/algorithms/detail/is_simple/multipoint.hpp
@@ -45,7 +45,6 @@ struct is_simple_multipoint
     template <typename Strategy>
     static inline bool apply(MultiPoint const& multipoint, Strategy const& strategy)
     {
-        //TODO: pass strategy
         typedef geometry::less
             <
                 typename point_type<MultiPoint>::type,

--- a/include/boost/geometry/algorithms/detail/is_simple/multipoint.hpp
+++ b/include/boost/geometry/algorithms/detail/is_simple/multipoint.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014-2021, Oracle and/or its affiliates.
+// Copyright (c) 2014-2023, Oracle and/or its affiliates.
 
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -44,12 +45,12 @@ struct is_simple_multipoint
     template <typename Strategy>
     static inline bool apply(MultiPoint const& multipoint, Strategy const& strategy)
     {
-        typedef typename Strategy::cs_tag cs_tag;
+        //TODO: pass strategy
         typedef geometry::less
             <
                 typename point_type<MultiPoint>::type,
                 -1,
-                cs_tag
+                Strategy
             > less_type;
 
         if (boost::empty(multipoint))

--- a/include/boost/geometry/algorithms/detail/is_valid/complement_graph.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/complement_graph.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014, 2018, 2019, Oracle and/or its affiliates.
+// Copyright (c) 2014-2023, Oracle and/or its affiliates.
 
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -32,7 +33,7 @@ namespace detail { namespace is_valid
 {
 
 
-template <typename TurnPoint, typename CSTag>
+template <typename TurnPoint, typename Strategy>
 class complement_graph_vertex
 {
 public:
@@ -53,9 +54,10 @@ public:
     {
         if ( m_turn_point != NULL && other.m_turn_point != NULL )
         {
+            //TODO: pass strategy
             return geometry::less
                 <
-                    TurnPoint, -1, CSTag
+                    TurnPoint, -1, Strategy
                 >()(*m_turn_point, *other.m_turn_point);
         }
         if ( m_turn_point == NULL && other.m_turn_point == NULL )
@@ -77,11 +79,11 @@ private:
 
 
 
-template <typename TurnPoint, typename CSTag>
+template <typename TurnPoint, typename Strategy>
 class complement_graph
 {
 private:
-    typedef complement_graph_vertex<TurnPoint, CSTag> vertex;
+    typedef complement_graph_vertex<TurnPoint, Strategy> vertex;
     typedef std::set<vertex> vertex_container;
 
 public:
@@ -224,9 +226,10 @@ public:
     }
 
 #ifdef BOOST_GEOMETRY_TEST_DEBUG
-    template <typename OStream, typename TP>
+    template <typename OutputStream>
     friend inline
-    void debug_print_complement_graph(OStream&, complement_graph<TP> const&);
+    void debug_print_complement_graph(OutputStream&,
+                                      complement_graph<TurnPoint, Strategy> const&);
 #endif // BOOST_GEOMETRY_TEST_DEBUG
 
 private:

--- a/include/boost/geometry/algorithms/detail/is_valid/complement_graph.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/complement_graph.hpp
@@ -54,7 +54,6 @@ public:
     {
         if ( m_turn_point != NULL && other.m_turn_point != NULL )
         {
-            //TODO: pass strategy
             return geometry::less
                 <
                     TurnPoint, -1, Strategy

--- a/include/boost/geometry/algorithms/detail/is_valid/debug_complement_graph.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/debug_complement_graph.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014, 2018, 2019, Oracle and/or its affiliates.
+// Copyright (c) 2014-2023, Oracle and/or its affiliates.
 
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -25,12 +26,12 @@ namespace detail { namespace is_valid
 
 
 #ifdef BOOST_GEOMETRY_TEST_DEBUG
-template <typename OutputStream, typename TurnPoint, typename CSTag>
+template <typename OutputStream, typename TurnPoint, typename Strategy>
 inline void
 debug_print_complement_graph(OutputStream& os,
-                             complement_graph<TurnPoint, CSTag> const& graph)
+                             complement_graph<TurnPoint, Strategy> const& graph)
 {
-    typedef typename complement_graph<TurnPoint>::vertex_handle vertex_handle;
+    typedef typename complement_graph<TurnPoint, Strategy>::vertex_handle vertex_handle;
 
     os << "num rings: " << graph.m_num_rings << std::endl;
     os << "vertex ids: {";
@@ -47,7 +48,7 @@ debug_print_complement_graph(OutputStream& os,
         os << "neighbors of " << it->id() << ": {";
         for (typename complement_graph
                  <
-                     TurnPoint
+                     TurnPoint, Strategy
                  >::neighbor_container::const_iterator
                  nit = graph.m_neighbors[it->id()].begin();
              nit != graph.m_neighbors[it->id()].end(); ++nit)
@@ -58,9 +59,9 @@ debug_print_complement_graph(OutputStream& os,
     }
 }
 #else
-template <typename OutputStream, typename TurnPoint, typename CSTag>
+template <typename OutputStream, typename TurnPoint, typename Strategy>
 inline void debug_print_complement_graph(OutputStream&,
-                                         complement_graph<TurnPoint, CSTag> const&)
+                                         complement_graph<TurnPoint, Strategy> const&)
 {
 }
 #endif

--- a/include/boost/geometry/algorithms/detail/is_valid/polygon.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/polygon.hpp
@@ -2,7 +2,7 @@
 
 // Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
 
-// Copyright (c) 2014-2021, Oracle and/or its affiliates.
+// Copyright (c) 2014-2023, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
@@ -405,7 +405,7 @@ protected:
             typedef complement_graph
                 <
                     typename turn_type::point_type,
-                    typename Strategy::cs_tag
+                    Strategy
                 > graph;
 
             graph g(geometry::num_interior_rings(polygon) + 1);

--- a/include/boost/geometry/algorithms/detail/overlay/pointlike_pointlike.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/pointlike_pointlike.hpp
@@ -255,7 +255,6 @@ struct multipoint_multipoint_point
                                        OutputIterator oit,
                                        Strategy const& strategy)
     {
-        //TODO: pass strategy
         typedef geometry::less<void, -1, Strategy> less_type;
 
         if ( OverlayType != overlay_difference

--- a/include/boost/geometry/algorithms/detail/overlay/pointlike_pointlike.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/pointlike_pointlike.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014-2020, Oracle and/or its affiliates.
+// Copyright (c) 2014-2023, Oracle and/or its affiliates.
 
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -254,7 +255,8 @@ struct multipoint_multipoint_point
                                        OutputIterator oit,
                                        Strategy const& strategy)
     {
-        typedef geometry::less<void, -1, typename Strategy::cs_tag> less_type;
+        //TODO: pass strategy
+        typedef geometry::less<void, -1, Strategy> less_type;
 
         if ( OverlayType != overlay_difference
              && boost::size(multipoint1) > boost::size(multipoint2) )

--- a/include/boost/geometry/algorithms/detail/relate/boundary_checker.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/boundary_checker.hpp
@@ -162,7 +162,6 @@ public:
     template <typename Point>
     bool is_endpoint_boundary(Point const& pt) const
     {
-        //TODO: pass strategy
         using less_type = geometry::less<mutable_point_type, -1, Strategy>;
 
         auto const multi_count = boost::size(m_geometry);

--- a/include/boost/geometry/algorithms/detail/relate/boundary_checker.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/boundary_checker.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014-2022 Oracle and/or its affiliates.
+// Copyright (c) 2014-2023, Oracle and/or its affiliates.
 
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -20,6 +21,10 @@
 #include <boost/geometry/geometries/helper_geometry.hpp>
 
 #include <boost/geometry/policies/compare.hpp>
+
+#include <boost/geometry/strategies/relate/cartesian.hpp>
+#include <boost/geometry/strategies/relate/geographic.hpp>
+#include <boost/geometry/strategies/relate/spherical.hpp>
 
 #include <boost/geometry/util/has_nan_coordinate.hpp>
 #include <boost/geometry/util/range.hpp>
@@ -157,7 +162,8 @@ public:
     template <typename Point>
     bool is_endpoint_boundary(Point const& pt) const
     {
-        using less_type = geometry::less<mutable_point_type, -1, typename Strategy::cs_tag>;
+        //TODO: pass strategy
+        using less_type = geometry::less<mutable_point_type, -1, Strategy>;
 
         auto const multi_count = boost::size(m_geometry);
 

--- a/include/boost/geometry/algorithms/detail/relate/multi_point_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/multi_point_geometry.hpp
@@ -135,7 +135,6 @@ struct multi_point_geometry_eb<Geometry, multi_linestring_tag>
         template <typename Point, typename Strategy>
         bool apply(Point const& boundary_point, Strategy const&)
         {
-            //TODO: pass strategy
             typedef geometry::less<void, -1, Strategy> less_type;
 
             if (! std::binary_search(m_points.begin(), m_points.end(),
@@ -160,7 +159,6 @@ struct multi_point_geometry_eb<Geometry, multi_linestring_tag>
     {
         typedef typename boost::range_value<MultiPoint>::type point_type;
         typedef std::vector<point_type> points_type;
-        //TODO: pass strategy
         typedef geometry::less<void, -1, Strategy> less_type;
 
         points_type points(boost::begin(multi_point), boost::end(multi_point));

--- a/include/boost/geometry/algorithms/detail/relate/multi_point_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/multi_point_geometry.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry
 
-// Copyright (c) 2017-2022 Oracle and/or its affiliates.
+// Copyright (c) 2014-2023, Oracle and/or its affiliates.
 
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -134,7 +135,8 @@ struct multi_point_geometry_eb<Geometry, multi_linestring_tag>
         template <typename Point, typename Strategy>
         bool apply(Point const& boundary_point, Strategy const&)
         {
-            typedef geometry::less<void, -1, typename Strategy::cs_tag> less_type;
+            //TODO: pass strategy
+            typedef geometry::less<void, -1, Strategy> less_type;
 
             if (! std::binary_search(m_points.begin(), m_points.end(),
                                      boundary_point, less_type()) )
@@ -158,7 +160,8 @@ struct multi_point_geometry_eb<Geometry, multi_linestring_tag>
     {
         typedef typename boost::range_value<MultiPoint>::type point_type;
         typedef std::vector<point_type> points_type;
-        typedef geometry::less<void, -1, typename Strategy::cs_tag> less_type;
+        //TODO: pass strategy
+        typedef geometry::less<void, -1, Strategy> less_type;
 
         points_type points(boost::begin(multi_point), boost::end(multi_point));
         std::sort(points.begin(), points.end(), less_type());

--- a/include/boost/geometry/algorithms/detail/relate/point_point.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/point_point.hpp
@@ -222,7 +222,6 @@ struct multipoint_multipoint
     {
         // sort points from the 1 MPt
         typedef typename geometry::point_type<SortedMultiPoint>::type point_type;
-        //TODO: pass strategy
         typedef geometry::less<void, -1, Strategy> less_type;
 
         std::vector<point_type> points(boost::begin(sorted_mpt), boost::end(sorted_mpt));

--- a/include/boost/geometry/algorithms/detail/relate/point_point.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/point_point.hpp
@@ -3,8 +3,9 @@
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
 // This file was modified by Oracle on 2013-2022.
-// Modifications copyright (c) 2013-2022, Oracle and/or its affiliates.
+// Modifications copyright (c) 2013-2023, Oracle and/or its affiliates.
 
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -67,7 +68,7 @@ std::pair<bool, bool> point_multipoint_check(Point const& point,
     // point_in_geometry could be used here but why iterate over MultiPoint twice?
     // we must search for a point in the exterior because all points in MultiPoint can be equal
 
-    
+
     auto const end = boost::end(multi_point);
     for (auto it = boost::begin(multi_point); it != end; ++it)
     {
@@ -153,8 +154,6 @@ struct multipoint_multipoint
                              Result & result,
                              Strategy const& /*strategy*/)
     {
-        typedef typename Strategy::cs_tag cs_tag;
-
         {
             // TODO: throw on empty input?
             bool empty1 = boost::empty(multi_point1);
@@ -178,17 +177,17 @@ struct multipoint_multipoint
         // The geometry containing smaller number of points will be analysed first
         if ( boost::size(multi_point1) < boost::size(multi_point2) )
         {
-            search_both<false, cs_tag>(multi_point1, multi_point2, result);
+            search_both<false, Strategy>(multi_point1, multi_point2, result);
         }
         else
         {
-            search_both<true, cs_tag>(multi_point2, multi_point1, result);
+            search_both<true, Strategy>(multi_point2, multi_point1, result);
         }
 
         update<exterior, exterior, result_dimension<MultiPoint1>::value>(result);
     }
 
-    template <bool Transpose, typename CSTag, typename MPt1, typename MPt2, typename Result>
+    template <bool Transpose, typename Strategy, typename MPt1, typename MPt2, typename Result>
     static inline void search_both(MPt1 const& first_sorted_mpt, MPt2 const& first_iterated_mpt,
                                    Result & result)
     {
@@ -197,7 +196,7 @@ struct multipoint_multipoint
           || relate::may_update<exterior, interior, '0'>(result) )
         {
             // NlogN + MlogN
-            bool is_disjoint = search<Transpose, CSTag>(first_sorted_mpt, first_iterated_mpt, result);
+            bool is_disjoint = search<Transpose, Strategy>(first_sorted_mpt, first_iterated_mpt, result);
 
             if ( BOOST_GEOMETRY_CONDITION(is_disjoint || result.interrupt) )
                 return;
@@ -208,12 +207,12 @@ struct multipoint_multipoint
           || relate::may_update<exterior, interior, '0'>(result) )
         {
             // MlogM + NlogM
-            search<! Transpose, CSTag>(first_iterated_mpt, first_sorted_mpt, result);
+            search<! Transpose, Strategy>(first_iterated_mpt, first_sorted_mpt, result);
         }
     }
 
     template <bool Transpose,
-              typename CSTag,
+              typename Strategy,
               typename SortedMultiPoint,
               typename IteratedMultiPoint,
               typename Result>
@@ -223,7 +222,8 @@ struct multipoint_multipoint
     {
         // sort points from the 1 MPt
         typedef typename geometry::point_type<SortedMultiPoint>::type point_type;
-        typedef geometry::less<void, -1, CSTag> less_type;
+        //TODO: pass strategy
+        typedef geometry::less<void, -1, Strategy> less_type;
 
         std::vector<point_type> points(boost::begin(sorted_mpt), boost::end(sorted_mpt));
 

--- a/include/boost/geometry/algorithms/detail/relate/topology_check.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/topology_check.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014-2020, Oracle and/or its affiliates.
+// Copyright (c) 2014-2023, Oracle and/or its affiliates.
 
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -170,7 +171,8 @@ struct topology_check<MultiLinestring, Strategy, multi_linestring_tag>
     }
 
 private:
-    typedef geometry::less<void, -1, typename Strategy::cs_tag> less_type;
+    //TODO: pass strategy
+    typedef geometry::less<void, -1, Strategy> less_type;
 
     void init() const
     {

--- a/include/boost/geometry/algorithms/detail/relate/topology_check.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/topology_check.hpp
@@ -171,7 +171,6 @@ struct topology_check<MultiLinestring, Strategy, multi_linestring_tag>
     }
 
 private:
-    //TODO: pass strategy
     typedef geometry::less<void, -1, Strategy> less_type;
 
     void init() const

--- a/include/boost/geometry/algorithms/detail/within/multi_point.hpp
+++ b/include/boost/geometry/algorithms/detail/within/multi_point.hpp
@@ -1,6 +1,8 @@
 // Boost.Geometry
 
-// Copyright (c) 2017-2020, Oracle and/or its affiliates.
+// Copyright (c) 2017-2023, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -77,8 +79,8 @@ struct multi_point_multi_point
                              Strategy const& /*strategy*/)
     {
         typedef typename boost::range_value<MultiPoint2>::type point2_type;
-        typedef typename Strategy::cs_tag cs_tag;
-        typedef geometry::less<void, -1, cs_tag> less_type;
+        //TODO: pass strategy
+        typedef geometry::less<void, -1, Strategy> less_type;
 
         less_type const less = less_type();
 

--- a/include/boost/geometry/algorithms/detail/within/multi_point.hpp
+++ b/include/boost/geometry/algorithms/detail/within/multi_point.hpp
@@ -79,7 +79,6 @@ struct multi_point_multi_point
                              Strategy const& /*strategy*/)
     {
         typedef typename boost::range_value<MultiPoint2>::type point2_type;
-        //TODO: pass strategy
         typedef geometry::less<void, -1, Strategy> less_type;
 
         less_type const less = less_type();

--- a/include/boost/geometry/algorithms/merge_elements.hpp
+++ b/include/boost/geometry/algorithms/merge_elements.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry
 
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022-2023, Oracle and/or its affiliates.
 
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Licensed under the Boost Software License version 1.0.
@@ -172,7 +173,8 @@ inline void merge(RandomIt const first, RandomIt const last, MultiGeometry& out,
 
     auto const less = [](auto const& l, auto const& r)
     {
-        return geometry::less<void, -1, typename Strategy::cs_tag>()(l.first, r.first);
+        //TODO: pass strategy
+        return geometry::less<void, -1, Strategy>()(l.first, r.first);
     };
 
     std::vector<merge_data<RandomIt>> stack_in;

--- a/include/boost/geometry/algorithms/merge_elements.hpp
+++ b/include/boost/geometry/algorithms/merge_elements.hpp
@@ -173,7 +173,6 @@ inline void merge(RandomIt const first, RandomIt const last, MultiGeometry& out,
 
     auto const less = [](auto const& l, auto const& r)
     {
-        //TODO: pass strategy
         return geometry::less<void, -1, Strategy>()(l.first, r.first);
     };
 

--- a/include/boost/geometry/policies/compare.hpp
+++ b/include/boost/geometry/policies/compare.hpp
@@ -2,9 +2,10 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017-2022.
-// Modifications copyright (c) 2017-2022, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017-2023.
+// Modifications copyright (c) 2017-2023, Oracle and/or its affiliates.
 
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -41,7 +42,7 @@ template
 <
     typename Point = void,
     int Dimension = -1,
-    typename CSTag = void
+    typename Strategy = void
 >
 struct less
 {
@@ -51,37 +52,32 @@ struct less
 
     inline bool operator()(Point const& left, Point const& right) const
     {
-        typedef typename strategy::compare::services::default_strategy
+        /*using strategy_type = typename strategy::compare::services::default_strategy
             <
                 strategy::compare::less,
+                strategy::compare::equals_epsilon,
                 Point, Point,
-                Dimension,
-                CSTag, CSTag
-            >::type strategy_type;
+                Dimension
+            >::type;
 
-        return strategy_type::apply(left, right);
-    }
-};
+        Strategy strategy;
+        using compare_strategy = decltype(
+            strategy.template compare
+                <
+                    strategy::compare::less,
+                    strategy::compare::equals_exact,
+                    -1
+                >());
 
-template <int Dimension, typename CSTag>
-struct less<void, Dimension, CSTag>
-{
-    typedef bool result_type;
-
-    template <typename Point1, typename Point2>
-    inline bool operator()(Point1 const& left, Point2 const& right) const
-    {
-        typedef typename strategy::compare::services::default_strategy
+        return compare_strategy::apply(left, right);
+*/
+        return Strategy::template compare_type
             <
-                strategy::compare::less,
-                Point1, Point2,
-                Dimension,
-                CSTag, CSTag
-            >::type strategy_type;
-
-        return strategy_type::apply(left, right);
+                strategy::compare::less
+            >::apply(left, right);
     }
 };
+
 
 template <typename Point, int Dimension>
 struct less<Point, Dimension, void>
@@ -95,6 +91,7 @@ struct less<Point, Dimension, void>
         typedef typename strategy::compare::services::default_strategy
             <
                 strategy::compare::less,
+                strategy::compare::equals_epsilon,
                 Point, Point,
                 Dimension
             >::type strategy_type;
@@ -103,22 +100,18 @@ struct less<Point, Dimension, void>
     }
 };
 
-template <int Dimension>
-struct less<void, Dimension, void>
+template <int Dimension, typename Strategy>
+struct less<void, Dimension, Strategy>
 {
     typedef bool result_type;
 
     template <typename Point1, typename Point2>
     inline bool operator()(Point1 const& left, Point2 const& right) const
     {
-        typedef typename strategy::compare::services::default_strategy
+        return Strategy::template compare_type
             <
-                strategy::compare::less,
-                Point1, Point2,
-                Dimension
-            >::type strategy_type;
-
-        return strategy_type::apply(left, right);
+                strategy::compare::less
+            >::apply(left, right);
     }
 };
 
@@ -146,6 +139,7 @@ struct greater
         typedef typename strategy::compare::services::default_strategy
             <
                 strategy::compare::greater,
+                strategy::compare::equals_epsilon,
                 Point, Point,
                 Dimension,
                 CSTag, CSTag
@@ -166,6 +160,7 @@ struct greater<void, Dimension, CSTag>
         typedef typename strategy::compare::services::default_strategy
             <
                 strategy::compare::greater,
+                strategy::compare::equals_epsilon,
                 Point1, Point2,
                 Dimension,
                 CSTag, CSTag
@@ -187,6 +182,7 @@ struct greater<Point, Dimension, void>
         typedef typename strategy::compare::services::default_strategy
             <
                 strategy::compare::greater,
+                strategy::compare::equals_epsilon,
                 Point, Point,
                 Dimension
             >::type strategy_type;
@@ -206,6 +202,7 @@ struct greater<void, Dimension, void>
         typedef typename strategy::compare::services::default_strategy
             <
                 strategy::compare::greater,
+                strategy::compare::equals_epsilon,
                 Point1, Point2,
                 Dimension
             >::type strategy_type;
@@ -240,6 +237,7 @@ struct equal_to
         typedef typename strategy::compare::services::default_strategy
             <
                 strategy::compare::equal_to,
+                strategy::compare::equals_epsilon,
                 Point, Point,
                 Dimension,
                 CSTag, CSTag
@@ -260,6 +258,7 @@ struct equal_to<void, Dimension, CSTag>
         typedef typename strategy::compare::services::default_strategy
             <
                 strategy::compare::equal_to,
+                strategy::compare::equals_epsilon,
                 Point1, Point2,
                 Dimension,
                 CSTag, CSTag
@@ -281,6 +280,7 @@ struct equal_to<Point, Dimension, void>
         typedef typename strategy::compare::services::default_strategy
             <
                 strategy::compare::equal_to,
+                strategy::compare::equals_epsilon,
                 Point, Point,
                 Dimension
             >::type strategy_type;
@@ -300,6 +300,7 @@ struct equal_to<void, Dimension, void>
         typedef typename strategy::compare::services::default_strategy
             <
                 strategy::compare::equal_to,
+                strategy::compare::equals_epsilon,
                 Point1, Point2,
                 Dimension
             >::type strategy_type;

--- a/include/boost/geometry/policies/compare.hpp
+++ b/include/boost/geometry/policies/compare.hpp
@@ -52,25 +52,6 @@ struct less
 
     inline bool operator()(Point const& left, Point const& right) const
     {
-        /*using strategy_type = typename strategy::compare::services::default_strategy
-            <
-                strategy::compare::less,
-                strategy::compare::equals_epsilon,
-                Point, Point,
-                Dimension
-            >::type;
-
-        Strategy strategy;
-        using compare_strategy = decltype(
-            strategy.template compare
-                <
-                    strategy::compare::less,
-                    strategy::compare::equals_exact,
-                    -1
-                >());
-
-        return compare_strategy::apply(left, right);
-*/
         return Strategy::template compare_type
             <
                 strategy::compare::less

--- a/include/boost/geometry/policies/compare.hpp
+++ b/include/boost/geometry/policies/compare.hpp
@@ -42,7 +42,7 @@ template
 <
     typename Point = void,
     int Dimension = -1,
-    typename Strategy = void
+    typename StrategyOrTag = void
 >
 struct less
 {
@@ -95,6 +95,160 @@ struct less<void, Dimension, Strategy>
             >::apply(left, right);
     }
 };
+
+// for backward compatibility
+
+template <typename Point, int Dimension>
+struct less<Point, Dimension, boost::geometry::cartesian_tag>
+{
+    typedef Point first_argument_type;
+    typedef Point second_argument_type;
+    typedef bool result_type;
+
+    inline bool operator()(Point const& left, Point const& right) const
+    {
+        typedef typename strategy::compare::services::default_strategy
+            <
+                strategy::compare::less,
+                strategy::compare::equals_epsilon,
+                Point, Point,
+                Dimension,
+                boost::geometry::cartesian_tag, boost::geometry::cartesian_tag
+            >::type strategy_type;
+
+        return strategy_type::apply(left, right);
+    }
+};
+
+template <typename Point, int Dimension>
+struct less<Point, Dimension, boost::geometry::spherical_tag>
+{
+    typedef Point first_argument_type;
+    typedef Point second_argument_type;
+    typedef bool result_type;
+
+    inline bool operator()(Point const& left, Point const& right) const
+    {
+        typedef typename strategy::compare::services::default_strategy
+            <
+                strategy::compare::less,
+                strategy::compare::equals_epsilon,
+                Point, Point,
+                Dimension,
+                boost::geometry::spherical_tag, boost::geometry::spherical_tag
+            >::type strategy_type;
+
+        return strategy_type::apply(left, right);
+    }
+};
+
+template <typename Point, int Dimension>
+struct less<Point, Dimension, boost::geometry::geographic_tag>
+{
+    typedef Point first_argument_type;
+    typedef Point second_argument_type;
+    typedef bool result_type;
+
+    inline bool operator()(Point const& left, Point const& right) const
+    {
+        typedef typename strategy::compare::services::default_strategy
+            <
+                strategy::compare::less,
+                strategy::compare::equals_epsilon,
+                Point, Point,
+                Dimension,
+                boost::geometry::geographic_tag, boost::geometry::geographic_tag
+            >::type strategy_type;
+
+        return strategy_type::apply(left, right);
+    }
+};
+
+template <int Dimension>
+struct less<void, Dimension, boost::geometry::cartesian_tag>
+{
+    typedef bool result_type;
+
+    template <typename Point1, typename Point2>
+    inline bool operator()(Point1 const& left, Point2 const& right) const
+    {
+        typedef typename strategy::compare::services::default_strategy
+            <
+                strategy::compare::less,
+                strategy::compare::equals_epsilon,
+                Point1, Point2,
+                Dimension,
+                boost::geometry::cartesian_tag, boost::geometry::cartesian_tag
+            >::type strategy_type;
+
+        return strategy_type::apply(left, right);
+    }
+};
+
+template <int Dimension>
+struct less<void, Dimension, boost::geometry::spherical_tag>
+{
+    typedef bool result_type;
+
+    template <typename Point1, typename Point2>
+    inline bool operator()(Point1 const& left, Point2 const& right) const
+    {
+        typedef typename strategy::compare::services::default_strategy
+            <
+                strategy::compare::less,
+                strategy::compare::equals_epsilon,
+                Point1, Point2,
+                Dimension,
+                boost::geometry::spherical_tag, boost::geometry::spherical_tag
+            >::type strategy_type;
+
+        return strategy_type::apply(left, right);
+    }
+};
+
+template <int Dimension>
+struct less<void, Dimension, boost::geometry::geographic_tag>
+{
+    typedef bool result_type;
+
+    template <typename Point1, typename Point2>
+    inline bool operator()(Point1 const& left, Point2 const& right) const
+    {
+        typedef typename strategy::compare::services::default_strategy
+            <
+                strategy::compare::less,
+                strategy::compare::equals_epsilon,
+                Point1, Point2,
+                Dimension,
+                boost::geometry::geographic_tag, boost::geometry::geographic_tag
+            >::type strategy_type;
+
+        return strategy_type::apply(left, right);
+    }
+};
+
+
+template <int Dimension>
+struct less<void, Dimension, void>
+{
+    typedef bool result_type;
+
+    template <typename Point1, typename Point2>
+    inline bool operator()(Point1 const& left, Point2 const& right) const
+    {
+        typedef typename strategy::compare::services::default_strategy
+            <
+                strategy::compare::less,
+                strategy::compare::equals_epsilon,
+                Point1, Point2,
+                Dimension
+            >::type strategy_type;
+
+        return strategy_type::apply(left, right);
+    }
+};
+
+
 
 
 /*!

--- a/include/boost/geometry/policies/compare.hpp
+++ b/include/boost/geometry/policies/compare.hpp
@@ -46,13 +46,13 @@ template
 >
 struct less
 {
-    typedef Point first_argument_type;
-    typedef Point second_argument_type;
-    typedef bool result_type;
+    using first_argument_type = Point;
+    using second_argument_type = Point;
+    using result_type = bool;
 
     inline bool operator()(Point const& left, Point const& right) const
     {
-        return Strategy::template compare_type
+        return StrategyOrTag::template compare_type
             <
                 strategy::compare::less
             >::apply(left, right);
@@ -63,19 +63,19 @@ struct less
 template <typename Point, int Dimension>
 struct less<Point, Dimension, void>
 {
-    typedef Point first_argument_type;
-    typedef Point second_argument_type;
-    typedef bool result_type;
+    using first_argument_type = Point;
+    using second_argument_type = Point;
+    using result_type = bool;
 
     inline bool operator()(Point const& left, Point const& right) const
     {
-        typedef typename strategy::compare::services::default_strategy
+        using strategy_type = typename strategy::compare::services::default_strategy
             <
                 strategy::compare::less,
                 strategy::compare::equals_epsilon,
                 Point, Point,
                 Dimension
-            >::type strategy_type;
+            >::type;
 
         return strategy_type::apply(left, right);
     }
@@ -84,7 +84,7 @@ struct less<Point, Dimension, void>
 template <int Dimension, typename Strategy>
 struct less<void, Dimension, Strategy>
 {
-    typedef bool result_type;
+    using result_type = bool;
 
     template <typename Point1, typename Point2>
     inline bool operator()(Point1 const& left, Point2 const& right) const
@@ -101,20 +101,20 @@ struct less<void, Dimension, Strategy>
 template <typename Point, int Dimension>
 struct less<Point, Dimension, boost::geometry::cartesian_tag>
 {
-    typedef Point first_argument_type;
-    typedef Point second_argument_type;
-    typedef bool result_type;
+    using first_argument_type = Point;
+    using second_argument_type = Point;
+    using result_type = bool;
 
     inline bool operator()(Point const& left, Point const& right) const
     {
-        typedef typename strategy::compare::services::default_strategy
+        using strategy_type = typename strategy::compare::services::default_strategy
             <
                 strategy::compare::less,
                 strategy::compare::equals_epsilon,
                 Point, Point,
                 Dimension,
                 boost::geometry::cartesian_tag, boost::geometry::cartesian_tag
-            >::type strategy_type;
+            >::type;
 
         return strategy_type::apply(left, right);
     }
@@ -123,20 +123,20 @@ struct less<Point, Dimension, boost::geometry::cartesian_tag>
 template <typename Point, int Dimension>
 struct less<Point, Dimension, boost::geometry::spherical_tag>
 {
-    typedef Point first_argument_type;
-    typedef Point second_argument_type;
-    typedef bool result_type;
+    using first_argument_type = Point;
+    using second_argument_type = Point;
+    using result_type = bool;
 
     inline bool operator()(Point const& left, Point const& right) const
     {
-        typedef typename strategy::compare::services::default_strategy
+        using strategy_type = typename strategy::compare::services::default_strategy
             <
                 strategy::compare::less,
                 strategy::compare::equals_epsilon,
                 Point, Point,
                 Dimension,
                 boost::geometry::spherical_tag, boost::geometry::spherical_tag
-            >::type strategy_type;
+            >::type;
 
         return strategy_type::apply(left, right);
     }
@@ -145,20 +145,20 @@ struct less<Point, Dimension, boost::geometry::spherical_tag>
 template <typename Point, int Dimension>
 struct less<Point, Dimension, boost::geometry::geographic_tag>
 {
-    typedef Point first_argument_type;
-    typedef Point second_argument_type;
-    typedef bool result_type;
+    using first_argument_type = Point;
+    using second_argument_type = Point;
+    using result_type = bool;
 
     inline bool operator()(Point const& left, Point const& right) const
     {
-        typedef typename strategy::compare::services::default_strategy
+        using strategy_type = typename strategy::compare::services::default_strategy
             <
                 strategy::compare::less,
                 strategy::compare::equals_epsilon,
                 Point, Point,
                 Dimension,
                 boost::geometry::geographic_tag, boost::geometry::geographic_tag
-            >::type strategy_type;
+            >::type;
 
         return strategy_type::apply(left, right);
     }
@@ -167,19 +167,19 @@ struct less<Point, Dimension, boost::geometry::geographic_tag>
 template <int Dimension>
 struct less<void, Dimension, boost::geometry::cartesian_tag>
 {
-    typedef bool result_type;
+    using result_type = bool;
 
     template <typename Point1, typename Point2>
     inline bool operator()(Point1 const& left, Point2 const& right) const
     {
-        typedef typename strategy::compare::services::default_strategy
+        using strategy_type = typename strategy::compare::services::default_strategy
             <
                 strategy::compare::less,
                 strategy::compare::equals_epsilon,
                 Point1, Point2,
                 Dimension,
                 boost::geometry::cartesian_tag, boost::geometry::cartesian_tag
-            >::type strategy_type;
+            >::type;
 
         return strategy_type::apply(left, right);
     }
@@ -188,19 +188,19 @@ struct less<void, Dimension, boost::geometry::cartesian_tag>
 template <int Dimension>
 struct less<void, Dimension, boost::geometry::spherical_tag>
 {
-    typedef bool result_type;
+    using result_type = bool;
 
     template <typename Point1, typename Point2>
     inline bool operator()(Point1 const& left, Point2 const& right) const
     {
-        typedef typename strategy::compare::services::default_strategy
+        using strategy_type = typename strategy::compare::services::default_strategy
             <
                 strategy::compare::less,
                 strategy::compare::equals_epsilon,
                 Point1, Point2,
                 Dimension,
                 boost::geometry::spherical_tag, boost::geometry::spherical_tag
-            >::type strategy_type;
+            >::type;
 
         return strategy_type::apply(left, right);
     }
@@ -209,19 +209,19 @@ struct less<void, Dimension, boost::geometry::spherical_tag>
 template <int Dimension>
 struct less<void, Dimension, boost::geometry::geographic_tag>
 {
-    typedef bool result_type;
+    using result_type = bool;
 
     template <typename Point1, typename Point2>
     inline bool operator()(Point1 const& left, Point2 const& right) const
     {
-        typedef typename strategy::compare::services::default_strategy
+        using strategy_type = typename strategy::compare::services::default_strategy
             <
                 strategy::compare::less,
                 strategy::compare::equals_epsilon,
                 Point1, Point2,
                 Dimension,
                 boost::geometry::geographic_tag, boost::geometry::geographic_tag
-            >::type strategy_type;
+            >::type;
 
         return strategy_type::apply(left, right);
     }
@@ -231,18 +231,18 @@ struct less<void, Dimension, boost::geometry::geographic_tag>
 template <int Dimension>
 struct less<void, Dimension, void>
 {
-    typedef bool result_type;
+    using result_type = bool;
 
     template <typename Point1, typename Point2>
     inline bool operator()(Point1 const& left, Point2 const& right) const
     {
-        typedef typename strategy::compare::services::default_strategy
+        using strategy_type = typename strategy::compare::services::default_strategy
             <
                 strategy::compare::less,
                 strategy::compare::equals_epsilon,
                 Point1, Point2,
                 Dimension
-            >::type strategy_type;
+            >::type;
 
         return strategy_type::apply(left, right);
     }
@@ -265,20 +265,20 @@ template
 >
 struct greater
 {
-    typedef Point first_argument_type;
-    typedef Point second_argument_type;
-    typedef bool result_type;
+    using first_argument_type = Point;
+    using second_argument_type = Point;
+    using result_type = bool;
 
     bool operator()(Point const& left, Point const& right) const
     {
-        typedef typename strategy::compare::services::default_strategy
+        using strategy_type = typename strategy::compare::services::default_strategy
             <
                 strategy::compare::greater,
                 strategy::compare::equals_epsilon,
                 Point, Point,
                 Dimension,
                 CSTag, CSTag
-            >::type strategy_type;
+            >::type;
 
         return strategy_type::apply(left, right);
     }
@@ -287,19 +287,19 @@ struct greater
 template <int Dimension, typename CSTag>
 struct greater<void, Dimension, CSTag>
 {
-    typedef bool result_type;
+    using result_type = bool;
 
     template <typename Point1, typename Point2>
     bool operator()(Point1 const& left, Point2 const& right) const
     {
-        typedef typename strategy::compare::services::default_strategy
+        using strategy_type = typename strategy::compare::services::default_strategy
             <
                 strategy::compare::greater,
                 strategy::compare::equals_epsilon,
                 Point1, Point2,
                 Dimension,
                 CSTag, CSTag
-            >::type strategy_type;
+            >::type;
 
         return strategy_type::apply(left, right);
     }
@@ -308,19 +308,19 @@ struct greater<void, Dimension, CSTag>
 template <typename Point, int Dimension>
 struct greater<Point, Dimension, void>
 {
-    typedef Point first_argument_type;
-    typedef Point second_argument_type;
-    typedef bool result_type;
+    using first_argument_type = Point;
+    using second_argument_type = Point;
+    using result_type = bool;
 
     bool operator()(Point const& left, Point const& right) const
     {
-        typedef typename strategy::compare::services::default_strategy
+        using strategy_type = typename strategy::compare::services::default_strategy
             <
                 strategy::compare::greater,
                 strategy::compare::equals_epsilon,
                 Point, Point,
                 Dimension
-            >::type strategy_type;
+            >::type;
 
         return strategy_type::apply(left, right);
     }
@@ -329,18 +329,18 @@ struct greater<Point, Dimension, void>
 template <int Dimension>
 struct greater<void, Dimension, void>
 {
-    typedef bool result_type;
+    using result_type = bool;
 
     template <typename Point1, typename Point2>
     bool operator()(Point1 const& left, Point2 const& right) const
     {
-        typedef typename strategy::compare::services::default_strategy
+        using strategy_type = typename strategy::compare::services::default_strategy
             <
                 strategy::compare::greater,
                 strategy::compare::equals_epsilon,
                 Point1, Point2,
                 Dimension
-            >::type strategy_type;
+            >::type;
 
         return strategy_type::apply(left, right);
     }
@@ -363,20 +363,20 @@ template
 >
 struct equal_to
 {
-    typedef Point first_argument_type;
-    typedef Point second_argument_type;
-    typedef bool result_type;
+    using first_argument_type = Point;
+    using second_argument_type = Point;
+    using result_type = bool;
 
     bool operator()(Point const& left, Point const& right) const
     {
-        typedef typename strategy::compare::services::default_strategy
+        using strategy_type = typename strategy::compare::services::default_strategy
             <
                 strategy::compare::equal_to,
                 strategy::compare::equals_epsilon,
                 Point, Point,
                 Dimension,
                 CSTag, CSTag
-            >::type strategy_type;
+            >::type;
 
         return strategy_type::apply(left, right);
     }
@@ -385,19 +385,19 @@ struct equal_to
 template <int Dimension, typename CSTag>
 struct equal_to<void, Dimension, CSTag>
 {
-    typedef bool result_type;
+    using result_type = bool;
 
     template <typename Point1, typename Point2>
     bool operator()(Point1 const& left, Point2 const& right) const
     {
-        typedef typename strategy::compare::services::default_strategy
+        using strategy_type = typename strategy::compare::services::default_strategy
             <
                 strategy::compare::equal_to,
                 strategy::compare::equals_epsilon,
                 Point1, Point2,
                 Dimension,
                 CSTag, CSTag
-            >::type strategy_type;
+            >::type;
 
         return strategy_type::apply(left, right);
     }
@@ -406,19 +406,19 @@ struct equal_to<void, Dimension, CSTag>
 template <typename Point, int Dimension>
 struct equal_to<Point, Dimension, void>
 {
-    typedef Point first_argument_type;
-    typedef Point second_argument_type;
-    typedef bool result_type;
+    using first_argument_type = Point;
+    using second_argument_type = Point;
+    using result_type = bool;
 
     bool operator()(Point const& left, Point const& right) const
     {
-        typedef typename strategy::compare::services::default_strategy
+        using strategy_type = typename strategy::compare::services::default_strategy
             <
                 strategy::compare::equal_to,
                 strategy::compare::equals_epsilon,
                 Point, Point,
                 Dimension
-            >::type strategy_type;
+            >::type;
 
         return strategy_type::apply(left, right);
     }
@@ -427,18 +427,18 @@ struct equal_to<Point, Dimension, void>
 template <int Dimension>
 struct equal_to<void, Dimension, void>
 {
-    typedef bool result_type;
+    using result_type = bool;
 
     template <typename Point1, typename Point2>
     bool operator()(Point1 const& left, Point2 const& right) const
     {
-        typedef typename strategy::compare::services::default_strategy
+        using strategy_type = typename strategy::compare::services::default_strategy
             <
                 strategy::compare::equal_to,
                 strategy::compare::equals_epsilon,
                 Point1, Point2,
                 Dimension
-            >::type strategy_type;
+            >::type;
 
         return strategy_type::apply(left, right);
     }

--- a/include/boost/geometry/policies/compare.hpp
+++ b/include/boost/geometry/policies/compare.hpp
@@ -38,6 +38,29 @@ namespace boost { namespace geometry
     on equal x-es then on y, etc.
     If a dimension is specified, only that dimension is considered
 */
+
+template
+<
+    typename Point = void,
+    int Dimension = -1,
+    typename StrategyOrTag = void
+>
+struct less_exact
+{
+    using first_argument_type = Point;
+    using second_argument_type = Point;
+    using result_type = bool;
+
+    inline bool operator()(Point const& left, Point const& right) const
+    {
+        return StrategyOrTag::template compare_type
+            <
+                strategy::compare::less,
+                strategy::compare::equals_exact
+            >::apply(left, right);
+    }
+};
+
 template
 <
     typename Point = void,
@@ -54,7 +77,8 @@ struct less
     {
         return StrategyOrTag::template compare_type
             <
-                strategy::compare::less
+                strategy::compare::less,
+                strategy::compare::equals_epsilon
             >::apply(left, right);
     }
 };
@@ -91,7 +115,8 @@ struct less<void, Dimension, Strategy>
     {
         return Strategy::template compare_type
             <
-                strategy::compare::less
+                strategy::compare::less,
+                strategy::compare::equals_epsilon
             >::apply(left, right);
     }
 };

--- a/include/boost/geometry/strategies/compare.hpp
+++ b/include/boost/geometry/strategies/compare.hpp
@@ -4,8 +4,10 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2017-2020.
-// Modifications copyright (c) 2017-2020, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017-2023.
+// Modifications copyright (c) 2017-2023, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
@@ -68,6 +70,24 @@ struct equal_to
     }
 };
 
+struct equals_epsilon
+{
+    template <typename T1, typename T2>
+    static inline bool apply(T1 const& l, T2 const& r)
+    {
+        return math::equals(l, r);
+    }
+};
+
+struct equals_exact
+{
+    template <typename T1, typename T2>
+    static inline bool apply(T1 const& l, T2 const& r)
+    {
+        return l == r;
+    }
+};
+
 
 #ifndef DOXYGEN_NO_DETAIL
 namespace detail
@@ -77,6 +97,7 @@ namespace detail
 template
 <
     typename ComparePolicy,
+    typename EqualsPolicy,
     std::size_t Dimension,
     std::size_t DimensionCount
 >
@@ -90,11 +111,12 @@ struct compare_loop
         typename geometry::coordinate_type<Point2>::type const&
             cright = geometry::get<Dimension>(right);
 
-        if (math::equals(cleft, cright))
+        if (EqualsPolicy::apply(cleft, cright))
         {
             return compare_loop
                 <
                     ComparePolicy,
+                    EqualsPolicy,
                     Dimension + 1, DimensionCount
                 >::apply(left, right);
         }
@@ -108,9 +130,10 @@ struct compare_loop
 template
 <
     typename ComparePolicy,
+    typename EqualsPolicy,
     std::size_t DimensionCount
 >
-struct compare_loop<ComparePolicy, DimensionCount, DimensionCount>
+struct compare_loop<ComparePolicy, EqualsPolicy, DimensionCount, DimensionCount>
 {
     template <typename Point1, typename Point2>
     static inline bool apply(Point1 const& , Point2 const& )
@@ -123,9 +146,10 @@ struct compare_loop<ComparePolicy, DimensionCount, DimensionCount>
 
 template
 <
+    typename EqualsPolicy,
     std::size_t DimensionCount
 >
-struct compare_loop<strategy::compare::equal_to, DimensionCount, DimensionCount>
+struct compare_loop<strategy::compare::equal_to, EqualsPolicy, DimensionCount, DimensionCount>
 {
     template <typename Point1, typename Point2>
     static inline bool apply(Point1 const& , Point2 const& )
@@ -143,6 +167,7 @@ struct compare_loop<strategy::compare::equal_to, DimensionCount, DimensionCount>
 template
 <
     typename ComparePolicy,
+    typename EqualsPolicy,
     int Dimension = -1
 >
 struct cartesian
@@ -152,7 +177,7 @@ struct cartesian
     {
         return compare::detail::compare_loop
             <
-                ComparePolicy, Dimension, Dimension + 1
+                ComparePolicy, EqualsPolicy, Dimension, Dimension + 1
             >::apply(left, right);
     }
 };
@@ -160,9 +185,10 @@ struct cartesian
 #ifndef DOXYGEN_NO_STRATEGY_SPECIALIZATIONS
 template
 <
-    typename ComparePolicy
+    typename ComparePolicy,
+    typename EqualsPolicy
 >
-struct cartesian<ComparePolicy, -1>
+struct cartesian<ComparePolicy, EqualsPolicy, -1>
 {
     template <typename Point1, typename Point2>
     static inline bool apply(Point1 const& left, Point2 const& right)
@@ -170,6 +196,7 @@ struct cartesian<ComparePolicy, -1>
         return compare::detail::compare_loop
             <
                 ComparePolicy,
+                EqualsPolicy,
                 0,
                 ((std::min)(geometry::dimension<Point1>::value,
                             geometry::dimension<Point2>::value))
@@ -185,6 +212,7 @@ namespace services
 template
 <
     typename ComparePolicy,
+    typename EqualsPolicy,
     typename Point1,
     typename Point2 = Point1,
     int Dimension = -1,
@@ -199,10 +227,17 @@ struct default_strategy
 };
 
 
-template <typename ComparePolicy, typename Point1, typename Point2, int Dimension>
-struct default_strategy<ComparePolicy, Point1, Point2, Dimension, cartesian_tag, cartesian_tag>
+template
+<
+    typename ComparePolicy,
+    typename EqualsPolicy,
+    typename Point1,
+    typename Point2,
+    int Dimension
+>
+struct default_strategy<ComparePolicy, EqualsPolicy, Point1, Point2, Dimension, cartesian_tag, cartesian_tag>
 {
-    typedef compare::cartesian<ComparePolicy, Dimension> type;
+    typedef compare::cartesian<ComparePolicy, EqualsPolicy, Dimension> type;
 };
 
 

--- a/include/boost/geometry/strategies/convex_hull/cartesian.hpp
+++ b/include/boost/geometry/strategies/convex_hull/cartesian.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2020-2021, Oracle and/or its affiliates.
+// Copyright (c) 2020-2023, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -11,12 +11,14 @@
 #ifndef BOOST_GEOMETRY_STRATEGIES_CONVEX_HULL_CARTESIAN_HPP
 #define BOOST_GEOMETRY_STRATEGIES_CONVEX_HULL_CARTESIAN_HPP
 
-#include <boost/geometry/strategies/side.hpp>
-#include <boost/geometry/strategy/cartesian/side_robust.hpp>
-
 #include <boost/geometry/strategies/cartesian/point_in_point.hpp>
 #include <boost/geometry/strategies/convex_hull/services.hpp>
+#include <boost/geometry/strategies/compare.hpp>
 #include <boost/geometry/strategies/detail.hpp>
+#include <boost/geometry/strategies/side.hpp>
+
+#include <boost/geometry/strategy/cartesian/side_robust.hpp>
+
 #include <boost/geometry/util/type_traits.hpp>
 
 
@@ -47,6 +49,14 @@ public:
             = strategy::side::side_robust<CalculationType>;
         return side_strategy_type();
     }
+
+    template <typename ComparePolicy>
+    using compare_type = typename strategy::compare::cartesian
+        <
+            ComparePolicy,
+            strategy::compare::equals_exact,
+            -1
+        >;
 };
 
 namespace services

--- a/include/boost/geometry/strategies/convex_hull/cartesian.hpp
+++ b/include/boost/geometry/strategies/convex_hull/cartesian.hpp
@@ -50,11 +50,11 @@ public:
         return side_strategy_type();
     }
 
-    template <typename ComparePolicy>
+    template <typename ComparePolicy, typename EqualsPolicy>
     using compare_type = typename strategy::compare::cartesian
         <
             ComparePolicy,
-            strategy::compare::equals_exact,
+            EqualsPolicy,
             -1
         >;
 };

--- a/include/boost/geometry/strategies/convex_hull/geographic.hpp
+++ b/include/boost/geometry/strategies/convex_hull/geographic.hpp
@@ -65,11 +65,11 @@ public:
             >(base_t::m_spheroid);
     }
 
-    template <typename ComparePolicy>
+    template <typename ComparePolicy, typename EqualsPolicy>
     using compare_type = typename strategy::compare::spherical
         <
             ComparePolicy,
-            strategy::compare::equals_exact,
+            EqualsPolicy,
             -1
         >;
 };

--- a/include/boost/geometry/strategies/convex_hull/geographic.hpp
+++ b/include/boost/geometry/strategies/convex_hull/geographic.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2020-2021, Oracle and/or its affiliates.
+// Copyright (c) 2020-2023, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -13,9 +13,11 @@
 
 
 #include <boost/geometry/strategies/convex_hull/services.hpp>
+#include <boost/geometry/strategies/compare.hpp>
 #include <boost/geometry/strategies/detail.hpp>
 #include <boost/geometry/strategies/geographic/side.hpp>
 #include <boost/geometry/strategies/spherical/point_in_point.hpp>
+
 #include <boost/geometry/util/type_traits.hpp>
 
 
@@ -62,6 +64,14 @@ public:
                 CalculationType
             >(base_t::m_spheroid);
     }
+
+    template <typename ComparePolicy>
+    using compare_type = typename strategy::compare::spherical
+        <
+            ComparePolicy,
+            strategy::compare::equals_exact,
+            -1
+        >;
 };
 
 namespace services

--- a/include/boost/geometry/strategies/convex_hull/spherical.hpp
+++ b/include/boost/geometry/strategies/convex_hull/spherical.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry
 
-// Copyright (c) 2020-2021, Oracle and/or its affiliates.
+// Copyright (c) 2020-2023, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -13,9 +13,11 @@
 
 
 #include <boost/geometry/strategies/convex_hull/services.hpp>
+#include <boost/geometry/strategies/compare.hpp>
 #include <boost/geometry/strategies/detail.hpp>
 #include <boost/geometry/strategies/spherical/point_in_point.hpp>
 #include <boost/geometry/strategies/spherical/ssf.hpp>
+
 #include <boost/geometry/util/type_traits.hpp>
 
 
@@ -44,6 +46,14 @@ public:
     {
         return strategy::side::spherical_side_formula<CalculationType>();
     }
+
+    template <typename ComparePolicy>
+    using compare_type = typename strategy::compare::spherical
+        <
+            ComparePolicy,
+            strategy::compare::equals_exact,
+            -1
+        >;
 };
 
 namespace services

--- a/include/boost/geometry/strategies/convex_hull/spherical.hpp
+++ b/include/boost/geometry/strategies/convex_hull/spherical.hpp
@@ -47,11 +47,11 @@ public:
         return strategy::side::spherical_side_formula<CalculationType>();
     }
 
-    template <typename ComparePolicy>
+    template <typename ComparePolicy, typename EqualsPolicy>
     using compare_type = typename strategy::compare::spherical
         <
             ComparePolicy,
-            strategy::compare::equals_exact,
+            EqualsPolicy,
             -1
         >;
 };

--- a/include/boost/geometry/strategies/relate/cartesian.hpp
+++ b/include/boost/geometry/strategies/relate/cartesian.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry
 
-// Copyright (c) 2020, Oracle and/or its affiliates.
+// Copyright (c) 2020-2023, Oracle and/or its affiliates.
 
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Licensed under the Boost Software License version 1.0.
@@ -187,6 +188,14 @@ public:
     {
         return strategy::within::cartesian_box_box();
     }
+
+    template <typename ComparePolicy>
+    using compare_type = typename strategy::compare::cartesian
+        <
+            ComparePolicy,
+            strategy::compare::equals_epsilon,
+            -1
+        >;
 };
 
 

--- a/include/boost/geometry/strategies/relate/cartesian.hpp
+++ b/include/boost/geometry/strategies/relate/cartesian.hpp
@@ -189,11 +189,11 @@ public:
         return strategy::within::cartesian_box_box();
     }
 
-    template <typename ComparePolicy>
+    template <typename ComparePolicy, typename EqualsPolicy>
     using compare_type = typename strategy::compare::cartesian
         <
             ComparePolicy,
-            strategy::compare::equals_epsilon,
+            EqualsPolicy,
             -1
         >;
 };

--- a/include/boost/geometry/strategies/relate/geographic.hpp
+++ b/include/boost/geometry/strategies/relate/geographic.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry
 
-// Copyright (c) 2020-2021, Oracle and/or its affiliates.
+// Copyright (c) 2020-2023, Oracle and/or its affiliates.
 
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Licensed under the Boost Software License version 1.0.
@@ -209,6 +210,17 @@ public:
     {
         return strategy::within::spherical_box_box();
     }
+
+    template <typename ComparePolicy>
+    using compare_type = typename strategy::compare::spherical
+        <
+            ComparePolicy,
+            strategy::compare::equals_epsilon,
+            -1
+        >;
+
+    //template <typename ComparePolicy, typename EqualsPolicy, int Dimension>
+    //using compare_type = strategy::compare::spherical<ComparePolicy, EqualsPolicy, Dimension>;
 };
 
 
@@ -280,6 +292,14 @@ struct strategy_converter<strategy::intersection::geographic_segments<FormulaPol
                     FormulaPolicy, SeriesOrder, Spheroid, CalculationType
                 >(base_t::m_spheroid);
         }
+
+        template <typename ComparePolicy>
+        using compare_type = typename strategy::compare::cartesian
+            <
+                ComparePolicy,
+                strategy::compare::equals_epsilon,
+                -1
+            >;
     };
 
     static auto get(strategy::intersection::geographic_segments<FormulaPolicy, SeriesOrder, Spheroid, CalculationType> const& s)

--- a/include/boost/geometry/strategies/relate/geographic.hpp
+++ b/include/boost/geometry/strategies/relate/geographic.hpp
@@ -211,16 +211,13 @@ public:
         return strategy::within::spherical_box_box();
     }
 
-    template <typename ComparePolicy>
+    template <typename ComparePolicy, typename EqualsPolicy>
     using compare_type = typename strategy::compare::spherical
         <
             ComparePolicy,
-            strategy::compare::equals_epsilon,
+            EqualsPolicy,
             -1
         >;
-
-    //template <typename ComparePolicy, typename EqualsPolicy, int Dimension>
-    //using compare_type = strategy::compare::spherical<ComparePolicy, EqualsPolicy, Dimension>;
 };
 
 
@@ -293,12 +290,12 @@ struct strategy_converter<strategy::intersection::geographic_segments<FormulaPol
                 >(base_t::m_spheroid);
         }
 
-        template <typename ComparePolicy>
-        using compare_type = typename strategy::compare::cartesian
+        template <typename ComparePolicy, typename EqualsPolicy>
+        using compare_type = typename strategy::compare::spherical
             <
                 ComparePolicy,
-                strategy::compare::equals_epsilon,
-                -1
+                EqualsPolicy,
+               -1
             >;
     };
 

--- a/include/boost/geometry/strategies/relate/spherical.hpp
+++ b/include/boost/geometry/strategies/relate/spherical.hpp
@@ -195,11 +195,11 @@ public:
         return strategy::within::spherical_box_box();
     }
 
-    template <typename ComparePolicy>
+    template <typename ComparePolicy, typename EqualsPolicy>
     using compare_type = typename strategy::compare::spherical
         <
             ComparePolicy,
-            strategy::compare::equals_epsilon,
+            EqualsPolicy,
             -1
         >;
 };

--- a/include/boost/geometry/strategies/relate/spherical.hpp
+++ b/include/boost/geometry/strategies/relate/spherical.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry
 
-// Copyright (c) 2020-2021, Oracle and/or its affiliates.
+// Copyright (c) 2020-2023, Oracle and/or its affiliates.
 
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Licensed under the Boost Software License version 1.0.
@@ -193,6 +194,14 @@ public:
     {
         return strategy::within::spherical_box_box();
     }
+
+    template <typename ComparePolicy>
+    using compare_type = typename strategy::compare::spherical
+        <
+            ComparePolicy,
+            strategy::compare::equals_epsilon,
+            -1
+        >;
 };
 
 

--- a/include/boost/geometry/strategies/spherical/compare.hpp
+++ b/include/boost/geometry/strategies/spherical/compare.hpp
@@ -2,9 +2,10 @@
 
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 
-// This file was modified by Oracle on 2017-2020.
-// Modifications copyright (c) 2017-2020, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2017-2023.
+// Modifications copyright (c) 2017-2023, Oracle and/or its affiliates.
 
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -60,6 +61,7 @@ get(P const& p, std::false_type /*different units*/)
 template
 <
     typename ComparePolicy,
+    typename EqualsPolicy,
     typename Point1,
     typename Point2,
     std::size_t DimensionCount
@@ -77,11 +79,11 @@ struct spherical_latitude
                              T1 const& l1, T2 const& r1)
     {
         // latitudes equal
-        if (math::equals(l1, r1))
+        if (EqualsPolicy::apply(l1, r1))
         {
             return compare::detail::compare_loop
                 <
-                    ComparePolicy, 2, DimensionCount
+                    ComparePolicy, EqualsPolicy, 2, DimensionCount
                 >::apply(left, right);
         }
         else
@@ -102,10 +104,11 @@ struct spherical_latitude
 template
 <
     typename ComparePolicy,
+    typename EqualsPolicy,
     typename Point1,
     typename Point2
 >
-struct spherical_latitude<ComparePolicy, Point1, Point2, 1>
+struct spherical_latitude<ComparePolicy, EqualsPolicy, Point1, Point2, 1>
 {
     template <typename T1, typename T2>
     static inline bool apply(Point1 const& left, Point2 const& right,
@@ -118,7 +121,7 @@ struct spherical_latitude<ComparePolicy, Point1, Point2, 1>
     {
         return compare::detail::compare_loop
             <
-                ComparePolicy, 1, 1
+                ComparePolicy, EqualsPolicy, 1, 1
             >::apply(left, right);
     }
 };
@@ -126,6 +129,7 @@ struct spherical_latitude<ComparePolicy, Point1, Point2, 1>
 template
 <
     typename ComparePolicy,
+    typename EqualsPolicy,
     typename Point1,
     typename Point2,
     std::size_t DimensionCount
@@ -167,16 +171,16 @@ struct spherical_longitude
         bool is_right_at_antimeridian = false;
 
             // longitudes equal
-        if (math::equals(l0, r0)
+        if (EqualsPolicy::apply(l0, r0)
                // both at antimeridian
             || are_both_at_antimeridian(l0, r0, is_left_at_antimeridian, is_right_at_antimeridian)
                // both at pole
-            || (math::equals(l1, r1)
+            || (EqualsPolicy::apply(l1, r1)
                 && math::is_latitude_pole<units_type, is_equatorial>(l1)))
         {
             return spherical_latitude
                 <
-                    ComparePolicy, Point1, Point2, DimensionCount
+                    ComparePolicy, EqualsPolicy, Point1, Point2, DimensionCount
                 >::apply(left, right, l1, r1);
         }
         // if left is at antimeridian and right is not at antimeridian
@@ -214,16 +218,17 @@ struct spherical_longitude
 template
 <
     typename ComparePolicy,
+    typename EqualsPolicy,
     int Dimension = -1
 >
 struct spherical
-    : cartesian<ComparePolicy, Dimension>
+    : cartesian<ComparePolicy, EqualsPolicy, Dimension>
 {};
 
 #ifndef DOXYGEN_NO_STRATEGY_SPECIALIZATIONS
 // all dimensions starting from longitude
-template <typename ComparePolicy>
-struct spherical<ComparePolicy, -1>
+template <typename ComparePolicy, typename EqualsPolicy>
+struct spherical<ComparePolicy, EqualsPolicy, -1>
 {
     template <typename Point1, typename Point2>
     static inline bool apply(Point1 const& left, Point2 const& right)
@@ -231,6 +236,7 @@ struct spherical<ComparePolicy, -1>
         return compare::detail::spherical_longitude
             <
                 ComparePolicy,
+                EqualsPolicy,
                 Point1,
                 Point2,
                 std::conditional_t
@@ -244,29 +250,29 @@ struct spherical<ComparePolicy, -1>
 };
 
 // only longitudes (and latitudes to check poles)
-template <typename ComparePolicy>
-struct spherical<ComparePolicy, 0>
+template <typename ComparePolicy, typename EqualsPolicy>
+struct spherical<ComparePolicy, EqualsPolicy, 0>
 {
     template <typename Point1, typename Point2>
     static inline bool apply(Point1 const& left, Point2 const& right)
     {
         return compare::detail::spherical_longitude
             <
-                ComparePolicy, Point1, Point2, 1
+                ComparePolicy, EqualsPolicy, Point1, Point2, 1
             >::apply(left, right);
     }
 };
 
 // only latitudes
-template <typename ComparePolicy>
-struct spherical<ComparePolicy, 1>
+template <typename ComparePolicy, typename EqualsPolicy>
+struct spherical<ComparePolicy, EqualsPolicy, 1>
 {
     template <typename Point1, typename Point2>
     static inline bool apply(Point1 const& left, Point2 const& right)
     {
         return compare::detail::spherical_latitude
             <
-                ComparePolicy, Point1, Point2, 2
+                ComparePolicy, EqualsPolicy, Point1, Point2, 2
             >::apply(left, right);
     }
 };
@@ -278,44 +284,48 @@ namespace services
 {
 
 
-template <typename ComparePolicy, typename Point1, typename Point2, int Dimension>
+template <typename ComparePolicy, typename EqualsPolicy, typename Point1, typename Point2, int Dimension>
 struct default_strategy
     <
-        ComparePolicy, Point1, Point2, Dimension,
+        ComparePolicy, EqualsPolicy,
+        Point1, Point2, Dimension,
         spherical_tag, spherical_tag
     >
 {
-    typedef compare::spherical<ComparePolicy, Dimension> type;
+    typedef compare::spherical<ComparePolicy, EqualsPolicy, Dimension> type;
 };
 
-template <typename ComparePolicy, typename Point1, typename Point2, int Dimension>
+template <typename ComparePolicy, typename EqualsPolicy, typename Point1, typename Point2, int Dimension>
 struct default_strategy
     <
-        ComparePolicy, Point1, Point2, Dimension,
+        ComparePolicy, EqualsPolicy,
+        Point1, Point2, Dimension,
         spherical_polar_tag, spherical_polar_tag
     >
 {
-    typedef compare::spherical<ComparePolicy, Dimension> type;
+    typedef compare::spherical<ComparePolicy, EqualsPolicy, Dimension> type;
 };
 
-template <typename ComparePolicy, typename Point1, typename Point2, int Dimension>
+template <typename ComparePolicy, typename EqualsPolicy, typename Point1, typename Point2, int Dimension>
 struct default_strategy
     <
-        ComparePolicy, Point1, Point2, Dimension,
+        ComparePolicy, EqualsPolicy,
+        Point1, Point2, Dimension,
         spherical_equatorial_tag, spherical_equatorial_tag
     >
 {
-    typedef compare::spherical<ComparePolicy, Dimension> type;
+    typedef compare::spherical<ComparePolicy, EqualsPolicy, Dimension> type;
 };
 
-template <typename ComparePolicy, typename Point1, typename Point2, int Dimension>
+template <typename ComparePolicy, typename EqualsPolicy, typename Point1, typename Point2, int Dimension>
 struct default_strategy
     <
-        ComparePolicy, Point1, Point2, Dimension,
+        ComparePolicy, EqualsPolicy,
+        Point1, Point2, Dimension,
         geographic_tag, geographic_tag
     >
 {
-    typedef compare::spherical<ComparePolicy, Dimension> type;
+    typedef compare::spherical<ComparePolicy, EqualsPolicy, Dimension> type;
 };
 
 

--- a/include/boost/geometry/strategy/cartesian/side_by_triangle.hpp
+++ b/include/boost/geometry/strategy/cartesian/side_by_triangle.hpp
@@ -4,8 +4,8 @@
 // Copyright (c) 2008-2015 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 
-// This file was modified by Oracle on 2015-2021.
-// Modifications copyright (c) 2015-2021, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2015-2023.
+// Modifications copyright (c) 2015-2023, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
@@ -172,7 +172,7 @@ public :
             // arguments, we cyclically permute them so that the first
             // argument is always the lexicographically smallest point.
 
-            using less = compare::cartesian<compare::less>;
+            using less = compare::cartesian<compare::less, compare::equals_epsilon>;
 
             if (less::apply(p, p1))
             {

--- a/test/algorithms/convex_hull/convex_hull_robust.cpp
+++ b/test/algorithms/convex_hull/convex_hull_robust.cpp
@@ -1,7 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 // Unit Test
 
-// Copyright (c) 2020 Oracle and/or its affiliates.
+// Copyright (c) 2020-2023 Oracle and/or its affiliates.
 // Contributed and/or modified by Vissarion Fisikopoulos, on behalf of Oracle
 
 // Use, modification and distribution is subject to the Boost Software License,
@@ -97,6 +97,24 @@ void test_all()
         polygon_wkt4, 5, 4, -0.015);
     test_geometry<bg::model::polygon<Pmp>, non_robust_cartesian_sbt>(
         polygon_wkt4, 5, 5, 3.472078301e+13);
+
+    // github issue https://github.com/boostorg/geometry/issues/1158
+    auto polygon_wkt5 = "polygon((1941.6475737576565734 554.21197550796682663,\
+        2201.1796067026721175 604.83253590728611471,\
+        2367.1836939680897558 1898.3918136409306499,\
+        1856.9044662310534477 2320.8057089752910542,\
+        2000.0000000000002274 551.77450949119793222,\
+        1999.9999999999995453 1721.4008337980080796,\
+        1999.9999999999993179 1966.6530570371892281,\
+        1941.6475737576565734 554.21197550796682663))";
+    test_geometry<bg::model::polygon<P>, robust_cartesian, precise_cartesian>(
+        polygon_wkt5, 8, 6, 598281.35103625199);
+    test_geometry<bg::model::polygon<P>, non_robust_cartesian_sbt, precise_cartesian>(
+        polygon_wkt5, 8, 6, 598281.35103625199);
+    test_geometry<bg::model::polygon<P>, non_robust_cartesian_fast, precise_cartesian>(
+        polygon_wkt5, 8, 6, 598281.35103625199);
+    test_geometry<bg::model::polygon<Pmp>, non_robust_cartesian_sbt>(
+        polygon_wkt5, 8, 6, 598281.35103625199);
 }
 
 

--- a/test/algorithms/set_operations/intersection/intersection_linear_linear.cpp
+++ b/test/algorithms/set_operations/intersection/intersection_linear_linear.cpp
@@ -1,11 +1,13 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014-2015, Oracle and/or its affiliates.
+// Copyright (c) 2014-2023, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
+// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
 // Licensed under the Boost Software License version 1.0.
 // http://www.boost.org/users/license.html
 
-// Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
 #include <iostream>
 
@@ -1381,7 +1383,7 @@ BOOST_AUTO_TEST_CASE( test_intersection_ml_ml_spikes )
 {
 #ifdef BOOST_GEOMETRY_TEST_DEBUG
     std::cout << std::endl << std::endl << std::endl;
-    std::cout << "*** MULTILINESTRING / MULTILINESTRING INTERSECTION" 
+    std::cout << "*** MULTILINESTRING / MULTILINESTRING INTERSECTION"
               << " (WITH SPIKES) ***"
               << std::endl;
     std::cout << std::endl;

--- a/test/cs_undefined/test_relops.hpp
+++ b/test/cs_undefined/test_relops.hpp
@@ -1,6 +1,8 @@
 // Boost.Geometry
 
-// Copyright (c) 2019-2021, Oracle and/or its affiliates.
+// Copyright (c) 2019-2023, Oracle and/or its affiliates.
+
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Licensed under the Boost Software License version 1.0.
@@ -130,7 +132,7 @@ inline void rel(G1 const& g1, G2 const& g2, S const& s)
     call_crosses<G1, G2>::apply(g1, g2, s);
     bg::disjoint(g1, g2, s);
     call_equals<G1, G2>::apply(g1, g2, s);
-    bg::intersects(g1, g2, s);    
+    bg::intersects(g1, g2, s);
     call_overlaps<G1, G2>::apply(g1, g2, s);
     call_touches<G1, G2>::apply(g1, g2, s);
     bg::within(g1, g2, s);


### PR DESCRIPTION
This PR propose a fix for https://github.com/boostorg/geometry/issues/1158

First, it enables passing (umbrella) strategies to less policy. Then different (umbrella) strategies can parameterize the less policy by different compare strategy. 

For, example floating point comparison in convex hull strategies does *not* need to be done approximately. Relate strategies still use the approximate comparison of fp numbers (`math::equals()` function).

Side note: I am not sure if approximate comparison of numbers is needed for relate strategy. I just left it as is in order for the tests to pass, but I think it needs some investigation. Related issue https://github.com/boostorg/geometry/issues/1148 

Next steps (to be implemented in new PRs)
- do the same for `greater` and `equal_to`
- move code from `strategies/compare.hpp` to `strategies/cartesian/compare.hpp` (if I understand the strategies code structure correctly, @awulkiew please correct me if I am wrong here)