### PR TITLE
Remove some access.hpp includes in overlay

### DIFF
--- a/include/boost/geometry/algorithms/detail/intersection/box_box.hpp
+++ b/include/boost/geometry/algorithms/detail/intersection/box_box.hpp
@@ -16,7 +16,7 @@
 
 
 #include <boost/geometry/algorithms/detail/intersection/interface.hpp>
-#include <boost/geometry/algorithms/detail/overlay/intersection_box_box.hpp>
+#include <boost/geometry/algorithms/detail/intersection/box_box_implementation.hpp>
 
 
 namespace boost { namespace geometry

--- a/include/boost/geometry/algorithms/detail/intersection/box_box_implementation.hpp
+++ b/include/boost/geometry/algorithms/detail/intersection/box_box_implementation.hpp
@@ -11,12 +11,11 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_INTERSECTION_BOX_BOX_HPP
-#define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_INTERSECTION_BOX_BOX_HPP
+#ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_INTERSECTION_BOX_BOX_IMPLEMENTATION_HPP
+#define BOOST_GEOMETRY_ALGORITHMS_DETAIL_INTERSECTION_BOX_BOX_IMPLEMENTATION_HPP
 
 
 #include <boost/geometry/core/access.hpp>
-#include <boost/geometry/core/coordinate_type.hpp>
 
 
 namespace boost { namespace geometry
@@ -42,18 +41,16 @@ struct intersection_box_box
             BoxOut& box_out,
             Strategy const& strategy)
     {
-        typedef typename coordinate_type<BoxOut>::type ct;
-
-        ct max1 = get<max_corner, Dimension>(box1);
-        ct min2 = get<min_corner, Dimension>(box2);
+        auto max1 = get<max_corner, Dimension>(box1);
+        auto min2 = get<min_corner, Dimension>(box2);
 
         if (max1 < min2)
         {
             return false;
         }
 
-        ct max2 = get<max_corner, Dimension>(box2);
-        ct min1 = get<min_corner, Dimension>(box1);
+        auto max2 = get<max_corner, Dimension>(box2);
+        auto min1 = get<min_corner, Dimension>(box1);
 
         if (max2 < min1)
         {
@@ -93,4 +90,4 @@ struct intersection_box_box<DimensionCount, DimensionCount>
 }} // namespace boost::geometry
 
 
-#endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_INTERSECTION_BOX_BOX_HPP
+#endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_INTERSECTION_BOX_BOX_IMPLEMENTATION_HPP

--- a/include/boost/geometry/algorithms/detail/overlay/backtrack_check_si.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/backtrack_check_si.hpp
@@ -20,7 +20,6 @@
 #include <boost/range/end.hpp>
 #include <boost/range/value_type.hpp>
 
-#include <boost/geometry/core/access.hpp>
 #include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>
 #include <boost/geometry/algorithms/detail/has_self_intersections.hpp>
 #if defined(BOOST_GEOMETRY_DEBUG_INTERSECTION) || defined(BOOST_GEOMETRY_OVERLAY_REPORT_WKT)

--- a/include/boost/geometry/algorithms/detail/overlay/cluster_exits.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/cluster_exits.hpp
@@ -20,7 +20,6 @@
 
 #include <boost/range/value_type.hpp>
 
-#include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/algorithms/detail/overlay/overlay_type.hpp>
 #include <boost/geometry/algorithms/detail/overlay/sort_by_side.hpp>

--- a/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
@@ -39,7 +39,6 @@
 #include <boost/geometry/algorithms/detail/sections/section_functions.hpp>
 #include <boost/geometry/algorithms/detail/sections/sectionalize.hpp>
 
-#include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/exterior_ring.hpp>
@@ -723,7 +722,7 @@ struct get_turns_cs
     }
 
 private:
-    template<std::size_t Index, typename Point>
+    /*template<std::size_t Index, typename Point>
     static inline int get_side(Box const& box, Point const& point)
     {
         // Inside -> 0
@@ -741,7 +740,7 @@ private:
         else if (c < left) return -1;
         else if (c > right) return 1;
         else return 0;
-    }
+    }*/
 
     template
     <

