### PR TITLE
Remove deprecated test-suite rule

### DIFF
--- a/test/Jamfile
+++ b/test/Jamfile
@@ -27,10 +27,7 @@ project boost-geometry-test
     ;
 
 # Run minimal testset
-test-suite boost-geometry-minimal
-    :
-    [ run minimal.cpp : : : : minimal ]
-    ;
+run minimal.cpp : : : : minimal ;
 
 # If not on Travis run all of the tests
 if ! [ os.environ TRAVIS ]

--- a/test/algorithms/Jamfile
+++ b/test/algorithms/Jamfile
@@ -16,56 +16,53 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-algorithms
-    :
-    [ run append.cpp                   : : : : algorithms_append ]
-    [ run assign.cpp                   : : : : algorithms_assign ]
-    [ run azimuth.cpp                  : : : : algorithms_azimuth ]
-    [ run centroid.cpp                 : : : : algorithms_centroid ]
-    [ run centroid_multi.cpp           : : : : algorithms_centroid_multi ]
-    [ run comparable_distance.cpp      : : : : algorithms_comparable_distance ]
-    [ run convert.cpp                  : : : : algorithms_convert ]
-    [ run convert_multi.cpp            : : : : algorithms_convert_multi ]
-    [ run correct.cpp                  : : : : algorithms_correct ]
-    [ run correct_multi.cpp            : : : : algorithms_correct_multi ]
-    [ run correct_closure.cpp          : : : : algorithms_correct_closure ]
-    [ run densify.cpp                  : : : : algorithms_densify ]
-    [ run for_each.cpp                 : : : : algorithms_for_each ]
-    [ run for_each_multi.cpp           : : : : algorithms_for_each_multi ]
-    [ run is_convex.cpp                : : : : algorithms_is_convex ]
-    [ run is_empty.cpp                 : : : : algorithms_is_empty ]
-    [ run is_simple.cpp                : : : : algorithms_is_simple ]
-    [ run is_simple_geo.cpp            : : : : algorithms_is_simple_geo ]
-    [ run is_valid.cpp                 : : : : algorithms_is_valid ]
-    [ run is_valid_failure.cpp         : : : : algorithms_is_valid_failure ]
-    [ run is_valid_geo.cpp             : : : : algorithms_is_valid_geo ]
-    [ run is_valid.cpp                 : : : <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_is_valid_alternative ]
-    [ run is_valid_failure.cpp         : : : <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_is_valid_failure_alternative ]
-    [ run is_valid_geo.cpp             : : : <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_is_valid_geo_alternative ]
-    [ run line_interpolate.cpp         : : : : algorithms_line_interpolate ]
-    [ run make.cpp                     : : : : algorithms_make ]
-    [ run maximum_gap.cpp              : : : : algorithms_maximum_gap ]
-    [ run merge_elements.cpp           : : : : algorithms_merge_elements ]
-    [ run num_geometries.cpp           : : : : algorithms_num_geometries ]
-    [ run num_geometries_multi.cpp     : : : : algorithms_num_geometries_multi ]
-    [ run num_interior_rings.cpp       : : : : algorithms_num_interior_rings ]
-    [ run num_interior_rings_multi.cpp : : : : algorithms_num_interior_rings_multi ]
-    [ run num_points.cpp               : : : : algorithms_num_points ]
-    [ run num_points_multi.cpp         : : : : algorithms_num_points_multi ]
-    [ run num_segments.cpp             : : : : algorithms_segments ]
-    [ run perimeter.cpp                : : : : algorithms_perimeter ]
-    [ run perimeter_multi.cpp          : : : : algorithms_perimeter_multi ]
-    [ run point_on_surface.cpp         : : : : algorithms_point_on_surface ]
-    [ run remove_spikes.cpp            : : : : algorithms_remove_spikes ]
-    [ run reverse.cpp                  : : : : algorithms_reverse ]
-    [ run reverse_multi.cpp            : : : : algorithms_reverse_multi ]
-    [ run simplify.cpp                 : : : : algorithms_simplify ]
-    [ run simplify_multi.cpp           : : : : algorithms_simplify_multi ]
-    [ run transform.cpp                : : : : algorithms_transform ]
-    [ run transform_multi.cpp          : : : : algorithms_transform_multi ]
-    [ run unique.cpp                   : : : : algorithms_unique ]
-    [ run unique_multi.cpp             : : : : algorithms_unique_multi ]
-    ;
+run append.cpp                   : : : : algorithms_append ;
+run assign.cpp                   : : : : algorithms_assign ;
+run azimuth.cpp                  : : : : algorithms_azimuth ;
+run centroid.cpp                 : : : : algorithms_centroid ;
+run centroid_multi.cpp           : : : : algorithms_centroid_multi ;
+run comparable_distance.cpp      : : : : algorithms_comparable_distance ;
+run convert.cpp                  : : : : algorithms_convert ;
+run convert_multi.cpp            : : : : algorithms_convert_multi ;
+run correct.cpp                  : : : : algorithms_correct ;
+run correct_multi.cpp            : : : : algorithms_correct_multi ;
+run correct_closure.cpp          : : : : algorithms_correct_closure ;
+run densify.cpp                  : : : : algorithms_densify ;
+run for_each.cpp                 : : : : algorithms_for_each ;
+run for_each_multi.cpp           : : : : algorithms_for_each_multi ;
+run is_convex.cpp                : : : : algorithms_is_convex ;
+run is_empty.cpp                 : : : : algorithms_is_empty ;
+run is_simple.cpp                : : : : algorithms_is_simple ;
+run is_simple_geo.cpp            : : : : algorithms_is_simple_geo ;
+run is_valid.cpp                 : : : : algorithms_is_valid ;
+run is_valid_failure.cpp         : : : : algorithms_is_valid_failure ;
+run is_valid_geo.cpp             : : : : algorithms_is_valid_geo ;
+run is_valid.cpp                 : : : <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_is_valid_alternative ;
+run is_valid_failure.cpp         : : : <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_is_valid_failure_alternative ;
+run is_valid_geo.cpp             : : : <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_is_valid_geo_alternative ;
+run line_interpolate.cpp         : : : : algorithms_line_interpolate ;
+run make.cpp                     : : : : algorithms_make ;
+run maximum_gap.cpp              : : : : algorithms_maximum_gap ;
+run merge_elements.cpp           : : : : algorithms_merge_elements ;
+run num_geometries.cpp           : : : : algorithms_num_geometries ;
+run num_geometries_multi.cpp     : : : : algorithms_num_geometries_multi ;
+run num_interior_rings.cpp       : : : : algorithms_num_interior_rings ;
+run num_interior_rings_multi.cpp : : : : algorithms_num_interior_rings_multi ;
+run num_points.cpp               : : : : algorithms_num_points ;
+run num_points_multi.cpp         : : : : algorithms_num_points_multi ;
+run num_segments.cpp             : : : : algorithms_segments ;
+run perimeter.cpp                : : : : algorithms_perimeter ;
+run perimeter_multi.cpp          : : : : algorithms_perimeter_multi ;
+run point_on_surface.cpp         : : : : algorithms_point_on_surface ;
+run remove_spikes.cpp            : : : : algorithms_remove_spikes ;
+run reverse.cpp                  : : : : algorithms_reverse ;
+run reverse_multi.cpp            : : : : algorithms_reverse_multi ;
+run simplify.cpp                 : : : : algorithms_simplify ;
+run simplify_multi.cpp           : : : : algorithms_simplify_multi ;
+run transform.cpp                : : : : algorithms_transform ;
+run transform_multi.cpp          : : : : algorithms_transform_multi ;
+run unique.cpp                   : : : : algorithms_unique ;
+run unique_multi.cpp             : : : : algorithms_unique_multi ;
 
 build-project area ;
 build-project buffer ;

--- a/test/algorithms/area/Jamfile
+++ b/test/algorithms/area/Jamfile
@@ -9,12 +9,8 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-algorithms-area
-    :
-    [ run area.cpp                     : : : : algorithms_area ]
-    [ run area_box_sg.cpp              : : : : algorithms_area_box_sg ]
-    [ run area_geo.cpp                 : : : : algorithms_area_geo ]
-    [ run area_multi.cpp               : : : : algorithms_area_multi ]
-    [ run area_sph_geo.cpp             : : : : algorithms_area_sph_geo ]
-    ;
-
+run area.cpp                     : : : : algorithms_area ;
+run area_box_sg.cpp              : : : : algorithms_area_box_sg ;
+run area_geo.cpp                 : : : : algorithms_area_geo ;
+run area_multi.cpp               : : : : algorithms_area_multi ;
+run area_sph_geo.cpp             : : : : algorithms_area_sph_geo ;

--- a/test/algorithms/buffer/Jamfile
+++ b/test/algorithms/buffer/Jamfile
@@ -12,35 +12,31 @@ project boost-geometry-algorithms-buffer
         <include>.
     ;
 
