### PR TITLE
Add missing headers and remove unused typedefs

### DIFF
--- a/include/boost/geometry/algorithms/detail/within/within_no_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/within/within_no_turns.hpp
@@ -18,6 +18,8 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_WITHIN_WITHIN_NO_TURNS_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_WITHIN_WITHIN_NO_TURNS_HPP
 
+#include <boost/type_traits/is_base_of.hpp>
+
 #include <boost/geometry/algorithms/detail/point_on_border.hpp>
 #include <boost/geometry/algorithms/detail/within/point_in_geometry.hpp>
 

--- a/include/boost/geometry/index/detail/serialization.hpp
+++ b/include/boost/geometry/index/detail/serialization.hpp
@@ -566,10 +566,7 @@ void load(Archive & ar, boost::geometry::index::rtree<V, P, I, E, A> & rt, unsig
     typedef boost::geometry::index::rtree<V, P, I, E, A> rtree;
     typedef detail::rtree::private_view<rtree> view;
     typedef typename view::size_type size_type;
-    typedef typename view::translator_type translator_type;
-    typedef typename view::value_type value_type;
     typedef typename view::options_type options_type;
-    typedef typename view::box_type box_type;
     typedef typename view::allocators_type allocators_type;
     typedef typename view::members_holder members_holder;
 

--- a/include/boost/geometry/util/rational.hpp
+++ b/include/boost/geometry/util/rational.hpp
@@ -16,6 +16,7 @@
 
 #include <boost/rational.hpp>
 #include <boost/numeric/conversion/bounds.hpp>
+#include <boost/numeric/conversion/converter.hpp>
 
 #include <boost/geometry/util/coordinate_cast.hpp>
 #include <boost/geometry/util/select_most_precise.hpp>


### PR DESCRIPTION
fixes failing CI header tests (and removes some unused typedefs appeared as warnings)