### PR TITLE
Fix get_distance_measure test failure using MSVC

### DIFF
--- a/test/algorithms/overlay/get_distance_measure.cpp
+++ b/test/algorithms/overlay/get_distance_measure.cpp
@@ -76,8 +76,8 @@ void test_get_distance_measure()
     do_test<Point>("simplex_left", {1.0, 0.0}, {1.0, 1.0}, {0.9, 0.5}, 1);
     do_test<Point>("simplex_right", {1.0, 0.0}, {1.0, 1.0}, {1.1, 0.5}, -1);
 
-    bool const is_float = std::is_same<coor_t, float>::value;
-    bool const is_double = std::is_same<coor_t, double>::value;
+    bool const is_float = std::is_floating_point<coor_t>::value && sizeof(coor_t) == 4;
+    bool const is_double = std::is_floating_point<coor_t>::value && sizeof(coor_t) == 8;
 
     // The issue 1183 where get_distance_measure failed for these coordinates.
     std::string const case_id = "issue_1183_";


### PR DESCRIPTION
Log is listed as follows.
```
Running 1 test case...
test/algorithms/overlay/get_distance_measure.cpp(60): error: in "test_main_caller( argc_ argv )": Case: issue_1183_3 ctype: e tr_side: -1 dm_side: 1
test/algorithms/overlay/get_distance_measure.cpp(60): error: in "test_main_caller( argc_ argv )": Case: issue_1183_4 ctype: e tr_side: -1 dm_side: 1
test/algorithms/overlay/get_distance_measure.cpp(60): error: in "test_main_caller( argc_ argv )": Case: issue_1183_5 ctype: e tr_side: -1 dm_side: 0
test/algorithms/overlay/get_distance_measure.cpp(60): error: in "test_main_caller( argc_ argv )": Case: issue_1183_6 ctype: e tr_side: -1 dm_side: 0
test/algorithms/overlay/get_distance_measure.cpp(60): error: in "test_main_caller( argc_ argv )": Case: issue_1183_7 ctype: e tr_side: -1 dm_side: 0
test/algorithms/overlay/get_distance_measure.cpp(60): error: in "test_main_caller( argc_ argv )": Case: issue_1183_8 ctype: e tr_side: -1 dm_side: 0
test/algorithms/overlay/get_distance_measure.cpp(60): error: in "test_main_caller( argc_ argv )": Case: issue_1183_9 ctype: e tr_side: -1 dm_side: 0
test/algorithms/overlay/get_distance_measure.cpp(60): error: in "test_main_caller( argc_ argv )": Case: issue_1183_10 ctype: e tr_side: -1 dm_side: 0
test/algorithms/overlay/get_distance_measure.cpp(60): error: in "test_main_caller( argc_ argv )": Case: issue_1183_11 ctype: e tr_side: -1 dm_side: 0
test/algorithms/overlay/get_distance_measure.cpp(60): error: in "test_main_caller( argc_ argv )": Case: issue_1183_12 ctype: e tr_side: -1 dm_side: 0

*** 10 failures are detected in the test module "Test Program"
```

The reason is that in MSVC the long double type is identical to the double type according to [document](https://learn.microsoft.com/en-us/cpp/c-language/type-long-double?view=msvc-170). We should treat 64-bit long double as double. Modification to float is made for consistency.

Full log is attached as [result.txt](https://github.com/boostorg/geometry/files/13611117/result.txt).