-test-suite boost-geometry-algorithms-buffer
-    :
-    [ run buffer.cpp                      : : : : algorithms_buffer ]
-    [ run buffer_gc.cpp                   : : : : algorithms_buffer_gc ]
-    [ run buffer_with_strategies.cpp      : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_with_strategies ]
-    [ run buffer_piece_border.cpp         : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_piece_border ]
-    [ run buffer_point.cpp                : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_point ]
-    [ run buffer_point_geo.cpp            : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_point_geo ]
-    [ run buffer_linestring.cpp           : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_linestring ]
-    [ run buffer_linestring_geo.cpp       : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_linestring_geo ]
-    [ run buffer_ring.cpp                 : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_ring ]
-    [ run buffer_polygon.cpp              : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_polygon ]
-    [ run buffer_polygon_geo.cpp          : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_polygon_geo ]
-    [ run buffer_multi_point.cpp          : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_multi_point ]
-    [ run buffer_multi_linestring.cpp     : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_multi_linestring ]
-    [ run buffer_multi_linestring_geo.cpp : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_multi_linestring_geo ]
-    [ run buffer_multi_polygon.cpp        : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_multi_polygon ]
-    [ run buffer_multi_polygon_geo.cpp    : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_multi_polygon_geo ]
-    [ run buffer_geo_spheroid.cpp         : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_geo_spheroid ]
-    [ run buffer_linestring_aimes.cpp     : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_linestring_aimes ]
-    [ run buffer_linestring.cpp           : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_buffer_linestring_alternative ]
-    [ run buffer_multi_linestring.cpp     : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_buffer_multi_linestring_alternative ]
-    [ run buffer_ring.cpp                 : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_buffer_ring_alternative ]
-    [ run buffer_polygon.cpp              : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_buffer_polygon_alternative ]
-    [ run buffer_multi_point.cpp          : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_buffer_multi_point_alternative ]
-    [ run buffer_multi_polygon.cpp        : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_buffer_multi_polygon_alternative ]
-    [ run buffer_linestring_aimes.cpp     : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_buffer_linestring_aimes_alternative ]
+run buffer.cpp                      : : : : algorithms_buffer ;
+run buffer_gc.cpp                   : : : : algorithms_buffer_gc ;
+run buffer_with_strategies.cpp      : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_with_strategies ;
+run buffer_piece_border.cpp         : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_piece_border ;
+run buffer_point.cpp                : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_point ;
+run buffer_point_geo.cpp            : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_point_geo ;
+run buffer_linestring.cpp           : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_linestring ;
+run buffer_linestring_geo.cpp       : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_linestring_geo ;
+run buffer_ring.cpp                 : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_ring ;
+run buffer_polygon.cpp              : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_polygon ;
+run buffer_polygon_geo.cpp          : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_polygon_geo ;
+run buffer_multi_point.cpp          : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_multi_point ;
+run buffer_multi_linestring.cpp     : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_multi_linestring ;
+run buffer_multi_linestring_geo.cpp : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_multi_linestring_geo ;
+run buffer_multi_polygon.cpp        : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_multi_polygon ;
+run buffer_multi_polygon_geo.cpp    : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_multi_polygon_geo ;
+run buffer_geo_spheroid.cpp         : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_geo_spheroid ;
+run buffer_linestring_aimes.cpp     : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_linestring_aimes ;
+run buffer_linestring.cpp           : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_buffer_linestring_alternative ;
+run buffer_multi_linestring.cpp     : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_buffer_multi_linestring_alternative ;
+run buffer_ring.cpp                 : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_buffer_ring_alternative ;
+run buffer_polygon.cpp              : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_buffer_polygon_alternative ;
+run buffer_multi_point.cpp          : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_buffer_multi_point_alternative ;
+run buffer_multi_polygon.cpp        : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_buffer_multi_polygon_alternative ;
+run buffer_linestring_aimes.cpp     : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_buffer_linestring_aimes_alternative ;
 # Uncomment next lines if you want to test this manually; requires access to data/ folder
-#    [ run buffer_countries.cpp            : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_countries ]
-#    [ run buffer_countries.cpp            : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_buffer_countries_alternative ]
-    ;
-
+#run buffer_countries.cpp           : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_buffer_countries ;
+#run buffer_countries.cpp           : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_buffer_countries_alternative ;

--- a/test/algorithms/closest_points/Jamfile.v2
+++ b/test/algorithms/closest_points/Jamfile.v2
@@ -8,12 +8,9 @@
 # Licensed under the Boost Software License version 1.0.
 # http://www.boost.org/users/license.html
 
-test-suite boost-geometry-algorithms-closest_points
-    :
-    [ run ar_ar.cpp       : : : : algorithms_closest_points_ar_ar ]
-    [ run l_ar.cpp        : : : : algorithms_closest_points_l_ar ]
-    [ run l_l.cpp         : : : : algorithms_closest_points_l_l ]
-    [ run pl_ar.cpp       : : : : algorithms_closest_points_pl_ar ]
-    [ run pl_l.cpp        : : : : algorithms_closest_points_pl_l ]
-    [ run pl_pl.cpp       : : : : algorithms_closest_points_pl_pl ]
-    ;
+run ar_ar.cpp       : : : : algorithms_closest_points_ar_ar ;
+run l_ar.cpp        : : : : algorithms_closest_points_l_ar ;
+run l_l.cpp         : : : : algorithms_closest_points_l_l ;
+run pl_ar.cpp       : : : : algorithms_closest_points_pl_ar ;
+run pl_l.cpp        : : : : algorithms_closest_points_pl_l ;
+run pl_pl.cpp       : : : : algorithms_closest_points_pl_pl ;

--- a/test/algorithms/convex_hull/Jamfile
+++ b/test/algorithms/convex_hull/Jamfile
@@ -8,14 +8,11 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-algorithms-convex_hull
-    :
-    [ run convex_hull.cpp              : : : : algorithms_convex_hull ]
-    [ run convex_hull_multi.cpp        : : : : algorithms_convex_hull_multi ]
-    [ run convex_hull_robust.cpp       : : : : algorithms_convex_hull_robust ]
-    [ run convex_hull_sph_geo.cpp      : : : : algorithms_convex_hull_sph_geo ]
-    [ run convex_hull.cpp              : : : <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_convex_hull_alternative ]
-    [ run convex_hull_multi.cpp        : : : <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_convex_hull_multi_alternative ]
-    [ run convex_hull_robust.cpp       : : : <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_convex_hull_robust_alternative ]
-    [ run convex_hull_sph_geo.cpp      : : : <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_convex_hull_sph_geo_alternative ]
-    ;
+run convex_hull.cpp              : : : : algorithms_convex_hull ;
+run convex_hull_multi.cpp        : : : : algorithms_convex_hull_multi ;
+run convex_hull_robust.cpp       : : : : algorithms_convex_hull_robust ;
+run convex_hull_sph_geo.cpp      : : : : algorithms_convex_hull_sph_geo ;
+run convex_hull.cpp              : : : <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_convex_hull_alternative ;
+run convex_hull_multi.cpp        : : : <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_convex_hull_multi_alternative ;
+run convex_hull_robust.cpp       : : : <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_convex_hull_robust_alternative ;
+run convex_hull_sph_geo.cpp      : : : <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_convex_hull_sph_geo_alternative ;

--- a/test/algorithms/covered_by/Jamfile
+++ b/test/algorithms/covered_by/Jamfile
@@ -14,10 +14,7 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-algorithms-covered_by
-    :
-    [ run covered_by.cpp         : : : : algorithms_covered_by ]
-    [ run covered_by_gc.cpp      : : : : algorithms_covered_by_gc ]
-    [ run covered_by_sph.cpp     : : : : algorithms_covered_by_sph ]
-    [ run covered_by_sph_geo.cpp : : : : algorithms_covered_by_sph_geo ]
-    ;
+run covered_by.cpp         : : : : algorithms_covered_by ;
+run covered_by_gc.cpp      : : : : algorithms_covered_by_gc ;
+run covered_by_sph.cpp     : : : : algorithms_covered_by_sph ;
+run covered_by_sph_geo.cpp : : : : algorithms_covered_by_sph_geo ;

--- a/test/algorithms/crosses/Jamfile
+++ b/test/algorithms/crosses/Jamfile
@@ -14,9 +14,6 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-algorithms-crosses
-    :
-    [ run crosses.cpp            : : : : algorithms_crosses ]
-    [ run crosses_gc.cpp         : : : : algorithms_crosses_gc ]
-    [ run crosses_sph.cpp        : : : : algorithms_crosses_sph ]
-    ;
+run crosses.cpp            : : : : algorithms_crosses ;
+run crosses_gc.cpp         : : : : algorithms_crosses_gc ;
+run crosses_sph.cpp        : : : : algorithms_crosses_sph ;

--- a/test/algorithms/detail/Jamfile
+++ b/test/algorithms/detail/Jamfile
@@ -13,13 +13,10 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-algorithms-detail
-    :
-    [ run calculate_point_order.cpp : : : : algorithms_calculate_point_order ]
-    [ run approximately_equals.cpp  : : : : algorithms_approximately_equals ]
-    [ run partition.cpp             : : : : algorithms_partition ]
-    [ run tupled_output.cpp         : : : : algorithms_tupled_output ]
-    [ run visit.cpp                 : : : : algorithms_visit ]
-    ;
+run calculate_point_order.cpp : : : : algorithms_calculate_point_order ;
+run approximately_equals.cpp  : : : : algorithms_approximately_equals ;
+run partition.cpp             : : : : algorithms_partition ;
+run tupled_output.cpp         : : : : algorithms_tupled_output ;
+run visit.cpp                 : : : : algorithms_visit ;
 
 build-project sections ;