--- a/include/boost/geometry/algorithms/detail/overlay/range_in_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/range_in_geometry.hpp
@@ -13,7 +13,6 @@
 
 
 #include <boost/geometry/algorithms/detail/covered_by/implementation.hpp>
-#include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/tags.hpp>
 #include <boost/geometry/iterators/point_iterator.hpp>
 

--- a/include/boost/geometry/algorithms/detail/overlay/self_turn_points.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/self_turn_points.hpp
@@ -24,7 +24,6 @@
 #include <boost/geometry/algorithms/detail/overlay/get_turns.hpp>
 #include <boost/geometry/algorithms/detail/sections/section_box_policies.hpp>
 
-#include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/point_order.hpp>
 #include <boost/geometry/core/tags.hpp>

--- a/include/boost/geometry/algorithms/detail/overlay/traversal.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/traversal.hpp
@@ -26,7 +26,6 @@
 #include <boost/geometry/algorithms/detail/overlay/is_self_turn.hpp>
 #include <boost/geometry/algorithms/detail/overlay/sort_by_side.hpp>
 #include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>
-#include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/util/condition.hpp>
 

--- a/include/boost/geometry/algorithms/detail/overlay/traversal_ring_creator.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/traversal_ring_creator.hpp
@@ -23,7 +23,6 @@
 #include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>
 #include <boost/geometry/algorithms/detail/overlay/traversal.hpp>
 #include <boost/geometry/algorithms/num_points.hpp>
-#include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/closure.hpp>
 

--- a/include/boost/geometry/algorithms/detail/overlay/traversal_switch_detector.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/traversal_switch_detector.hpp
@@ -21,7 +21,11 @@
 #include <boost/geometry/algorithms/detail/overlay/cluster_info.hpp>
 #include <boost/geometry/algorithms/detail/overlay/is_self_turn.hpp>
 #include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>
+
+#if defined(BOOST_GEOMETRY_DEBUG_TRAVERSAL_SWITCH_DETECTOR)
 #include <boost/geometry/core/access.hpp>
+#endif
+
 #include <boost/geometry/util/condition.hpp>
 
 #include <cstddef>

--- a/include/boost/geometry/algorithms/detail/sections/range_by_section.hpp
+++ b/include/boost/geometry/algorithms/detail/sections/range_by_section.hpp
@@ -21,7 +21,6 @@
 #include <boost/range/size.hpp>
 #include <boost/range/value_type.hpp>
 
-#include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/closure.hpp>
 #include <boost/geometry/core/exterior_ring.hpp>

--- a/include/boost/geometry/index/detail/algorithms/intersection_content.hpp
+++ b/include/boost/geometry/index/detail/algorithms/intersection_content.hpp
@@ -16,7 +16,7 @@
 #define BOOST_GEOMETRY_INDEX_DETAIL_ALGORITHMS_INTERSECTION_CONTENT_HPP
 
 #include <boost/geometry/algorithms/detail/disjoint/box_box.hpp>
-#include <boost/geometry/algorithms/detail/overlay/intersection_box_box.hpp>
+#include <boost/geometry/algorithms/detail/intersection/box_box_implementation.hpp>
 
 #include <boost/geometry/index/detail/algorithms/content.hpp>
 


### PR DESCRIPTION
This removes the include of access.hpp from some files in the overlay algorithm that don't use it (AFAICS they don't use get, set or the {max,min}_corner constants) and moves the box_box_intersection implementation out of the overlay algorithm where it is not used directly.

(This is a by-product of my larger attempt to locate and separate direct computations involving coordinates from the overlay-code, which I think is a prerequisite for implementing and testing numerically robust strategies. Because I don't know how long that might take, whether it will succeed and how much the develop-branch might change in the mean time, I thought it made sense to push this self-contained change now.)