### PR TITLE
Fixes for miscellaneous gcc/clang warnings in the test suite.

### DIFF
--- a/include/boost/geometry/formulas/meridian_direct.hpp
+++ b/include/boost/geometry/formulas/meridian_direct.hpp
@@ -84,8 +84,8 @@ public:
             {
                 result.reverse_azimuth =  pi;
             }
-            else if (result.lat2 < -half_pi &&
-                     result.lat2 >  -one_and_a_half_pi)
+            else if (result.lat2 > -one_and_a_half_pi &&
+                     result.lat2 < -half_pi)
             {
                 result.reverse_azimuth =  c0;
             }

--- a/test/algorithms/buffer/buffer_linestring_geo.cpp
+++ b/test/algorithms/buffer/buffer_linestring_geo.cpp
@@ -71,7 +71,7 @@ void test_linestring()
     }
 
     settings.test_area = false;
-    auto const n = sizeof(testcases_aimes) / sizeof(testcases_aimes[0]);
+    int const n = sizeof(testcases_aimes) / sizeof(testcases_aimes[0]);
 
     // Cases (ouf of 197) where the guessed area estimations are not met.
     // If this needs to be changed, be sure to

--- a/test/algorithms/buffer/buffer_piece_border.cpp
+++ b/test/algorithms/buffer/buffer_piece_border.cpp
@@ -161,10 +161,10 @@ void test_point(std::string const& wkt, bool expected_outside,
     Point point;
     bg::read_wkt(wkt, point);
     border.point_on_piece(point, false, false, state);
-    BOOST_CHECK(expected_outside == state.count > 0);
-    BOOST_CHECK(expected_on_offsetted == state.count_on_offsetted > 0);
-    BOOST_CHECK(expected_on_edge == state.count_on_edge > 0);
-    BOOST_CHECK(expected_on_origin == state.count_on_origin > 0);
+    BOOST_CHECK(expected_outside == (state.count > 0));
+    BOOST_CHECK(expected_on_offsetted == (state.count_on_offsetted > 0));
+    BOOST_CHECK(expected_on_edge == (state.count_on_edge > 0));
+    BOOST_CHECK(expected_on_origin == (state.count_on_origin > 0));
 
 #ifdef TEST_WITH_SVG
     std::string style = "fill:" + color + ";stroke:rgb(0,0,0);stroke-width:1";

--- a/test/algorithms/set_operations/intersection/intersection_integer.cpp
+++ b/test/algorithms/set_operations/intersection/intersection_integer.cpp
@@ -64,7 +64,7 @@ void test_all()
 }
 
 template <typename CoordinateType>
-void test_ticket_10868(std::string const& wkt_out)
+void test_ticket_10868(/*std::string const& wkt_out*/)
 {
     using point_type = bg::model::point<CoordinateType, 2, bg::cs::cartesian>;
     using polygon_type = bg::model::polygon

--- a/test/algorithms/set_operations/union/union_issues.cpp
+++ b/test/algorithms/set_operations/union/union_issues.cpp
@@ -43,7 +43,7 @@ void issue_1103()
     bg::union_(poly1, poly2, result);
 
     // Verify result. Before commit b1bebca the result was empty.
-    BOOST_CHECK_EQUAL(1, boost::size(result));
+    BOOST_CHECK_EQUAL(1, static_cast<int>(boost::size(result)));
     BOOST_CHECK_CLOSE(2.0, bg::area(result), 0.0001);
 }
 


### PR DESCRIPTION
This fixes a couple of warnings to declutter the output of running `b2 test` with GCC 13 or Clang 16 (and possibly other versions which I do not have installed):
* a missing template keyword warning with GCC (which looks like a compiler bug to me but the workaround only costs two brackets),
* some warnings for comparing signed and unsigned integers,
* missing parentheses warnings,
* an unused parameter warning (just commented out because the lining that would have used it is also just commented out).

The remaining warnings (with the compilers that I have) come from Boost.Polygon and Boost.Test.