--- a/test/algorithms/detail/sections/Jamfile
+++ b/test/algorithms/detail/sections/Jamfile
@@ -13,9 +13,6 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-algorithms-detail-sections
-    : 
-    [ run sectionalize.cpp       : : : : algorithms_sectionalize ]
-    [ run sectionalize_const.cpp : : : : algorithms_sectionalize_const ]
-    [ run range_by_section.cpp   : : : : algorithms_range_by_section ]
-     ;
+run sectionalize.cpp       : : : : algorithms_sectionalize ;
+run sectionalize_const.cpp : : : : algorithms_sectionalize_const ;
+run range_by_section.cpp   : : : : algorithms_range_by_section ;

--- a/test/algorithms/disjoint/Jamfile
+++ b/test/algorithms/disjoint/Jamfile
@@ -14,17 +14,14 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-algorithms-disjoint
-    :
-    [ run disjoint.cpp                    : : : : algorithms_disjoint ]
-    [ run disjoint_coverage_a_a.cpp       : : : : algorithms_disjoint_coverage_a_a ]
-    [ run disjoint_coverage_l_a.cpp       : : : : algorithms_disjoint_coverage_l_a ]
-    [ run disjoint_coverage_l_l.cpp       : : : : algorithms_disjoint_coverage_l_l ]
-    [ run disjoint_coverage_p_a.cpp       : : : : algorithms_disjoint_coverage_p_a ]
-    [ run disjoint_coverage_p_l.cpp       : : : : algorithms_disjoint_coverage_p_l ]
-    [ run disjoint_coverage_p_p.cpp       : : : : algorithms_disjoint_coverage_p_p ]
-    [ run disjoint_multi.cpp              : : : : algorithms_disjoint_multi ]
-    [ run disjoint_point_box_geometry.cpp : : : : algorithms_disjoint_point_box_geometry ]
-    [ run disjoint_seg_box.cpp            : : : : algorithms_disjoint_seg_box ]
-    [ run disjoint_sph.cpp                : : : : algorithms_disjoint_sph ]
-    ;
+run disjoint.cpp                    : : : : algorithms_disjoint ;
+run disjoint_coverage_a_a.cpp       : : : : algorithms_disjoint_coverage_a_a ;
+run disjoint_coverage_l_a.cpp       : : : : algorithms_disjoint_coverage_l_a ;
+run disjoint_coverage_l_l.cpp       : : : : algorithms_disjoint_coverage_l_l ;
+run disjoint_coverage_p_a.cpp       : : : : algorithms_disjoint_coverage_p_a ;
+run disjoint_coverage_p_l.cpp       : : : : algorithms_disjoint_coverage_p_l ;
+run disjoint_coverage_p_p.cpp       : : : : algorithms_disjoint_coverage_p_p ;
+run disjoint_multi.cpp              : : : : algorithms_disjoint_multi ;
+run disjoint_point_box_geometry.cpp : : : : algorithms_disjoint_point_box_geometry ;
+run disjoint_seg_box.cpp            : : : : algorithms_disjoint_seg_box ;
+run disjoint_sph.cpp                : : : : algorithms_disjoint_sph ;

--- a/test/algorithms/distance/Jamfile
+++ b/test/algorithms/distance/Jamfile
@@ -15,21 +15,18 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-algorithms-distance
-    :
-    [ run distance.cpp                     : : : : algorithms_distance ]
-    [ run distance_ca_ar_ar.cpp            : : : : algorithms_distance_ca_ar_ar ]
-    [ run distance_ca_l_ar.cpp             : : : : algorithms_distance_ca_l_ar ]
-    [ run distance_ca_l_l.cpp              : : : : algorithms_distance_ca_l_l ]
-    [ run distance_ca_pl_ar.cpp            : : : : algorithms_distance_ca_pl_ar ]
-    [ run distance_ca_pl_l.cpp             : : : : algorithms_distance_ca_pl_l ]
-    [ run distance_ca_pl_pl.cpp            : : : : algorithms_distance_ca_pl_pl ]
-    [ run distance_se_geo_ar_ar.cpp           : : : : algorithms_distance_se_geo_ar_ar ]
-    [ run distance_se_geo_l_ar.cpp            : : : : algorithms_distance_se_geo_l_ar ]
-    [ run distance_se_geo_l_l.cpp             : : : : algorithms_distance_se_geo_l_l ]
-    [ run distance_se_geo_pl_ar.cpp           : : : : algorithms_distance_se_geo_pl_ar ]
-    [ run distance_geo_pl_l.cpp            : : : : algorithms_distance_geo_pl_l ]
-    [ run distance_se_geo_pl_pl.cpp           : : : : algorithms_distance_se_geo_pl_pl ]
-    [ run distance_se_pl_l.cpp             : : : : algorithms_distance_se_pl_l ]
-    [ run distance_se_pl_pl.cpp            : : : : algorithms_distance_se_pl_pl ]
-    ;
+run distance.cpp                     : : : : algorithms_distance ;
+run distance_ca_ar_ar.cpp            : : : : algorithms_distance_ca_ar_ar ;
+run distance_ca_l_ar.cpp             : : : : algorithms_distance_ca_l_ar ;
+run distance_ca_l_l.cpp              : : : : algorithms_distance_ca_l_l ;
+run distance_ca_pl_ar.cpp            : : : : algorithms_distance_ca_pl_ar ;
+run distance_ca_pl_l.cpp             : : : : algorithms_distance_ca_pl_l ;
+run distance_ca_pl_pl.cpp            : : : : algorithms_distance_ca_pl_pl ;
+run distance_se_geo_ar_ar.cpp        : : : : algorithms_distance_se_geo_ar_ar ;
+run distance_se_geo_l_ar.cpp         : : : : algorithms_distance_se_geo_l_ar ;
+run distance_se_geo_l_l.cpp          : : : : algorithms_distance_se_geo_l_l ;
+run distance_se_geo_pl_ar.cpp        : : : : algorithms_distance_se_geo_pl_ar ;
+run distance_geo_pl_l.cpp            : : : : algorithms_distance_geo_pl_l ;
+run distance_se_geo_pl_pl.cpp        : : : : algorithms_distance_se_geo_pl_pl ;
+run distance_se_pl_l.cpp             : : : : algorithms_distance_se_pl_l ;
+run distance_se_pl_pl.cpp            : : : : algorithms_distance_se_pl_pl ;

--- a/test/algorithms/envelope_expand/Jamfile
+++ b/test/algorithms/envelope_expand/Jamfile
@@ -14,11 +14,8 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-algorithms-envelope_expand
-    :
-    [ run envelope.cpp                 : : : : algorithms_envelope ]
-    [ run envelope_multi.cpp           : : : : algorithms_envelope_multi ]
-    [ run envelope_on_spheroid.cpp     : : : : algorithms_envelope_on_spheroid ]
-    [ run expand.cpp                   : : : : algorithms_expand ]
-    [ run expand_on_spheroid.cpp       : : : : algorithms_expand_on_spheroid ]
-    ;
+run envelope.cpp                 : : : : algorithms_envelope ;
+run envelope_multi.cpp           : : : : algorithms_envelope_multi ;
+run envelope_on_spheroid.cpp     : : : : algorithms_envelope_on_spheroid ;
+run expand.cpp                   : : : : algorithms_expand ;
+run expand_on_spheroid.cpp       : : : : algorithms_expand_on_spheroid ;

--- a/test/algorithms/equals/Jamfile
+++ b/test/algorithms/equals/Jamfile
@@ -14,11 +14,8 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-algorithms-equals
-    :
-    [ run equals.cpp             : : : : algorithms_equals ]
-    [ run equals_gc.cpp          : : : : algorithms_equals_gc ]
-    [ run equals_multi.cpp       : : : : algorithms_equals_multi ]
-    [ run equals_on_spheroid.cpp : : : : algorithms_equals_on_spheroid ]
-    [ run equals_sph.cpp         : : : : algorithms_equals_sph ]
-    ;
+run equals.cpp             : : : : algorithms_equals ;
+run equals_gc.cpp          : : : : algorithms_equals_gc ;
+run equals_multi.cpp       : : : : algorithms_equals_multi ;
+run equals_on_spheroid.cpp : : : : algorithms_equals_on_spheroid ;
+run equals_sph.cpp         : : : : algorithms_equals_sph ;

--- a/test/algorithms/intersects/Jamfile
+++ b/test/algorithms/intersects/Jamfile
@@ -14,13 +14,9 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-algorithms-intersects
-    :
-    [ run intersects.cpp              : : : : algorithms_intersects ]
-    [ run intersects_box_geometry.cpp : : : : algorithms_intersects_box_geometry ]
-    [ run intersects_multi.cpp        : : : : algorithms_intersects_multi ]
-    [ run intersects_self.cpp         : : : : algorithms_intersects_self ]
-    [ run intersects_sph_geo.cpp      : : : : algorithms_intersects_sph_geo ]
-    [ run intersects_sph.cpp          : : : : algorithms_intersects_sph ]
-    ;
-
+run intersects.cpp              : : : : algorithms_intersects ;
+run intersects_box_geometry.cpp : : : : algorithms_intersects_box_geometry ;
+run intersects_multi.cpp        : : : : algorithms_intersects_multi ;
+run intersects_self.cpp         : : : : algorithms_intersects_self ;
+run intersects_sph_geo.cpp      : : : : algorithms_intersects_sph_geo ;
+run intersects_sph.cpp          : : : : algorithms_intersects_sph ;

