### PR TITLE
Modernize noexcept specifications

### DIFF
--- a/include/boost/geometry/algorithms/centroid.hpp
+++ b/include/boost/geometry/algorithms/centroid.hpp
@@ -91,7 +91,7 @@ public:
     \brief Returns the explanatory string.
     \return Pointer to a null-terminated string with explanatory information.
     */
-    virtual char const* what() const throw()
+    virtual char const* what() const noexcept
     {
         return "Boost.Geometry Centroid calculation exception";
     }

--- a/include/boost/geometry/algorithms/detail/has_self_intersections.hpp
+++ b/include/boost/geometry/algorithms/detail/has_self_intersections.hpp
@@ -53,7 +53,7 @@ public:
 
     inline overlay_invalid_input_exception() {}
 
-    virtual char const* what() const throw()
+    virtual char const* what() const noexcept
     {
         return "Boost.Geometry Overlay invalid input exception";
     }

--- a/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turn_info.hpp
@@ -46,10 +46,7 @@ public:
         message += method;
     }
 
-    virtual ~turn_info_exception() throw()
-    {}
-
-    virtual char const* what() const throw()
+    virtual char const* What() const noexcept
     {
         return message.c_str();
     }

--- a/include/boost/geometry/algorithms/detail/overlay/inconsistent_turns_exception.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/inconsistent_turns_exception.hpp
@@ -22,10 +22,7 @@ public:
 
     inline inconsistent_turns_exception() {}
 
-    virtual ~inconsistent_turns_exception() throw()
-    {}
-
-    virtual char const* what() const throw()
+    virtual char const* what() const noexcept
     {
         return "Boost.Geometry Inconsistent Turns exception";
     }

--- a/include/boost/geometry/core/exception.hpp
+++ b/include/boost/geometry/core/exception.hpp
@@ -33,7 +33,7 @@ namespace boost { namespace geometry
 class exception : public std::exception
 {
 public:
-    virtual char const* what() const throw()
+    virtual char const* what() const noexcept
     {
         return "Boost.Geometry exception";
     }
@@ -52,7 +52,7 @@ public:
 
     inline invalid_input_exception() {}
 
-    virtual char const* what() const throw()
+    virtual char const* what() const noexcept
     {
         return "Boost.Geometry Invalid-Input exception";
     }
@@ -77,7 +77,7 @@ public:
 
     inline empty_input_exception() {}
 
-    virtual char const* what() const throw()
+    virtual char const* what() const noexcept
     {
         return "Boost.Geometry Empty-Input exception";
     }
@@ -96,7 +96,7 @@ public:
 
     inline invalid_output_exception() {}
 
-    virtual char const* what() const throw()
+    virtual char const* what() const noexcept
     {
         return "Boost.Geometry Invalid-Output exception";
     }

--- a/include/boost/geometry/extensions/gis/io/shapefile/read.hpp
+++ b/include/boost/geometry/extensions/gis/io/shapefile/read.hpp
@@ -52,7 +52,7 @@ public:
         : m_msg(msg)
     {}
 
-    virtual char const* what() const throw()
+    virtual char const* what() const noexcept
     {
         //return "Shapefile read error";
         return m_msg.what();

--- a/include/boost/geometry/extensions/gis/io/shapelib/shape_creator.hpp
+++ b/include/boost/geometry/extensions/gis/io/shapelib/shape_creator.hpp
@@ -32,7 +32,7 @@ public:
         : m_filename(filename)
     {}
 
-    virtual char const* what() const throw()
+    virtual char const* what() const noexcept
     {
         return m_filename.c_str();
     }

--- a/include/boost/geometry/extensions/gis/io/wkb/detail/parser.hpp
+++ b/include/boost/geometry/extensions/gis/io/wkb/detail/parser.hpp
@@ -49,7 +49,7 @@ public:
 
     inline read_wkb_exception() {}
 
-    virtual char const* what() const throw()
+    virtual char const* what() const noexcept
     {
         return "Boost.Geometry Read WKB exception";
     }

--- a/include/boost/geometry/io/wkt/read.hpp
+++ b/include/boost/geometry/io/wkt/read.hpp
@@ -96,9 +96,7 @@ struct read_wkt_exception : public geometry::exception
         complete = message + "' in (" + wkt.substr(0, 100) + ")";
     }
 
-    virtual ~read_wkt_exception() throw() {}
-
-    virtual const char* what() const throw()
+    virtual const char* what() const noexcept
     {
         return complete.c_str();
     }

--- a/include/boost/geometry/srs/projections/exception.hpp
+++ b/include/boost/geometry/srs/projections/exception.hpp
@@ -43,7 +43,7 @@ public:
         , m_msg(msg)
     {}
 
-    virtual char const* what() const throw()
+    virtual char const* what() const noexcept
     {
         //return "Boost.Geometry Projection exception";
         return m_msg.what();

--- a/include/boost/geometry/srs/projections/str_cast.hpp
+++ b/include/boost/geometry/srs/projections/str_cast.hpp
@@ -21,7 +21,7 @@ namespace boost { namespace geometry
 
 class bad_str_cast : public geometry::exception
 {
-    virtual char const* what() const throw()
+    virtual char const* what() const noexcept
     {
         return "Unable to convert from string.";
     }

--- a/index/test/rtree/exceptions/test_throwing.hpp
+++ b/index/test/rtree/exceptions/test_throwing.hpp
@@ -15,7 +15,7 @@
 
 struct throwing_value_copy_exception : public std::exception
 {
-    const char * what() const throw() { return "value copy failed."; }
+    const char * what() const noexcept { return "value copy failed."; }
 };
 
 struct throwing_value
@@ -79,7 +79,7 @@ struct value< std::pair<bg::model::point<T, 2, C>, throwing_value> >
 
 struct throwing_varray_exception : public std::exception
 {
-    const char * what() const throw() { return "static vector exception."; }
+    const char * what() const noexcept { return "static vector exception."; }
 };
 
 struct throwing_varray_settings

--- a/index/test/rtree/exceptions/test_throwing_node.hpp
+++ b/index/test/rtree/exceptions/test_throwing_node.hpp
@@ -250,7 +250,7 @@ public:
 
 struct node_bad_alloc : public std::exception
 {
-    const char * what() const throw() { return "internal node creation failed."; }
+    const char * what() const noexcept { return "internal node creation failed."; }
 };
 
 struct throwing_node_settings

--- a/test/core/assert.cpp
+++ b/test/core/assert.cpp
@@ -20,7 +20,7 @@
 struct assert_failure_exception
     : std::exception
 {
-    const char * what() const throw()
+    const char * what() const noexcept
     {
         return "assertion failure";
     }


### PR DESCRIPTION
As boost::geometry mandates C++14 since 1.75, I assume this can be merged in C++03-incompatible form.