### PR TITLE
Feat/enhance tag casts

### DIFF
--- a/include/boost/geometry/algorithms/convert.hpp
+++ b/include/boost/geometry/algorithms/convert.hpp
@@ -40,6 +40,7 @@
 
 #include <boost/geometry/core/closure.hpp>
 #include <boost/geometry/core/point_order.hpp>
+#include <boost/geometry/core/tag_cast.hpp>
 #include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/geometries/concepts/check.hpp>

--- a/include/boost/geometry/algorithms/detail/buffer/buffer_inserter.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/buffer_inserter.hpp
@@ -37,6 +37,7 @@
 #include <boost/geometry/core/closure.hpp>
 #include <boost/geometry/core/exterior_ring.hpp>
 #include <boost/geometry/core/interior_rings.hpp>
+#include <boost/geometry/core/tag_cast.hpp>
 
 #include <boost/geometry/geometries/linestring.hpp>
 #include <boost/geometry/geometries/ring.hpp>
@@ -177,8 +178,7 @@ struct buffer_range
             output_point_type const& p1,
             output_point_type const& p2)
     {
-        typedef typename cs_tag<output_point_type>::type cs_tag;
-        return direction_code<cs_tag>(p0, p1, p2) == 1;
+        return direction_code<cs_tag_t<output_point_type>>(p0, p1, p2) == 1;
     }
 
     template <typename Strategies>
