### PR TITLE
Use fp_equals comparison in side_strategy for convex_hull.

### DIFF
--- a/include/boost/geometry/strategies/convex_hull/cartesian.hpp
+++ b/include/boost/geometry/strategies/convex_hull/cartesian.hpp
@@ -46,7 +46,7 @@ public:
     static auto side()
     {
         using side_strategy_type
-            = strategy::side::side_robust<CalculationType>;
+            = strategy::side::side_robust<CalculationType, strategy::side::fp_equals_policy>;
         return side_strategy_type();
     }
 


### PR DESCRIPTION
This changes the default side strategy for convex_hull for cartesian coordinates so that it uses an exact comparison to zero for the side value. This is IMHO the only way to use that strategy to guarantee exact (and thereby consistent) results, which was the intention behind the strategy. The motivation is issue #1208 , which is fixed by this change. I see no testcase breaking.

From git blame, I don't see the motivation for the current non-exact comparison. If it was to be more lenient in is_convex, which uses the same umbrella strategy, then maybe those should be separate umbrella strategies. I think in the construction of the hull this non-robustness is more problematic. If it was done like this to avoid near-collinear points on edges of the output, maybe there should be a separate iteration over the hull after construction with another side-strategy.