--- a/test/algorithms/length/Jamfile
+++ b/test/algorithms/length/Jamfile
@@ -8,10 +8,7 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-algorithms-length
-    :
-    [ run length.cpp                     : : : : algorithms_length ]
-    [ run length_multi.cpp               : : : : algorithms_length_multi ]
-    [ run length_sph.cpp                 : : : : algorithms_length_sph ]
-    [ run length_geo.cpp                 : : : : algorithms_length_geo ]
-    ;
+run length.cpp                     : : : : algorithms_length ;
+run length_multi.cpp               : : : : algorithms_length_multi ;
+run length_sph.cpp                 : : : : algorithms_length_sph ;
+run length_geo.cpp                 : : : : algorithms_length_geo ;

--- a/test/algorithms/overlaps/Jamfile
+++ b/test/algorithms/overlaps/Jamfile
@@ -14,12 +14,8 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-algorithms-overlaps
-    :
-    [ run overlaps.cpp       : : : : algorithms_overlaps ]
-    [ run overlaps_areal.cpp : : : : algorithms_overlaps_areal ]
-    [ run overlaps_box.cpp   : : : : algorithms_overlaps_box ]
-    [ run overlaps_gc.cpp    : : : : algorithms_overlaps_gc ]
-    [ run overlaps_sph.cpp   : : : : algorithms_overlaps_sph ]
-    ;
-
+run overlaps.cpp       : : : : algorithms_overlaps ;
+run overlaps_areal.cpp : : : : algorithms_overlaps_areal ;
+run overlaps_box.cpp   : : : : algorithms_overlaps_box ;
+run overlaps_gc.cpp    : : : : algorithms_overlaps_gc ;
+run overlaps_sph.cpp   : : : : algorithms_overlaps_sph ;

--- a/test/algorithms/overlay/Jamfile
+++ b/test/algorithms/overlay/Jamfile
@@ -13,32 +13,29 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-algorithms-overlay
-    : 
-    [ run assemble.cpp                     : : : : algorithms_assemble ]
-    [ run copy_segment_point.cpp           : : : : algorithms_copy_segment_point ]
-    [ run get_clusters.cpp                 : : : : algorithms_get_clusters ]
-    [ run get_distance_measure.cpp         : : : : algorithms_get_distance_measure ]
-    [ run get_ring.cpp                     : : : : algorithms_get_ring ]
-    [ run get_turn_info.cpp                : : : : algorithms_get_turn_info ]
-    [ run get_turns.cpp                    : : : : algorithms_get_turns ]
-    [ run get_turns_const.cpp              : : : : algorithms_get_turns_const ]
-    [ run get_turns_areal_areal.cpp        : : : : algorithms_get_turns_areal_areal ]
-    [ run get_turns_areal_areal_sph.cpp    : : : : algorithms_get_turns_areal_areal_sph ]
-    [ run get_turns_linear_areal.cpp       : : : : algorithms_get_turns_linear_areal ]
-    [ run get_turns_linear_areal_sph.cpp   : : : : algorithms_get_turns_linear_areal_sph ]
-    [ run get_turns_linear_linear.cpp      : : : : algorithms_get_turns_linear_linear ]
-    [ run get_turns_linear_linear.cpp      : : : <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_get_turns_linear_linear_alternative ]
-    [ run get_turns_linear_linear_geo.cpp  : : : : algorithms_get_turns_linear_linear_geo ]
-    [ run get_turns_linear_linear_sph.cpp  : : : : algorithms_get_turns_linear_linear_sph ]
-    [ run overlay.cpp                      : : : : algorithms_overlay ]
-    [ run sort_by_side_basic.cpp           : : : : algorithms_sort_by_side_basic ]
-    [ run sort_by_side.cpp                 : : : : algorithms_sort_by_side ]
-    #[ run handle_touch.cpp                : : : : algorithms_handle_touch ]
-    [ run relative_order.cpp               : : : : algorithms_relative_order ]
-    [ run select_rings.cpp                 : : : : algorithms_select_rings ]
-    [ run self_intersection_points.cpp     : : : : algorithms_self_intersection_points ]
-    #[ run traverse.cpp                    : : : : algorithms_traverse ]
-    #[ run traverse_ccw.cpp                : : : : algorithms_traverse_ccw ]
-    #[ run traverse_multi.cpp              : : : : algorithms_traverse_multi ]
-     ;
+run assemble.cpp                     : : : : algorithms_assemble ;
+run copy_segment_point.cpp           : : : : algorithms_copy_segment_point ;
+run get_clusters.cpp                 : : : : algorithms_get_clusters ;
+run get_distance_measure.cpp         : : : : algorithms_get_distance_measure ;
+run get_ring.cpp                     : : : : algorithms_get_ring ;
+run get_turn_info.cpp                : : : : algorithms_get_turn_info ;
+run get_turns.cpp                    : : : : algorithms_get_turns ;
+run get_turns_const.cpp              : : : : algorithms_get_turns_const ;
+run get_turns_areal_areal.cpp        : : : : algorithms_get_turns_areal_areal ;
+run get_turns_areal_areal_sph.cpp    : : : : algorithms_get_turns_areal_areal_sph ;
+run get_turns_linear_areal.cpp       : : : : algorithms_get_turns_linear_areal ;
+run get_turns_linear_areal_sph.cpp   : : : : algorithms_get_turns_linear_areal_sph ;
+run get_turns_linear_linear.cpp      : : : : algorithms_get_turns_linear_linear ;
+run get_turns_linear_linear.cpp      : : : <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_get_turns_linear_linear_alternative ;
+run get_turns_linear_linear_geo.cpp  : : : : algorithms_get_turns_linear_linear_geo ;
+run get_turns_linear_linear_sph.cpp  : : : : algorithms_get_turns_linear_linear_sph ;
+run overlay.cpp                      : : : : algorithms_overlay ;
+run sort_by_side_basic.cpp           : : : : algorithms_sort_by_side_basic ;
+run sort_by_side.cpp                 : : : : algorithms_sort_by_side ;
+#run handle_touch.cpp                : : : : algorithms_handle_touch ;
+run relative_order.cpp               : : : : algorithms_relative_order ;
+run select_rings.cpp                 : : : : algorithms_select_rings ;
+run self_intersection_points.cpp     : : : : algorithms_self_intersection_points ;
+#run traverse.cpp                    : : : : algorithms_traverse ;
+#run traverse_ccw.cpp                : : : : algorithms_traverse_ccw ;
+#run traverse_multi.cpp              : : : : algorithms_traverse_multi ;

--- a/test/algorithms/perimeter/Jamfile
+++ b/test/algorithms/perimeter/Jamfile
@@ -8,9 +8,6 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-algorithms-perimeter
-    :
-    [ run perimeter.cpp                  : : : : algorithms_perimeter ]
-    [ run perimeter_geo.cpp              : : : : algorithms_perimeter_geo ]
-    [ run perimeter_sph.cpp              : : : : algorithms_perimeter_sph ]
-    ;
+run perimeter.cpp                  : : : : algorithms_perimeter ;
+run perimeter_geo.cpp              : : : : algorithms_perimeter_geo ;
+run perimeter_sph.cpp              : : : : algorithms_perimeter_sph ;

--- a/test/algorithms/relate/Jamfile
+++ b/test/algorithms/relate/Jamfile
@@ -14,14 +14,11 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-algorithms-relate
-    :
-    [ run relate_const_custom.cpp       : : : : algorithms_relate_const_custom ]
-    [ run relate_areal_areal.cpp        : : : : algorithms_relate_areal_areal ]
-    [ run relate_areal_areal_sph.cpp    : : : : algorithms_relate_areal_areal_sph ]
-    [ run relate_linear_areal.cpp       : : : : algorithms_relate_linear_areal ]
-    [ run relate_linear_areal_sph.cpp   : : : : algorithms_relate_linear_areal_sph ]
-    [ run relate_linear_linear.cpp      : : : : algorithms_relate_linear_linear ]
-    [ run relate_linear_linear_sph.cpp  : : : : algorithms_relate_linear_linear_sph ]
-    [ run relate_pointlike_geometry.cpp : : : : algorithms_relate_pointlike_geometry ]
-    ;
+run relate_const_custom.cpp       : : : : algorithms_relate_const_custom ;
+run relate_areal_areal.cpp        : : : : algorithms_relate_areal_areal ;
+run relate_areal_areal_sph.cpp    : : : : algorithms_relate_areal_areal_sph ;
+run relate_linear_areal.cpp       : : : : algorithms_relate_linear_areal ;
+run relate_linear_areal_sph.cpp   : : : : algorithms_relate_linear_areal_sph ;
+run relate_linear_linear.cpp      : : : : algorithms_relate_linear_linear ;
+run relate_linear_linear_sph.cpp  : : : : algorithms_relate_linear_linear_sph ;
+run relate_pointlike_geometry.cpp : : : : algorithms_relate_pointlike_geometry ;

