### PR TITLE
[similarity] add similarity distance

### DIFF
--- a/include/boost/geometry/algorithms/discrete_hausdorff_distance.hpp
+++ b/include/boost/geometry/algorithms/discrete_hausdorff_distance.hpp
@@ -15,17 +15,6 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DISCRETE_HAUSDORFF_DISTANCE_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DISCRETE_HAUSDORFF_DISTANCE_HPP
 
-#include <algorithm>
-
-#ifdef BOOST_GEOMETRY_DEBUG_HAUSDORFF_DISTANCE
-#include <iostream>
-#endif
-
-#include <iterator>
-#include <utility>
-#include <vector>
-#include <limits>
-
 #include <boost/geometry/algorithms/detail/dummy_geometries.hpp>
 #include <boost/geometry/algorithms/detail/throw_on_empty_input.hpp>
 #include <boost/geometry/algorithms/not_implemented.hpp>
@@ -38,6 +27,11 @@
 #include <boost/geometry/strategies/discrete_distance/spherical.hpp>
 #include <boost/geometry/strategies/distance_result.hpp>
 #include <boost/geometry/util/range.hpp>
+
+#include <algorithm>
+#include <iterator>
+#include <utility>
+#include <limits>
 
 // Note that in order for this to work umbrella strategy has to contain
 // index strategies.

