### PR TITLE
fix compilation of converter and is_base_of

### DIFF
--- a/include/boost/geometry/algorithms/convert.hpp
+++ b/include/boost/geometry/algorithms/convert.hpp
@@ -24,7 +24,6 @@
 #include <cstddef>
 #include <type_traits>
 
-#include <boost/numeric/conversion/cast.hpp>
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 #include <boost/range/size.hpp>
@@ -45,6 +44,7 @@
 
 #include <boost/geometry/geometries/concepts/check.hpp>
 
+#include <boost/geometry/util/numeric_cast.hpp>
 #include <boost/geometry/util/range.hpp>
 
 #include <boost/geometry/views/detail/closed_clockwise_view.hpp>
@@ -80,7 +80,7 @@ struct point_to_box
         typedef typename coordinate_type<Box>::type coordinate_type;
 
         set<Index, Dimension>(box,
-                boost::numeric_cast<coordinate_type>(get<Dimension>(point)));
+                util::numeric_cast<coordinate_type>(get<Dimension>(point)));
         point_to_box
             <
                 Point, Box,

--- a/include/boost/geometry/algorithms/detail/assign_indexed_point.hpp
+++ b/include/boost/geometry/algorithms/detail/assign_indexed_point.hpp
@@ -21,12 +21,11 @@
 
 #include <cstddef>
 
-#include <boost/numeric/conversion/cast.hpp>
-
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/geometries/concepts/check.hpp>
 #include <boost/geometry/util/algorithm.hpp>
