### PR TITLE
GHA: build docs from BOOST_ROOT

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -88,13 +88,18 @@ jobs:
         echo "using xsltproc ;" >> $HOME/user-config.jam
         test -f $HOME/user-config.jam && cat $HOME/user-config.jam
 
-    - name: Build examples
+    - name: Build documentation method 1
       run: |
         cd $BOOST_ROOT
-        $BOOST_ROOT/b2 libs/geometry/doc/src/examples
+        ./b2 libs/geometry/doc/
 
-    - name: Build documentation
+    - name: Build documentation method 2
       run: |
         cd $BOOST_ROOT
         cd libs/geometry/doc
         $BOOST_ROOT/b2
+
+    - name: Build examples
+      run: |
+        cd $BOOST_ROOT
+        $BOOST_ROOT/b2 libs/geometry/doc/src/examples


### PR DESCRIPTION
Hi,
I have some scripts that build each boost library's documentation individually, to test they are working as expected. (Those scripts are in release-tools/build_docs).  

For all other boost libraries, this technique works:

```
cd $BOOST_ROOT
./b2 _path_to_library_docs_
```

boostorg/geometry is an exception. This pull request demonstrates that. Would you be able to decipher why it happens and adjust the process?

Notice that even the "Build examples" job follows this pattern.

```
cd $BOOST_ROOT
./b2 _path_to_examples_
```

With earlier versions of geometry, I was implementing a hack, that probably wasn't ideal. 
- Manually run ./b2 $librarypath/doc/src/docutils/tools/doxygen_xml2qbk
- That built dist/bin/doxygen_xml2qbk which I added to PATH, so it could be discovered.  

It solved the problem temporarily.  Now the hack is not working either, but a more official solution is preferable, anyway.
