### PR TITLE
[strategies] Fix msvc conversion warning in centroid::average

### DIFF
--- a/include/boost/geometry/strategies/cartesian/centroid_average.hpp
+++ b/include/boost/geometry/strategies/cartesian/centroid_average.hpp
@@ -3,7 +3,7 @@
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
-// Copyright (c) 2017 Adam Wulkiewicz, Lodz, Poland.
+// Copyright (c) 2017-2023 Adam Wulkiewicz, Lodz, Poland.
 
 // This file was modified by Oracle on 2015-2021.
 // Modifications copyright (c) 2015-2021 Oracle and/or its affiliates.
@@ -89,7 +89,8 @@ public :
         centroid = state.centroid;
         if ( state.count > 0 )
         {
-            divide_value(centroid, state.count);
+            using coord_t = typename coordinate_type<ResultPoint>::type;
+            divide_value(centroid, static_cast<coord_t>(state.count));
             return true;
         }
         return false;


### PR DESCRIPTION
Msvc complains about the conversion from integer to floating point at some higher warning level.