--- a/test/algorithms/set_operations/difference/Jamfile
+++ b/test/algorithms/set_operations/difference/Jamfile
@@ -14,20 +14,17 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-algorithms-difference
-    :
-    [ run difference.cpp                    : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_difference ]
-    [ run difference_multi.cpp              : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_difference_multi ]
-    [ run difference.cpp                    : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_difference_alternative ]
-    [ run difference_multi.cpp              : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_difference_multi_alternative ]
-    [ run difference_multi_spike.cpp        : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_difference_multi_spike ]
-    [ run difference_areal_linear.cpp       : : : : algorithms_difference_areal_linear ]
-    [ run difference_gc.cpp                 : : : : algorithms_difference_gc ]
-    [ run difference_l_a_sph.cpp            : : : : algorithms_difference_l_a_sph ]
-    [ run difference_linear_linear.cpp      : : : : algorithms_difference_linear_linear ]
-    [ run difference_multi_areal_linear.cpp : : : : algorithms_difference_multi_areal_linear ]
-    [ run difference_pl_a.cpp               : : : : algorithms_difference_pl_a ]
-    [ run difference_pl_l.cpp               : : : : algorithms_difference_pl_l ]
-    [ run difference_pl_pl.cpp              : : : : algorithms_difference_pl_pl ]
-    [ run difference_tupled.cpp             : : : : algorithms_difference_tupled ]
-    ;
+run difference.cpp                    : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_difference ;
+run difference_multi.cpp              : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_difference_multi ;
+run difference.cpp                    : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_difference_alternative ;
+run difference_multi.cpp              : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_difference_multi_alternative ;
+run difference_multi_spike.cpp        : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_difference_multi_spike ;
+run difference_areal_linear.cpp       : : : : algorithms_difference_areal_linear ;
+run difference_gc.cpp                 : : : : algorithms_difference_gc ;
+run difference_l_a_sph.cpp            : : : : algorithms_difference_l_a_sph ;
+run difference_linear_linear.cpp      : : : : algorithms_difference_linear_linear ;
+run difference_multi_areal_linear.cpp : : : : algorithms_difference_multi_areal_linear ;
+run difference_pl_a.cpp               : : : : algorithms_difference_pl_a ;
+run difference_pl_l.cpp               : : : : algorithms_difference_pl_l ;
+run difference_pl_pl.cpp              : : : : algorithms_difference_pl_pl ;
+run difference_tupled.cpp             : : : : algorithms_difference_tupled ;

--- a/test/algorithms/set_operations/intersection/Jamfile
+++ b/test/algorithms/set_operations/intersection/Jamfile
@@ -14,20 +14,17 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-algorithms-intersection
-    :
-    [ run intersection.cpp                    : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_intersection ]
-    [ run intersection_multi.cpp              : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_intersection_multi ]
-    [ run intersection.cpp                    : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_intersection_alternative ]
-    [ run intersection_multi.cpp              : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_intersection_multi_alternative ]
-    [ run intersection_linear_linear.cpp      : : : : algorithms_intersection_linear_linear ]
-    [ run intersection_linear_linear.cpp      : : : <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_intersection_linear_linear_alternative ]
-    [ run intersection_areal_areal_linear.cpp : : : : algorithms_intersection_areal_areal_linear ]
-    [ run intersection_box.cpp                : : : : algorithms_intersection_box ]
-    [ run intersection_gc.cpp                 : : : : algorithms_intersection_gc ]
-    [ run intersection_pl_a.cpp               : : : : algorithms_intersection_pl_a ]
-    [ run intersection_pl_l.cpp               : : : : algorithms_intersection_pl_l ]
-    [ run intersection_pl_pl.cpp              : : : : algorithms_intersection_pl_pl ]
-    [ run intersection_tupled.cpp             : : : : algorithms_intersection_tupled ]
-    [ run intersection_integer.cpp            : : : : algorithms_intersection_integer ]
-    ;
+run intersection.cpp                    : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_intersection ;
+run intersection_multi.cpp              : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_intersection_multi ;
+run intersection.cpp                    : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_intersection_alternative ;
+run intersection_multi.cpp              : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_intersection_multi_alternative ;
+run intersection_linear_linear.cpp      : : : : algorithms_intersection_linear_linear ;
+run intersection_linear_linear.cpp      : : : <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_intersection_linear_linear_alternative ;
+run intersection_areal_areal_linear.cpp : : : : algorithms_intersection_areal_areal_linear ;
+run intersection_box.cpp                : : : : algorithms_intersection_box ;
+run intersection_gc.cpp                 : : : : algorithms_intersection_gc ;
+run intersection_pl_a.cpp               : : : : algorithms_intersection_pl_a ;
+run intersection_pl_l.cpp               : : : : algorithms_intersection_pl_l ;
+run intersection_pl_pl.cpp              : : : : algorithms_intersection_pl_pl ;
+run intersection_tupled.cpp             : : : : algorithms_intersection_tupled ;
+run intersection_integer.cpp            : : : : algorithms_intersection_integer ;

--- a/test/algorithms/set_operations/sym_difference/Jamfile
+++ b/test/algorithms/set_operations/sym_difference/Jamfile
@@ -14,10 +14,7 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-algorithms-sym_difference
-    :
-    [ run sym_difference_areal_areal.cpp   : : : : algorithms_sym_difference_areal_areal ]
-    [ run sym_difference_linear_linear.cpp : : : : algorithms_sym_difference_linear_linear ]
-    [ run sym_difference_gc.cpp            : : : : algorithms_sym_difference_gc ]
-	[ run sym_difference_tupled.cpp        : : : : algorithms_sym_difference_tupled ]
-    ;
+run sym_difference_areal_areal.cpp   : : : : algorithms_sym_difference_areal_areal ;
+run sym_difference_linear_linear.cpp : : : : algorithms_sym_difference_linear_linear ;
+run sym_difference_gc.cpp            : : : : algorithms_sym_difference_gc ;
+run sym_difference_tupled.cpp        : : : : algorithms_sym_difference_tupled ;

--- a/test/algorithms/set_operations/union/Jamfile
+++ b/test/algorithms/set_operations/union/Jamfile
@@ -14,18 +14,15 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-algorithms-union
-    :
-    [ run union.cpp               : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_union ]
-    [ run union_multi.cpp         : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_union_multi ]
-    [ run union.cpp               : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_union_alternative ]
-    [ run union_multi.cpp         : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_union_multi_alternative ]
-    [ run union_aa_geo.cpp        : : : : algorithms_union_aa_geo ]
-    [ run union_aa_sph.cpp        : : : : algorithms_union_aa_sph ]
-    [ run union_gc.cpp            : : : : algorithms_union_gc ]
-    [ run union_linear_linear.cpp : : : : algorithms_union_linear_linear ]
-    [ run union_pl_pl.cpp         : : : : algorithms_union_pl_pl ]
-    [ run union_issues.cpp        : : : : algorithms_union_issues ]
-    [ run union_tupled.cpp        : : : : algorithms_union_tupled ]
-    [ run union_other_types.cpp   : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_union_other_types ]
-    ;
+run union.cpp               : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_union ;
+run union_multi.cpp         : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_union_multi ;
+run union.cpp               : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_union_alternative ;
+run union_multi.cpp         : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE <define>BOOST_GEOMETRY_ROBUSTNESS_ALTERNATIVE : algorithms_union_multi_alternative ;
+run union_aa_geo.cpp        : : : : algorithms_union_aa_geo ;
+run union_aa_sph.cpp        : : : : algorithms_union_aa_sph ;
+run union_gc.cpp            : : : : algorithms_union_gc ;
+run union_linear_linear.cpp : : : : algorithms_union_linear_linear ;
+run union_pl_pl.cpp         : : : : algorithms_union_pl_pl ;
+run union_issues.cpp        : : : : algorithms_union_issues ;
+run union_tupled.cpp        : : : : algorithms_union_tupled ;
+run union_other_types.cpp   : : : <define>BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE : algorithms_union_other_types ;

--- a/test/algorithms/similarity/Jamfile
+++ b/test/algorithms/similarity/Jamfile
@@ -8,8 +8,5 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-algorithms-similarity
-    :
-    [ run discrete_frechet_distance.cpp                       : : : : algorithms_discrete_frechet_distance ]
-    [ run discrete_hausdorff_distance.cpp                     : : : : algorithms_discrete_hausdorff_distance ]
-    ;
+run discrete_frechet_distance.cpp                       : : : : algorithms_discrete_frechet_distance ;
+run discrete_hausdorff_distance.cpp                     : : : : algorithms_discrete_hausdorff_distance ;

--- a/test/algorithms/touches/Jamfile
+++ b/test/algorithms/touches/Jamfile
@@ -14,12 +14,9 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-algorithms-touches
-    :
-    [ run touches.cpp       : : : : algorithms_touches ]
-    [ run touches_box.cpp   : : : : algorithms_touches_box ]
-    [ run touches_gc.cpp    : : : : algorithms_touches_gc ]
-    [ run touches_multi.cpp : : : : algorithms_touches_multi ]
-    [ run touches_self.cpp  : : : : algorithms_touches_self ]
-    [ run touches_sph.cpp   : : : : algorithms_touches_sph ]
-    ;
+run touches.cpp       : : : : algorithms_touches ;
+run touches_box.cpp   : : : : algorithms_touches_box ;
+run touches_gc.cpp    : : : : algorithms_touches_gc ;
+run touches_multi.cpp : : : : algorithms_touches_multi ;
+run touches_self.cpp  : : : : algorithms_touches_self ;
+run touches_sph.cpp   : : : : algorithms_touches_sph ;