@@ -929,11 +929,7 @@ inline void buffer_inserter(GeometryInput const& geometry_input, OutputIterator 
 
     dispatch::buffer_inserter
         <
-            typename tag_cast
-                <
-                    typename tag<GeometryInput>::type,
-                    multi_tag
-                >::type,
+            tag_cast_t<tag_t<GeometryInput>, multi_tag>,
             GeometryInput,
             GeometryOutput
         >::apply(geometry_input, collection,

--- a/include/boost/geometry/algorithms/detail/centroid/translating_transformer.hpp
+++ b/include/boost/geometry/algorithms/detail/centroid/translating_transformer.hpp
@@ -45,13 +45,12 @@ namespace detail { namespace centroid
 // cartesian. But if it was needed then one should translate using
 // CS-specific technique, e.g. in spherical/geographic a translation
 // vector should contain coordinates being multiplies of 2PI or 360 deg.
-template <typename Geometry,
-          typename CastedTag = typename tag_cast
-                                <
-                                    typename tag<Geometry>::type,
-                                    areal_tag
-                                >::type,
-    typename CSTag = typename cs_tag<Geometry>::type>
+template
+<
+    typename Geometry,
+    typename CastedTag = tag_cast_t<tag_t<Geometry>, areal_tag>,
+    typename CSTag = cs_tag_t<Geometry>
+>
 struct translating_transformer
 {
     typedef typename geometry::point_type<Geometry>::type point_type;

--- a/include/boost/geometry/algorithms/detail/disjoint/linear_areal.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/linear_areal.hpp
@@ -61,8 +61,8 @@ namespace detail { namespace disjoint
 {
 
 template <typename Geometry1, typename Geometry2,
-          typename Tag1 = typename tag<Geometry1>::type,
-          typename Tag1OrMulti = typename tag_cast<Tag1, multi_tag>::type>
+          typename Tag1 = tag_t<Geometry1>,
+          typename Tag1OrMulti = tag_cast_t<Tag1, multi_tag>>
 struct disjoint_no_intersections_policy
 {
     /*!

--- a/include/boost/geometry/algorithms/detail/envelope/range_of_boxes.hpp
+++ b/include/boost/geometry/algorithms/detail/envelope/range_of_boxes.hpp
@@ -235,7 +235,7 @@ struct envelope_range_of_boxes
 
         static const bool is_equatorial = ! std::is_same
                                             <
-                                                typename cs_tag<box_type>::type,
+                                                cs_tag_t<box_type>,
                                                 spherical_polar_tag
                                             >::value;
 

--- a/include/boost/geometry/algorithms/detail/equals/collect_vectors.hpp
+++ b/include/boost/geometry/algorithms/detail/equals/collect_vectors.hpp
@@ -334,7 +334,7 @@ private:
 
 
 // Default version (cartesian)
-template <typename Box, typename Collection, typename CSTag = typename cs_tag<Box>::type>
+template <typename Box, typename Collection, typename CSTag = cs_tag_t<Box>>
 struct box_collect_vectors
 {
     // Calculate on coordinate type, but if it is integer,

--- a/include/boost/geometry/algorithms/detail/equals/interface.hpp
+++ b/include/boost/geometry/algorithms/detail/equals/interface.hpp
@@ -49,10 +49,10 @@ template
 <
     typename Geometry1,
     typename Geometry2,
-    typename Tag1 = typename tag<Geometry1>::type,
-    typename Tag2 = typename tag<Geometry2>::type,
-    typename CastedTag1 = typename tag_cast<Tag1, pointlike_tag, linear_tag, areal_tag>::type,
-    typename CastedTag2 = typename tag_cast<Tag2, pointlike_tag, linear_tag, areal_tag>::type,
+    typename Tag1 = tag_t<Geometry1>,
+    typename Tag2 = tag_t<Geometry2>,
+    typename CastedTag1 = tag_cast_t<Tag1, pointlike_tag, linear_tag, areal_tag>,
+    typename CastedTag2 = tag_cast_t<Tag2, pointlike_tag, linear_tag, areal_tag>,
     std::size_t DimensionCount = dimension<Geometry1>::type::value,
     bool Reverse = reverse_dispatch<Geometry1, Geometry2>::type::value
 >

--- a/include/boost/geometry/algorithms/detail/extreme_points.hpp
+++ b/include/boost/geometry/algorithms/detail/extreme_points.hpp
@@ -546,10 +546,10 @@ inline bool extreme_points(Geometry const& geometry,
                            Extremes& extremes,
                            Intruders& intruders)
 {
-    typedef typename strategy::side::services::default_strategy
+    using strategy_type = typename strategy::side::services::default_strategy
             <
-                typename cs_tag<Geometry>::type
-            >::type strategy_type;
+                cs_tag_t<Geometry>
+            >::type;
 
     return geometry::extreme_points<Edge>(geometry,extremes, intruders, strategy_type());
 }

--- a/include/boost/geometry/algorithms/detail/for_each_range.hpp
+++ b/include/boost/geometry/algorithms/detail/for_each_range.hpp
@@ -29,7 +29,6 @@
 
 #include <boost/geometry/core/static_assert.hpp>
 #include <boost/geometry/core/tag.hpp>
-#include <boost/geometry/core/tag_cast.hpp>
 #include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/util/type_traits.hpp>

--- a/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_turns.hpp
@@ -45,6 +45,7 @@
 #include <boost/geometry/core/interior_rings.hpp>
 #include <boost/geometry/core/reverse_dispatch.hpp>
 #include <boost/geometry/core/ring_type.hpp>
+#include <boost/geometry/core/tag_cast.hpp>
 #include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/geometries/box.hpp>
@@ -811,7 +812,7 @@ struct get_turns_multi_polygon_cs
 template <typename Geometry>
 struct topological_tag_base
 {
-    typedef typename tag_cast<typename tag<Geometry>::type, pointlike_tag, linear_tag, areal_tag>::type type;
+    using type = tag_cast_t<tag_t<Geometry>, pointlike_tag, linear_tag, areal_tag>;
 };
 
 template <typename Geometry1, typename Geometry2, typename AssignPolicy,

--- a/include/boost/geometry/algorithms/detail/overlay/intersection_insert.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/intersection_insert.hpp
@@ -42,6 +42,7 @@
 #include <boost/geometry/core/point_order.hpp>
 #include <boost/geometry/core/reverse_dispatch.hpp>
 #include <boost/geometry/core/static_assert.hpp>
+#include <boost/geometry/core/tag_cast.hpp>
 
 #include <boost/geometry/geometries/concepts/check.hpp>
 
@@ -504,13 +505,13 @@ template
     bool Reverse1 = detail::overlay::do_reverse<geometry::point_order<Geometry1>::value>::value,
     bool Reverse2 = detail::overlay::do_reverse<geometry::point_order<Geometry2>::value>::value,
     // tag dispatching:
-    typename TagIn1 = typename geometry::tag<Geometry1>::type,
-    typename TagIn2 = typename geometry::tag<Geometry2>::type,
+    typename TagIn1 = tag_t<Geometry1>,
+    typename TagIn2 = tag_t<Geometry2>,
     typename TagOut = typename detail::setop_insert_output_tag<GeometryOut>::type,
     // metafunction finetuning helpers:
-    typename CastedTagIn1 = typename geometry::tag_cast<TagIn1, areal_tag, linear_tag, pointlike_tag>::type,
-    typename CastedTagIn2 = typename geometry::tag_cast<TagIn2, areal_tag, linear_tag, pointlike_tag>::type,
-    typename CastedTagOut = typename geometry::tag_cast<TagOut, areal_tag, linear_tag, pointlike_tag>::type
+    typename CastedTagIn1 = tag_cast_t<TagIn1, areal_tag, linear_tag, pointlike_tag>,
+    typename CastedTagIn2 = tag_cast_t<TagIn2, areal_tag, linear_tag, pointlike_tag>,
+    typename CastedTagOut = tag_cast_t<TagOut, areal_tag, linear_tag, pointlike_tag>
 >
 struct intersection_insert
 {
@@ -1064,7 +1065,7 @@ struct intersection_insert
     > : detail_dispatch::overlay::pointlike_linear_point
         <
             Point, Linear, PointOut, OverlayType,
-            point_tag, typename tag_cast<Tag, segment_tag, linear_tag>::type
+            point_tag, tag_cast_t<Tag, segment_tag, linear_tag>
         >
 {};
 
@@ -1086,7 +1087,7 @@ struct intersection_insert
         <
             MultiPoint, Linear, PointOut, OverlayType,
             multi_point_tag,
-            typename tag_cast<Tag, segment_tag, linear_tag>::type
+            tag_cast_t<Tag, segment_tag, linear_tag>
         >
 {};
 

--- a/include/boost/geometry/algorithms/detail/sections/section_functions.hpp
+++ b/include/boost/geometry/algorithms/detail/sections/section_functions.hpp
@@ -16,6 +16,7 @@
 
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
+#include <boost/geometry/core/tag_cast.hpp>
 
 // For spherical/geographic longitudes covered_by point/box
 #include <boost/geometry/strategies/cartesian/point_in_box.hpp>
@@ -36,11 +37,7 @@ template
 <
     std::size_t Dimension,
     typename Geometry,
-    typename CastedCSTag = typename tag_cast
-                            <
-                                typename cs_tag<Geometry>::type,
-                                spherical_tag
-                            >::type
+    typename CastedCSTag = tag_cast_t<cs_tag_t<Geometry>, spherical_tag>
 >
 struct preceding_check
 {

--- a/include/boost/geometry/algorithms/detail/sections/sectionalize.hpp
+++ b/include/boost/geometry/algorithms/detail/sections/sectionalize.hpp
@@ -46,6 +46,7 @@
 #include <boost/geometry/core/exterior_ring.hpp>
 #include <boost/geometry/core/point_order.hpp>
 #include <boost/geometry/core/static_assert.hpp>
+#include <boost/geometry/core/tag_cast.hpp>
 #include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/geometries/concepts/check.hpp>
@@ -148,11 +149,7 @@ template
     typename DimensionVector,
     std::size_t Index,
     std::size_t Count,
-    typename CastedCSTag = typename tag_cast
-                            <
-                                typename cs_tag<Point>::type,
-                                spherical_tag
-                            >::type
+    typename CastedCSTag = tag_cast_t<cs_tag_t<Point>, spherical_tag>
 >
 struct get_direction_loop
 {
@@ -497,14 +494,14 @@ struct sectionalize_part
 
                 // In cartesian this is envelope of previous point expanded with current point
                 // in non-cartesian this is envelope of a segment
-                box_first_in_section<typename cs_tag<point_type>::type>
+                box_first_in_section<cs_tag_t<point_type>>
                     ::apply(section.bounding_box, previous_point, current_point, strategy);
             }
             else
             {
                 // In cartesian this is expand with current point
                 // in non-cartesian this is expand with a segment
-                box_next_in_section<typename cs_tag<point_type>::type>
+                box_next_in_section<cs_tag_t<point_type>>
                     ::apply(section.bounding_box, previous_point, current_point, strategy);
             }
 

--- a/include/boost/geometry/algorithms/detail/touches/interface.hpp
+++ b/include/boost/geometry/algorithms/detail/touches/interface.hpp
@@ -49,10 +49,10 @@ template
 <
     typename Geometry1,
     typename Geometry2,
-    typename Tag1 = typename tag<Geometry1>::type,
-    typename Tag2 = typename tag<Geometry2>::type,
-    typename CastedTag1 = typename tag_cast<Tag1, pointlike_tag, linear_tag, areal_tag>::type,
-    typename CastedTag2 = typename tag_cast<Tag2, pointlike_tag, linear_tag, areal_tag>::type,
+    typename Tag1 = tag_t<Geometry1>,
+    typename Tag2 = tag_t<Geometry2>,
+    typename CastedTag1 = tag_cast_t<Tag1, pointlike_tag, linear_tag, areal_tag>,
+    typename CastedTag2 = tag_cast_t<Tag2, pointlike_tag, linear_tag, areal_tag>,
     bool Reverse = reverse_dispatch<Geometry1, Geometry2>::type::value
 >
 struct touches

--- a/include/boost/geometry/algorithms/detail/tupled_output.hpp
+++ b/include/boost/geometry/algorithms/detail/tupled_output.hpp
@@ -520,10 +520,10 @@ struct expect_output_assert
                     TupledOut,
                     is_tag_same_as_pred<Tag>::template pred
                 >::value,
-            typename geometry::tag_cast
+            tag_cast_t
                 <
                     Tag, pointlike_tag, linear_tag, areal_tag
-                >::type
+                >
         >
 {};
 
@@ -539,29 +539,6 @@ template
 struct expect_output
     : expect_output_assert<Geometry1, Geometry2, TupledOut, Tags>...
 {};
-
-
-template <typename CastedTag>
-struct single_tag_from_base_tag;
-
-template <>
-struct single_tag_from_base_tag<pointlike_tag>
-{
-    typedef point_tag type;
-};
-
-template <>
-struct single_tag_from_base_tag<linear_tag>
-{
-    typedef linestring_tag type;
-};
-
-template <>
-struct single_tag_from_base_tag<areal_tag>
-{
-    typedef polygon_tag type;
-};
-
 
 template
 <

--- a/include/boost/geometry/algorithms/detail/within/multi_point.hpp
+++ b/include/boost/geometry/algorithms/detail/within/multi_point.hpp
@@ -30,7 +30,6 @@
 #include <boost/geometry/algorithms/envelope.hpp>
 #include <boost/geometry/algorithms/detail/partition.hpp>
 #include <boost/geometry/core/tag.hpp>
-#include <boost/geometry/core/tag_cast.hpp>
 #include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/geometries/box.hpp>

--- a/include/boost/geometry/algorithms/difference.hpp
+++ b/include/boost/geometry/algorithms/difference.hpp
@@ -21,6 +21,8 @@
 #include <boost/geometry/algorithms/detail/overlay/intersection_insert.hpp>
 #include <boost/geometry/algorithms/detail/visit.hpp>
 #include <boost/geometry/core/geometry_types.hpp>
+#include <boost/geometry/core/primary_single_tag.hpp>
+#include <boost/geometry/core/tag_cast.hpp>
 #include <boost/geometry/geometries/adapted/boost_variant.hpp> // For backward compatibility
 #include <boost/geometry/strategies/default_strategy.hpp>
 #include <boost/geometry/strategies/detail.hpp>
@@ -106,14 +108,10 @@ template
 >
 struct call_intersection_insert_tupled_base
 {
-    typedef typename geometry::detail::single_tag_from_base_tag
+    using single_tag = primary_single_tag_t
         <
-            typename geometry::tag_cast
-                <
-                    typename geometry::tag<Geometry1>::type,
-                    pointlike_tag, linear_tag, areal_tag
-                >::type
-        >::type single_tag;
+            tag_cast_t<tag_t<Geometry1>, pointlike_tag, linear_tag, areal_tag>
+        >;
 
     typedef detail::expect_output
         <
@@ -283,11 +281,7 @@ inline OutputIterator difference_insert(Geometry1 const& geometry1,
 template
 <
     typename Geometry, typename Collection,
-    typename CastedTag = typename geometry::tag_cast
-        <
-            typename geometry::tag<Geometry>::type,
-            pointlike_tag, linear_tag, areal_tag
-        >::type
+    typename CastedTag = tag_cast_t<tag_t<Geometry>, pointlike_tag, linear_tag, areal_tag>
 >
 struct multi_output_type
 {

--- a/include/boost/geometry/algorithms/dispatch/closest_points.hpp
+++ b/include/boost/geometry/algorithms/dispatch/closest_points.hpp
@@ -34,22 +34,22 @@ namespace dispatch
 template
 <
     typename Geometry1, typename Geometry2,
-    typename Tag1 = typename tag_cast
+    typename Tag1 = tag_cast_t
         <
-            typename tag<Geometry1>::type,
+            tag_t<Geometry1>,
             segment_tag,
             box_tag,
             linear_tag,
             areal_tag
-        >::type,
-    typename Tag2 = typename tag_cast
+        >,
+    typename Tag2 = tag_cast_t
         <
-            typename tag<Geometry2>::type,
+            tag_t<Geometry2>,
             segment_tag,
             box_tag,
             linear_tag,
             areal_tag
-        >::type,
+        >,
     bool Reverse = reverse_dispatch<Geometry1, Geometry2>::type::value
 >
 struct closest_points : not_implemented<Tag1, Tag2>

--- a/include/boost/geometry/algorithms/dispatch/disjoint.hpp
+++ b/include/boost/geometry/algorithms/dispatch/disjoint.hpp
@@ -45,16 +45,16 @@ template
 <
     typename Geometry1, typename Geometry2,
     std::size_t DimensionCount = dimension<Geometry1>::type::value,
-    typename Tag1 = typename tag_cast
+    typename Tag1 = tag_cast_t
         <
-            typename tag<Geometry1>::type,
+            tag_t<Geometry1>,
             segment_tag, box_tag, linear_tag, areal_tag
-        >::type,
-    typename Tag2 = typename tag_cast
+        >,
+    typename Tag2 = tag_cast_t
         <
-            typename tag<Geometry2>::type,
+            tag_t<Geometry2>,
             segment_tag, box_tag, linear_tag, areal_tag
-        >::type,
+        >,
     bool Reverse = reverse_dispatch<Geometry1, Geometry2>::type::value
 >
 struct disjoint

--- a/include/boost/geometry/algorithms/dispatch/distance.hpp
+++ b/include/boost/geometry/algorithms/dispatch/distance.hpp
@@ -98,22 +98,22 @@ template
         <
             Geometry1, Geometry2
         >::type,
-    typename Tag1 = typename tag_cast
+    typename Tag1 = tag_cast_t
         <
-            typename tag<Geometry1>::type,
+            tag_t<Geometry1>,
             segment_tag,
             box_tag,
             linear_tag,
             areal_tag
-        >::type,
-    typename Tag2 = typename tag_cast
+        >,
+    typename Tag2 = tag_cast_t
         <
-            typename tag<Geometry2>::type,
+            tag_t<Geometry2>,
             segment_tag,
             box_tag,
             linear_tag,
             areal_tag
-        >::type,
+        >,
     typename StrategyTag = typename distance_strategy_tag
         <
             Geometry1, Geometry2, Strategy

--- a/include/boost/geometry/algorithms/for_each.hpp
+++ b/include/boost/geometry/algorithms/for_each.hpp
@@ -369,7 +369,7 @@ namespace dispatch
 template
 <
     typename Geometry,
-    typename Tag = typename tag_cast<typename tag<Geometry>::type, multi_tag>::type
+    typename Tag = tag_cast_t<tag_t<Geometry>, multi_tag>
 >
 struct for_each_point: not_implemented<Tag>
 {};

--- a/include/boost/geometry/algorithms/num_geometries.hpp
+++ b/include/boost/geometry/algorithms/num_geometries.hpp
@@ -51,12 +51,7 @@ namespace dispatch
 template
 <
     typename Geometry,
-    typename Tag = typename tag_cast
-                            <
-                                typename tag<Geometry>::type,
-                                single_tag,
-                                multi_tag
-                            >::type
+    typename Tag = tag_cast_t<tag_t<Geometry>, single_tag, multi_tag>
 >
 struct num_geometries: not_implemented<Tag>
 {};

--- a/include/boost/geometry/algorithms/num_points.hpp
+++ b/include/boost/geometry/algorithms/num_points.hpp
@@ -86,10 +86,7 @@ template
 <
     typename Geometry,
     bool AddForOpen,
-    typename Tag = typename tag_cast
-        <
-            typename tag<Geometry>::type, multi_tag
-        >::type
+    typename Tag = tag_cast_t<tag_t<Geometry>, multi_tag>
 >
 struct num_points: not_implemented<Tag>
 {};

--- a/include/boost/geometry/algorithms/point_on_surface.hpp
+++ b/include/boost/geometry/algorithms/point_on_surface.hpp
@@ -310,10 +310,10 @@ inline void point_on_surface(Geometry const& geometry, Point & point,
 template <typename Geometry, typename Point>
 inline void point_on_surface(Geometry const& geometry, Point & point)
 {
-    typedef typename strategy::side::services::default_strategy
+    using strategy_type = typename strategy::side::services::default_strategy
         <
-            typename cs_tag<Geometry>::type
-        >::type strategy_type;
+            cs_tag_t<Geometry>
+        >::type;
 
     point_on_surface(geometry, point, strategy_type());
 }

--- a/include/boost/geometry/algorithms/remove_spikes.hpp
+++ b/include/boost/geometry/algorithms/remove_spikes.hpp
@@ -258,10 +258,10 @@ struct remove_spikes
 
     static void apply(Geometry& geometry, geometry::default_strategy const&)
     {
-        typedef typename strategy::side::services::default_strategy
+        using side_strategy = typename strategy::side::services::default_strategy
             <
-                typename cs_tag<Geometry>::type
-            >::type side_strategy;
+                cs_tag_t<Geometry>
+            >::type;
 
         apply(geometry, side_strategy());
     }

--- a/include/boost/geometry/algorithms/sym_difference.hpp
+++ b/include/boost/geometry/algorithms/sym_difference.hpp
@@ -18,6 +18,8 @@
 
 #include <iterator>
 
+#include <boost/geometry/core/primary_single_tag.hpp>
+#include <boost/geometry/core/tag_cast.hpp>
 #include <boost/geometry/algorithms/difference.hpp>
 #include <boost/geometry/algorithms/union.hpp>
 #include <boost/geometry/geometries/adapted/boost_variant.hpp>
@@ -268,14 +270,14 @@ template
     typename Geometry1,
     typename Geometry2,
     typename GeometryOut,
-    typename TagIn1 = typename geometry::tag_cast
+    typename TagIn1 = tag_cast_t
         <
-            typename tag<Geometry1>::type, pointlike_tag, linear_tag, areal_tag
-        >::type,
-    typename TagIn2 = typename geometry::tag_cast
+            tag_t<Geometry1>, pointlike_tag, linear_tag, areal_tag
+        >,
+    typename TagIn2 = tag_cast_t
         <
-            typename tag<Geometry2>::type, pointlike_tag, linear_tag, areal_tag
-        >::type,
+            tag_t<Geometry2>, pointlike_tag, linear_tag, areal_tag
+        >,
     typename TagOut = typename detail::setop_insert_output_tag<GeometryOut>::type
 >
 struct sym_difference_insert
@@ -380,15 +382,11 @@ struct sym_difference_insert
     >
     : detail::expect_output
         <
-            Geometry1, Geometry2, GeometryOut,
-            typename detail::single_tag_from_base_tag<TagIn1>::type,
-            typename detail::single_tag_from_base_tag<TagIn2>::type
+            Geometry1, Geometry2, GeometryOut, primary_single_tag_t<TagIn1>, primary_single_tag_t<TagIn2>
         >
     , detail::sym_difference::sym_difference_different_inputs_tupled_output
         <
-            GeometryOut,
-            typename detail::single_tag_from_base_tag<TagIn1>::type,
-            typename detail::single_tag_from_base_tag<TagIn2>::type
+            GeometryOut, primary_single_tag_t<TagIn1>, primary_single_tag_t<TagIn2>
         >
 {};
 

--- a/include/boost/geometry/algorithms/transform.hpp
+++ b/include/boost/geometry/algorithms/transform.hpp
@@ -203,8 +203,8 @@ struct select_strategy
 {
     typedef typename strategy::transform::services::default_strategy
         <
-            typename cs_tag<Point1>::type,
-            typename cs_tag<Point2>::type,
+            cs_tag_t<Point1>,
+            cs_tag_t<Point2>,
             typename coordinate_system<Point1>::type,
             typename coordinate_system<Point2>::type,
             dimension<Point1>::type::value,
@@ -268,8 +268,8 @@ namespace dispatch
 template
 <
     typename Geometry1, typename Geometry2,
-    typename Tag1 = typename tag_cast<typename tag<Geometry1>::type, multi_tag>::type,
-    typename Tag2 = typename tag_cast<typename tag<Geometry2>::type, multi_tag>::type
+    typename Tag1 = tag_cast_t<tag_t<Geometry1>, multi_tag>,
+    typename Tag2 = tag_cast_t<tag_t<Geometry2>, multi_tag>
 >
 struct transform {};
 

--- a/include/boost/geometry/algorithms/union.hpp
+++ b/include/boost/geometry/algorithms/union.hpp
@@ -24,7 +24,9 @@
 #include <boost/geometry/algorithms/detail/overlay/pointlike_pointlike.hpp>
 #include <boost/geometry/algorithms/not_implemented.hpp>
 #include <boost/geometry/core/point_order.hpp>
+#include <boost/geometry/core/primary_single_tag.hpp>
 #include <boost/geometry/core/reverse_dispatch.hpp>
+#include <boost/geometry/core/tag_cast.hpp>
 #include <boost/geometry/geometries/adapted/boost_variant.hpp>
 #include <boost/geometry/geometries/concepts/check.hpp>
 #include <boost/geometry/strategies/default_strategy.hpp>
@@ -47,12 +49,12 @@ namespace dispatch
 template
 <
     typename Geometry1, typename Geometry2, typename GeometryOut,
-    typename TagIn1 = typename tag<Geometry1>::type,
-    typename TagIn2 = typename tag<Geometry2>::type,
+    typename TagIn1 = tag_t<Geometry1>,
+    typename TagIn2 = tag_t<Geometry2>,
     typename TagOut = typename detail::setop_insert_output_tag<GeometryOut>::type,
-    typename CastedTagIn1 = typename geometry::tag_cast<TagIn1, areal_tag, linear_tag, pointlike_tag>::type,
-    typename CastedTagIn2 = typename geometry::tag_cast<TagIn2, areal_tag, linear_tag, pointlike_tag>::type,
-    typename CastedTagOut = typename geometry::tag_cast<TagOut, areal_tag, linear_tag, pointlike_tag>::type,
+    typename CastedTagIn1 = tag_cast_t<TagIn1, areal_tag, linear_tag, pointlike_tag>,
+    typename CastedTagIn2 = tag_cast_t<TagIn2, areal_tag, linear_tag, pointlike_tag>,
+    typename CastedTagOut = tag_cast_t<TagOut, areal_tag, linear_tag, pointlike_tag>,
     bool Reverse = geometry::reverse_dispatch<Geometry1, Geometry2>::type::value
 >
 struct union_insert: not_implemented<TagIn1, TagIn2, TagOut>
@@ -164,10 +166,7 @@ struct union_insert
         false
     >
 {
-    using single_tag = typename geometry::detail::single_tag_from_base_tag
-        <
-            CastedTagIn
-        >::type;
+    using single_tag = primary_single_tag_t<CastedTagIn>;
 
     using expect_check = detail::expect_output
         <
@@ -278,20 +277,14 @@ struct union_insert
         false
     >
 {
-    using single_tag1 = typename geometry::detail::single_tag_from_base_tag
-        <
-            CastedTagIn1
-        >::type;
+    using single_tag1 = primary_single_tag_t<CastedTagIn1>;
 
     using expect_check1 = detail::expect_output
         <
             Geometry1, Geometry2, SingleTupledOut, single_tag1
         >;
 
-    using single_tag2 = typename geometry::detail::single_tag_from_base_tag
-        <
-            CastedTagIn2
-        >::type;
+    using single_tag2 = primary_single_tag_t<CastedTagIn2>;
 
     using expect_check2 = detail::expect_output
         <

--- a/include/boost/geometry/core/primary_single_tag.hpp
+++ b/include/boost/geometry/core/primary_single_tag.hpp
@@ -1,0 +1,55 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+
+// Copyright (c) 2024-2024 Barend Gehrels, Amsterdam, the Netherlands.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_PRIMARY_SINGLE_TAG_HPP
+#define BOOST_GEOMETRY_PRIMARY_SINGLE_TAG_HPP
+
+#include <boost/geometry/core/tags.hpp>
+
+namespace boost { namespace geometry
+{
+
+/*!
+\brief Metafunction defining a type being the primary tag
+    (point, linestring, polygon) of the tag related to its topological dimension.
+\details pointlike_tag will be casted to point_tag, linear_tag to linestring_tag,
+    areal_tag to polygon_tag.
+\ingroup core
+\tparam Tag The tag to get the canonical tag from
+*/
+template <typename Tag>
+struct primary_single_tag
+{
+
+};
+
+template <>
+struct primary_single_tag<pointlike_tag>
+{
+    using type = point_tag;
+};
+
+template <>
+struct primary_single_tag<linear_tag>
+{
+    using type = linestring_tag;
+};
+
+template <>
+struct primary_single_tag<areal_tag>
+{
+    using type = polygon_tag;
+};
+
+template <typename Tag>
+using primary_single_tag_t = typename primary_single_tag<Tag>::type;
+
+
+}} // namespace boost::geometry
+
+#endif // BOOST_GEOMETRY_PRIMARY_SINGLE_TAG_HPP

--- a/include/boost/geometry/core/tag_cast.hpp
+++ b/include/boost/geometry/core/tag_cast.hpp
@@ -66,7 +66,6 @@ struct tag_cast<Tag, BaseTag, BaseTags...>
 template <typename Tag, typename ...BaseTags>
 using tag_cast_t = typename tag_cast<Tag, BaseTags...>::type;
 
-
 }} // namespace boost::geometry
 
 #endif // BOOST_GEOMETRY_CORE_TAG_CAST_HPP

--- a/include/boost/geometry/geometries/helper_geometry.hpp
+++ b/include/boost/geometry/geometries/helper_geometry.hpp
@@ -40,7 +40,7 @@ template
     typename Point,
     typename NewCoordinateType,
     typename NewUnits,
-    typename CS_Tag = typename cs_tag<Point>::type
+    typename CS_Tag = cs_tag_t<Point>
 >
 struct helper_point
 {

--- a/include/boost/geometry/io/dsv/write.hpp
+++ b/include/boost/geometry/io/dsv/write.hpp
@@ -326,11 +326,11 @@ public:
     {
         dispatch::dsv
             <
-                typename tag_cast
+                tag_cast_t
                     <
-                        typename tag<Geometry>::type,
+                        tag_t<Geometry>,
                         multi_tag
-                    >::type,
+                    >,
                 Geometry
             >::apply(os, m.m_geometry, m.m_settings);
         os.flush();

--- a/include/boost/geometry/io/svg/svg_mapper.hpp
+++ b/include/boost/geometry/io/svg/svg_mapper.hpp
@@ -186,11 +186,7 @@ struct devarianted_svg_map
     {
         svg_map
             <
-                typename tag_cast
-                    <
-                        typename tag<Geometry>::type,
-                        multi_tag
-                    >::type,
+                tag_cast_t<tag_t<Geometry>, multi_tag>,
                 typename std::remove_const<Geometry>::type,
                 SvgPoint
             >::apply(stream, style, size, geometry, strategy);

--- a/include/boost/geometry/strategies/agnostic/point_in_point.hpp
+++ b/include/boost/geometry/strategies/agnostic/point_in_point.hpp
@@ -29,7 +29,7 @@ namespace strategy { namespace within
 template
 <
     typename Point1, typename Point2,
-    typename CSTag = typename cs_tag<Point1>::type
+    typename CSTag = cs_tag_t<Point1>
 >
 struct point_in_point
     : strategy::within::cartesian_point_point

--- a/include/boost/geometry/strategies/agnostic/point_in_poly_oriented_winding.hpp
+++ b/include/boost/geometry/strategies/agnostic/point_in_poly_oriented_winding.hpp
@@ -65,10 +65,10 @@ class oriented_winding
         >::type calculation_type;
 
 
-    typedef typename strategy::side::services::default_strategy
+    using strategy_side_type = typename strategy::side::services::default_strategy
         <
-            typename cs_tag<Point>::type
-        >::type strategy_side_type;
+            cs_tag_t<Point>
+        >::type;
 
 
     /*! subclass to keep state */

--- a/include/boost/geometry/strategies/agnostic/point_in_poly_winding.hpp
+++ b/include/boost/geometry/strategies/agnostic/point_in_poly_winding.hpp
@@ -45,11 +45,7 @@ template
     typename Point,
     typename PointOfSegment,
     typename CalculationType,
-    typename CSTag = typename tag_cast
-                        <
-                            typename cs_tag<Point>::type,
-                            spherical_tag
-                        >::type
+    typename CSTag = tag_cast_t<cs_tag_t<Point>, spherical_tag>
 >
 struct winding_base_type
 {
@@ -65,7 +61,7 @@ struct winding_base_type<Point, PointOfSegment, CalculationType, cartesian_tag>
         <
             typename strategy::side::services::default_strategy
                 <
-                    typename cs_tag<Point>::type
+                    cs_tag_t<Point>
                 >::type,
             CalculationType
         >;
@@ -76,10 +72,7 @@ struct winding_base_type<Point, PointOfSegment, CalculationType, spherical_tag>
 {
     using type = within::detail::spherical_winding_base
         <
-            typename strategy::side::services::default_strategy
-                <
-                    typename cs_tag<Point>::type
-                >::type,
+            typename strategy::side::services::default_strategy<cs_tag_t<Point>>::type,
             CalculationType
         >;
 };

--- a/include/boost/geometry/strategies/compare.hpp
+++ b/include/boost/geometry/strategies/compare.hpp
@@ -216,8 +216,8 @@ template
     typename Point1,
     typename Point2 = Point1,
     int Dimension = -1,
-    typename CSTag1 = typename cs_tag<Point1>::type,
-    typename CSTag2 = typename cs_tag<Point2>::type
+    typename CSTag1 = cs_tag_t<Point1>,
+    typename CSTag2 = cs_tag_t<Point2>
 >
 struct default_strategy
 {

--- a/include/boost/geometry/strategies/concepts/within_concept.hpp
+++ b/include/boost/geometry/strategies/concepts/within_concept.hpp
@@ -369,9 +369,9 @@ inline void check()
         <
             Geometry1,
             Geometry2,
-            typename tag<Geometry1>::type,
-            typename tag<Geometry2>::type,
-            typename tag_cast<typename tag<Geometry2>::type, areal_tag>::type,
+            tag_t<Geometry1>,
+            tag_t<Geometry2>,
+            tag_cast_t<tag_t<Geometry2>, areal_tag>,
             Strategy
         > c;
     boost::ignore_unused(c);

--- a/include/boost/geometry/strategies/convex_hull.hpp
+++ b/include/boost/geometry/strategies/convex_hull.hpp
@@ -40,7 +40,7 @@ template
 <
     typename Geometry1,
     typename Point,
-    typename CsTag = typename cs_tag<Point>::type
+    typename CsTag = cs_tag_t<Point>
 >
 struct strategy_convex_hull
 {

--- a/include/boost/geometry/strategies/covered_by.hpp
+++ b/include/boost/geometry/strategies/covered_by.hpp
@@ -54,26 +54,26 @@ template
     typename GeometryContaining,
     typename TagContained = typename tag<GeometryContained>::type,
     typename TagContaining = typename tag<GeometryContaining>::type,
-    typename CastedTagContained = typename tag_cast
+    typename CastedTagContained = tag_cast_t
                                     <
-                                        typename tag<GeometryContained>::type,
+                                        tag_t<GeometryContained>,
                                         pointlike_tag, linear_tag, polygonal_tag, areal_tag
-                                    >::type,
-    typename CastedTagContaining = typename tag_cast
+                                    >,
+    typename CastedTagContaining = tag_cast_t
                                     <
-                                        typename tag<GeometryContaining>::type,
+                                        tag_t<GeometryContaining>,
                                         pointlike_tag, linear_tag, polygonal_tag, areal_tag
-                                    >::type,
-    typename CsTagContained = typename tag_cast
+                                    >,
+    typename CsTagContained = tag_cast_t
                                 <
-                                    typename cs_tag<typename point_type<GeometryContained>::type>::type,
+                                    cs_tag_t<point_type_t<GeometryContained>>,
                                     spherical_tag
-                                >::type,
-    typename CsTagContaining = typename tag_cast
+                                >,
+    typename CsTagContaining = tag_cast_t
                                 <
-                                    typename cs_tag<typename point_type<GeometryContaining>::type>::type,
+                                    cs_tag_t<point_type_t<GeometryContaining>>,
                                     spherical_tag
-                                >::type
+                                >
 >
 struct default_strategy
 {

--- a/include/boost/geometry/strategies/disjoint.hpp
+++ b/include/boost/geometry/strategies/disjoint.hpp
@@ -33,12 +33,12 @@ template
 <
     typename Geometry1,
     typename Geometry2,
-    typename Tag1 = typename geometry::tag<Geometry1>::type,
-    typename Tag2 = typename geometry::tag<Geometry2>::type,
+    typename Tag1 = tag_t<Geometry1>,
+    typename Tag2 = tag_t<Geometry2>,
     int TopDim1 = geometry::topological_dimension<Geometry1>::value,
     int TopDim2 = geometry::topological_dimension<Geometry2>::value,
-    typename CsTag1 = typename cs_tag<Geometry1>::type,
-    typename CsTag2 = typename cs_tag<Geometry2>::type
+    typename CsTag1 = cs_tag_t<Geometry1>,
+    typename CsTag2 = cs_tag_t<Geometry2>
 >
 struct default_strategy
     : relate::services::default_strategy

--- a/include/boost/geometry/strategies/distance.hpp
+++ b/include/boost/geometry/strategies/distance.hpp
@@ -94,8 +94,8 @@ template
     typename GeometryTag2,
     typename Point1,
     typename Point2 = Point1,
-    typename CsTag1 = typename cs_tag<Point1>::type,
-    typename CsTag2 = typename cs_tag<Point2>::type,
+    typename CsTag1 = cs_tag_t<Point1>,
+    typename CsTag2 = cs_tag_t<Point2>,
     typename UnderlyingStrategy = void
 >
 struct default_strategy

--- a/include/boost/geometry/strategies/normalize.hpp
+++ b/include/boost/geometry/strategies/normalize.hpp
@@ -229,11 +229,7 @@ struct spherical_point
         detail::normalize_point
             <
                 PointIn, PointOut,
-                (! std::is_same
-                    <
-                        typename cs_tag<PointIn>::type,
-                        spherical_polar_tag
-                    >::value)
+                (! std::is_same<cs_tag_t<PointIn>, spherical_polar_tag>::value)
             >::apply(point_in, point_out);
     }
 };
@@ -246,11 +242,7 @@ struct spherical_box
         detail::normalize_box
             <
                 BoxIn, BoxOut,
-                (! std::is_same
-                    <
-                        typename cs_tag<BoxIn>::type,
-                        spherical_polar_tag
-                    >::value)
+                (! std::is_same<cs_tag_t<BoxIn>, spherical_polar_tag>::value)
             >::apply(box_in, box_out);
     }
 };

--- a/include/boost/geometry/strategies/within.hpp
+++ b/include/boost/geometry/strategies/within.hpp
@@ -52,28 +52,28 @@ template
 <
     typename GeometryContained,
     typename GeometryContaining,
-    typename TagContained = typename tag<GeometryContained>::type,
-    typename TagContaining = typename tag<GeometryContaining>::type,
-    typename CastedTagContained = typename tag_cast
+    typename TagContained = tag_t<GeometryContained>,
+    typename TagContaining = tag_t<GeometryContaining>,
+    typename CastedTagContained = tag_cast_t
                                     <
-                                        typename tag<GeometryContained>::type,
+                                        tag_t<GeometryContained>,
                                         pointlike_tag, linear_tag, polygonal_tag, areal_tag
-                                    >::type,
-    typename CastedTagContaining = typename tag_cast
+                                    >,
+    typename CastedTagContaining = tag_cast_t
                                     <
-                                        typename tag<GeometryContaining>::type,
+                                        tag_t<GeometryContaining>,
                                         pointlike_tag, linear_tag, polygonal_tag, areal_tag
-                                    >::type,
-    typename CsTagContained = typename tag_cast
+                                    >,
+    typename CsTagContained = tag_cast_t
                                 <
-                                    typename cs_tag<typename point_type<GeometryContained>::type>::type,
+                                    cs_tag_t<point_type_t<GeometryContained>>,
                                     spherical_tag
-                                >::type,
-    typename CsTagContaining = typename tag_cast
+                                >,
+    typename CsTagContaining = tag_cast_t
                                 <
-                                    typename cs_tag<typename point_type<GeometryContaining>::type>::type,
+                                    cs_tag_t<point_type_t<GeometryContaining>>,
                                     spherical_tag
-                                >::type
+                                >
 >
 struct default_strategy
 {

--- a/include/boost/geometry/strategy/relate.hpp
+++ b/include/boost/geometry/strategy/relate.hpp
@@ -90,10 +90,7 @@ namespace detail
 
 template <typename Geometry>
 struct default_intersection_strategy
-    : strategy::intersection::services::default_strategy
-        <
-            typename cs_tag<Geometry>::type
-        >
+    : strategy::intersection::services::default_strategy<cs_tag_t<Geometry>>
 {};
 
 template <typename PointLike, typename Geometry>

--- a/include/boost/geometry/strategy/spherical/envelope_segment.hpp
+++ b/include/boost/geometry/strategy/spherical/envelope_segment.hpp
@@ -343,7 +343,7 @@ public:
                              Box& mbr,
                              Strategy const& strategy)
     {
-        typedef envelope_segment_convert_polar<Units, typename cs_tag<Box>::type> convert_polar;
+        typedef envelope_segment_convert_polar<Units, cs_tag_t<Box>> convert_polar;
 
         convert_polar::pre(lat1, lat2);
 

--- a/include/boost/geometry/strategy/spherical/expand_point.hpp
+++ b/include/boost/geometry/strategy/spherical/expand_point.hpp
@@ -189,7 +189,7 @@ struct spherical_point
         expand::detail::point_loop_on_spheroid
             <
                 dimension<Point>::value,
-                ! std::is_same<typename cs_tag<Point>::type, spherical_polar_tag>::value
+                ! std::is_same<cs_tag_t<Point>, spherical_polar_tag>::value
             >::apply(box, point);
     }
 };

--- a/test/algorithms/distance/distance_brute_force.hpp
+++ b/test/algorithms/distance/distance_brute_force.hpp
@@ -129,18 +129,8 @@ template
     typename Geometry1,
     typename Geometry2,
     typename Strategy,
-    typename Tag1 = typename tag_cast
-        <
-            typename tag<Geometry1>::type,
-            segment_tag,
-            linear_tag
-        >::type,
-    typename Tag2 = typename tag_cast
-        <
-            typename tag<Geometry2>::type,
-            segment_tag,
-            linear_tag
-        >::type,
+    typename Tag1 = tag_cast_t<tag_t<Geometry1>, segment_tag, linear_tag>,
+    typename Tag2 = tag_cast_t<tag_t<Geometry2>, segment_tag, linear_tag>,
     bool Reverse = reverse_dispatch<Geometry1, Geometry2>::type::value
 >
 struct distance_brute_force

--- a/test/util/is_implemented.cpp
+++ b/test/util/is_implemented.cpp
@@ -49,8 +49,8 @@ template
 <
     typename Geometry1, typename Geometry2,
     typename Strategy,
-    typename Tag1 = typename tag_cast<typename tag<Geometry1>::type, multi_tag>::type,
-    typename Tag2 = typename tag_cast<typename tag<Geometry2>::type, multi_tag>::type,
+    typename Tag1 = tag_cast_t<tag_t<Geometry1>, multi_tag>,
+    typename Tag2 = tag_cast_t<tag_t<Geometry2>, multi_tag>,
     typename StrategyTag = typename strategy::services::tag<Strategy>::type,
     bool Reverse = reverse_dispatch<Geometry1, Geometry2>::type::value
 >


### PR DESCRIPTION
This PR:
* uses `tag_cast_t` i/o `tag_cast`
* where this happens, also uses `tag_t`
* uses `cs_tag_t` i/o `cs_tag`
* extracts `single_tag_base_of` to (renamed) a separate meta-function file `primary_single_tag` (I think it's more clear)