### PR TITLE
Switch to `boost::core::invoke_swap`. Add missing includes.

### DIFF
--- a/include/boost/geometry/formulas/karney_inverse.hpp
+++ b/include/boost/geometry/formulas/karney_inverse.hpp
@@ -32,6 +32,7 @@
 #define BOOST_GEOMETRY_FORMULAS_KARNEY_INVERSE_HPP
 
 
+#include <boost/core/invoke_swap.hpp>
 #include <boost/math/constants/constants.hpp>
 #include <boost/math/special_functions/hypot.hpp>
 
@@ -191,7 +192,7 @@ public:
         if (swap_point < 0)
         {
             lon12_sign *= -1;
-            swap(lat1, lat2);
+            boost::core::invoke_swap(lat1, lat2);
         }
 
         // Enforce lat1 to be <= 0.
@@ -448,9 +449,9 @@ public:
 
         if (swap_point < 0)
         {
-            swap(sin_alpha1, sin_alpha2);
-            swap(cos_alpha1, cos_alpha2);
-            swap(result.geodesic_scale, M21);
+            boost::core::invoke_swap(sin_alpha1, sin_alpha2);
+            boost::core::invoke_swap(cos_alpha1, cos_alpha2);
+            boost::core::invoke_swap(result.geodesic_scale, M21);
         }
 
         sin_alpha1 *= swap_point * lon12_sign;

--- a/include/boost/geometry/index/detail/rtree/node/variant_dynamic.hpp
+++ b/include/boost/geometry/index/detail/rtree/node/variant_dynamic.hpp
@@ -16,8 +16,10 @@
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_RTREE_NODE_VARIANT_DYNAMIC_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_RTREE_NODE_VARIANT_DYNAMIC_HPP
 
+#include <utility>
 #include <boost/container/allocator_traits.hpp>
 #include <boost/container/vector.hpp>
+#include <boost/core/invoke_swap.hpp>
 #include <boost/core/pointer_traits.hpp>
 #include <boost/variant/static_visitor.hpp>
 #include <boost/variant/variant.hpp>
@@ -184,7 +186,7 @@ public:
 
     void swap(allocators & a)
     {
-        boost::swap(node_allocator(), a.node_allocator());
+        boost::core::invoke_swap(node_allocator(), a.node_allocator());
     }
 
     bool operator==(allocators const& a) const { return node_allocator() == a.node_allocator(); }

--- a/include/boost/geometry/index/detail/rtree/node/variant_static.hpp
+++ b/include/boost/geometry/index/detail/rtree/node/variant_static.hpp
@@ -15,6 +15,12 @@
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_RTREE_NODE_VARIANT_STATIC_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_RTREE_NODE_VARIANT_STATIC_HPP
 
+#include <utility>
+#include <boost/container/allocator_traits.hpp>
+#include <boost/core/invoke_swap.hpp>
+#include <boost/variant/static_visitor.hpp>
+#include <boost/variant/variant.hpp>
+
 #include <boost/geometry/index/detail/rtree/node/variant_dynamic.hpp>
 #include <boost/geometry/index/detail/varray.hpp>
 
@@ -146,7 +152,7 @@ public:
 
     void swap(allocators & a)
     {
-        boost::swap(node_allocator(), a.node_allocator());
+        boost::core::invoke_swap(node_allocator(), a.node_allocator());
     }
 
     bool operator==(allocators const& a) const { return node_allocator() == a.node_allocator(); }

--- a/include/boost/geometry/index/detail/rtree/node/weak_dynamic.hpp
+++ b/include/boost/geometry/index/detail/rtree/node/weak_dynamic.hpp
@@ -19,7 +19,7 @@
 #include <boost/container/allocator_traits.hpp>
 #include <boost/container/vector.hpp>
 #include <boost/core/pointer_traits.hpp>
-#include <boost/core/swap.hpp>
+#include <boost/core/invoke_swap.hpp>
 
 #include <boost/geometry/index/detail/rtree/options.hpp>
 #include <boost/geometry/index/detail/rtree/node/concept.hpp>