--- a/test/algorithms/within/Jamfile
+++ b/test/algorithms/within/Jamfile
@@ -14,15 +14,12 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-algorithms-within
-    :
-    [ run within.cpp                    : : : : algorithms_within ]
-    [ run within_areal_areal.cpp        : : : : algorithms_within_areal_areal ]
-    [ run within_gc.cpp                 : : : : algorithms_within_gc ]
-    [ run within_linear_areal.cpp       : : : : algorithms_within_linear_areal ]
-    [ run within_linear_linear.cpp      : : : : algorithms_within_linear_linear ]
-    [ run within_multi.cpp              : : : : algorithms_within_multi ]
-    [ run within_pointlike_geometry.cpp : : : : algorithms_within_pointlike_geometry ]
-    [ run within_sph.cpp                : : : : algorithms_within_sph ]
-    [ run within_sph_geo.cpp            : : : : algorithms_within_sph_geo ]
-    ;
+run within.cpp                    : : : : algorithms_within ;
+run within_areal_areal.cpp        : : : : algorithms_within_areal_areal ;
+run within_gc.cpp                 : : : : algorithms_within_gc ;
+run within_linear_areal.cpp       : : : : algorithms_within_linear_areal ;
+run within_linear_linear.cpp      : : : : algorithms_within_linear_linear ;
+run within_multi.cpp              : : : : algorithms_within_multi ;
+run within_pointlike_geometry.cpp : : : : algorithms_within_pointlike_geometry ;
+run within_sph.cpp                : : : : algorithms_within_sph ;
+run within_sph_geo.cpp            : : : : algorithms_within_sph_geo ;

--- a/test/arithmetic/Jamfile
+++ b/test/arithmetic/Jamfile
@@ -9,11 +9,8 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-arithmetic
-    :
-    [ run general.cpp                 : : : : arithmetic_general ]
-    [ run dot_product.cpp             : : : : arithmetic_dot_product ]
-    [ run cross_product.cpp           : : : : arithmetic_cross_product ]
-    [ run infinite_line_functions.cpp : : : : arithmetic_infinite_line_functions ]
-    [ compile-fail cross_product.cpp  : <define>TEST_FAIL_CROSS_PRODUCT : arithmetic_cross_product_cf ]
-    ;
+run general.cpp                 : : : : arithmetic_general ;
+run dot_product.cpp             : : : : arithmetic_dot_product ;
+run cross_product.cpp           : : : : arithmetic_cross_product ;
+run infinite_line_functions.cpp : : : : arithmetic_infinite_line_functions ;
+compile-fail cross_product.cpp  : <define>TEST_FAIL_CROSS_PRODUCT : arithmetic_cross_product_cf ;

--- a/test/concepts/Jamfile
+++ b/test/concepts/Jamfile
@@ -9,22 +9,19 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-concepts
-    :
-    [ run linestring_concept.cpp                                : : : : concepts_linestring_concept ]
-    [ compile point_array.cpp                                   : :     concepts_point_array ]
-    [ compile point_concept_checker.cpp                         : :     concepts_point_concept_checker ]
-    [ compile point_well_formed.cpp                             : :     concepts_point_well_formed ]
-    [ compile point_well_formed_non_cartesian.cpp               : :     concepts_point_well_formed_non_cartesian ]
-    [ compile point_well_formed_traits.cpp                      : :     concepts_point_well_formed_traits ]
-    [ compile-fail point_geographic_custom_with_wrong_units.cpp : :     concepts_point_geographic_custom_with_wrong_units ]
-    [ compile-fail point_geographic_with_wrong_units.cpp        : :     concepts_point_geographic_with_wrong_units ]
-    [ compile-fail point_spherical_custom_with_wrong_units.cpp  : :     concepts_point_spherical_custom_with_wrong_units ]
-    [ compile-fail point_spherical_with_wrong_units.cpp         : :     concepts_point_spherical_with_wrong_units ]
-    [ compile-fail point_with_incorrect_dimension.cpp           : :     concepts_point_with_incorrect_dimension ]
-    [ compile-fail point_without_coordinate_type.cpp            : :     concepts_point_without_coordinate_type ]
-    [ compile-fail point_without_dimension.cpp                  : :     concepts_point_without_dimension ]
-    [ compile-fail point_without_getter.cpp                     : :     concepts_point_without_getter ]
-    [ compile-fail point_without_setter.cpp                     : :     concepts_point_without_setter ]
-#    [ run polygon_concept.cpp                                   : : : : concepts_polygon_concept ]
-    ;
+run linestring_concept.cpp                                : : : : concepts_linestring_concept ;
+compile point_array.cpp                                   : :     concepts_point_array ;
+compile point_concept_checker.cpp                         : :     concepts_point_concept_checker ;
+compile point_well_formed.cpp                             : :     concepts_point_well_formed ;
+compile point_well_formed_non_cartesian.cpp               : :     concepts_point_well_formed_non_cartesian ;
+compile point_well_formed_traits.cpp                      : :     concepts_point_well_formed_traits ;
+compile-fail point_geographic_custom_with_wrong_units.cpp : :     concepts_point_geographic_custom_with_wrong_units ;
+compile-fail point_geographic_with_wrong_units.cpp        : :     concepts_point_geographic_with_wrong_units ;
+compile-fail point_spherical_custom_with_wrong_units.cpp  : :     concepts_point_spherical_custom_with_wrong_units ;
+compile-fail point_spherical_with_wrong_units.cpp         : :     concepts_point_spherical_with_wrong_units ;
+compile-fail point_with_incorrect_dimension.cpp           : :     concepts_point_with_incorrect_dimension ;
+compile-fail point_without_coordinate_type.cpp            : :     concepts_point_without_coordinate_type ;
+compile-fail point_without_dimension.cpp                  : :     concepts_point_without_dimension ;
+compile-fail point_without_getter.cpp                     : :     concepts_point_without_getter ;
+compile-fail point_without_setter.cpp                     : :     concepts_point_without_setter ;
+#run polygon_concept.cpp                                 : : : : concepts_polygon_concept ;

--- a/test/core/Jamfile
+++ b/test/core/Jamfile
@@ -12,22 +12,19 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-core
-    :
-    [ run access.cpp                : : : : core_access ]
-    [ run assert.cpp                : : : : core_assert ]
-    [ run coordinate_dimension.cpp  : : : : core_coordinate_dimension ]
-    [ run coordinate_system.cpp     : : : : core_coordinate_system ]
-    [ run coordinate_type.cpp       : : : : core_coordinate_type ]
-    [ run geometry_id.cpp           : : : : core_geometry_id ]
-    [ run point_type.cpp            : : : : core_point_type ]
-    [ run radian_access.cpp         : : : : core_radian_access ]
-    [ run radius.cpp                : : : : core_radius ]
-#    [ run reverse_dispatch.cpp      : : : : core_reverse_dispatch ]
-    [ run ring.cpp                  : : : : core_ring ]
-    [ run tag.cpp                   : : : : core_tag ]
-    [ run topological_dimension.cpp : : : : core_topological_dimension ]
-    [ run visit.cpp                 : : : : core_visit ]
-    ;
+run access.cpp                : : : : core_access ;
+run assert.cpp                : : : : core_assert ;
+run coordinate_dimension.cpp  : : : : core_coordinate_dimension ;
+run coordinate_system.cpp     : : : : core_coordinate_system ;
+run coordinate_type.cpp       : : : : core_coordinate_type ;
+run geometry_id.cpp           : : : : core_geometry_id ;
+run point_type.cpp            : : : : core_point_type ;
+run radian_access.cpp         : : : : core_radian_access ;
+run radius.cpp                : : : : core_radius ;
+#run reverse_dispatch.cpp    : : : : core_reverse_dispatch ;
+run ring.cpp                  : : : : core_ring ;
+run tag.cpp                   : : : : core_tag ;
+run topological_dimension.cpp : : : : core_topological_dimension ;
+run visit.cpp                 : : : : core_visit ;
 
 # The reverse_dispatch somehow asks for UAC-control on MinGW...

--- a/test/cs_undefined/Jamfile
+++ b/test/cs_undefined/Jamfile
@@ -7,16 +7,13 @@
 # Licensed under the Boost Software License version 1.0.
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-cs_undefined
-    :
-    [ compile distance.cpp        : : csundef_distance ]
-	[ compile envelope_expand.cpp : : csundef_envelope_expand ]
-	[ compile index.cpp           : : csundef_index ]
-	[ compile is.cpp              : : csundef_is ]
-	[ compile measure.cpp         : : csundef_measure ]
-	[ compile other.cpp           : : csundef_other ]
-	[ compile relops1.cpp         : : csundef_relops1 ]
-	[ compile relops2.cpp         : : csundef_relops2 ]
-	[ compile setops1.cpp         : : csundef_setops1 ]
-    [ compile setops2.cpp         : : csundef_setops2 ]
-    ;
+compile distance.cpp        : : csundef_distance ;
+compile envelope_expand.cpp : : csundef_envelope_expand ;
+compile index.cpp           : : csundef_index ;
+compile is.cpp              : : csundef_is ;
+compile measure.cpp         : : csundef_measure ;
+compile other.cpp           : : csundef_other ;
+compile relops1.cpp         : : csundef_relops1 ;
+compile relops2.cpp         : : csundef_relops2 ;
+compile setops1.cpp         : : csundef_setops1 ;
+compile setops2.cpp         : : csundef_setops2 ;

