### PR TITLE
Add missing headers for is_inverse_spheroidal_coordinates function

### DIFF
--- a/include/boost/geometry/algorithms/detail/envelope/range_of_boxes.hpp
+++ b/include/boost/geometry/algorithms/detail/envelope/range_of_boxes.hpp
@@ -32,8 +32,8 @@
 #include <boost/geometry/core/coordinate_system.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
 
+#include <boost/geometry/util/is_inverse_spheroidal_coordinates.hpp>
 #include <boost/geometry/util/math.hpp>
-#include <boost/geometry/util/normalize_spheroidal_coordinates.hpp>
 #include <boost/geometry/util/range.hpp>
 
 #include <boost/geometry/views/detail/indexed_point_view.hpp>

--- a/include/boost/geometry/strategy/spherical/expand_box.hpp
+++ b/include/boost/geometry/strategy/spherical/expand_box.hpp
@@ -38,6 +38,8 @@
 
 #include <boost/geometry/strategy/expand.hpp>
 
+#include <boost/geometry/util/is_inverse_spheroidal_coordinates.hpp>
+
 #include <boost/geometry/views/detail/indexed_point_view.hpp>
 
 namespace boost { namespace geometry

--- a/test/algorithms/envelope_expand/expand_on_spheroid.cpp
+++ b/test/algorithms/envelope_expand/expand_on_spheroid.cpp
@@ -38,6 +38,7 @@
 #include <boost/geometry/io/wkt/wkt.hpp>
 
 #include <boost/geometry/util/condition.hpp>
+#include <boost/geometry/util/is_inverse_spheroidal_coordinates.hpp>
 
 #include <boost/geometry/views/detail/indexed_point_view.hpp>
 


### PR DESCRIPTION
Fixes failing tests due to missing header files.