@@ -228,8 +228,8 @@ public:
 
     void swap(allocators & a)
     {
-        boost::swap(internal_node_allocator(), a.internal_node_allocator());
-        boost::swap(leaf_allocator(), a.leaf_allocator());
+        boost::core::invoke_swap(internal_node_allocator(), a.internal_node_allocator());
+        boost::core::invoke_swap(leaf_allocator(), a.leaf_allocator());
     }
 
     bool operator==(allocators const& a) const { return leaf_allocator() == a.leaf_allocator(); }

--- a/include/boost/geometry/index/detail/rtree/node/weak_static.hpp
+++ b/include/boost/geometry/index/detail/rtree/node/weak_static.hpp
@@ -15,6 +15,10 @@
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_RTREE_NODE_WEAK_STATIC_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_RTREE_NODE_WEAK_STATIC_HPP
 
+#include <utility>
+#include <boost/container/allocator_traits.hpp>
+#include <boost/core/invoke_swap.hpp>
+
 #include <boost/geometry/index/detail/rtree/node/weak_dynamic.hpp>
 #include <boost/geometry/index/detail/varray.hpp>
 
@@ -155,8 +159,8 @@ public:
 
     void swap(allocators & a)
     {
-        boost::swap(internal_node_allocator(), a.internal_node_allocator());
-        boost::swap(leaf_allocator(), a.leaf_allocator());
+        boost::core::invoke_swap(internal_node_allocator(), a.internal_node_allocator());
+        boost::core::invoke_swap(leaf_allocator(), a.leaf_allocator());
     }
 
     bool operator==(allocators const& a) const { return leaf_allocator() == a.leaf_allocator(); }

--- a/include/boost/geometry/index/detail/utilities.hpp
+++ b/include/boost/geometry/index/detail/utilities.hpp
@@ -12,7 +12,7 @@
 
 #include <type_traits>
 
-#include <boost/core/swap.hpp>
+#include <boost/core/invoke_swap.hpp>
 
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_UTILITIES_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_UTILITIES_HPP
@@ -40,7 +40,7 @@ static inline void move_cond(T &, T &, std::false_type) {}
 template <typename T> inline
 void swap_cond(T & l, T & r, std::true_type)
 {
-    ::boost::swap(l, r);
+    ::boost::core::invoke_swap(l, r);
 }
 
 template <typename T> inline

--- a/include/boost/geometry/index/detail/varray.hpp
+++ b/include/boost/geometry/index/detail/varray.hpp
@@ -21,7 +21,6 @@
 #include <boost/concept_check.hpp>
 #include <boost/config.hpp>
 #include <boost/core/ignore_unused.hpp>
-#include <boost/core/swap.hpp>
 #include <boost/integer.hpp>
 
 // TODO - use std::reverse_iterator and std::iterator_traits