--- a/test/formulas/Jamfile
+++ b/test/formulas/Jamfile
@@ -9,13 +9,10 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-formulas
-    :
-    [ run inverse.cpp                        : : : : formulas_inverse ]
-    [ run inverse_karney.cpp                 : : : : formulas_inverse_karney ]
-    [ run direct.cpp                         : : : : formulas_direct ]
-    [ run direct_accuracy.cpp                : : : : formulas_direct_accuracy ]
-    [ run direct_meridian.cpp                : : : : formulas_direct_meridian ]
-    [ run intersection.cpp                   : : : : formulas_intersection ]
-    [ run vertex_longitude.cpp               : : : : formulas_vertex_longitude ]
-    ;
+run inverse.cpp                        : : : : formulas_inverse ;
+run inverse_karney.cpp                 : : : : formulas_inverse_karney ;
+run direct.cpp                         : : : : formulas_direct ;
+run direct_accuracy.cpp                : : : : formulas_direct_accuracy ;
+run direct_meridian.cpp                : : : : formulas_direct_meridian ;
+run intersection.cpp                   : : : : formulas_intersection ;
+run vertex_longitude.cpp               : : : : formulas_vertex_longitude ;

--- a/test/geometries/Jamfile
+++ b/test/geometries/Jamfile
@@ -9,34 +9,31 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-geometries
-    :
-    [ run adapted.cpp              : : : : geometries_adapted ]
-    [ run boost_array_as_point.cpp : : : : geometries_boost_array_as_point ]
-    [ run boost_fusion.cpp         : : : : geometries_boost_fusion ]
-    [ run boost_polygon.cpp        : : : : geometries_boost_polygon ] 
-    [ run boost_range.cpp          : : : : geometries_boost_range ]
-    [ run boost_tuple.cpp          : : : : geometries_boost_tuple ]
-    [ run box.cpp                  : : : : geometries_box ]
-    #[ compile-fail custom_linestring.cpp
-    #    : # requirements
-    #    <define>TEST_FAIL_CLEAR
-    #    : # target name
-    #    geometries_custom_linestring_test_fail_clear
-    #]
-    [ run custom_linestring.cpp    : : : : geometries_custom_linestring ]
-    [ run initialization.cpp       : : : : geometries_initialization ]
-    [ run linestring.cpp           : : : : geometries_linestring ]
-    [ run multi_linestring.cpp     : : : : geometries_multi_linestring ]
-    [ run multi_point.cpp          : : : : geometries_multi_point ]
-    [ run multi_polygon.cpp        : : : : geometries_multi_polygon ]
-    [ run point.cpp                : : : : geometries_point ]
-    [ run point_xy.cpp             : : : : geometries_point_xy ]
-    [ run point_xyz.cpp            : : : : geometries_point_xyz ]
-    [ run polygon.cpp              : : : : geometries_polygon ]
-    [ run ring.cpp                 : : : : geometries_ring ]
-    [ run segment.cpp              : : : : geometries_segment ]
-    [ run infinite_line.cpp        : : : : geometries_infinite_line ]
-    ;
+run adapted.cpp              : : : : geometries_adapted ;
+run boost_array_as_point.cpp : : : : geometries_boost_array_as_point ;
+run boost_fusion.cpp         : : : : geometries_boost_fusion ;
+run boost_polygon.cpp        : : : : geometries_boost_polygon ; 
+run boost_range.cpp          : : : : geometries_boost_range ;
+run boost_tuple.cpp          : : : : geometries_boost_tuple ;
+run box.cpp                  : : : : geometries_box ;
+#[ compile-fail custom_linestring.cpp
+#    : # requirements
+#    <define>TEST_FAIL_CLEAR
+#    : # target name
+#    geometries_custom_linestring_test_fail_clear
+#]
+run custom_linestring.cpp    : : : : geometries_custom_linestring ;
+run initialization.cpp       : : : : geometries_initialization ;
+run linestring.cpp           : : : : geometries_linestring ;
+run multi_linestring.cpp     : : : : geometries_multi_linestring ;
+run multi_point.cpp          : : : : geometries_multi_point ;
+run multi_polygon.cpp        : : : : geometries_multi_polygon ;
+run point.cpp                : : : : geometries_point ;
+run point_xy.cpp             : : : : geometries_point_xy ;
+run point_xyz.cpp            : : : : geometries_point_xyz ;
+run polygon.cpp              : : : : geometries_polygon ;
+run ring.cpp                 : : : : geometries_ring ;
+run segment.cpp              : : : : geometries_segment ;
+run infinite_line.cpp        : : : : geometries_infinite_line ;
 
 build-project custom_non_copiable ;

--- a/test/geometries/custom_non_copiable/Jamfile
+++ b/test/geometries/custom_non_copiable/Jamfile
@@ -6,12 +6,9 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-geometries-custom-non-copiable
-    :
-    [ run custom_ring.cpp                 : : : : cnc_ring ]
-    [ run custom_polygon.cpp              : : : : cnc_polygon ]
-    [ run custom_multi_polygon.cpp        : : : : cnc_multi_polygon ]
-    [ run custom_linestring.cpp           : : : : cnc_linestring ]
-    [ run custom_multi_linestring.cpp     : : : : cnc_multi_linestring ]
-    [ run custom_different_geometries.cpp : : : : cnc_different_geometries ]
-    ;
+run custom_ring.cpp                 : : : : cnc_ring ;
+run custom_polygon.cpp              : : : : cnc_polygon ;
+run custom_multi_polygon.cpp        : : : : cnc_multi_polygon ;
+run custom_linestring.cpp           : : : : cnc_linestring ;
+run custom_multi_linestring.cpp     : : : : cnc_multi_linestring ;
+run custom_different_geometries.cpp : : : : cnc_different_geometries ;

--- a/test/io/dsv/Jamfile
+++ b/test/io/dsv/Jamfile
@@ -9,8 +9,4 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-io-dsv
-    :
-    [ run dsv_multi.cpp : : : : dsv_multi ]
-    ;
-
+run dsv_multi.cpp : : : : dsv_multi ;

--- a/test/io/svg/Jamfile
+++ b/test/io/svg/Jamfile
@@ -8,8 +8,4 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-io-svg
-    :
-    [ run svg.cpp       : : : : io_svg ]
-    ;
-
+run svg.cpp       : : : : io_svg ;

--- a/test/io/wkt/Jamfile
+++ b/test/io/wkt/Jamfile
@@ -9,9 +9,5 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-io-wkt
-    :
-    [ run wkt.cpp       : : : : io_wkt ]
-    [ run wkt_multi.cpp : : : : io_wkt_multi ]
-    ;
-
+run wkt.cpp       : : : : io_wkt ;
+run wkt_multi.cpp : : : : io_wkt_multi ;

--- a/test/iterators/Jamfile
+++ b/test/iterators/Jamfile
@@ -14,12 +14,9 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-iterators
-    :
-    [ run closing_iterator.cpp       : : : : iterators_closing_iterator ]
-    [ run concatenate_iterator.cpp   : : : : iterators_concatenate_iterator ]
-    [ run ever_circling_iterator.cpp : : : : iterators_ever_circling_iterator ]
-    [ run flatten_iterator.cpp       : : : : iterators_flatten_iterator ]
-    [ run point_iterator.cpp         : : : : iterators_point_iterator ]
-    [ run segment_iterator.cpp       : : : : iterators_segment_iterator ]
-    ;
+run closing_iterator.cpp       : : : : iterators_closing_iterator ;
+run concatenate_iterator.cpp   : : : : iterators_concatenate_iterator ;
+run ever_circling_iterator.cpp : : : : iterators_ever_circling_iterator ;
+run flatten_iterator.cpp       : : : : iterators_flatten_iterator ;
+run point_iterator.cpp         : : : : iterators_point_iterator ;
+run segment_iterator.cpp       : : : : iterators_segment_iterator ;

--- a/test/policies/Jamfile
+++ b/test/policies/Jamfile
@@ -9,8 +9,5 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-policies
-    :
-    [ run compare.cpp        : : : : policies_compare ]
-    [ run rescale_policy.cpp : : : : policies_rescale_policy ]
-    ;
+run compare.cpp        : : : : policies_compare ;
+run rescale_policy.cpp : : : : policies_rescale_policy ;

--- a/test/srs/Jamfile
+++ b/test/srs/Jamfile
@@ -13,19 +13,16 @@
 # http://www.boost.org/LICENSE_1_0.txt)
 
 # TODO: move project transformer test to strategies
