### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -38,8 +38,8 @@ jobs:
         fi
         echo "BOOST_SELF=$(basename $GITHUB_WORKSPACE)" >> $GITHUB_ENV
         echo "BOOST_ROOT=$GITHUB_WORKSPACE/boost-root" >> $GITHUB_ENV
-        echo "::set-output name=boost_self::$(basename $GITHUB_WORKSPACE)"
-        echo "::set-output name=boost_root::$GITHUB_WORKSPACE/boost-root"
+        echo "boost_self=$(basename $GITHUB_WORKSPACE)" >> $GITHUB_OUTPUT
+        echo "boost_root=$GITHUB_WORKSPACE/boost-root" >> $GITHUB_OUTPUT
 
     - name: Clone boostorg/boost
       run: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -38,8 +38,8 @@ jobs:
         fi
         echo "BOOST_SELF=$(basename $GITHUB_WORKSPACE)" >> $GITHUB_ENV
         echo "BOOST_ROOT=$GITHUB_WORKSPACE/boost-root" >> $GITHUB_ENV
-        echo "boost_self=$(basename $GITHUB_WORKSPACE)" >> $GITHUB_OUTPUT
-        echo "boost_root=$GITHUB_WORKSPACE/boost-root" >> $GITHUB_OUTPUT
+        echo "boost_self=$(basename $GITHUB_WORKSPACE)" >> "$GITHUB_OUTPUT"
+        echo "boost_root=$GITHUB_WORKSPACE/boost-root" >> "$GITHUB_OUTPUT"
 
     - name: Clone boostorg/boost
       run: |

--- a/.github/workflows/headers.yml
+++ b/.github/workflows/headers.yml
@@ -28,8 +28,8 @@ jobs:
         fi
         echo "BOOST_SELF=$(basename $GITHUB_WORKSPACE)" >> $GITHUB_ENV
         echo "BOOST_ROOT=$GITHUB_WORKSPACE/boost-root" >> $GITHUB_ENV
-        echo "::set-output name=boost_self::$(basename $GITHUB_WORKSPACE)"
-        echo "::set-output name=boost_root::$GITHUB_WORKSPACE/boost-root"
+        echo "boost_self=$(basename $GITHUB_WORKSPACE)" >> $GITHUB_OUTPUT
+        echo "boost_root=$GITHUB_WORKSPACE/boost-root" >> $GITHUB_OUTPUT
 
     - name: Clone boostorg/boost
       run: |

--- a/.github/workflows/headers.yml
+++ b/.github/workflows/headers.yml
@@ -28,8 +28,8 @@ jobs:
         fi
         echo "BOOST_SELF=$(basename $GITHUB_WORKSPACE)" >> $GITHUB_ENV
         echo "BOOST_ROOT=$GITHUB_WORKSPACE/boost-root" >> $GITHUB_ENV
-        echo "boost_self=$(basename $GITHUB_WORKSPACE)" >> $GITHUB_OUTPUT
-        echo "boost_root=$GITHUB_WORKSPACE/boost-root" >> $GITHUB_OUTPUT
+        echo "boost_self=$(basename $GITHUB_WORKSPACE)" >> "$GITHUB_OUTPUT"
+        echo "boost_root=$GITHUB_WORKSPACE/boost-root" >> "$GITHUB_OUTPUT"
 
     - name: Clone boostorg/boost
       run: |

--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -102,8 +102,8 @@ jobs:
           fi
           echo "BOOST_SELF=$(basename $GITHUB_WORKSPACE)" >> $GITHUB_ENV
           echo "BOOST_ROOT=$GITHUB_WORKSPACE/boost-root" >> $GITHUB_ENV
-          echo "boost_self=$(basename $GITHUB_WORKSPACE)" >> $GITHUB_OUTPUT
-          echo "boost_root=$GITHUB_WORKSPACE/boost-root" >> $GITHUB_OUTPUT
+          echo "boost_self=$(basename $GITHUB_WORKSPACE)" >> "$GITHUB_OUTPUT"
+          echo "boost_root=$GITHUB_WORKSPACE/boost-root" >> "$GITHUB_OUTPUT"
 
       - name: Clone boostorg/boost
         run: |
@@ -221,8 +221,8 @@ jobs:
           fi
           echo "BOOST_SELF=$(basename $GITHUB_WORKSPACE)" >> $GITHUB_ENV
           echo "BOOST_ROOT=$GITHUB_WORKSPACE/boost-root" >> $GITHUB_ENV
-          echo "boost_self=$(basename $GITHUB_WORKSPACE)" >> $GITHUB_OUTPUT
-          echo "boost_root=$GITHUB_WORKSPACE/boost-root" >> $GITHUB_OUTPUT
+          echo "boost_self=$(basename $GITHUB_WORKSPACE)" >> "$GITHUB_OUTPUT"
+          echo "boost_root=$GITHUB_WORKSPACE/boost-root" >> "$GITHUB_OUTPUT"
 
       - name: Clone boostorg/boost
         run: |


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