--- a/include/boost/geometry/algorithms/similarity.hpp
+++ b/include/boost/geometry/algorithms/similarity.hpp
@@ -1,0 +1,330 @@
+// Boost.Geometry
+
+// Copyright (c) 2023 Barend Gehrels, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+
+#ifndef BOOST_GEOMETRY_ALGORITHMS_SIMILARITY_HPP
+#define BOOST_GEOMETRY_ALGORITHMS_SIMILARITY_HPP
+
+#include <cstdint>
+#include <vector>
+
+#include <boost/geometry/core/point_type.hpp>
+#include <boost/geometry/algorithms/distance.hpp>
+#include <boost/geometry/algorithms/length.hpp>
+
+
+namespace boost { namespace geometry
+{
+
+template <typename CoordinateType>
+struct similarity_info
+{
+    CoordinateType distance = 0;
+    bool is_reversed = false;
+}; 
+
+#ifndef DOXYGEN_NO_DETAIL
+namespace detail { namespace similarity
+{
+
+// Structure containing projections of a geometry on another geometry,
+// and additionally the points of the geometry itself
+template <typename Point>
+struct projection
+{
+    using coor_t = typename coordinate_type<Point>::type;
+
+    // Indicates if it is a projection of the other geometry, or a point of the own geometry.
+    bool is_projection = true;
+
+    // For a projection of P on Q, this is the index in P
+    // For a non projected point, it is also the index in P
+    std::size_t source_index = 0;
+
+    // For a projection of P on Q, this is the index of a segment in Q
+    // For a non projected point, it is identical to source_index
+    std::size_t segment_index = 0;
+
+    // For a projection of P on Q, this is the offset on the segment in Q
+    // For a non projected point, the offset is always 0.0
+    coor_t offset = 0;
+
+    // For a projection of P on Q, this is the distance from point P 
+    // to its projection in Q.
+    // For a non projected point, it is 0.0
+    coor_t distance = 0;
+
+    // The projected point, or the point of the geometry itself
+    Point point;
+};
+
+template <typename Point, typename Geometry>
+auto get_projection(std::size_t index, Point const& point, Geometry const& target)
+{
+    using coor_t = typename coordinate_type<Point>::type;
+    using closest_strategy = geometry::strategy::closest_points::detail::compute_closest_point_to_segment<coor_t>;
+    projection<Point> result;
+
+    for (std::size_t i = 0; i + 1 < target.size(); i++)
+    {
+        auto const& current = target[i];
+        auto const& next = target[i + 1];
+        projection<Point> other;
+        auto const pp = closest_strategy::apply(point, current, next);
+        geometry::convert(pp, other.point);
+        other.distance = geometry::distance(point, other.point);
+        if (i == 0 || other.distance < result.distance)
+        {
+            result = other;
+            result.is_projection = true;
+            result.source_index = index;
+            result.segment_index = i;
+            result.offset = geometry::distance(current, result.point);
+        }
+    }
+    return result;
+}
+
+// Calculate projected points of all points of "source" on "target"
+// The result is therefore similar to target.
+template <typename Geometry1, typename Geometry2>
+auto get_projections(Geometry1 const& source, Geometry2 const& target)
+{
+    std::vector<projection<typename point_type<Geometry1>::type>> result;
+    result.resize(source.size());
+    detail::for_each_with_index(source, [&target, &result](std::size_t index, const auto& point)
+    {
+        result[index] = get_projection(index, point, target);
+    });
+    return result;
+}
+
+// Reverse in the projections: the segment index and the offset.
+// All the rest (source_index, distance, point) is the same for the reversed version.
+// >------+-----+------> 4 points, 3 segments, last segment index is 2
+//   *                   segment_index 0, reverse: 2 (2 - 0)
+//           *           segment_index 1, reverse: 1 (2 - 1)
+//                  *    segment_index 2, reverse: 0 (2 - 2)
+template <typename Projections, typename Geometry2>
+void reverse_projections(Geometry2 const& target, Projections& projections)
+{
+    std::size_t const last_segment_index = target.size() - 2;
+    for (auto& projection : projections)
+    {
+        auto const si = projection.segment_index;
+        if (si > last_segment_index)
+        {
+            // Defensive check.
+            continue;
+        }
+        auto const segment_length = geometry::distance(target[si], target[si + 1]);
+        projection.segment_index = last_segment_index - si;
+        projection.offset = segment_length - projection.offset;
+    }
+}
+
+// Add "self" points on collection which was created projecting an other line
+// onto this line.
+// Sort all points along the line.
+template <typename It, typename Enriched>
+void enrich_with_self(It begin, It end, Enriched& enriched)
+{
+    using info_t = std::decay_t<decltype(enriched.front())>;
+    std::size_t index = 0;
+    for (It it = begin; it != end; ++it)
+    {
+        info_t info;
+        info.is_projection = false;
+        info.source_index = index;
+        info.segment_index = index;
+        info.point = *it;
+        enriched.push_back(std::move(info));
+        index++;
+    }
+
+    std::sort(enriched.begin(), enriched.end(), 
+        [](const auto& lhs, const auto& rhs){
+            auto const lt = std::tie(lhs.segment_index, lhs.offset, lhs.source_index, lhs.is_projection);
+            auto const rt = std::tie(rhs.segment_index, rhs.offset, rhs.source_index, rhs.is_projection);
+            return lt < rt;
+        });
+}
+
+template <typename Projections>
+bool is_reversed(Projections const& projections)
+{
+    std::size_t count_right_order = 0;
+    std::size_t count_wrong_order = 0;
+    for (std::size_t i = 0; i + 1 < projections.size(); i++)
+    {
+        auto const current = std::tie(projections[i].segment_index, projections[i].offset);
+        auto const next = std::tie(projections[i + 1].segment_index, projections[i + 1].offset);
+
+        if (current <= next)
+        {
+            count_right_order++;
+        }
+        else
+        {
+            count_wrong_order++;
+        }
+    }
+
+    return count_wrong_order > count_right_order;
+}
+
+template <typename Projection, typename Ring>
+bool fill_quadrilateral(Projection const& p0, Projection const& p1, Projection const& q0, Projection const& q1, Ring& ring)
+{
+    using point_t = typename point_type<Ring>::type;
+    using side_strategy = typename strategy::side::services::default_strategy
+    <
+        typename cs_tag<point_t>::type
+    >::type;
+
+    int const side_q0_p = side_strategy::apply(p0.point, p1.point, q0.point);
+    int const side_q1_p = side_strategy::apply(p0.point, p1.point, q1.point);
+    int const side_p0_q = side_strategy::apply(q0.point, q1.point, p0.point);
+    int const side_p1_q = side_strategy::apply(q0.point, q1.point, p1.point);
+
+    if (side_q0_p == 0 && side_q1_p == 0 && side_p0_q == 0 && side_p1_q == 0)
+    {
+        // All sides are the same. This happens a lot when the inputs are the same.
+        // Constructing the quadrilateral and calculating its area can be skipped.
+        return false;
+    }
+
+    // Construct a clockwise ring (a quadrilateral).
+    // For example
+    // [2] +-----------+ [3]  [i + 1] (1)
+    //     |           |
+    //     p           q
+    //     |           |
+    // [1] +-----------+ [0]  [i] (0)
+    // Here q(0) is right (-1) from p, so taken q(0) first. 
+    // (Stated otherwise, p(0) is left (1) from q)
+    // Then take p(0) as [1], second point.
+    // As third point [2] then p(1) is taken because it is left (1) from q.
+    // Finally q(1) used as [3] and the ring is closed [4].
+    bool const first_q0 = side_q0_p == -1 || side_p0_q == 1;
+    bool const third_p1 = side_p1_q == 1 || side_q1_p == -1;
+
+    ring[0] = (first_q0 ? q0 : p0).point;
+    ring[1] = (first_q0 ? p0 : q0).point;
+    ring[2] = (third_p1 ? p1 : q1).point;
+    ring[3] = (third_p1 ? q1 : p1).point;
+    ring[4] = ring[0];
+
+    return true;
+}
+
+template <typename It, typename Ring, typename Visitor>
+auto get_areal_sum(It p_it, It p_end, It q_it, It q_end, Ring& ring, Visitor& visitor)
+{
+    typename coordinate_type<Ring>::type sum_area = 0;
+
+    auto p_prev = p_it++;
+    auto q_prev = q_it++;
+
+    for ( ; p_it != p_end; ++p_it, ++q_it)
+    {
+        if (fill_quadrilateral(*p_prev, *p_it, *q_prev, *q_it, ring))
+        {
+            auto const area = geometry::area(ring);
+
+            // The area should be positive - taking the abs is a defensive check.
+            sum_area += std::abs(area);
+
+            visitor.visit_quadrilateral(ring, *p_prev, *p_it, *q_prev, *q_it);
+        }
+
+        p_prev = p_it;
+        q_prev = q_it;
+    }
+    return sum_area;
+}
+
+}} // namespace detail::similarity
+#endif // DOXYGEN_NO_DETAIL
+
+
+struct similarity_default_visitor
+{
+    template <typename T, typename I> void visit_quadrilateral(T const& , I const& , I const& , I const& , I const& ) {}
+    template <typename C> void visit_projections(int, C const&) {}
+};
+
+
+template <typename Geometry1, typename Geometry2, typename Visitor>
+auto similarity(Geometry1 const& p, Geometry2 const& q, Visitor& visitor = similarity_default_visitor())
+{
+    using namespace detail::similarity;
+
+    using point_t = typename point_type<Geometry1>::type;
+    using coor_t = typename coordinate_type<Geometry1>::type;
+
+    similarity_info<coor_t> result;
+
+    // Get projections of P on Q.
+    // Later, the points of Q are added to these projections.
+    // Therefore, this variable can be seen as an enriched version of range Q.
+    auto q_enriched = get_projections(p, q);
+
+    result.is_reversed = is_reversed(q_enriched);
+
+    if (result.is_reversed)
+    {
+        // Reverse Q to align with P, and add own points using reversed iterators
+        reverse_projections(q, q_enriched);
+        enrich_with_self(boost::rbegin(q), boost::rend(q), q_enriched);
+    }
+    else
+    {
+        enrich_with_self(boost::begin(q), boost::end(q), q_enriched);
+    }
+
+    // Do the same for P. Because Q is possibly reversed to align with P, 
+    // such a check is not necessary for P again.
+    auto p_enriched = get_projections(q, p);
+    enrich_with_self(boost::begin(p), boost::end(p), p_enriched);
+
+    // Optional debug step.
+    visitor.visit_projections(0, p_enriched);
+    visitor.visit_projections(1, q_enriched);
+
+    if (q_enriched.size() != p_enriched.size())
+    {
+        // Defensive check.
+        // They should always have the same size: 
+        // each other projected points, plus their own points.
+        return result;
+    }
+
+    using ring_t = boost::geometry::model::ring<point_t>;
+
+    ring_t ring;
+    ring.resize(5);
+
+    auto const sum_area = get_areal_sum(boost::begin(p_enriched), boost::end(p_enriched), 
+        boost::begin(q_enriched), boost::end(q_enriched), ring, visitor);
+
+    auto const length = (std::min)(geometry::length(p), geometry::length(q));
+    result.distance = length > 0 ? sum_area / length : std::sqrt(sum_area);        
+    return result;
+}
+
+template <typename Geometry1, typename Geometry2>
+auto similarity_distance(Geometry1 const& a, Geometry2 const& b)
+{
+    similarity_default_visitor v;
+    return similarity(a, b, v).distance;
+}
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_ALGORITHMS_SIMILARITY_HPP

--- a/include/boost/geometry/algorithms/similarity.hpp
+++ b/include/boost/geometry/algorithms/similarity.hpp
@@ -10,13 +10,12 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_SIMILARITY_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_SIMILARITY_HPP
 
-#include <cstdint>
-#include <vector>
-
 #include <boost/geometry/core/point_type.hpp>
 #include <boost/geometry/algorithms/distance.hpp>
 #include <boost/geometry/algorithms/length.hpp>
 
+#include <cstdint>
+#include <vector>
 
 namespace boost { namespace geometry
 {
@@ -77,7 +76,7 @@ auto get_projection(std::size_t index, Point const& point, Geometry const& targe
         projection<Point> other;
         auto const pp = closest_strategy::apply(point, current, next);
         geometry::convert(pp, other.point);
-        other.distance = geometry::distance(point, other.point);
+        other.distance = geometry::comparable_distance(point, other.point);
         if (i == 0 || other.distance < result.distance)
         {
             result = other;
@@ -87,6 +86,7 @@ auto get_projection(std::size_t index, Point const& point, Geometry const& targe
             result.offset = geometry::distance(current, result.point);
         }
     }
+    result.distance = geometry::distance(result.point, point);
     return result;
 }
 
@@ -193,6 +193,8 @@ bool fill_quadrilateral(Projection const& p0, Projection const& p1, Projection c
     int const side_p1_q = side_strategy::apply(q0.point, q1.point, p1.point);
 
     if (side_q0_p == 0 && side_q1_p == 0 && side_p0_q == 0 && side_p1_q == 0)
+    // This might be enough:
+    // if (side_q0_p == 0 && side_q1_p == 0)
     {
         // All sides are the same. This happens a lot when the inputs are the same.
         // Constructing the quadrilateral and calculating its area can be skipped.
@@ -319,7 +321,7 @@ auto similarity(Geometry1 const& p, Geometry2 const& q, Visitor& visitor = simil
 }
 
 template <typename Geometry1, typename Geometry2>
-auto similarity_distance(Geometry1 const& a, Geometry2 const& b)
+auto average_distance(Geometry1 const& a, Geometry2 const& b)
 {
     similarity_default_visitor v;
     return similarity(a, b, v).distance;

--- a/include/boost/geometry/io/geojson/geojson_writer.hpp
+++ b/include/boost/geometry/io/geojson/geojson_writer.hpp
@@ -1,0 +1,184 @@
+// Boost.Geometry
+
+// Copyright (c) 2023 Barend Gehrels, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_TEST_GEOJSON_WRITER_HPP
+#define BOOST_GEOMETRY_TEST_GEOJSON_WRITER_HPP
+
+#include <boost/geometry/core/access.hpp>
+#include <boost/geometry/io/dsv/write.hpp>
+
+#include <ostream>
+#include <string>
+
+namespace boost { namespace geometry
+{
+
+#ifndef DOXYGEN_NO_DISPATCH
+namespace dispatch
+{
+
+template <typename GeometryTag>
+struct geojson_feature_type
+{
+    BOOST_GEOMETRY_STATIC_ASSERT_FALSE("Not or not yet implemented for this Geometry type.",
+                                       GeometryTag);
+};
+
+template <>
+struct geojson_feature_type<point_tag> { static inline const char* apply() { return "Point"; } };
+
+template <>
+struct geojson_feature_type<segment_tag>  { static inline const char* apply() { return "LineString"; } };
+
+template <>
+struct geojson_feature_type<ring_tag>  { static inline const char* apply() { return "Polygon"; } };
+
+template <>
+struct geojson_feature_type<linestring_tag>  { static inline const char* apply() { return "LineString"; } };
+
+template <>
+struct geojson_feature_type<polygon_tag>  { static inline const char* apply() { return "Polygon"; } };
+
+template <>
+struct geojson_feature_type<multi_polygon_tag>  { static inline const char* apply() { return "MultiPolygon"; } };
+
+} // namespace dispatch
+#endif
+
+/*!
+\brief Helper class to create geojson output
+*/
+struct geojson_writer
+{
+
+  private:
+    std::ostream& m_out;
+
+    static const char* comma_space() { return ", "; }
+    static const char* colon() { return ": "; }
+    static const char* gtag() { return "\"geometry\""; }
+    static const char* ttag() { return "\"type\""; }
+    static const char* ctag() { return "\"coordinates\""; }
+    static char comma() { return ','; }
+    static char quote() { return '"'; }
+    static char cbopen() { return '{'; }
+    static char cbclose() { return '}'; }
+
+    std::size_t feature_count = 0;
+    std::size_t property_count = 0;
+
+    void start_feature()
+    {
+        end_properties();
+        end_feature();
+
+        if (feature_count > 0)
+        {
+            m_out << comma() << std::endl;
+        }
+        feature_count++;
+
+        m_out << cbopen() << std::endl << ttag() << colon() << quote() << "Feature" << quote();
+    }
+
+    void start_property()
+    {
+        // Write a comma, either after the "geometry" tag, or after the previous property
+        m_out << comma() << std::endl;
+
+        if (property_count == 0)
+        {
+            // No properties yet, start the list of properties
+            m_out << quote() << "properties" << quote() << colon() << cbopen() << std::endl;
+        }
+        property_count++;
+    }
+
+    void end_properties()
+    {
+        if (property_count > 0)
+        {
+            m_out << cbclose() << std::endl;
+            property_count = 0;
+        }
+    }
+    void end_feature()
+    {
+        if (feature_count > 0)
+        {
+            m_out << cbclose() << std::endl;
+        }
+    }
+
+  public:
+    geojson_writer(std::ostream& out) : m_out(out)
+    {
+        m_out << cbopen() << ttag() << colon() << quote() << "FeatureCollection" << quote()
+              << comma_space() << quote() << "features" << quote() << colon() << "[" << std::endl;
+    }
+    ~geojson_writer()
+    {
+        end_properties();
+        end_feature();
+
+        m_out << "]" << cbclose();
+    }
+
+    // Set a property. It is expected that a feature is already started.
+    template <typename T>
+    void add_property(const std::string& name, T const& value)
+    {
+        start_property();
+        m_out << quote() << name << quote() << colon() << value;
+    }
+
+    // Overload to get it quoted
+    void add_property(const std::string& name, std::string const& value)
+    {
+        start_property();
+        m_out << quote() << name << quote() << colon() << quote() << value << quote();
+    }
+
+    // Overload to get it quoted
+    void add_property(const std::string& name, const char* value)
+    {
+        start_property();
+        m_out << quote() << name << quote() << colon() << quote() << value << quote();
+    }
+
+    // The method "feature" should be called to start a feature.
+    // After that, properties can be added.
+    template <typename Geometry>
+    void feature(const Geometry& geometry)
+    {
+        start_feature();
+
+        // Write the comma after either the "Feature" tag
+        m_out << comma() << std::endl;
+
+        // Write the geometry
+        using tag_t = typename tag<Geometry>::type;
+        m_out << gtag() << colon() << cbopen() << ttag() << colon() << quote()
+              << dispatch::geojson_feature_type<tag_t>::apply() << quote() << comma_space()
+              << ctag() << colon();
+
+        // A ring is modelled as a geojson polygon, and therefore the opening and closing
+        // list marks should be duplicated to indicate empty interior rings.
+        const bool dup = std::is_same<tag_t, ring_tag>::value;
+        const char* list_open = dup ? "[[" : "[";
+        const char* list_close = dup ? "]]" : "]";
+        m_out << geometry::dsv(geometry, comma_space(), "[", "]", comma_space(), list_open,
+                               list_close) << cbclose() << std::endl;
+    }
+
+};
+
+}} // namespace boost::geometry
+
+
+#endif

--- a/research/similarity.cpp
+++ b/research/similarity.cpp
@@ -1,0 +1,217 @@
+// NOTE: this is used in the Haussdorf algorithm.
+// However, it does not speed it up, it slows it down (for this test)
+// Without: 47 ms
+// With: 312 ms
+// #define BOOST_GEOMETRY_ENABLE_SIMILARITY_RTREE
+
+#include <boost/geometry.hpp>
+
+#include <boost/geometry/io/geojson/geojson_writer.hpp>
+
+#include <boost/geometry/algorithms/similarity.hpp>
+
+#include <fstream>
+
+const double g_scale = 1.0e6;
+
+namespace
+{
+
+template <typename Geometry>
+double fixed_hausdorff(const Geometry& geometry1, const Geometry& geometry2)
+{
+    namespace bg = boost::geometry;
+    return std::max(bg::discrete_hausdorff_distance(geometry1, geometry2),
+        bg::discrete_hausdorff_distance(geometry2, geometry1));
+}
+
+}
+
+
+struct geojson_visitor
+{
+    geojson_visitor()
+    {
+        m_stream_coll << std::setprecision(20);
+        m_stream_quad << std::setprecision(20);
+    }
+    template <typename T, typename I> void visit_quadrilateral(T const& ring,
+        I const& a, I const& b, I const& c, I const& d) 
+    {
+        m_quad.feature(ring);
+        m_quad.add_property("role", 7);
+        m_quad.add_property("area", boost::geometry::area(ring));
+    }
+    template <typename C> void visit_projections(int source, C const& collection) 
+    {
+        for (const auto& info : collection)
+        {
+            m_collection.feature(info.point);
+            m_collection.add_property("source", source);
+            m_collection.add_property("is_projection", info.is_projection ? 1 : 0);
+            m_collection.add_property("distance", info.distance);
+            m_collection.add_property("source_index", info.source_index);
+            m_collection.add_property("segment_index", info.segment_index);
+            m_collection.add_property("offset", info.offset);
+        }
+    }
+
+    std::ofstream m_stream_coll{"/tmp/collection.geojson"};
+    std::ofstream m_stream_quad{"/tmp/quad.geojson"};
+    boost::geometry::geojson_writer m_collection{m_stream_coll};
+    boost::geometry::geojson_writer m_quad{m_stream_quad};
+};
+
+
+template <typename Geometry>
+void test_case(Geometry const& p, Geometry const& q, double scale = g_scale, const char* filename = nullptr)
+{
+    std::cout << "Frechet: " << scale * boost::geometry::discrete_frechet_distance(p, q)
+        << " Hausdorff: " << scale * fixed_hausdorff(p, q)
+        << " Average: " << scale * boost::geometry::similarity_distance(p, q)
+        << std::endl;
+
+    if (filename != nullptr)
+    {
+        std::ofstream fout{filename};
+        fout << std::setprecision(20);
+        boost::geometry::geojson_writer writer(fout);
+        writer.feature(p);
+        writer.add_property("name", "p");
+        
+        writer.feature(q);
+        writer.add_property("name", "q");
+
+        for (const auto& pnt : p)
+        {
+            writer.feature(pnt);
+            writer.add_property("name", "p");
+        }
+        for (const auto& pnt : q)
+        {
+            writer.feature(pnt);
+            writer.add_property("name", "q");
+        }
+    }
+}
+
+template <typename Geometry>
+void performance_test(Geometry const& p, Geometry const& q)
+{
+    std::size_t n = 100000;
+    auto start = std::chrono::steady_clock::now();
+    for (std::size_t i = 0; i < n; i++)
+    {
+        double f = boost::geometry::discrete_frechet_distance(p, q);
+    }
+    auto finish = std::chrono::steady_clock::now();
+    double elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(finish - start).count();
+    std::cout << "Frechet: " << std::setprecision(6) << elapsed << " ms" << std::endl;
+
+    start = std::chrono::steady_clock::now();
+    for (std::size_t i = 0; i < n; i++)
+    {
+        double h = fixed_hausdorff(p, q);
+    }
+    finish = std::chrono::steady_clock::now();
+    elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(finish - start).count();
+    std::cout << "Hausdorff: " << std::setprecision(6) << elapsed << " ms" << std::endl;
+
+    start = std::chrono::steady_clock::now();
+    for (std::size_t i = 0; i < n; i++)
+    {
+        double h = boost::geometry::similarity_distance(p, q);
+    }
+    finish = std::chrono::steady_clock::now();
+    elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(finish - start).count();
+    std::cout << "Average: " << std::setprecision(6) << elapsed << " ms" << std::endl;
+}
+
+int main()
+{
+    namespace bg = boost::geometry;
+    auto reverse = [](auto const& g) 
+    {
+        auto result = g;
+        std::reverse(result.begin(), result.end());
+        return result;
+    };
+
+    auto simplify = [](auto const& g, double simplify_distance) 
+    {
+        std::decay_t<decltype(g)> result;
+        bg::simplify(g, result, simplify_distance);
+        return result;
+    };
+
+    using coordinate_type = double;
+    using point = boost::geometry::model::d2::point_xy<coordinate_type>;
+    using linestring = boost::geometry::model::linestring<point>;
+    using ring = boost::geometry::model::ring<point>;
+
+    // Two lines consistently 0.5 apart
+    std::string const simplex1 = "LINESTRING(1.0 1.0, 2.0 1.0)";
+    std::string const simplex2 = "LINESTRING(1.0 1.1, 2.0 1.1)";
+    // With extra point in between
+    std::string const simplex3 = "LINESTRING(1.0 1.1, 1.5 1.1,2.0 1.1)";
+    // With a "spike"
+    std::string const simplex4 = "LINESTRING(1.0 1.1, 1.49 1.1, 1.5 2.5, 1.51 1.1, 2.0 1.1)";
+
+    std::string const west1 = "LINESTRING(5.134673416614532 52.27074444293976,5.134786069393158 52.27136671543121,5.134778022766113 52.27139353752136,5.134756565093994 52.27141231298447,5.134694874286652 52.27144449949265,5.134069919586182 52.27149546146393,5.133965313434601 52.27146327495575,5.133906304836273 52.27141231298447,5.133863389492035 52.27112531661987,5.133847296237946 52.27108776569366,5.133809745311737 52.27106094360352,5.133764147758484 52.27100998163223,5.133707821369171 52.27053791284561,5.133721232414246 52.27049767971039,5.133863389492035 52.27035015821457)";
+    std::string const west2 = "LINESTRING(5.134670734405518 52.27073907852173,5.134778022766113 52.27136135101318,5.134778022766113 52.27139353752136,5.134756565093994 52.27140426635742,5.134692192077637 52.2714364528656,5.134069919586182 52.2714900970459,5.134016275405884 52.27147936820984,5.133962631225586 52.27145791053772,5.133898258209229 52.27140426635742,5.133844614028931 52.27108240127563,5.133801698684692 52.27106094360352,5.133758783340454 52.27100729942322,5.133705139160156 52.2705352306366,5.133715867996216 52.27049231529236,5.13385534286499 52.27034211158752)";
+    std::string const east1 = "LINESTRING(5.141247510910034 52.27364659309387,5.140657424926758 52.27396845817566,5.14061450958252 52.2740113735199,5.140560865402222 52.27447271347046,5.140872001647949 52.27483749389648,5.140936374664307 52.27486968040466,5.141386985778809 52.27483749389648)";
+    std::string const east2 = "LINESTRING(5.141247510910034 52.27364659309387,5.140665471553802 52.27397114038467,5.14061450958252 52.27401673793793,5.1405930519104 52.27407306432724,5.140560865402222 52.2744807600975,5.140606462955475 52.27453976869583,5.140874683856964 52.27483749389648,5.140941739082336 52.27486968040466,5.141386985778809 52.27483749389648)";
+    std::string const complete = "LINESTRING(5.135158896446228 52.26660043001175,5.134890675544739 52.2666272521019,5.134839713573456 52.26665943861008,5.13435423374176 52.26669162511826,5.134295225143433 52.26670503616333,5.13424426317215 52.26672381162643,5.134182572364807 52.26675063371658,5.134131610393524 52.26690083742142,5.134077966213226 52.26698398590088,5.134086012840271 52.26706176996231,5.134115517139435 52.26712614297867,5.134161114692688 52.26717710494995,5.134324729442596 52.26729512214661,5.134397149085999 52.26735413074493,5.134442746639252 52.26739972829819,5.134464204311371 52.26744264364243,5.134584903717041 52.2677618265152)";
+    std::string const part1 = "LINESTRING(5.134332776069641 52.26669698953629,5.134295225143433 52.26670503616333,5.13424426317215 52.26672381162643,5.134182572364807 52.26675063371658,5.134131610393524 52.26690083742142,5.134077966213226 52.26698398590088,5.134086012840271 52.26706176996231,5.134115517139435 52.26712614297867,5.134161114692688 52.26717710494995,5.134324729442596 52.26729512214661,5.134397149085999 52.26735413074493,5.134442746639252 52.26739972829819,5.134464204311371 52.26744264364243,5.134584903717041 52.2677618265152)";
+    std::string const part2 = "LINESTRING(5.135158896446228 52.26660043001175,5.134890675544739 52.2666272521019,5.134839713573456 52.26665943861008,5.13435423374176 52.26669162511826,5.134332776069641 52.26669698953629)";
+
+    // test_case(bg::from_wkt<linestring>(west1), bg::from_wkt<linestring>(west2));
+    // return 0;
+
+    std::cout << "Simplex cases: " << std::endl;
+    test_case(bg::from_wkt<linestring>(simplex1), bg::from_wkt<linestring>(simplex2), 1.0, "/tmp/simplex1.geojson");
+    test_case(bg::from_wkt<linestring>(simplex1), bg::from_wkt<linestring>(simplex3), 1.0, "/tmp/simplex2.geojson");
+    test_case(bg::from_wkt<linestring>(simplex1), bg::from_wkt<linestring>(simplex4), 1.0, "/tmp/simplex3.geojson");
+
+    std::cout << std::endl<< "Real cases: " << std::endl;
+    test_case(bg::from_wkt<linestring>(west1), bg::from_wkt<linestring>(west2), g_scale, "/tmp/west.geojson");
+    test_case(bg::from_wkt<linestring>(east1), bg::from_wkt<linestring>(east2), g_scale, "/tmp/east.geojson");
+
+    std::cout << std::endl<< "Reversed:" << std::endl;
+    test_case(bg::from_wkt<linestring>(west1), reverse(bg::from_wkt<linestring>(west2)));
+    test_case(bg::from_wkt<linestring>(east1), reverse(bg::from_wkt<linestring>(east2)));
+
+    std::cout << std::endl<< "Simplified (west): " << std::endl;
+    test_case(bg::from_wkt<linestring>(west2), simplify(bg::from_wkt<linestring>(west2), 0.0005), g_scale, "/tmp/simplified1.geojson");
+    test_case(bg::from_wkt<linestring>(west2), simplify(bg::from_wkt<linestring>(west2), 0.0001), g_scale, "/tmp/simplified2.geojson");
+    test_case(bg::from_wkt<linestring>(west2), simplify(bg::from_wkt<linestring>(west2), 0.00001), g_scale, "/tmp/simplified3.geojson");
+    test_case(bg::from_wkt<linestring>(west2), simplify(bg::from_wkt<linestring>(west2), 0.000001), g_scale, "/tmp/simplified4.geojson");
+
+    std::cout << std::endl<< "Simplified (east): " << std::endl;
+    test_case(bg::from_wkt<linestring>(east2), simplify(bg::from_wkt<linestring>(east2), 0.0005), g_scale, "/tmp/simplified_east1.geojson");
+    test_case(bg::from_wkt<linestring>(east2), simplify(bg::from_wkt<linestring>(east2), 0.0001), g_scale, "/tmp/simplified_east2.geojson");
+    test_case(bg::from_wkt<linestring>(east2), simplify(bg::from_wkt<linestring>(east2), 0.00001), g_scale, "/tmp/simplified_east3.geojson");
+    test_case(bg::from_wkt<linestring>(east2), simplify(bg::from_wkt<linestring>(east2), 0.000001), g_scale, "/tmp/simplified_east4.geojson");
+
+    std::cout << std::endl<< "Not similar: " << std::endl;
+    test_case(bg::from_wkt<linestring>(west1), bg::from_wkt<linestring>(east1));
+    test_case(bg::from_wkt<linestring>(west2), bg::from_wkt<linestring>(east2));
+
+    std::cout << std::endl << "Parts (TODO):" << std::endl;
+    test_case(bg::from_wkt<linestring>(complete), bg::from_wkt<linestring>(part1));
+    test_case(bg::from_wkt<linestring>(complete), bg::from_wkt<linestring>(part2));
+
+    std::cout << std::endl<< "Identical: " << std::endl;
+    test_case(bg::from_wkt<linestring>(west1), bg::from_wkt<linestring>(west1));
+    test_case(bg::from_wkt<linestring>(east1), bg::from_wkt<linestring>(east1));
+
+    // std::cout << std::endl << "Performance:" << std::endl;
+    // performance_test(bg::from_wkt<linestring>(west1), bg::from_wkt<linestring>(west2));
+
+    // With a visitor
+    geojson_visitor v;
+    auto result = bg::similarity(bg::from_wkt<linestring>(west1), bg::from_wkt<linestring>(west2), v);
+
+
+    return 0;
+}


### PR DESCRIPTION
This is a new similarity distance, comparable to Hausdorff or Frechet.

It calculates the area between two lines and divides them by the line length. This is an average distance, measuring quite well how similar two lines are. It is less sensible to outliers (such as Hausdorff/Frechet) and not discrete.

For example this case (west1/west2):

![image](https://github.com/boostorg/geometry/assets/334849/997498fb-2b4a-40a7-ae6f-2985a00b29f9)

They are quite similar. Distance impressions are:
`Frechet: 53.4426 Hausdorff: 53.4426 Average: 5.61308`

How it works in detail: 
 * it projects all points on the other line
 * and vice versa
 * it adds their own points too. Then both collections have an equal amount of points, and because of the projections, their locations are comparable (especially if they are already similar)
 * it checks if one of the lines should be reversed
 * then it calculates areas of all four-corner rings and sums them
 * and it divides by the shortest length

**(See the comment below for an enhanced description)**

Zoomed in:
![image](https://github.com/boostorg/geometry/assets/334849/9767757e-4101-4baf-8066-a2f3e9c6dab4)

Apart from this, this PR also adds an experimental `geojson_writer`

If you like it, I'll also add a version for rings. For polygons/multi it is a bit more complex (especially if the number of objects are unequal), to be worked out.

The `geojson_writer` is really useful for visualizing results (or debug steps). But it is not completely finished either.

Complete output of the test program:
```
Simplex cases: 
Frechet: 0.1 Hausdorff: 0.1 Average: 0.1
Frechet: 0.509902 Hausdorff: 0.509902 Average: 0.1
Frechet: 1.58114 Hausdorff: 1.58114 Average: 0.114

Real cases: 
Frechet: 53.4426 Hausdorff: 53.4426 Average: 5.61308
Frechet: 81.0897 Hausdorff: 81.0897 Average: 3.98684

Reversed:
Frechet: 990.622 Hausdorff: 53.4426 Average: 5.61308
Frechet: 1199.04 Hausdorff: 81.0897 Average: 3.98684

Simplified (west): 
Frechet: 494.575 Hausdorff: 494.575 Average: 61.4674
Frechet: 475.107 Hausdorff: 475.107 Average: 24.5124
Frechet: 54.7065 Hausdorff: 54.7065 Average: 0.733346
Frechet: 23.9904 Hausdorff: 23.9904 Average: 0

Simplified (east): 
Frechet: 520.245 Hausdorff: 520.245 Average: 124.301
Frechet: 74.5731 Hausdorff: 74.5731 Average: 7.53191
Frechet: 74.5731 Hausdorff: 74.5731 Average: 0.511786
Frechet: 0 Hausdorff: 0 Average: 0

Not similar: 
Frechet: 8760.18 Hausdorff: 7737.14 Average: 4925.39
Frechet: 8771.21 Hausdorff: 7746.79 Average: 4848.01

Parts (TODO):
Frechet: 831.744 Hausdorff: 831.744 Average: 7.25765
Frechet: 1094.28 Hausdorff: 1094.28 Average: 199.363

Identical: 
Frechet: 0 Hausdorff: 0 Average: 0
Frechet: 0 Hausdorff: 0 Average: 0

Performance:
Frechet: 105 ms
Hausdorff: 78 ms
Average: 498 ms
```

Showing that:
* hausdorff was not symmetric (I created an issue for that)
* frechet gives different results for reversed cases
* frechet and hausdorff are often, but not always, the same
* the new method is much slower (we can use an index to enhance this)
* because frechet/hausdorff are discrete, its behavior is not good when there are points in between (see simplex 2, or the simplified cases)
* because frechet/hausdorff use a max distance, a spike large influence (simplex 3)

_I also tried to give a "partial" result, which happens if one line is partly identical to the other line. This is possible, but not yet finished. It uses the projections and then recursively finds the best division point. But this is not part of the PR._