@@ -1566,7 +1565,6 @@ private:
         {
             //std::iter_swap(first_sm, first_la);
             //std::swap(*first_sm, *first_la);                                      // may throw
-            //boost::swap(*first_sm, *first_la);
             value_type temp(std::move(*first_sm));                                  // may throw
             *first_sm = std::move(*first_la);                                       // may throw
             *first_la = std::move(temp);                                            // may throw

--- a/include/boost/geometry/index/rtree.hpp
+++ b/include/boost/geometry/index/rtree.hpp
@@ -24,6 +24,7 @@
 // Boost
 #include <boost/container/new_allocator.hpp>
 #include <boost/tuple/tuple.hpp>
+#include <boost/core/invoke_swap.hpp>
 
 // Boost.Geometry
 #include <boost/geometry/core/static_assert.hpp>
@@ -657,9 +658,9 @@ public:
                     src.m_members.parameters(),
                     std::move(src.m_members.allocators()))
     {
-        boost::swap(m_members.values_count, src.m_members.values_count);
-        boost::swap(m_members.leafs_level, src.m_members.leafs_level);
-        boost::swap(m_members.root, src.m_members.root);
+        boost::core::invoke_swap(m_members.values_count, src.m_members.values_count);
+        boost::core::invoke_swap(m_members.leafs_level, src.m_members.leafs_level);
+        boost::core::invoke_swap(m_members.root, src.m_members.root);
     }
 
     /*!
@@ -683,9 +684,9 @@ public:
     {
         if ( src.m_members.allocators() == allocator )
         {
-            boost::swap(m_members.values_count, src.m_members.values_count);
-            boost::swap(m_members.leafs_level, src.m_members.leafs_level);
-            boost::swap(m_members.root, src.m_members.root);
+            boost::core::invoke_swap(m_members.values_count, src.m_members.values_count);
+            boost::core::invoke_swap(m_members.leafs_level, src.m_members.leafs_level);
+            boost::core::invoke_swap(m_members.root, src.m_members.root);
         }
         else
         {
@@ -758,9 +759,9 @@ public:
                 m_members.equal_to() = src.m_members.equal_to();
                 m_members.parameters() = src.m_members.parameters();
 
-                boost::swap(m_members.values_count, src.m_members.values_count);
-                boost::swap(m_members.leafs_level, src.m_members.leafs_level);
-                boost::swap(m_members.root, src.m_members.root);
+                boost::core::invoke_swap(m_members.values_count, src.m_members.values_count);
+                boost::core::invoke_swap(m_members.leafs_level, src.m_members.leafs_level);
+                boost::core::invoke_swap(m_members.root, src.m_members.root);
 
                 // NOTE: if propagate is true for std allocators on darwin 4.2.1, glibc++
                 // (allocators stored as base classes of members_holder)
@@ -795,9 +796,9 @@ public:
     */
     void swap(rtree & other)
     {
-        boost::swap(m_members.indexable_getter(), other.m_members.indexable_getter());
-        boost::swap(m_members.equal_to(), other.m_members.equal_to());
-        boost::swap(m_members.parameters(), other.m_members.parameters());
+        boost::core::invoke_swap(m_members.indexable_getter(), other.m_members.indexable_getter());
+        boost::core::invoke_swap(m_members.equal_to(), other.m_members.equal_to());
+        boost::core::invoke_swap(m_members.parameters(), other.m_members.parameters());
 
         // NOTE: if propagate is true for std allocators on darwin 4.2.1, glibc++
         // (allocators stored as base classes of members_holder)
@@ -808,9 +809,9 @@ public:
         > propagate;
         detail::swap_cond(m_members.allocators(), other.m_members.allocators(), propagate());
 
-        boost::swap(m_members.values_count, other.m_members.values_count);
-        boost::swap(m_members.leafs_level, other.m_members.leafs_level);
-        boost::swap(m_members.root, other.m_members.root);
+        boost::core::invoke_swap(m_members.values_count, other.m_members.values_count);
+        boost::core::invoke_swap(m_members.leafs_level, other.m_members.leafs_level);
+        boost::core::invoke_swap(m_members.root, other.m_members.root);
     }
 
     /*!

--- a/include/boost/geometry/util/series_expansion.hpp
+++ b/include/boost/geometry/util/series_expansion.hpp
@@ -30,6 +30,7 @@
 #ifndef BOOST_GEOMETRY_UTIL_SERIES_EXPANSION_HPP
 #define BOOST_GEOMETRY_UTIL_SERIES_EXPANSION_HPP
 
+#include <boost/array.hpp>
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/util/math.hpp>
 

--- a/index/test/rtree/exceptions/test_throwing_node.hpp
+++ b/index/test/rtree/exceptions/test_throwing_node.hpp
@@ -13,6 +13,13 @@
 #define BOOST_GEOMETRY_INDEX_TEST_RTREE_THROWING_NODE_HPP
 
 #include <rtree/exceptions/test_throwing.hpp>
+#include <boost/core/invoke_swap.hpp>
+#include <boost/move/core.hpp>
+#include <boost/move/utility_core.hpp>
+#include <boost/variant/variant.hpp>
+#include <boost/variant/static_visitor.hpp>
+#include <exception>
+#include <stddef.h>
 
 struct throwing_nodes_stats
 {
@@ -235,7 +242,7 @@ public:
 
     void swap(allocators & a)
     {
-        boost::swap(node_allocator(), a.node_allocator());
+        boost::core::invoke_swap(node_allocator(), a.node_allocator());
     }
 
     bool operator==(allocators const& a) const { return node_allocator() == a.node_allocator(); }


### PR DESCRIPTION
`boost::swap` is deprecated and will be removed. Use `boost::core::invoke_swap` as a replacement.

Also add missing includes.