+#include <boost/geometry/util/numeric_cast.hpp>
 
 
 namespace boost { namespace geometry
@@ -60,7 +59,7 @@ inline void assign_point_to_index(Point const& point, Geometry& geometry)
     detail::for_each_dimension<Geometry>([&](auto dimension)
     {
         geometry::set<Index, dimension>(geometry,
-            boost::numeric_cast
+            util::numeric_cast
                 <
                     typename coordinate_type<Geometry>::type
                 >(geometry::get<dimension>(point)));
@@ -92,7 +91,7 @@ inline void assign_point_from_index(Geometry const& geometry, Point& point)
     detail::for_each_dimension<Geometry>([&](auto dimension)
     {
         geometry::set<dimension>(point,
-            boost::numeric_cast
+            util::numeric_cast
                 <
                     typename coordinate_type<Point>::type
                 >(geometry::get<Index, dimension>(geometry)));

--- a/include/boost/geometry/algorithms/detail/assign_values.hpp
+++ b/include/boost/geometry/algorithms/detail/assign_values.hpp
@@ -27,7 +27,6 @@
 #include <boost/concept/requires.hpp>
 #include <boost/concept_check.hpp>
 #include <boost/numeric/conversion/bounds.hpp>
-#include <boost/numeric/conversion/cast.hpp>
 
 #include <boost/geometry/algorithms/append.hpp>
 #include <boost/geometry/algorithms/clear.hpp>
@@ -40,6 +39,7 @@
 
 #include <boost/geometry/util/algorithm.hpp>
 #include <boost/geometry/util/is_inverse_spheroidal_coordinates.hpp>
+#include <boost/geometry/util/numeric_cast.hpp>
 
 
 namespace boost { namespace geometry
@@ -117,8 +117,8 @@ inline void assign_box_2d_corner(Box const& box, Point& point)
     // Copy coordinates
     typedef typename coordinate_type<Point>::type coordinate_type;
 
-    geometry::set<0>(point, boost::numeric_cast<coordinate_type>(get<Corner1, 0>(box)));
-    geometry::set<1>(point, boost::numeric_cast<coordinate_type>(get<Corner2, 1>(box)));
+    geometry::set<0>(point, util::numeric_cast<coordinate_type>(get<Corner1, 0>(box)));
+    geometry::set<1>(point, util::numeric_cast<coordinate_type>(get<Corner2, 1>(box)));
 }
 
 
@@ -136,10 +136,10 @@ struct assign_2d_box_or_segment
     static inline void apply(Geometry& geometry,
                 Type const& x1, Type const& y1, Type const& x2, Type const& y2)
     {
-        geometry::set<0, 0>(geometry, boost::numeric_cast<coordinate_type>(x1));
-        geometry::set<0, 1>(geometry, boost::numeric_cast<coordinate_type>(y1));
-        geometry::set<1, 0>(geometry, boost::numeric_cast<coordinate_type>(x2));
-        geometry::set<1, 1>(geometry, boost::numeric_cast<coordinate_type>(y2));
+        geometry::set<0, 0>(geometry, util::numeric_cast<coordinate_type>(x1));
+        geometry::set<0, 1>(geometry, util::numeric_cast<coordinate_type>(y1));
+        geometry::set<1, 0>(geometry, util::numeric_cast<coordinate_type>(x2));
+        geometry::set<1, 1>(geometry, util::numeric_cast<coordinate_type>(y2));
     }
 };
 
@@ -167,8 +167,8 @@ struct assign<point_tag, Point, 2>
     template <typename T>
     static inline void apply(Point& point, T const& c1, T const& c2)
     {
-        set<0>(point, boost::numeric_cast<coordinate_type>(c1));
-        set<1>(point, boost::numeric_cast<coordinate_type>(c2));
+        set<0>(point, util::numeric_cast<coordinate_type>(c1));
+        set<1>(point, util::numeric_cast<coordinate_type>(c2));
     }
 };
 
@@ -180,9 +180,9 @@ struct assign<point_tag, Point, 3>
     template <typename T>
     static inline void apply(Point& point, T const& c1, T const& c2, T const& c3)
     {
-        set<0>(point, boost::numeric_cast<coordinate_type>(c1));
-        set<1>(point, boost::numeric_cast<coordinate_type>(c2));
-        set<2>(point, boost::numeric_cast<coordinate_type>(c3));
+        set<0>(point, util::numeric_cast<coordinate_type>(c1));
+        set<1>(point, util::numeric_cast<coordinate_type>(c2));
+        set<2>(point, util::numeric_cast<coordinate_type>(c3));
     }
 };
 

--- a/include/boost/geometry/algorithms/detail/buffer/buffer_inserter.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/buffer_inserter.hpp
@@ -18,7 +18,6 @@
 #include <iterator>
 
 #include <boost/core/ignore_unused.hpp>
-#include <boost/numeric/conversion/cast.hpp>
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 #include <boost/range/rbegin.hpp>

--- a/include/boost/geometry/algorithms/detail/convert_indexed_to_indexed.hpp
+++ b/include/boost/geometry/algorithms/detail/convert_indexed_to_indexed.hpp
@@ -17,10 +17,10 @@
 
 #include <cstddef>
 
-#include <boost/numeric/conversion/cast.hpp>
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
+#include <boost/geometry/util/numeric_cast.hpp>
 
 
 namespace boost { namespace geometry
@@ -45,10 +45,10 @@ struct indexed_to_indexed
         typedef typename coordinate_type<Destination>::type coordinate_type;
 
         geometry::set<min_corner, Dimension>(destination,
-            boost::numeric_cast<coordinate_type>(
+            util::numeric_cast<coordinate_type>(
                 geometry::get<min_corner, Dimension>(source)));
         geometry::set<max_corner, Dimension>(destination,
-            boost::numeric_cast<coordinate_type>(
+            util::numeric_cast<coordinate_type>(
                 geometry::get<max_corner, Dimension>(source)));
 
         indexed_to_indexed

--- a/include/boost/geometry/algorithms/detail/convert_point_to_point.hpp
+++ b/include/boost/geometry/algorithms/detail/convert_point_to_point.hpp
@@ -18,10 +18,10 @@
 
 #include <cstddef>
 
-#include <boost/numeric/conversion/cast.hpp>
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
+#include <boost/geometry/util/numeric_cast.hpp>
 
 
 namespace boost { namespace geometry
@@ -45,7 +45,7 @@ struct point_to_point
     {
         typedef typename coordinate_type<Destination>::type coordinate_type;
 
-        set<Dimension>(destination, boost::numeric_cast<coordinate_type>(get<Dimension>(source)));
+        set<Dimension>(destination, util::numeric_cast<coordinate_type>(get<Dimension>(source)));
         point_to_point<Source, Destination, Dimension + 1, DimensionCount>::apply(source, destination);
     }
 };

--- a/include/boost/geometry/algorithms/detail/distance/segment_to_box.hpp
+++ b/include/boost/geometry/algorithms/detail/distance/segment_to_box.hpp
@@ -18,7 +18,6 @@
 #include <vector>
 
 #include <boost/core/ignore_unused.hpp>
-#include <boost/numeric/conversion/cast.hpp>
 
 #include <boost/geometry/algorithms/detail/assign_box_corners.hpp>
 #include <boost/geometry/algorithms/detail/assign_indexed_point.hpp>
@@ -44,6 +43,7 @@
 #include <boost/geometry/util/condition.hpp>
 #include <boost/geometry/util/has_nan_coordinate.hpp>
 #include <boost/geometry/util/math.hpp>
+#include <boost/geometry/util/numeric_cast.hpp>
 
 #include <boost/geometry/strategies/disjoint.hpp>
 #include <boost/geometry/strategies/distance.hpp>
@@ -285,7 +285,7 @@ private:
         template <typename T>
         static inline Result apply(T const& t)
         {
-            return boost::numeric_cast<Result>(t);
+            return util::numeric_cast<Result>(t);
         }
     };
 

--- a/include/boost/geometry/algorithms/detail/equals/collect_vectors.hpp
+++ b/include/boost/geometry/algorithms/detail/equals/collect_vectors.hpp
@@ -20,7 +20,6 @@
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_EQUALS_COLLECT_VECTORS_HPP
 
 
-#include <boost/numeric/conversion/cast.hpp>
 #include <boost/range/size.hpp>
 
 #include <boost/geometry/algorithms/detail/normalize.hpp>
@@ -35,6 +34,7 @@
 #include <boost/geometry/geometries/concepts/check.hpp>
 
 #include <boost/geometry/util/math.hpp>
+#include <boost/geometry/util/numeric_cast.hpp>
 #include <boost/geometry/util/range.hpp>
 
 #include <boost/geometry/views/detail/closed_clockwise_view.hpp>
@@ -77,7 +77,7 @@ struct collected_vector_cartesian
 
     bool normalize()
     {
-        T magnitude = math::sqrt(boost::numeric_cast<T>(dx * dx + dy * dy));
+        T magnitude = math::sqrt(util::numeric_cast<T>(dx * dx + dy * dy));
 
         // NOTE: shouldn't here math::equals() be called?
         if (magnitude > 0)

--- a/include/boost/geometry/algorithms/detail/recalculate.hpp
+++ b/include/boost/geometry/algorithms/detail/recalculate.hpp
@@ -21,8 +21,6 @@
 
 #include <boost/concept/requires.hpp>
 #include <boost/concept_check.hpp>
-#include <boost/numeric/conversion/bounds.hpp>
-#include <boost/numeric/conversion/cast.hpp>
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 #include <boost/range/size.hpp>

--- a/include/boost/geometry/algorithms/detail/relate/areal_areal.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/areal_areal.hpp
@@ -31,6 +31,8 @@
 
 #include <boost/geometry/geometries/helper_geometry.hpp>
 
+#include <boost/geometry/util/numeric_cast.hpp>
+
 namespace boost { namespace geometry
 {
 
@@ -836,7 +838,7 @@ struct areal_areal
             segment_identifier const& seg_id = turn.operations[OpId].seg_id;
 
             signed_size_type
-                count = boost::numeric_cast<signed_size_type>(
+                count = util::numeric_cast<signed_size_type>(
                             geometry::num_interior_rings(
                                 detail::single_geometry(analyser.geometry, seg_id)));
 

--- a/include/boost/geometry/algorithms/detail/relate/follow_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/follow_helpers.hpp
@@ -30,6 +30,7 @@
 
 #include <boost/geometry/util/condition.hpp>
 #include <boost/geometry/util/range.hpp>
+#include <boost/geometry/util/type_traits.hpp>
 
 #include <type_traits>
 
@@ -42,10 +43,12 @@ namespace detail { namespace relate {
 // NOTE: This iterates through single geometries for which turns were not generated.
 //       It doesn't mean that the geometry is disjoint, only that no turns were detected.
 
-template <std::size_t OpId,
-          typename Geometry,
-          typename Tag = typename geometry::tag<Geometry>::type,
-          bool IsMulti = std::is_base_of<multi_tag, Tag>::value
+template
+<
+    std::size_t OpId,
+    typename Geometry,
+    typename Tag = typename geometry::tag<Geometry>::type,
+    bool IsMulti = util::is_multi<Geometry>::value
 >
 struct for_each_disjoint_geometry_if
     : public not_implemented<Tag>

--- a/include/boost/geometry/algorithms/detail/single_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/single_geometry.hpp
@@ -18,6 +18,7 @@
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/tag.hpp>
 #include <boost/geometry/util/range.hpp>
+#include <boost/geometry/util/type_traits.hpp>
 
 namespace boost { namespace geometry {
 
@@ -29,11 +30,7 @@ namespace detail_dispatch {
 template
 <
     typename Geometry,
-    bool IsMulti = std::is_base_of
-                    <
-                        multi_tag,
-                        typename geometry::tag<Geometry>::type
-                    >::value
+    bool IsMulti = util::is_multi<Geometry>::value
 >
 struct single_geometry
 {

--- a/include/boost/geometry/algorithms/detail/sub_range.hpp
+++ b/include/boost/geometry/algorithms/detail/sub_range.hpp
@@ -25,6 +25,7 @@
 #include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/util/range.hpp>
+#include <boost/geometry/util/type_traits.hpp>
 
 namespace boost { namespace geometry {
 
@@ -33,9 +34,12 @@ namespace boost { namespace geometry {
 #ifndef DOXYGEN_NO_DISPATCH
 namespace detail_dispatch {
 
-template <typename Geometry,
-          typename Tag = typename geometry::tag<Geometry>::type,
-          bool IsMulti = std::is_base_of<multi_tag, Tag>::value>
+template
+<
+    typename Geometry,
+    typename Tag = typename geometry::tag<Geometry>::type,
+    bool IsMulti = util::is_multi<Geometry>::value
+>
 struct sub_range : not_implemented<Tag>
 {};
 

--- a/include/boost/geometry/algorithms/detail/within/within_no_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/within/within_no_turns.hpp
@@ -19,10 +19,9 @@
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_WITHIN_WITHIN_NO_TURNS_HPP
 
 
-#include <type_traits>
-
 #include <boost/geometry/algorithms/detail/point_on_border.hpp>
 #include <boost/geometry/algorithms/detail/within/point_in_geometry.hpp>
+#include <boost/geometry/util/type_traits.hpp>
 
 namespace boost { namespace geometry {
 
@@ -145,8 +144,8 @@ template <typename Geometry1,
           typename Geometry2,
           typename Tag1 = typename geometry::tag<Geometry1>::type,
           typename Tag2 = typename geometry::tag<Geometry2>::type,
-          bool IsMulti1 = std::is_base_of<geometry::multi_tag, Tag1>::value,
-          bool IsMulti2 = std::is_base_of<geometry::multi_tag, Tag2>::value>
+          bool IsMulti1 = util::is_multi<Geometry1>::value,
+          bool IsMulti2 = util::is_multi<Geometry2>::value>
 struct within_no_turns_multi
 {
     template <typename Strategy> static inline

--- a/include/boost/geometry/algorithms/detail/within/within_no_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/within/within_no_turns.hpp
@@ -18,6 +18,9 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_WITHIN_WITHIN_NO_TURNS_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_WITHIN_WITHIN_NO_TURNS_HPP
 
+
+#include <type_traits>
+
 #include <boost/geometry/algorithms/detail/point_on_border.hpp>
 #include <boost/geometry/algorithms/detail/within/point_in_geometry.hpp>
 
@@ -142,8 +145,8 @@ template <typename Geometry1,
           typename Geometry2,
           typename Tag1 = typename geometry::tag<Geometry1>::type,
           typename Tag2 = typename geometry::tag<Geometry2>::type,
-          bool IsMulti1 = boost::is_base_of<geometry::multi_tag, Tag1>::value,
-          bool IsMulti2 = boost::is_base_of<geometry::multi_tag, Tag2>::value>
+          bool IsMulti1 = std::is_base_of<geometry::multi_tag, Tag1>::value,
+          bool IsMulti2 = std::is_base_of<geometry::multi_tag, Tag2>::value>
 struct within_no_turns_multi
 {
     template <typename Strategy> static inline

--- a/include/boost/geometry/arithmetic/determinant.hpp
+++ b/include/boost/geometry/arithmetic/determinant.hpp
@@ -16,9 +16,9 @@
 
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/geometries/concepts/point_concept.hpp>
+#include <boost/geometry/util/numeric_cast.hpp>
 #include <boost/geometry/util/select_coordinate_type.hpp>
 
-#include <boost/numeric/conversion/cast.hpp>
 
 namespace boost { namespace geometry
 {
@@ -33,7 +33,7 @@ class calculate_determinant
     template <typename T>
     static inline ReturnType rt(T const& v)
     {
-        return boost::numeric_cast<ReturnType>(v);
+        return util::numeric_cast<ReturnType>(v);
     }
 
 public :

--- a/include/boost/geometry/core/radian_access.hpp
+++ b/include/boost/geometry/core/radian_access.hpp
@@ -23,13 +23,12 @@
 
 #include <cstddef>
 
-#include <boost/numeric/conversion/cast.hpp>
-
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/core/coordinate_promotion.hpp>
 
 #include <boost/geometry/util/math.hpp>
+#include <boost/geometry/util/numeric_cast.hpp>
 
 
 
@@ -48,7 +47,7 @@ struct degree_radian_converter
 
     static inline coordinate_type get(Geometry const& geometry)
     {
-        return boost::numeric_cast
+        return util::numeric_cast
             <
                 coordinate_type
             >(geometry::get<Dimension>(geometry)
@@ -57,7 +56,7 @@ struct degree_radian_converter
 
     static inline void set(Geometry& geometry, coordinate_type const& radians)
     {
-        geometry::set<Dimension>(geometry, boost::numeric_cast
+        geometry::set<Dimension>(geometry, util::numeric_cast
             <
                 coordinate_type
             >(radians * math::r2d<coordinate_type>()));
@@ -113,7 +112,7 @@ struct degree_radian_converter_box_segment
 
     static inline coordinate_type get(Geometry const& geometry)
     {
-        return boost::numeric_cast
+        return util::numeric_cast
             <
                 coordinate_type
             >(geometry::get<Index, Dimension>(geometry)
@@ -122,7 +121,7 @@ struct degree_radian_converter_box_segment
 
     static inline void set(Geometry& geometry, coordinate_type const& radians)
     {
-        geometry::set<Index, Dimension>(geometry, boost::numeric_cast
+        geometry::set<Index, Dimension>(geometry, util::numeric_cast
             <
                 coordinate_type
             >(radians * math::r2d<coordinate_type>()));

--- a/include/boost/geometry/policies/relate/intersection_ratios.hpp
+++ b/include/boost/geometry/policies/relate/intersection_ratios.hpp
@@ -14,7 +14,6 @@
 #include <string>
 
 #include <boost/concept_check.hpp>
-#include <boost/numeric/conversion/cast.hpp>
 
 #include <boost/geometry/algorithms/detail/assign_indexed_point.hpp>
 #include <boost/geometry/core/access.hpp>

--- a/include/boost/geometry/policies/robustness/get_rescale_policy.hpp
+++ b/include/boost/geometry/policies/robustness/get_rescale_policy.hpp
@@ -38,6 +38,7 @@
 #include <boost/geometry/policies/robustness/no_rescale_policy.hpp>
 #include <boost/geometry/policies/robustness/rescale_policy.hpp>
 #include <boost/geometry/policies/robustness/robust_type.hpp>
+#include <boost/geometry/util/numeric_cast.hpp>
 #include <boost/geometry/util/type_traits.hpp>
 
 // TEMP
@@ -70,7 +71,7 @@ inline void scale_box_to_integer_range(Box const& box,
         <
             typename geometry::coordinate_type<Point>::type
         >::type num_type;
-    num_type const diff = boost::numeric_cast<num_type>(detail::get_max_size(box));
+    num_type const diff = util::numeric_cast<num_type>(detail::get_max_size(box));
     num_type const range = 10000000.0; // Define a large range to get precise integer coordinates
     num_type const half = 0.5;
     if (math::equals(diff, num_type())
@@ -81,8 +82,8 @@ inline void scale_box_to_integer_range(Box const& box,
     }
     else
     {
-        factor = boost::numeric_cast<num_type>(
-            boost::numeric_cast<boost::long_long_type>(half + range / diff));
+        factor = util::numeric_cast<num_type>(
+            util::numeric_cast<boost::long_long_type>(half + range / diff));
         BOOST_GEOMETRY_ASSERT(factor >= 1);
     }
 
@@ -90,7 +91,7 @@ inline void scale_box_to_integer_range(Box const& box,
     detail::assign_point_from_index<0>(box, min_point);
     num_type const two = 2;
     boost::long_long_type const min_coordinate
-        = boost::numeric_cast<boost::long_long_type>(-range / two);
+        = util::numeric_cast<boost::long_long_type>(-range / two);
     assign_values(min_robust_point, min_coordinate, min_coordinate);
 }
 

--- a/include/boost/geometry/policies/robustness/segment_ratio.hpp
+++ b/include/boost/geometry/policies/robustness/segment_ratio.hpp
@@ -21,6 +21,8 @@
 #include <boost/geometry/core/assert.hpp>
 #include <boost/geometry/core/coordinate_promotion.hpp>
 #include <boost/geometry/util/math.hpp>
+#include <boost/geometry/util/numeric_cast.hpp>
+
 
 namespace boost { namespace geometry
 {
@@ -227,8 +229,8 @@ public:
         m_approximation =
             m_denominator == zero_instance() ? floating_point_type{0}
             : (
-                boost::numeric_cast<floating_point_type>(m_numerator) * scale()
-                / boost::numeric_cast<floating_point_type>(m_denominator)
+                util::numeric_cast<floating_point_type>(m_numerator) * scale()
+                / util::numeric_cast<floating_point_type>(m_denominator)
             );
     }
 

--- a/include/boost/geometry/strategies/cartesian/centroid_bashein_detmer.hpp
+++ b/include/boost/geometry/strategies/cartesian/centroid_bashein_detmer.hpp
@@ -22,13 +22,13 @@
 #include <cstddef>
 
 #include <boost/math/special_functions/fpclassify.hpp>
-#include <boost/numeric/conversion/cast.hpp>
 
 #include <boost/geometry/arithmetic/determinant.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/point_type.hpp>
 #include <boost/geometry/strategies/centroid.hpp>
 #include <boost/geometry/util/math.hpp>
+#include <boost/geometry/util/numeric_cast.hpp>
 #include <boost/geometry/util/select_most_precise.hpp>
 
 
@@ -190,10 +190,10 @@ public :
         typedef typename calculation_type<GeometryPoint, ResultPoint>::type calc_type;
 
         // Get coordinates and promote them to calculation_type
-        calc_type const x1 = boost::numeric_cast<calc_type>(get<0>(p1));
-        calc_type const y1 = boost::numeric_cast<calc_type>(get<1>(p1));
-        calc_type const x2 = boost::numeric_cast<calc_type>(get<0>(p2));
-        calc_type const y2 = boost::numeric_cast<calc_type>(get<1>(p2));
+        calc_type const x1 = util::numeric_cast<calc_type>(get<0>(p1));
+        calc_type const y1 = util::numeric_cast<calc_type>(get<1>(p1));
+        calc_type const x2 = util::numeric_cast<calc_type>(get<0>(p2));
+        calc_type const y2 = util::numeric_cast<calc_type>(get<1>(p2));
         calc_type const ai = geometry::detail::determinant<calc_type>(p1, p2);
         state.count++;
         state.sum_a2 += ai;
@@ -225,9 +225,9 @@ public :
                 // which means that the centroid can still be filled with INF
                 // if e.g. calculation_type is double and centroid contains floats
                 set<0>(centroid,
-                    boost::numeric_cast<coordinate_type>(state.sum_x / a3));
+                    util::numeric_cast<coordinate_type>(state.sum_x / a3));
                 set<1>(centroid,
-                    boost::numeric_cast<coordinate_type>(state.sum_y / a3));
+                    util::numeric_cast<coordinate_type>(state.sum_y / a3));
                 return true;
             }
         }

--- a/include/boost/geometry/strategies/cartesian/centroid_weighted_length.hpp
+++ b/include/boost/geometry/strategies/cartesian/centroid_weighted_length.hpp
@@ -19,7 +19,6 @@
 #define BOOST_GEOMETRY_STRATEGIES_CARTESIAN_CENTROID_WEIGHTED_LENGTH_HPP
 
 #include <boost/math/special_functions/fpclassify.hpp>
-#include <boost/numeric/conversion/cast.hpp>
 
 #include <boost/geometry/algorithms/assign.hpp>
 
@@ -32,6 +31,7 @@
 #include <boost/geometry/strategies/centroid.hpp>
 
 #include <boost/geometry/util/algorithm.hpp>
+#include <boost/geometry/util/numeric_cast.hpp>
 #include <boost/geometry/util/select_most_precise.hpp>
 
 
@@ -132,7 +132,7 @@ public :
                 typedef typename geometry::coordinate_type<ResultPoint>::type coordinate_type;
                 geometry::set<dimension>(
                     centroid,
-                    boost::numeric_cast<coordinate_type>(
+                    util::numeric_cast<coordinate_type>(
                         geometry::get<dimension>(state.average_sum) / state.length
                     )
                 );

--- a/include/boost/geometry/strategies/cartesian/densify.hpp
+++ b/include/boost/geometry/strategies/cartesian/densify.hpp
@@ -22,6 +22,7 @@
 #include <boost/geometry/strategies/densify.hpp>
 #include <boost/geometry/util/algorithm.hpp>
 #include <boost/geometry/util/math.hpp>
+#include <boost/geometry/util/numeric_cast.hpp>
 #include <boost/geometry/util/select_most_precise.hpp>
 
 
@@ -68,8 +69,8 @@ public:
         // dir01 = p1 - p0
         geometry::detail::for_each_dimension<calc_point_t>([&](auto index)
         {
-            calc_t const coord0 = boost::numeric_cast<calc_t>(get<index>(p0));
-            calc_t const coord1 = boost::numeric_cast<calc_t>(get<index>(p1));
+            calc_t const coord0 = util::numeric_cast<calc_t>(get<index>(p0));
+            calc_t const coord1 = util::numeric_cast<calc_t>(get<index>(p1));
             set<index>(cp0, coord0);
             set<index>(dir01, coord1 - coord0);
         });
@@ -96,7 +97,7 @@ public:
                 // out = p0 + d * dir01
                 calc_t const coord = get<index>(cp0) + get<index>(dir01) * num / den;
 
-                set<index>(out, boost::numeric_cast<out_coord_t>(coord));
+                set<index>(out, util::numeric_cast<out_coord_t>(coord));
             });
 
             policy.apply(out);

--- a/include/boost/geometry/strategies/cartesian/disjoint_segment_box.hpp
+++ b/include/boost/geometry/strategies/cartesian/disjoint_segment_box.hpp
@@ -23,11 +23,6 @@
 #include <cstddef>
 #include <utility>
 
-#include <boost/numeric/conversion/cast.hpp>
-
-#include <boost/geometry/util/math.hpp>
-#include <boost/geometry/util/calculation_type.hpp>
-
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/tags.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
@@ -38,6 +33,9 @@
 #include <boost/geometry/strategies/cartesian/point_in_box.hpp>
 #include <boost/geometry/strategies/disjoint.hpp>
 
+#include <boost/geometry/util/math.hpp>
+#include <boost/geometry/util/numeric_cast.hpp>
+#include <boost/geometry/util/calculation_type.hpp>
 
 namespace boost { namespace geometry { namespace strategy { namespace disjoint
 {
@@ -62,22 +60,22 @@ struct compute_tmin_tmax_per_dim
                 SegmentPoint
             >::type point_coordinate_type;
 
-        RelativeDistance c_p0 = boost::numeric_cast
+        RelativeDistance c_p0 = util::numeric_cast
             <
                 point_coordinate_type
             >( geometry::get<I>(p0) );
 
-        RelativeDistance c_p1 = boost::numeric_cast
+        RelativeDistance c_p1 = util::numeric_cast
             <
                 point_coordinate_type
             >( geometry::get<I>(p1) );
 
-        RelativeDistance c_b_min = boost::numeric_cast
+        RelativeDistance c_b_min = util::numeric_cast
             <
                 box_coordinate_type
             >( geometry::get<geometry::min_corner, I>(box) );
 
-        RelativeDistance c_b_max = boost::numeric_cast
+        RelativeDistance c_b_max = util::numeric_cast
             <
                 box_coordinate_type
             >( geometry::get<geometry::max_corner, I>(box) );

--- a/include/boost/geometry/strategies/cartesian/distance_pythagoras.hpp
+++ b/include/boost/geometry/strategies/cartesian/distance_pythagoras.hpp
@@ -26,8 +26,9 @@
 
 #include <boost/geometry/strategies/distance.hpp>
 
-#include <boost/geometry/util/math.hpp>
 #include <boost/geometry/util/calculation_type.hpp>
+#include <boost/geometry/util/math.hpp>
+#include <boost/geometry/util/numeric_cast.hpp>
 
 
 namespace boost { namespace geometry
@@ -46,8 +47,8 @@ struct compute_pythagoras
     template <typename Point1, typename Point2>
     static inline T apply(Point1 const& p1, Point2 const& p2)
     {
-        T const c1 = boost::numeric_cast<T>(get<I-1>(p1));
-        T const c2 = boost::numeric_cast<T>(get<I-1>(p2));
+        T const c1 = util::numeric_cast<T>(get<I-1>(p1));
+        T const c2 = util::numeric_cast<T>(get<I-1>(p2));
         T const d = c1 - c2;
         return d * d + compute_pythagoras<I-1, T>::apply(p1, p2);
     }
@@ -59,7 +60,7 @@ struct compute_pythagoras<0, T>
     template <typename Point1, typename Point2>
     static inline T apply(Point1 const&, Point2 const&)
     {
-        return boost::numeric_cast<T>(0);
+        return util::numeric_cast<T>(0);
     }
 };
 
@@ -163,7 +164,7 @@ public :
         // The cast is necessary for MSVC which considers sqrt __int64 as an ambiguous call
         return math::sqrt
             (
-                 boost::numeric_cast<typename calculation_type<P1, P2>::type>
+                 util::numeric_cast<typename calculation_type<P1, P2>::type>
                     (
                         comparable::pythagoras<CalculationType>::apply(p1, p2)
                     )

--- a/include/boost/geometry/strategies/cartesian/distance_pythagoras_box_box.hpp
+++ b/include/boost/geometry/strategies/cartesian/distance_pythagoras_box_box.hpp
@@ -28,9 +28,9 @@
 
 #include <boost/geometry/strategies/distance.hpp>
 
-#include <boost/geometry/util/math.hpp>
 #include <boost/geometry/util/calculation_type.hpp>
-
+#include <boost/geometry/util/math.hpp>
+#include <boost/geometry/util/numeric_cast.hpp>
 
 
 namespace boost { namespace geometry
@@ -50,14 +50,14 @@ struct compute_pythagoras_box_box
     static inline void apply(Box1 const& box1, Box2 const& box2, T& result)
     {
         T const b1_min_coord =
-            boost::numeric_cast<T>(geometry::get<min_corner, I-1>(box1));
+            util::numeric_cast<T>(geometry::get<min_corner, I-1>(box1));
         T const b1_max_coord =
-            boost::numeric_cast<T>(geometry::get<max_corner, I-1>(box1));
+            util::numeric_cast<T>(geometry::get<max_corner, I-1>(box1));
 
         T const b2_min_coord =
-            boost::numeric_cast<T>(geometry::get<min_corner, I-1>(box2));
+            util::numeric_cast<T>(geometry::get<min_corner, I-1>(box2));
         T const b2_max_coord =
-            boost::numeric_cast<T>(geometry::get<max_corner, I-1>(box2));
+            util::numeric_cast<T>(geometry::get<max_corner, I-1>(box2));
 
         if ( b1_max_coord < b2_min_coord )
         {
@@ -187,7 +187,7 @@ public :
         // The cast is necessary for MSVC which considers sqrt __int64 as an ambiguous call
         return math::sqrt
             (
-                 boost::numeric_cast<typename calculation_type
+                 util::numeric_cast<typename calculation_type
                      <
                          Box1, Box2
                      >::type>

--- a/include/boost/geometry/strategies/cartesian/distance_pythagoras_point_box.hpp
+++ b/include/boost/geometry/strategies/cartesian/distance_pythagoras_point_box.hpp
@@ -28,9 +28,9 @@
 
 #include <boost/geometry/strategies/distance.hpp>
 
-#include <boost/geometry/util/math.hpp>
 #include <boost/geometry/util/calculation_type.hpp>
-
+#include <boost/geometry/util/math.hpp>
+#include <boost/geometry/util/numeric_cast.hpp>
 
 
 namespace boost { namespace geometry
@@ -49,11 +49,11 @@ struct compute_pythagoras_point_box
     template <typename Point, typename Box, typename T>
     static inline void apply(Point const& point, Box const& box, T& result)
     {
-        T const p_coord = boost::numeric_cast<T>(geometry::get<I-1>(point));
+        T const p_coord = util::numeric_cast<T>(geometry::get<I-1>(point));
         T const b_min_coord =
-            boost::numeric_cast<T>(geometry::get<min_corner, I-1>(box));
+            util::numeric_cast<T>(geometry::get<min_corner, I-1>(box));
         T const b_max_coord =
-            boost::numeric_cast<T>(geometry::get<max_corner, I-1>(box));
+            util::numeric_cast<T>(geometry::get<max_corner, I-1>(box));
 
         if ( p_coord < b_min_coord )
         {
@@ -182,7 +182,7 @@ public :
         // The cast is necessary for MSVC which considers sqrt __int64 as an ambiguous call
         return math::sqrt
             (
-                 boost::numeric_cast<typename calculation_type
+                 util::numeric_cast<typename calculation_type
                      <
                          Point, Box
                      >::type>

--- a/include/boost/geometry/strategies/cartesian/intersection.hpp
+++ b/include/boost/geometry/strategies/cartesian/intersection.hpp
@@ -31,6 +31,7 @@
 #include <boost/geometry/algorithms/detail/recalculate.hpp>
 
 #include <boost/geometry/util/math.hpp>
+#include <boost/geometry/util/numeric_cast.hpp>
 #include <boost/geometry/util/promote_integral.hpp>
 #include <boost/geometry/util/select_calculation_type.hpp>
 
@@ -177,17 +178,17 @@ struct cartesian_segments
             typedef typename promote_integral<CoordinateType>::type calc_type;
 
             calc_type const numerator
-                = boost::numeric_cast<calc_type>(ratio.numerator());
+                = util::numeric_cast<calc_type>(ratio.numerator());
             calc_type const denominator
-                = boost::numeric_cast<calc_type>(ratio.denominator());
-            calc_type const dx_calc = boost::numeric_cast<calc_type>(dx);
-            calc_type const dy_calc = boost::numeric_cast<calc_type>(dy);
+                = util::numeric_cast<calc_type>(ratio.denominator());
+            calc_type const dx_calc = util::numeric_cast<calc_type>(dx);
+            calc_type const dy_calc = util::numeric_cast<calc_type>(dy);
 
             set<0>(point, get<0, 0>(segment)
-                   + boost::numeric_cast<CoordinateType>(
+                   + util::numeric_cast<CoordinateType>(
                          math::divide<calc_type>(numerator * dx_calc, denominator)));
             set<1>(point, get<0, 1>(segment)
-                   + boost::numeric_cast<CoordinateType>(
+                   + util::numeric_cast<CoordinateType>(
                          math::divide<calc_type>(numerator * dy_calc, denominator)));
         }
 

--- a/include/boost/geometry/strategies/cartesian/line_interpolate.hpp
+++ b/include/boost/geometry/strategies/cartesian/line_interpolate.hpp
@@ -17,6 +17,7 @@
 #include <boost/geometry/strategies/line_interpolate.hpp>
 #include <boost/geometry/strategies/cartesian/distance_pythagoras.hpp>
 #include <boost/geometry/util/algorithm.hpp>
+#include <boost/geometry/util/numeric_cast.hpp>
 #include <boost/geometry/util/select_calculation_type.hpp>
 
 
@@ -67,10 +68,10 @@ public:
             // NOTE: numeric_cast is a leftover from convert, it could probably be ommited.
             // NOTE: the order of points is different than in the formula above
             //       this is also a leftover from the previous implementation
-            calc_t coord0 = boost::numeric_cast<calc_t>(get<dimension>(p0));
-            calc_t coord1 = boost::numeric_cast<calc_t>(get<dimension>(p1));
+            calc_t coord0 = util::numeric_cast<calc_t>(get<dimension>(p0));
+            calc_t coord1 = util::numeric_cast<calc_t>(get<dimension>(p1));
             calc_t result = calc_t(coord1 * fraction) + calc_t(coord0 * one_minus_fraction);
-            set<dimension>(p, boost::numeric_cast<coord_t>(result));
+            set<dimension>(p, util::numeric_cast<coord_t>(result));
         });
     }
 };

--- a/include/boost/geometry/strategies/geographic/disjoint_segment_box.hpp
+++ b/include/boost/geometry/strategies/geographic/disjoint_segment_box.hpp
@@ -16,8 +16,6 @@
 #include <cstddef>
 #include <utility>
 
-#include <boost/numeric/conversion/cast.hpp>
-
 #include <boost/geometry/util/math.hpp>
 #include <boost/geometry/util/calculation_type.hpp>
 

--- a/include/boost/geometry/strategies/normalize.hpp
+++ b/include/boost/geometry/strategies/normalize.hpp
@@ -14,8 +14,6 @@
 #include <cstddef>
 #include <type_traits>
 
-#include <boost/numeric/conversion/cast.hpp>
-
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_system.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
@@ -25,6 +23,7 @@
 
 #include <boost/geometry/util/normalize_spheroidal_coordinates.hpp>
 #include <boost/geometry/util/normalize_spheroidal_box_coordinates.hpp>
+#include <boost/geometry/util/numeric_cast.hpp>
 
 #include <boost/geometry/views/detail/indexed_point_view.hpp>
 
@@ -57,7 +56,7 @@ struct assign_loop
                              PointIn const& point_in,
                              PointOut& point_out)
     {
-        geometry::set<Dimension>(point_out, boost::numeric_cast
+        geometry::set<Dimension>(point_out, util::numeric_cast
             <
                 typename coordinate_type<PointOut>::type
             >(geometry::get<Dimension>(point_in)));
@@ -90,7 +89,7 @@ struct assign_loop<0, DimensionCount>
                              PointIn const& point_in,
                              PointOut& point_out)
     {
-        geometry::set<0>(point_out, boost::numeric_cast
+        geometry::set<0>(point_out, util::numeric_cast
             <
                 typename coordinate_type<PointOut>::type
             >(longitude));
@@ -111,7 +110,7 @@ struct assign_loop<1, DimensionCount>
                              PointIn const& point_in,
                              PointOut& point_out)
     {
-        geometry::set<1>(point_out, boost::numeric_cast
+        geometry::set<1>(point_out, util::numeric_cast
             <
                 typename coordinate_type<PointOut>::type
             >(latitude));

--- a/include/boost/geometry/strategies/spherical/disjoint_segment_box.hpp
+++ b/include/boost/geometry/strategies/spherical/disjoint_segment_box.hpp
@@ -16,11 +16,6 @@
 #include <cstddef>
 #include <utility>
 
-#include <boost/numeric/conversion/cast.hpp>
-
-#include <boost/geometry/util/math.hpp>
-#include <boost/geometry/util/calculation_type.hpp>
-
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/tags.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
@@ -35,6 +30,9 @@
 #include <boost/geometry/strategies/normalize.hpp>
 #include <boost/geometry/strategies/spherical/azimuth.hpp>
 #include <boost/geometry/strategies/spherical/disjoint_box_box.hpp>
+
+#include <boost/geometry/util/math.hpp>
+#include <boost/geometry/util/calculation_type.hpp>
 
 
 namespace boost { namespace geometry { namespace strategy { namespace disjoint

--- a/include/boost/geometry/strategies/spherical/distance_segment_box.hpp
+++ b/include/boost/geometry/strategies/spherical/distance_segment_box.hpp
@@ -25,6 +25,9 @@
 #include <boost/geometry/strategies/cartesian/point_in_box.hpp> // spherical
 #include <boost/geometry/strategies/spherical/ssf.hpp>
 
+#include <boost/geometry/util/numeric_cast.hpp>
+
+
 namespace boost { namespace geometry
 {
 
@@ -148,7 +151,7 @@ struct generic_segment_box
         if (less_equal(geometry::get_as_radian<0>(bottom_left),
                        geometry::get_as_radian<0>(p_max)))
         {
-            result = boost::numeric_cast<ReturnType>(
+            result = util::numeric_cast<ReturnType>(
                 strategies.distance(bottom_left, seg).apply(bottom_left, p0, p1));
         }
         else

--- a/include/boost/geometry/strategies/strategy_transform.hpp
+++ b/include/boost/geometry/strategies/strategy_transform.hpp
@@ -23,8 +23,6 @@
 #include <cmath>
 #include <functional>
 
-#include <boost/numeric/conversion/cast.hpp>
-
 #include <boost/geometry/algorithms/convert.hpp>
 #include <boost/geometry/arithmetic/arithmetic.hpp>
 #include <boost/geometry/core/access.hpp>
@@ -34,6 +32,7 @@
 #include <boost/geometry/strategies/transform.hpp>
 
 #include <boost/geometry/util/math.hpp>
+#include <boost/geometry/util/numeric_cast.hpp>
 #include <boost/geometry/util/select_coordinate_type.hpp>
 
 namespace boost { namespace geometry
@@ -60,7 +59,7 @@ struct transform_coordinates
         typedef typename select_coordinate_type<Src, Dst>::type coordinate_type;
 
         F<coordinate_type> function;
-        set<D>(dest, boost::numeric_cast<coordinate_type>(function(get<D>(source), value)));
+        set<D>(dest, util::numeric_cast<coordinate_type>(function(get<D>(source), value)));
         transform_coordinates<Src, Dst, D + 1, N, F>::transform(source, dest, value);
     }
 };

--- a/include/boost/geometry/strategies/transform/map_transformer.hpp
+++ b/include/boost/geometry/strategies/transform/map_transformer.hpp
@@ -18,6 +18,8 @@
 #include <cstddef>
 
 #include <boost/geometry/strategies/transform/matrix_transformers.hpp>
+#include <boost/geometry/util/numeric_cast.hpp>
+
 
 namespace boost { namespace geometry
 {
@@ -117,8 +119,8 @@ private :
         // Scale is in PIXELS/MAPUNITS (meters)
         W wdx = wx2 - wx1;
         W wdy = wy2 - wy1;
-        type sx = (px2 - px1) / boost::numeric_cast<type>(wdx);
-        type sy = (py2 - py1) / boost::numeric_cast<type>(wdy);
+        type sx = (px2 - px1) / util::numeric_cast<type>(wdx);
+        type sy = (py2 - py1) / util::numeric_cast<type>(wdy);
 
         if (SameScale)
         {

--- a/include/boost/geometry/strategies/transform/matrix_transformers.hpp
+++ b/include/boost/geometry/strategies/transform/matrix_transformers.hpp
@@ -36,6 +36,7 @@
 #include <boost/geometry/core/coordinate_promotion.hpp>
 #include <boost/geometry/core/cs.hpp>
 #include <boost/geometry/util/math.hpp>
+#include <boost/geometry/util/numeric_cast.hpp>
 #include <boost/geometry/util/select_coordinate_type.hpp>
 #include <boost/geometry/util/select_most_precise.hpp>
 
@@ -61,7 +62,7 @@ struct set_point_from_vec
     static inline void apply(Point & p, Vector const& v)
     {
         typedef typename geometry::coordinate_type<Point>::type coord_t;
-        set<Dimension>(p, boost::numeric_cast<coord_t>(qvm::A<Dimension>(v)));
+        set<Dimension>(p, util::numeric_cast<coord_t>(qvm::A<Dimension>(v)));
         set_point_from_vec<Point, Dimension + 1, DimensionCount>::apply(p, v);
     }
 };
@@ -197,8 +198,8 @@ public :
         ct const& c2 = get<1>(p1);
 
         typedef typename geometry::coordinate_type<P2>::type ct2;
-        set<0>(p2, boost::numeric_cast<ct2>(c1 * qvm::A<0,0>(this->m_matrix) + c2 * qvm::A<0,1>(this->m_matrix) + qvm::A<0,2>(this->m_matrix)));
-        set<1>(p2, boost::numeric_cast<ct2>(c1 * qvm::A<1,0>(this->m_matrix) + c2 * qvm::A<1,1>(this->m_matrix) + qvm::A<1,2>(this->m_matrix)));
+        set<0>(p2, util::numeric_cast<ct2>(c1 * qvm::A<0,0>(this->m_matrix) + c2 * qvm::A<0,1>(this->m_matrix) + qvm::A<0,2>(this->m_matrix)));
+        set<1>(p2, util::numeric_cast<ct2>(c1 * qvm::A<1,0>(this->m_matrix) + c2 * qvm::A<1,1>(this->m_matrix) + qvm::A<1,2>(this->m_matrix)));
 
         return true;
     }
@@ -241,9 +242,9 @@ public :
 
         typedef typename geometry::coordinate_type<P2>::type ct2;
 
-        set<0>(p2, boost::numeric_cast<ct2>(
+        set<0>(p2, util::numeric_cast<ct2>(
             c1 * qvm::A<0,0>(this->m_matrix) + c2 * qvm::A<0,1>(this->m_matrix) + c3 * qvm::A<0,2>(this->m_matrix) + qvm::A<0,3>(this->m_matrix)));
-        set<1>(p2, boost::numeric_cast<ct2>(
+        set<1>(p2, util::numeric_cast<ct2>(
             c1 * qvm::A<1,0>(this->m_matrix) + c2 * qvm::A<1,1>(this->m_matrix) + c3 * qvm::A<1,2>(this->m_matrix) + qvm::A<1,3>(this->m_matrix)));
 
         return true;
@@ -290,11 +291,11 @@ public :
 
         typedef typename geometry::coordinate_type<P2>::type ct2;
 
-        set<0>(p2, boost::numeric_cast<ct2>(
+        set<0>(p2, util::numeric_cast<ct2>(
             c1 * qvm::A<0,0>(this->m_matrix) + c2 * qvm::A<0,1>(this->m_matrix) + c3 * qvm::A<0,2>(this->m_matrix) + qvm::A<0,3>(this->m_matrix)));
-        set<1>(p2, boost::numeric_cast<ct2>(
+        set<1>(p2, util::numeric_cast<ct2>(
             c1 * qvm::A<1,0>(this->m_matrix) + c2 * qvm::A<1,1>(this->m_matrix) + c3 * qvm::A<1,2>(this->m_matrix) + qvm::A<1,3>(this->m_matrix)));
-        set<2>(p2, boost::numeric_cast<ct2>(
+        set<2>(p2, util::numeric_cast<ct2>(
             c1 * qvm::A<2,0>(this->m_matrix) + c2 * qvm::A<2,1>(this->m_matrix) + c3 * qvm::A<2,2>(this->m_matrix) + qvm::A<2,3>(this->m_matrix)));
 
         return true;

--- a/include/boost/geometry/strategy/spherical/envelope_segment.hpp
+++ b/include/boost/geometry/strategy/spherical/envelope_segment.hpp
@@ -16,7 +16,6 @@
 #include <utility>
 
 #include <boost/core/ignore_unused.hpp>
-#include <boost/numeric/conversion/cast.hpp>
 
 #include <boost/geometry/algorithms/detail/envelope/transform_units.hpp>
 
@@ -40,6 +39,7 @@
 #include <boost/geometry/strategy/spherical/expand_box.hpp>
 
 #include <boost/geometry/util/math.hpp>
+#include <boost/geometry/util/numeric_cast.hpp>
 
 namespace boost { namespace geometry { namespace strategy { namespace envelope
 {
@@ -288,22 +288,22 @@ private:
         geometry::set
             <
                 min_corner, 0
-            >(helper_mbr, boost::numeric_cast<box_coordinate_type>(lon1));
+            >(helper_mbr, util::numeric_cast<box_coordinate_type>(lon1));
 
         geometry::set
             <
                 min_corner, 1
-            >(helper_mbr, boost::numeric_cast<box_coordinate_type>(lat1));
+            >(helper_mbr, util::numeric_cast<box_coordinate_type>(lat1));
 
         geometry::set
             <
                 max_corner, 0
-            >(helper_mbr, boost::numeric_cast<box_coordinate_type>(lon2));
+            >(helper_mbr, util::numeric_cast<box_coordinate_type>(lon2));
 
         geometry::set
             <
                 max_corner, 1
-            >(helper_mbr, boost::numeric_cast<box_coordinate_type>(lat2));
+            >(helper_mbr, util::numeric_cast<box_coordinate_type>(lat2));
 
         geometry::detail::envelope::transform_units(helper_mbr, mbr);
     }

--- a/include/boost/geometry/util/math.hpp
+++ b/include/boost/geometry/util/math.hpp
@@ -31,10 +31,10 @@
 #include <boost/math/constants/constants.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 //#include <boost/math/special_functions/round.hpp>
-#include <boost/numeric/conversion/cast.hpp>
 
 #include <boost/geometry/core/cs.hpp>
 
+#include <boost/geometry/util/numeric_cast.hpp>
 #include <boost/geometry/util/select_most_precise.hpp>
 
 namespace boost { namespace geometry
@@ -351,7 +351,7 @@ struct square_root<T, true>
         return square_root_for_fundamental_fp
             <
                 double
-            >::apply(boost::numeric_cast<double>(value));
+            >::apply(util::numeric_cast<double>(value));
     }
 };
 
@@ -499,7 +499,7 @@ struct rounding_cast
 {
     static inline Result apply(Source const& v)
     {
-        return boost::numeric_cast<Result>(v);
+        return util::numeric_cast<Result>(v);
     }
 };
 
@@ -519,7 +519,7 @@ struct rounding_cast<Result, Source, true, false>
 {
     static inline Result apply(Source const& v)
     {
-        return boost::numeric_cast<Result>(v < Source(0) ?
+        return util::numeric_cast<Result>(v < Source(0) ?
                                             v - Source(0.5) :
                                             v + Source(0.5));
     }

--- a/include/boost/geometry/util/numeric_cast.hpp
+++ b/include/boost/geometry/util/numeric_cast.hpp
@@ -12,7 +12,8 @@
 #include <boost/numeric/conversion/cast.hpp>
 #include <boost/rational.hpp>
 
-namespace boost { namespace geometry
+namespace boost { namespace geometry { namespace util
+
 {
 
 #ifndef DOXYGEN_NO_DETAIL
@@ -42,9 +43,6 @@ struct numeric_caster<Target, rational<T>>
 } // namespace detail
 #endif
 
-namespace util
-{
-
 // Calls either boost::numeric_cast, or functionality specific for Boost.Geometry
 // such as rational_cast for Boost.Rational
 template <typename Target, typename Source>
@@ -53,8 +51,6 @@ inline Target numeric_cast(Source const& source)
     return detail::numeric_caster<Target, Source>::apply(source);
 }
 
-}
-
-}} // namespace boost::geometry
+}}} // namespace boost::geometry::util
 
 #endif // BOOST_GEOMETRY_UTIL_NUMERIC_CAST_HPP

--- a/include/boost/geometry/util/numeric_cast.hpp
+++ b/include/boost/geometry/util/numeric_cast.hpp
@@ -1,0 +1,60 @@
+// Boost.Geometry
+
+// Copyright (c) 2024 Barend Gehrels, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_UTIL_NUMERIC_CAST_HPP
+#define BOOST_GEOMETRY_UTIL_NUMERIC_CAST_HPP
+
+#include <boost/numeric/conversion/cast.hpp>
+#include <boost/rational.hpp>
+
+namespace boost { namespace geometry
+{
+
+#ifndef DOXYGEN_NO_DETAIL
+namespace detail
+{
+
+/// brief calls numeric cast
+template <typename Target, typename Source>
+struct numeric_caster
+{
+    static inline Target apply(Source const& source)
+    {
+        return boost::numeric_cast<Target>(source);
+    }
+};
+
+// Specialization for Boost.Rational
+template <typename Target, typename T>
+struct numeric_caster<Target, rational<T>>
+{
+   static inline Target apply(rational<T> const& source)
+    {
+        return boost::rational_cast<Target>(source);
+    }
+};
+
+} // namespace detail
+#endif
+
+namespace util
+{
+
+// Calls either boost::numeric_cast, or functionality specific for Boost.Geometry
+// such as rational_cast for Boost.Rational
+template <typename Target, typename Source>
+inline Target numeric_cast(Source const& source)
+{
+    return detail::numeric_caster<Target, Source>::apply(source);
+}
+
+}
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_UTIL_NUMERIC_CAST_HPP

--- a/include/boost/geometry/util/rational.hpp
+++ b/include/boost/geometry/util/rational.hpp
@@ -18,6 +18,7 @@
 #include <boost/numeric/conversion/bounds.hpp>
 
 #include <boost/geometry/util/coordinate_cast.hpp>
+#include <boost/geometry/util/numeric_cast.hpp>
 #include <boost/geometry/util/select_most_precise.hpp>
 
 
@@ -132,48 +133,6 @@ struct bounds<rational<T> >
 };
 
 }} // namespace boost::numeric
-
-
-// Support for boost::numeric_cast to int and to double (necessary for SVG-mapper)
-namespace boost { namespace numeric
-{
-
-template
-<
-    typename T,
-    typename Traits,
-    typename OverflowHandler,
-    typename Float2IntRounder,
-    typename RawConverter,
-    typename UserRangeChecker
->
-struct converter<int, rational<T>, Traits, OverflowHandler, Float2IntRounder, RawConverter, UserRangeChecker>
-{
-    static inline int convert(rational<T> const& arg)
-    {
-        return int(rational_cast<double>(arg));
-    }
-};
-
-template
-<
-    typename T,
-    typename Traits,
-    typename OverflowHandler,
-    typename Float2IntRounder,
-    typename RawConverter,
-    typename UserRangeChecker
->
-struct converter<double, rational<T>, Traits, OverflowHandler, Float2IntRounder, RawConverter, UserRangeChecker>
-{
-    static inline double convert(rational<T> const& arg)
-    {
-        return rational_cast<double>(arg);
-    }
-};
-
-
-}}
 
 
 #endif // BOOST_GEOMETRY_UTIL_RATIONAL_HPP

--- a/test/algorithms/overlay/overlay.cpp
+++ b/test/algorithms/overlay/overlay.cpp
@@ -318,9 +318,9 @@ struct map_visitor
         // Create a rounded off point
         std::pair<int, int> p
             = std::make_pair(
-                boost::numeric_cast<int>(half
+                util::numeric_cast<int>(half
                     + ten * bg::get<0>(turn.point)),
-                boost::numeric_cast<int>(half
+                util::numeric_cast<int>(half
                     + ten * bg::get<1>(turn.point))
                 );
         m_mapper.text(turn.point, text, style, margin, m_offsets[p], lineheight);

--- a/test/algorithms/overlay/traverse.cpp
+++ b/test/algorithms/overlay/traverse.cpp
@@ -246,9 +246,9 @@ struct test_traverse
                     // Create a rounded off point
                     std::pair<int, int> p
                         = std::make_pair(
-                            boost::numeric_cast<int>(half
+                            util::numeric_cast<int>(half
                                 + ten * bg::get<0>(turn.point)),
-                            boost::numeric_cast<int>(half
+                            util::numeric_cast<int>(half
                                 + ten * bg::get<1>(turn.point))
                             );
                 std::string style =  "fill:rgb(0,0,0);font-family:Arial;font-size:8px";
@@ -303,8 +303,8 @@ struct test_traverse
                     /*out
 
                         << std::setprecision(3)
-                        << "dist: " << boost::numeric_cast<double>(turn.operations[0].enriched.distance)
-                        << " / "  << boost::numeric_cast<double>(turn.operations[1].enriched.distance)
+                        << "dist: " << util::numeric_cast<double>(turn.operations[0].enriched.distance)
+                        << " / "  << util::numeric_cast<double>(turn.operations[1].enriched.distance)
                         << std::endl
                         << "vis: " << bg::visited_char(turn.operations[0].visited)
                         << " / "  << bg::visited_char(turn.operations[1].visited);

--- a/test/algorithms/overlay/traverse_ccw.cpp
+++ b/test/algorithms/overlay/traverse_ccw.cpp
@@ -144,8 +144,8 @@ intersect(Geometry1 const& g1, Geometry2 const& g2, std::string const& name,
                 // Create a rounded off point
                 std::pair<int, int> p
                     = std::make_pair(
-                        boost::numeric_cast<int>(0.5 + 10 * bg::get<0>(turn.point)),
-                        boost::numeric_cast<int>(0.5 + 10 * bg::get<1>(turn.point))
+                        util::numeric_cast<int>(0.5 + 10 * bg::get<0>(turn.point)),
+                        util::numeric_cast<int>(0.5 + 10 * bg::get<1>(turn.point))
                         );
                 std::string style =  "fill:rgb(0,0,0);font-family:Arial;font-size:10px";
 

--- a/test/to_svg.hpp
+++ b/test/to_svg.hpp
@@ -53,9 +53,9 @@ inline void turns_to_svg(Turns const& turns, Mapper& mapper)
             // Create a rounded off point
             std::pair<int, int> p
                     = std::make_pair(
-                          boost::numeric_cast<int>(half
+                          util::numeric_cast<int>(half
                                                    + ten * bg::get<0>(turn.point)),
-                          boost::numeric_cast<int>(half
+                          util::numeric_cast<int>(half
                                                    + ten * bg::get<1>(turn.point))
                           );
             std::string style =  "fill:rgb(0,0,0);font-family:Arial;font-size:12px";

--- a/test/util/rational.cpp
+++ b/test/util/rational.cpp
@@ -17,6 +17,7 @@
 
 #include <boost/geometry/geometries/geometries.hpp>
 #include <boost/geometry/io/wkt/wkt.hpp>
+#include <boost/geometry/util/numeric_cast.hpp>
 #include <boost/geometry/util/rational.hpp>
 
 void test_coordinate_cast(std::string const& s, int expected_nom, int expected_denom)
@@ -26,6 +27,15 @@ void test_coordinate_cast(std::string const& s, int expected_nom, int expected_d
     BOOST_CHECK_EQUAL(a.denominator(), expected_denom);
 }
 
+void test_numeric_cast()
+{
+    const boost::rational<int> r1(3, 4);
+    BOOST_CHECK_CLOSE(bg::detail::numeric_cast<double>(r1), 0.75, 0.00001);
+
+    const boost::rational<int> r2(10, 4);
+    BOOST_CHECK_CLOSE(bg::detail::numeric_cast<double>(r2), 2.5, 0.00001);
+    BOOST_CHECK_EQUAL(bg::detail::numeric_cast<int>(r2), 2);
+}
 
 void test_wkt(std::string const& wkt, std::string const expected_wkt)
 {
@@ -51,6 +61,8 @@ int test_main(int, char* [])
 
     test_coordinate_cast("3/2", 3, 2);
     test_coordinate_cast("-3/2", -3, 2);
+
+    test_numeric_cast();
 
     test_wkt("POINT(1.5 2.75)", "POINT(3/2 11/4)");
     test_wkt("POINT(3/2 11/4)", "POINT(3/2 11/4)");


### PR DESCRIPTION
This fixes two new errors:
* `is_base_of` was called from `Boost`, while in the rest of the library it was called from `std`. Fixed ✅ 
* `converter` reported an error, apparently it is changed in the underlying Boost library. Fixed ✅ 

The first one is trivial. For the second one (related to Boost.Rational) there were three options
* fix `converter` call - with the risk that it will happen again
* add `numeric_cast_traits` - I got it working, but it is quite a lot of code, and it will give problems if a library user does it also for Boost.Rational 
* add another level of indirection, as we often do, so add a `geometry::detail::numeric_cast`

I selected the third option. If affected quite some files, but the changes were mechanic.

Add error 1: this was the message
```
In file included from /home/runner/work/geometry/geometry/boost-root/libs/geometry/test/headers/main.cpp:14:
./boost/geometry/algorithms/detail/within/within_no_turns.hpp:145:34: error: ‘is_base_of’ is not a member of ‘boost’; did you mean ‘std::is_base_of’?
  145 |           bool IsMulti1 = boost::is_base_of<geometry::multi_tag, Tag1>::value,
      |                                  ^~~~~~~~~~

```

Add error 2: this was the message
```
gcc.compile.c++ bin.v2/libs/geometry/test/headers/h-util-rational.test/gcc-11/debug/threading-multi/visibility-hidden/h-util-rational.o
In file included from /home/runner/work/geometry/geometry/boost-root/libs/geometry/test/headers/main.cpp:14:
./boost/geometry/util/rational.hpp:150:8: error: ‘converter’ is not a class template
  150 | struct converter<int, rational<T>, Traits, OverflowHandler, Float2IntRounder, RawConverter, UserRangeChecker>
      |        ^~~~~~~~~
./boost/geometry/util/rational.hpp:167:112: error: wrong number of template arguments (7, should be 6)
  167 | struct converter<double, rational<T>, Traits, OverflowHandler, Float2IntRounder, RawConverter, UserRangeChecker>
      |                                                                                                                ^
./boost/geometry/util/rational.hpp:150:109: note: provided for ‘template<class T, class Traits, class OverflowHandler, class Float2IntRounder, class RawConverter, class UserRangeChecker> struct boost::numeric::converter’
  150 | struct converter<int, rational<T>, Traits, OverflowHandler, Float2IntRounder, RawConverter, UserRangeChecker>
      |                                                                                                             ^
```
