### PR TITLE
Fix BOOST_GEOMETRY_CONSTEXPR call in index (including support for c++17)

### DIFF
--- a/include/boost/geometry/index/detail/rtree/visitors/insert.hpp
+++ b/include/boost/geometry/index/detail/rtree/visitors/insert.hpp
@@ -328,11 +328,11 @@ protected:
         // Enlarge it in case if it's not bounding geometry type.
         // It's because Points and Segments are compared WRT machine epsilon
         // This ensures that leafs bounds correspond to the stored elements
-        if (BOOST_GEOMETRY_CONSTEXPR ((std::is_same<Element, value_type>::value
+        if BOOST_GEOMETRY_CONSTEXPR ((std::is_same<Element, value_type>::value)
                                     && ! index::detail::is_bounding_geometry
                                             <
                                                 typename indexable_type<translator_type>::type
-                                            >::value)))
+                                            >::value)
         {
             geometry::detail::expand_by_epsilon(m_element_bounds);
         }
@@ -424,15 +424,16 @@ protected:
         // Enlarge bounds of a leaf node.
         // It's because Points and Segments are compared WRT machine epsilon
         // This ensures that leafs' bounds correspond to the stored elements.
-        if (BOOST_GEOMETRY_CONSTEXPR ((std::is_same<Node, leaf>::value
+        if BOOST_GEOMETRY_CONSTEXPR ((std::is_same<Node, leaf>::value)
                                      && ! index::detail::is_bounding_geometry
                                             <
                                                 typename indexable_type<translator_type>::type
-                                            >::value)))
+                                            >::value)
         {
             geometry::detail::expand_by_epsilon(n_box);
             geometry::detail::expand_by_epsilon(additional_nodes[0].first);
         }
+
 #endif
 
         // node is not the root - just add the new node


### PR DESCRIPTION
This PR fixes the issue discussed here: https://github.com/boostorg/geometry/pull/1265#discussion_r1543737915