### PR TITLE
Update release notes for 1.83

### DIFF
--- a/doc/release_notes.qbk
+++ b/doc/release_notes.qbk
@@ -6,7 +6,7 @@
   Copyright (c) 2009-2017 Mateusz Loskot <mateusz@loskot.net>, London, UK.
   Copyright (c) 2011-2017 Adam Wulkiewicz, Lodz, Poland.
 
-  This file was modified by Oracle on 2015-2022.
+  This file was modified by Oracle on 2015-2023.
   Modifications copyright (c) 2015-2023, Oracle and/or its affiliates.
   Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
   Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
@@ -23,16 +23,19 @@
 [heading Boost 1.83]
 [/=================]
 
-[*Major improvements]
-
 [*Improvements]
+
+* [https://github.com/boostorg/geometry/pull/1140 1140] Drop dependencies and replace boost with std in several places
+* [https://github.com/boostorg/geometry/pull/1154 1154] Add missing headers so that all headers compile independently complying with Boost policy
+* [https://github.com/boostorg/geometry/pull/1157 1157] Check const Ring concept in calculate_point_order
 
 [*Solved issues]
 
 * [@https://github.com/boostorg/geometry/issues/1100 1100] Fix for union
 * [@https://github.com/boostorg/geometry/issues/1139 1139] Fix for different geometry types
-
-[*Breaking changes]
+* [@https://github.com/boostorg/geometry/issues/1158 1158] Fix for convex hull
+* [*https://github.com/boostorg/geometry/issues/1161 1161] Fix within algorithm for geometries having a pole as a vertex
+* Various fixes of errors and warnings
 
 [/=================]
 [heading Boost 1.82]


### PR DESCRIPTION
This are the release notes for 1.83. Please review asap so I can prepare the release.

Waiting for approval for 
- https://github.com/boostorg/geometry/pull/1177
- https://github.com/boostorg/geometry/pull/1162

in order to get included into the release. 