### PR TITLE
Fix covered_by incorrect results 

### DIFF
--- a/include/boost/geometry/strategies/spherical/point_in_poly_winding.hpp
+++ b/include/boost/geometry/strategies/spherical/point_in_poly_winding.hpp
@@ -3,8 +3,8 @@
 // Copyright (c) 2007-2012 Barend Gehrels, Amsterdam, the Netherlands.
 // Copyright (c) 2013-2017 Adam Wulkiewicz, Lodz, Poland.
 
-// This file was modified by Oracle on 2013-2023.
-// Modifications copyright (c) 2013-2023 Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013-2024.
+// Modifications copyright (c) 2013-2024 Oracle and/or its affiliates.
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -395,8 +395,13 @@ protected:
         }
 
         calc_t const p = get<0>(point);
-        calc_t const s1 = get<0>(seg1);
-        calc_t const s2 = get<0>(seg2);
+        calc_t s1 = get<0>(seg1);
+        calc_t s2 = get<0>(seg2);
+
+        // In case of a segment that contains a pole endpoint we need an arbitrary but consistent
+        // longitude for that endpoint different than p's longitude
+        if (s1_is_pole) s1 = (p != 0) ? 0 : 1;
+        if (s2_is_pole) s2 = (p != 0) ? 0 : 1;
 
         calc_t const s1_p = math::longitude_distance_signed<units_t>(s1, p);
 

--- a/test/algorithms/covered_by/covered_by_sph_geo.cpp
+++ b/test/algorithms/covered_by/covered_by_sph_geo.cpp
@@ -306,6 +306,11 @@ void test_point_polygon()
         BOOST_CHECK_EQUAL(bg::covered_by(Point(-1, -61), poly_s_complex_5edges, ws), false);
         BOOST_CHECK_EQUAL(bg::covered_by(Point(15, -81), poly_s_complex_5edges, ws), false);
         BOOST_CHECK_EQUAL(bg::covered_by(Point(7, -50), poly_s_complex_5edges, ws), false);
+
+        //multiple points representing South pole
+        bg::model::polygon<Point> poly_multiple_poles;
+        bg::read_wkt("POLYGON((75 -90, 75 -6, 120 -45, 163 -90, 75 -90))", poly_multiple_poles);
+        BOOST_CHECK_EQUAL(bg::covered_by(Point(119, -46), poly_multiple_poles, ws), true);
     }
     // Polygon covering nearly half of the globe but no poles
     {


### PR DESCRIPTION
Fix covered_by incorrect results for polygons with multiple defined points as a pole.

Resolves https://github.com/boostorg/geometry/issues/1279 (the special case arise as part of issue https://github.com/boostorg/geometry/issues/1161)