### PR TITLE
Add if constexpr macro and replace condition macro.

### DIFF
--- a/include/boost/geometry/algorithms/densify.hpp
+++ b/include/boost/geometry/algorithms/densify.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry
 
-// Copyright (c) 2017-2021, Oracle and/or its affiliates.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
+// Copyright (c) 2017-2021, Oracle and/or its affiliates.
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Licensed under the Boost Software License version 1.0.
@@ -33,7 +34,7 @@
 #include <boost/geometry/strategies/densify/geographic.hpp>
 #include <boost/geometry/strategies/densify/spherical.hpp>
 #include <boost/geometry/strategies/detail.hpp>
-#include <boost/geometry/util/condition.hpp>
+#include <boost/geometry/util/constexpr.hpp>
 #include <boost/geometry/util/range.hpp>
 
 
@@ -102,7 +103,7 @@ struct densify_range
             strategy.apply(p0, p1, policy, len);
         }
 
-        if (BOOST_GEOMETRY_CONDITION(AppendLastPoint))
+        if BOOST_GEOMETRY_CONSTEXPR (AppendLastPoint)
         {
             convert_and_push_back(rng_out, *prev); // back(rng)
         }
@@ -130,7 +131,7 @@ struct densify_ring
 
         strategy.apply(p0, p1, policy, len);
 
-        if (BOOST_GEOMETRY_CONDITION(IsClosed2))
+        if BOOST_GEOMETRY_CONSTEXPR (IsClosed2)
         {
             convert_and_push_back(ring_out, p1);
         }

--- a/include/boost/geometry/algorithms/detail/buffer/buffer_inserter.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/buffer_inserter.hpp
@@ -1,7 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
 // Copyright (c) 2012-2020 Barend Gehrels, Amsterdam, the Netherlands.
-// Copyright (c) 2022 Adam Wulkiewicz, Lodz, Poland.
+// Copyright (c) 2022-2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2017-2022.
 // Modifications copyright (c) 2017-2022 Oracle and/or its affiliates.
@@ -44,7 +44,7 @@
 #include <boost/geometry/strategies/buffer.hpp>
 #include <boost/geometry/strategies/side.hpp>
 
-#include <boost/geometry/util/condition.hpp>
+#include <boost/geometry/util/constexpr.hpp>
 #include <boost/geometry/util/math.hpp>
 #include <boost/geometry/util/type_traits.hpp>
 
