### PR TITLE
Fix BOOST_GEOMETRY_CONSTEXPR call in index

### DIFF
--- a/include/boost/geometry/index/detail/rtree/visitors/insert.hpp
+++ b/include/boost/geometry/index/detail/rtree/visitors/insert.hpp
@@ -328,11 +328,11 @@ protected:
         // Enlarge it in case if it's not bounding geometry type.
         // It's because Points and Segments are compared WRT machine epsilon
         // This ensures that leafs bounds correspond to the stored elements
-        if BOOST_GEOMETRY_CONSTEXPR (std::is_same<Element, value_type>::value
+        if (BOOST_GEOMETRY_CONSTEXPR ((std::is_same<Element, value_type>::value
                                     && ! index::detail::is_bounding_geometry
                                             <
                                                 typename indexable_type<translator_type>::type
-                                            >::value)
+                                            >::value)))
         {
             geometry::detail::expand_by_epsilon(m_element_bounds);
         }
@@ -424,11 +424,11 @@ protected:
         // Enlarge bounds of a leaf node.
         // It's because Points and Segments are compared WRT machine epsilon
         // This ensures that leafs' bounds correspond to the stored elements.
-        if BOOST_GEOMETRY_CONSTEXPR (std::is_same<Node, leaf>::value
+        if (BOOST_GEOMETRY_CONSTEXPR ((std::is_same<Node, leaf>::value
                                      && ! index::detail::is_bounding_geometry
                                             <
                                                 typename indexable_type<translator_type>::type
-                                            >::value)
+                                            >::value)))
         {
             geometry::detail::expand_by_epsilon(n_box);
             geometry::detail::expand_by_epsilon(additional_nodes[0].first);


### PR DESCRIPTION
This PR fixes the compilation error 
`error: macro "BOOST_GEOMETRY_CONSTEXPR" passed 2 arguments, but takes just 1`
introduced by cb2f53d9d90f9d602833e87ebf9699890b4f74d7