### PR TITLE
Fixes compile error in tests and add removed tests for is_simple and is_valid

### DIFF
--- a/test/algorithms/is_simple.cpp
+++ b/test/algorithms/is_simple.cpp
@@ -269,6 +269,25 @@ BOOST_AUTO_TEST_CASE( test_geometry_with_NaN_coordinates )
     test_simple(mls, true, false);
 }
 
+BOOST_AUTO_TEST_CASE( test_geometry_with_NaN_coordinates_2 )
+{
+#ifdef BOOST_GEOMETRY_TEST_DEBUG
+    std::cout << std::endl << std::endl;
+    std::cout << "************************************" << std::endl;
+    std::cout << " is_valid: geometry with NaN coordinates" << std::endl;
+    std::cout << "************************************" << std::endl;
+#endif
+
+    linestring_type ls1, ls2;
+    bg::read_wkt("LINESTRING(1 1,1.115235e+308 1.738137e+308)", ls1);
+    bg::read_wkt("LINESTRING(-1 1,1.115235e+308 1.738137e+308)", ls2);
+
+    multi_linestring_type mls;
+    bg::intersection(ls1, ls2, mls);
+
+    test_simple(mls, false, false);
+}
+
 BOOST_AUTO_TEST_CASE( test_is_simple_variant )
 {
 #ifdef BOOST_GEOMETRY_TEST_DEBUG

--- a/test/algorithms/is_valid.cpp
+++ b/test/algorithms/is_valid.cpp
@@ -1450,6 +1450,36 @@ BOOST_AUTO_TEST_CASE( test_with_NaN_coordinates )
         >::apply("mls-NaN", mls, false);
 }
 
+BOOST_AUTO_TEST_CASE( test_with_NaN_coordinates_2 )
+{
+#ifdef BOOST_GEOMETRY_TEST_DEBUG
+    std::cout << std::endl << std::endl;
+    std::cout << "************************************" << std::endl;
+    std::cout << " is_valid: geometry with NaN coordinates" << std::endl;
+    std::cout << "************************************" << std::endl;
+#endif
+
+    linestring_type ls1, ls2;
+    bg::read_wkt("LINESTRING(1 1,1.115235e+308 1.738137e+308)", ls1);
+    bg::read_wkt("LINESTRING(-1 1,1.115235e+308 1.738137e+308)", ls2);
+
+    multi_linestring_type mls;
+    bg::intersection(ls1, ls2, mls);
+
+    typedef validity_tester_linear<true> tester_allow_spikes;
+    typedef validity_tester_linear<false> tester_disallow_spikes;
+
+    test_valid
+        <
+            tester_allow_spikes, multi_linestring_type
+        >::apply("mls-NaN", mls, false);
+
+    test_valid
+        <
+            tester_disallow_spikes, multi_linestring_type
+        >::apply("mls-NaN", mls, false);
+}
+
 BOOST_AUTO_TEST_CASE( test_is_valid_variant )
 {
 #ifdef BOOST_GEOMETRY_TEST_DEBUG

--- a/test/util/rational.cpp
+++ b/test/util/rational.cpp
@@ -30,11 +30,11 @@ void test_coordinate_cast(std::string const& s, int expected_nom, int expected_d
 void test_numeric_cast()
 {
     const boost::rational<int> r1(3, 4);
-    BOOST_CHECK_CLOSE(bg::detail::numeric_cast<double>(r1), 0.75, 0.00001);
+    BOOST_CHECK_CLOSE(bg::util::numeric_cast<double>(r1), 0.75, 0.00001);
 
     const boost::rational<int> r2(10, 4);
-    BOOST_CHECK_CLOSE(bg::detail::numeric_cast<double>(r2), 2.5, 0.00001);
-    BOOST_CHECK_EQUAL(bg::detail::numeric_cast<int>(r2), 2);
+    BOOST_CHECK_CLOSE(bg::util::numeric_cast<double>(r2), 2.5, 0.00001);
+    BOOST_CHECK_EQUAL(bg::util::numeric_cast<int>(r2), 2);
 }
 
 void test_wkt(std::string const& wkt, std::string const expected_wkt)


### PR DESCRIPTION
Following comment https://github.com/boostorg/geometry/pull/1237#discussion_r1501810625 this PR adds removed tests for is_simple and is_valid with geometries whose coordinates are close to the maximum double. 
The tests are passing with the fix of https://github.com/boostorg/geometry/pull/1237 but the results are different i.e. the intersection does not create NaN coordinates, it is more accurate but still can create invalid geometries.

This PR also fixes a compile error in tests (wrong namespace for numeric_cast).