-test-suite boost-geometry-srs
-    :
-    [ run projection.cpp                  : : : : srs_projection ]
-    [ run projection_epsg.cpp             : : : : srs_projection_epsg ]
-    [ run projection_interface_d.cpp      : : : : srs_projection_interface_d ]
-	[ run projection_interface_p4.cpp     : : : : srs_projection_interface_p4 ]
-	[ run projection_interface_s.cpp      : : : : srs_projection_interface_s ]
-    [ run projection_selftest.cpp         : : : : srs_projection_selftest ]
-    [ run projections.cpp                 : : : : srs_projections ]
-    [ run projections_combined.cpp        : : : : srs_projections_combined ]
-    [ run projections_static.cpp          : : : : srs_projections_static ]
-    [ compile spar.cpp                    : :     srs_spar ]
-    [ run srs_transformer.cpp             : : : : srs_srs_transformer ]
-	[ run transformation_epsg.cpp         : : : : srs_transformation_epsg ]
-    [ run transformation_interface.cpp    : : : : srs_transformation_interface ]
-    ;
+run projection.cpp                  : : : : srs_projection ;
+run projection_epsg.cpp             : : : : srs_projection_epsg ;
+run projection_interface_d.cpp      : : : : srs_projection_interface_d ;
+run projection_interface_p4.cpp     : : : : srs_projection_interface_p4 ;
+run projection_interface_s.cpp      : : : : srs_projection_interface_s ;
+run projection_selftest.cpp         : : : : srs_projection_selftest ;
+run projections.cpp                 : : : : srs_projections ;
+run projections_combined.cpp        : : : : srs_projections_combined ;
+run projections_static.cpp          : : : : srs_projections_static ;
+compile spar.cpp                    : :     srs_spar ;
+run srs_transformer.cpp             : : : : srs_srs_transformer ;
+run transformation_epsg.cpp         : : : : srs_transformation_epsg ;
+run transformation_interface.cpp    : : : : srs_transformation_interface ;

--- a/test/strategies/Jamfile
+++ b/test/strategies/Jamfile
@@ -15,35 +15,32 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-strategies
-    :
-    [ run andoyer.cpp                        : : : : strategies_andoyer ]
-    [ run buffer_join.cpp                    : : : : strategies_buffer_join ]
-    [ run buffer_join_geo.cpp                : : : : strategies_buffer_join_geo ]
-    [ run buffer_side_straight.cpp           : : : : strategies_buffer_side_straight ]
-    [ run cross_track.cpp                    : : : : strategies_cross_track ]
-    [ run crossings_multiply.cpp             : : : : strategies_crossings_multiply ]
-    [ run distance_default_result.cpp        : : : : strategies_distance_default_result ]
-    [ run distance_cross_track.cpp           : : : : strategies_distance_cross_track ]
-    [ run douglas_peucker.cpp                : : : : strategies_douglas_peucker ]
-    [ run envelope_segment.cpp               : : : : strategies_envelope_segment ]
-    [ run franklin.cpp                       : : : : strategies_franklin ]
-    [ run haversine.cpp                      : : : : strategies_haversine ]
-    [ run point_in_box.cpp                   : : : : strategies_point_in_box ]
-    [ run projected_point.cpp                : : : : strategies_projected_point ]
-    [ run projected_point_ax.cpp             : : : : strategies_projected_point_ax ]
-    [ run pythagoras.cpp                     : : : : strategies_pythagoras ]
-    [ run pythagoras_point_box.cpp           : : : : strategies_pythagoras_point_box ]
-    [ run segment_intersection.cpp           : : : : strategies_segment_intersection           ]
-    [ run segment_intersection_collinear.cpp : : : : strategies_segment_intersection_collinear ]
-    [ run segment_intersection_geo.cpp       : : : : strategies_segment_intersection_geo ]
-    [ run segment_intersection_sph.cpp       : : : : strategies_segment_intersection_sph ]
-    [ run spherical_side.cpp                 : : : : strategies_spherical_side ]
-    [ run side_rounded_input.cpp             : : : : strategies_side_rounded_input ]
-    [ run thomas.cpp                         : : : : strategies_thomas ]
-    [ run transform_cs.cpp                   : : : : strategies_transform_cs ]
-    [ run transformer.cpp                    : : : : strategies_transformer ]
-    [ run matrix_transformer.cpp             : : : : strategies_matrix_transformer ]
-    [ run vincenty.cpp                       : : : : strategies_vincenty ]
-    [ run winding.cpp                        : : : : strategies_winding ]
-    ;
+run andoyer.cpp                        : : : : strategies_andoyer ;
+run buffer_join.cpp                    : : : : strategies_buffer_join ;
+run buffer_join_geo.cpp                : : : : strategies_buffer_join_geo ;
+run buffer_side_straight.cpp           : : : : strategies_buffer_side_straight ;
+run cross_track.cpp                    : : : : strategies_cross_track ;
+run crossings_multiply.cpp             : : : : strategies_crossings_multiply ;
+run distance_default_result.cpp        : : : : strategies_distance_default_result ;
+run distance_cross_track.cpp           : : : : strategies_distance_cross_track ;
+run douglas_peucker.cpp                : : : : strategies_douglas_peucker ;
+run envelope_segment.cpp               : : : : strategies_envelope_segment ;
+run franklin.cpp                       : : : : strategies_franklin ;
+run haversine.cpp                      : : : : strategies_haversine ;
+run point_in_box.cpp                   : : : : strategies_point_in_box ;
+run projected_point.cpp                : : : : strategies_projected_point ;
+run projected_point_ax.cpp             : : : : strategies_projected_point_ax ;
+run pythagoras.cpp                     : : : : strategies_pythagoras ;
+run pythagoras_point_box.cpp           : : : : strategies_pythagoras_point_box ;
+run segment_intersection.cpp           : : : : strategies_segment_intersection           ;
+run segment_intersection_collinear.cpp : : : : strategies_segment_intersection_collinear ;
+run segment_intersection_geo.cpp       : : : : strategies_segment_intersection_geo ;
+run segment_intersection_sph.cpp       : : : : strategies_segment_intersection_sph ;
+run spherical_side.cpp                 : : : : strategies_spherical_side ;
+run side_rounded_input.cpp             : : : : strategies_side_rounded_input ;
+run thomas.cpp                         : : : : strategies_thomas ;
+run transform_cs.cpp                   : : : : strategies_transform_cs ;
+run transformer.cpp                    : : : : strategies_transformer ;
+run matrix_transformer.cpp             : : : : strategies_matrix_transformer ;
+run vincenty.cpp                       : : : : strategies_vincenty ;
+run winding.cpp                        : : : : strategies_winding ;

--- a/test/util/Jamfile
+++ b/test/util/Jamfile
@@ -14,20 +14,17 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-util
-    :
-    [ run algorithm.cpp                 : : : : util_algorithm ]
-    [ run calculation_type.cpp          : : : : util_calculation_type ]
-    [ run for_each_coordinate.cpp       : : : : util_for_each_coordinate ]
-    [ run math_abs.cpp                  : : : : util_math_abs ]
-    [ run math_divide.cpp               : : : : util_math_divide ]
-    [ run math_equals.cpp               : : : : util_math_equals ]
-    [ run math_sqrt.cpp                 : : : : util_math_sqrt ]
-    [ run math_normalize_spheroidal.cpp : : : : util_math_normalize_spheroidal ]
-    [ run promote_integral.cpp          : : : : util_promote_integral ]
-    [ run range.cpp                     : : : : util_range ]
-    [ run rational.cpp                  : : : : util_rational ]
-    [ run select_most_precise.cpp       : : : : util_select_most_precise ]
-    [ run tuples.cpp                    : : : : util_tuples ]
-    [ run write_dsv.cpp                 : : : : util_write_dsv ]
-    ;
+run algorithm.cpp                 : : : : util_algorithm ;
+run calculation_type.cpp          : : : : util_calculation_type ;
+run for_each_coordinate.cpp       : : : : util_for_each_coordinate ;
+run math_abs.cpp                  : : : : util_math_abs ;
+run math_divide.cpp               : : : : util_math_divide ;
+run math_equals.cpp               : : : : util_math_equals ;
+run math_sqrt.cpp                 : : : : util_math_sqrt ;
+run math_normalize_spheroidal.cpp : : : : util_math_normalize_spheroidal ;
+run promote_integral.cpp          : : : : util_promote_integral ;
+run range.cpp                     : : : : util_range ;
+run rational.cpp                  : : : : util_rational ;
+run select_most_precise.cpp       : : : : util_select_most_precise ;
+run tuples.cpp                    : : : : util_tuples ;
+run write_dsv.cpp                 : : : : util_write_dsv ;

--- a/test/views/Jamfile
+++ b/test/views/Jamfile
@@ -13,12 +13,9 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-test-suite boost-geometry-views
-    :
-    [ run box_view.cpp             : : : : views_box_view ]
-    [ run closeable_view.cpp       : : : : views_closeable_view ]
-    [ run random_access_view.cpp   : : : : views_random_access_view ]
-    [ run reversible_closeable.cpp : : : : views_reversible_closeable ]
-    [ run reversible_view.cpp      : : : : views_reversible_view ]    
-    [ run segment_view.cpp         : : : : views_segment_view ]
-    ;
+run box_view.cpp             : : : : views_box_view ;
+run closeable_view.cpp       : : : : views_closeable_view ;
+run random_access_view.cpp   : : : : views_random_access_view ;
+run reversible_closeable.cpp : : : : views_reversible_closeable ;
+run reversible_view.cpp      : : : : views_reversible_view ;    
+run segment_view.cpp         : : : : views_segment_view ;


### PR DESCRIPTION
According to
https://github.com/bfgroup/b2/commit/597350653ada0f192dbe4b6d6ee509429f1cda45, b2 deprecated test-suite rule in 2007.