@@ -942,17 +942,17 @@ inline void buffer_inserter(GeometryInput const& geometry_input, OutputIterator 
 {
     boost::ignore_unused(visit_pieces_policy);
 
-    typedef detail::buffer::buffered_piece_collection
-    <
-        typename geometry::ring_type<GeometryOutput>::type,
-        Strategies,
-        DistanceStrategy,
-        RobustPolicy
-    > collection_type;
+    using collection_type = detail::buffer::buffered_piece_collection
+        <
+            typename geometry::ring_type<GeometryOutput>::type,
+            Strategies,
+            DistanceStrategy,
+            RobustPolicy
+        >;
     collection_type collection(strategies, distance_strategy, robust_policy);
     collection_type const& const_collection = collection;
 
-    bool const areal = util::is_areal<GeometryInput>::value;
+    static constexpr bool areal = util::is_areal<GeometryInput>::value;
 
     dispatch::buffer_inserter
         <
@@ -969,7 +969,7 @@ inline void buffer_inserter(GeometryInput const& geometry_input, OutputIterator 
                  robust_policy, strategies);
 
     collection.get_turns();
-    if (BOOST_GEOMETRY_CONDITION(areal))
+    if BOOST_GEOMETRY_CONSTEXPR (areal)
     {
         collection.check_turn_in_original();
     }
@@ -989,7 +989,7 @@ inline void buffer_inserter(GeometryInput const& geometry_input, OutputIterator 
     // phase 1: turns (after enrichment/clustering)
     visit_pieces_policy.apply(const_collection, 1);
 
-    if (BOOST_GEOMETRY_CONDITION(areal))
+    if BOOST_GEOMETRY_CONSTEXPR (areal)
     {
         collection.deflate_check_turns();
     }
@@ -1001,8 +1001,7 @@ inline void buffer_inserter(GeometryInput const& geometry_input, OutputIterator 
     // - the output is counter clockwise
     // and avoid reversing twice
     bool reverse = distance_strategy.negative() && areal;
-    if (BOOST_GEOMETRY_CONDITION(
-            geometry::point_order<GeometryOutput>::value == counterclockwise))
+    if BOOST_GEOMETRY_CONSTEXPR (geometry::point_order<GeometryOutput>::value == counterclockwise)
     {
         reverse = ! reverse;
     }
@@ -1011,9 +1010,12 @@ inline void buffer_inserter(GeometryInput const& geometry_input, OutputIterator 
         collection.reverse();
     }
 
-    if (BOOST_GEOMETRY_CONDITION(distance_strategy.negative() && areal))
+    if BOOST_GEOMETRY_CONSTEXPR (areal)
     {
-        collection.discard_nonintersecting_deflated_rings();
+        if (distance_strategy.negative())
+        {
+            collection.discard_nonintersecting_deflated_rings();
+        }
     }
 
     collection.template assign<GeometryOutput>(out);

--- a/include/boost/geometry/algorithms/detail/is_valid/linear.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/linear.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014-2021, Oracle and/or its affiliates.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
+// Copyright (c) 2014-2021, Oracle and/or its affiliates.
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -31,7 +32,7 @@
 #include <boost/geometry/core/point_type.hpp>
 #include <boost/geometry/core/tags.hpp>
 
-#include <boost/geometry/util/condition.hpp>
+#include <boost/geometry/util/constexpr.hpp>
 
 
 namespace boost { namespace geometry
@@ -158,10 +159,12 @@ public:
                              VisitPolicy& visitor,
                              Strategy const& strategy)
     {
-        if (BOOST_GEOMETRY_CONDITION(
-                AllowEmptyMultiGeometries && boost::empty(multilinestring)))
+        if BOOST_GEOMETRY_CONSTEXPR (AllowEmptyMultiGeometries)
         {
-            return visitor.template apply<no_failure>();
+            if (boost::empty(multilinestring))
+            {
+                return visitor.template apply<no_failure>();
+            }
         }
 
         using per_ls = per_linestring<VisitPolicy, Strategy>;

--- a/include/boost/geometry/algorithms/detail/is_valid/multipolygon.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/multipolygon.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014-2021, Oracle and/or its affiliates.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
+// Copyright (c) 2014-2021, Oracle and/or its affiliates.
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -27,7 +28,7 @@
 #include <boost/geometry/core/ring_type.hpp>
 #include <boost/geometry/core/tags.hpp>
 
-#include <boost/geometry/util/condition.hpp>
+#include <boost/geometry/util/constexpr.hpp>
 #include <boost/geometry/util/range.hpp>
 
 #include <boost/geometry/geometries/box.hpp>
@@ -282,10 +283,12 @@ public:
     {
         using debug_phase = debug_validity_phase<MultiPolygon>;
 
-        if (BOOST_GEOMETRY_CONDITION(AllowEmptyMultiGeometries)
-            && boost::empty(multipolygon))
+        if BOOST_GEOMETRY_CONSTEXPR (AllowEmptyMultiGeometries)
         {
-            return visitor.template apply<no_failure>();
+            if (boost::empty(multipolygon))
+            {
+                return visitor.template apply<no_failure>();
+            }
         }
 
         // check validity of all polygons ring

--- a/include/boost/geometry/algorithms/detail/is_valid/polygon.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/polygon.hpp
@@ -1,9 +1,8 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
+// Copyright (c) 2017-2023 Adam Wulkiewicz, Lodz, Poland.
 
 // Copyright (c) 2014-2021, Oracle and/or its affiliates.
-
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -35,7 +34,7 @@
 #include <boost/geometry/core/ring_type.hpp>
 #include <boost/geometry/core/tags.hpp>
 
-#include <boost/geometry/util/condition.hpp>
+#include <boost/geometry/util/constexpr.hpp>
 #include <boost/geometry/util/range.hpp>
 #include <boost/geometry/util/sequence.hpp>
 
@@ -447,7 +446,7 @@ public:
             return false;
         }
 
-        if (BOOST_GEOMETRY_CONDITION(CheckRingValidityOnly))
+        if BOOST_GEOMETRY_CONSTEXPR (CheckRingValidityOnly)
         {
             return true;
         }

--- a/include/boost/geometry/io/wkt/write.hpp
+++ b/include/boost/geometry/io/wkt/write.hpp
@@ -50,7 +50,7 @@
 #include <boost/geometry/strategies/io/geographic.hpp>
 #include <boost/geometry/strategies/io/spherical.hpp>
 
-#include <boost/geometry/util/condition.hpp>
+#include <boost/geometry/util/constexpr.hpp>
 #include <boost/geometry/util/type_traits.hpp>
 
 
@@ -129,7 +129,7 @@ struct wkt_range
 
         if (boost::size(range) > 0)
         {
-            if (WriteDoubleBrackets)
+            if BOOST_GEOMETRY_CONSTEXPR (WriteDoubleBrackets)
             {
                 os << "(";
             }
@@ -143,15 +143,17 @@ struct wkt_range
             }
 
             // optionally, close range to ring by repeating the first point
-            if (BOOST_GEOMETRY_CONDITION(ForceClosurePossible)
-                && force_closure
-                && boost::size(range) > 1
-                && wkt_range::disjoint(*begin, *(end - 1)))
+            if BOOST_GEOMETRY_CONSTEXPR (ForceClosurePossible)
             {
-                os << ",";
-                stream_type::apply(os, *begin);
+                if (force_closure
+                    && boost::size(range) > 1
+                    && wkt_range::disjoint(*begin, *(end - 1)))
+                {
+                    os << ",";
+                    stream_type::apply(os, *begin);
+                }
             }
-            if (WriteDoubleBrackets)
+            if BOOST_GEOMETRY_CONSTEXPR (WriteDoubleBrackets)
             {
                 os << ")";
             }

--- a/include/boost/geometry/policies/is_valid/failing_reason_policy.hpp
+++ b/include/boost/geometry/policies/is_valid/failing_reason_policy.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2015, Oracle and/or its affiliates.
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
 
+// Copyright (c) 2015, Oracle and/or its affiliates.
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -14,7 +15,7 @@
 #include <sstream>
 
 #include <boost/geometry/io/dsv/write.hpp>
-#include <boost/geometry/util/condition.hpp>
+#include <boost/geometry/util/constexpr.hpp>
 #include <boost/geometry/util/range.hpp>
 #include <boost/geometry/algorithms/validity_failure_type.hpp>
 #include <boost/geometry/algorithms/detail/overlay/debug_turn_info.hpp>
@@ -69,10 +70,12 @@ private:
     static inline
     validity_failure_type transform_failure_type(validity_failure_type failure)
     {
-        if (BOOST_GEOMETRY_CONDITION(
-                AllowDuplicates && failure == failure_duplicate_points))
+        if BOOST_GEOMETRY_CONSTEXPR (AllowDuplicates)
         {
-            return no_failure;
+            if (failure == failure_duplicate_points)
+            {
+                return no_failure;
+            }
         }
         return failure;
     }
@@ -81,10 +84,12 @@ private:
     validity_failure_type transform_failure_type(validity_failure_type failure,
                                                  bool is_linear)
     {
-        if (BOOST_GEOMETRY_CONDITION(
-                is_linear && AllowSpikes && failure == failure_spikes))
+        if BOOST_GEOMETRY_CONSTEXPR (AllowSpikes)
         {
-            return no_failure;
+            if (is_linear && failure == failure_spikes)
+            {
+                return no_failure;
+            }
         }
         return transform_failure_type(failure);
     }
@@ -123,9 +128,12 @@ private:
                                  bool is_linear,
                                  SpikePoint const& spike_point)
         {
-            if (BOOST_GEOMETRY_CONDITION(is_linear && AllowSpikes))
+            if BOOST_GEOMETRY_CONSTEXPR (AllowSpikes)
             {
-                return;
+                if (is_linear)
+                {
+                    return;
+                }
             }
 
             oss << ". A spike point was found with apex at "
@@ -173,7 +181,7 @@ private:
         static inline void apply(std::ostringstream& oss,
                                  Point const& point)
         {
-            if (BOOST_GEOMETRY_CONDITION(AllowDuplicates))
+            if BOOST_GEOMETRY_CONSTEXPR (AllowDuplicates)
             {
                 return;
             }

--- a/include/boost/geometry/util/constexpr.hpp
+++ b/include/boost/geometry/util/constexpr.hpp
@@ -1,0 +1,27 @@
+// Boost.Geometry
+ 
+// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_UTIL_CONSTEXPR_HPP
+#define BOOST_GEOMETRY_UTIL_CONSTEXPR_HPP
+
+
+#include <boost/geometry/util/condition.hpp>
+
+
+#ifndef BOOST_NO_CXX17_IF_CONSTEXPR
+
+#define BOOST_GEOMETRY_CONSTEXPR(CONDITION) constexpr (CONDITION)
+
+#else
+
+#define BOOST_GEOMETRY_CONSTEXPR(CONDITION) (BOOST_GEOMETRY_CONDITION(CONDITION))
+
+#endif
+
+
+#endif // BOOST_GEOMETRY_UTIL_CONSTEXPR_HPP


### PR DESCRIPTION
This is a proposal adding conditional support of C++17 `if constexpr`. I modified only several files for now so we can start a discussion. If we have an agreement I'll modify other places.

My intention was to have a solution as close as possible to the original language feature and to keep `if` keyword so editors can highlight it as usual, i.e.:
```
if constexpr (static_condition)
```
vs
```
if BOOST_GEOMETRY_CONSTEXPR (static_condition)
```


It's a followup of https://github.com/boostorg/geometry/pull/1160
