### PR TITLE
chore: change point_type to point_type_t and use 'using' at those places

### DIFF
--- a/include/boost/geometry/algorithms/detail/buffer/buffer_inserter.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/buffer_inserter.hpp
@@ -86,8 +86,8 @@ inline void simplify_input(RangeIn const& range,
 template <typename RingOutput>
 struct buffer_range
 {
-    typedef typename point_type<RingOutput>::type output_point_type;
-    typedef typename coordinate_type<RingOutput>::type coordinate_type;
+    using output_point_type = point_type_t<RingOutput>;
+    using coordinate_type = coordinate_type_t<RingOutput>;
 
     template
     <
@@ -432,7 +432,7 @@ struct buffer_inserter<point_tag, Point, RingOutput>
     {
         detail::buffer::buffer_point
         <
-            typename point_type<RingOutput>::type
+            point_type_t<RingOutput>
         >(point, collection, distance_strategy, point_strategy);
     }
 };
@@ -446,7 +446,7 @@ template
 >
 struct buffer_inserter_ring
 {
-    using output_point_type = typename point_type<RingOutput>::type;
+    using output_point_type = point_type_t<RingOutput>;
 
     template
     <
@@ -609,8 +609,8 @@ template
 >
 struct buffer_inserter<linestring_tag, Linestring, Polygon>
 {
-    using output_ring_type = typename ring_type<Polygon>::type;
-    using output_point_type = typename point_type<output_ring_type>::type;
+    using output_ring_type = ring_type_t<Polygon>;
+    using output_point_type = point_type_t<output_ring_type>;
 
     template
     <

--- a/include/boost/geometry/algorithms/detail/buffer/implementation.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/implementation.hpp
@@ -78,15 +78,13 @@ struct buffer_all<Input, Output, TagIn, multi_polygon_tag>
     {
         typedef typename boost::range_value<Output>::type polygon_type;
 
-        typedef typename point_type<Input>::type point_type;
-
         if (geometry::is_empty(geometry_in))
         {
             // Then output geometry is kept empty as well
             return;
         }
 
-        model::box<point_type> box;
+        model::box<point_type_t<Input>> box;
         geometry::envelope(geometry_in, box);
         geometry::buffer(box, box, distance_strategy.max_distance(join_strategy, end_strategy));
 

--- a/include/boost/geometry/algorithms/detail/closest_feature/geometry_to_range.hpp
+++ b/include/boost/geometry/algorithms/detail/closest_feature/geometry_to_range.hpp
@@ -120,14 +120,8 @@ public:
         typename strategy::distance::services::return_type
             <
                 Strategy,
-                typename point_type<Geometry>::type,
-                typename point_type
-                    <
-                        typename std::iterator_traits
-                            <
-                                RangeIterator
-                            >::value_type
-                    >::type
+                point_type_t<Geometry>,
+                point_type_t<typename std::iterator_traits<RangeIterator>::value_type>
             >::type dist_min;
 
         return apply(geometry, first, last, strategy, dist_min);

--- a/include/boost/geometry/algorithms/detail/closest_feature/range_to_range.hpp
+++ b/include/boost/geometry/algorithms/detail/closest_feature/range_to_range.hpp
@@ -177,14 +177,14 @@ public:
         typename strategy::distance::services::return_type
             <
                 Strategy,
-                typename point_type<rtree_value_type>::type,
-                typename point_type
+                point_type_t<rtree_value_type>,
+                point_type_t
                     <
                         typename std::iterator_traits
                             <
                                 QueryRangeIterator
                             >::value_type
-                    >::type
+                    >
             >::type dist_min;
 
         return apply(rtree_first, rtree_last, queries_first, queries_last,

--- a/include/boost/geometry/algorithms/detail/closest_points/linear_or_areal_to_areal.hpp
+++ b/include/boost/geometry/algorithms/detail/closest_points/linear_or_areal_to_areal.hpp
@@ -39,8 +39,8 @@ struct linear_to_areal
         using point_type = typename std::conditional
             <
                 std::is_same<typename coordinate_type<Linear>::type, most_precise_type>::value,
-                typename point_type<Linear>::type,
-                typename point_type<Areal>::type
+                point_type_t<Linear>,
+                point_type_t<Areal>
             >::type;
 
         using linestring_type = geometry::model::linestring<point_type>;
@@ -108,7 +108,7 @@ struct segment_to_areal
                              Strategies const& strategies,
                              bool = false)
     {
-        using linestring_type = geometry::model::linestring<typename point_type<Segment>::type>;
+        using linestring_type = geometry::model::linestring<point_type_t<Segment>>;
         linestring_type linestring;
         convert(segment, linestring);
         linear_to_areal::apply(linestring, areal, shortest_seg, strategies);
@@ -142,8 +142,8 @@ struct areal_to_areal
         using point_type = typename std::conditional
             <
                 std::is_same<typename coordinate_type<Areal1>::type, most_precise_type>::value,
-                typename point_type<Areal1>::type,
-                typename point_type<Areal2>::type
+                point_type_t<Areal1>,
+                point_type_t<Areal2>
             >::type;
 
         using linestring_type = geometry::model::linestring<point_type>;

--- a/include/boost/geometry/algorithms/detail/closest_points/linear_to_linear.hpp
+++ b/include/boost/geometry/algorithms/detail/closest_points/linear_to_linear.hpp
@@ -43,7 +43,7 @@ struct linear_to_linear
         {
             dispatch::closest_points
                 <
-                    typename point_type<Linear1>::type,
+                    point_type_t<Linear1>,
                     Linear2
                 >::apply(*points_begin(linear1), linear2, shortest_seg, strategies);
             return;
@@ -53,7 +53,7 @@ struct linear_to_linear
         {
             dispatch::closest_points
                 <
-                    typename point_type<Linear2>::type,
+                    point_type_t<Linear2>,
                     Linear1
                 >::apply(*points_begin(linear2), linear1, shortest_seg, strategies);
             detail::closest_points::swap_segment_points::apply(shortest_seg);
@@ -91,7 +91,7 @@ struct segment_to_linear
                              bool = false)
     {
         using linestring_type = geometry::model::linestring
-            <typename point_type<Segment>::type>;
+            <point_type_t<Segment>>;
         linestring_type linestring;
         convert(segment, linestring);
         linear_to_linear::apply(linestring, linear, shortest_seg, strategies);

--- a/include/boost/geometry/algorithms/detail/closest_points/multipoint_to_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/closest_points/multipoint_to_geometry.hpp
@@ -125,7 +125,7 @@ struct segment_to_multipoint
     {
         using linestring_type = geometry::model::linestring
             <
-                typename point_type<Segment>::type
+                point_type_t<Segment>
             >;
         linestring_type linestring;
         convert(segment, linestring);
@@ -150,7 +150,7 @@ struct multipoint_to_segment
     {
         using linestring_type = geometry::model::linestring
             <
-                typename point_type<Segment>::type
+                point_type_t<Segment>
             >;
         linestring_type linestring;
         convert(segment, linestring);

--- a/include/boost/geometry/algorithms/detail/closest_points/point_to_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/closest_points/point_to_geometry.hpp
@@ -68,7 +68,7 @@ struct point_to_segment
     static inline void apply(Point const& point, Segment const& segment,
                              OutputSegment& shortest_seg, Strategies const& strategies)
     {
-        typename point_type<Segment>::type p[2];
+        point_type_t<Segment> p[2];
         geometry::detail::assign_point_from_index<0>(segment, p[0]);
         geometry::detail::assign_point_from_index<1>(segment, p[1]);
 

--- a/include/boost/geometry/algorithms/detail/closest_points/segment_to_segment.hpp
+++ b/include/boost/geometry/algorithms/detail/closest_points/segment_to_segment.hpp
@@ -54,7 +54,7 @@ public:
     {
         using intersection_return_type = segment_intersection_points
             <
-                typename point_type<Segment1>::type
+                point_type_t<Segment1>
             >;
 
         using intersection_policy = policies::relate::segments_intersection_points
@@ -74,11 +74,11 @@ public:
             return;
         }
 
-        typename point_type<Segment1>::type p[2];
+        point_type_t<Segment1> p[2];
         detail::assign_point_from_index<0>(segment1, p[0]);
         detail::assign_point_from_index<1>(segment1, p[1]);
 
-        typename point_type<Segment2>::type q[2];
+        point_type_t<Segment2> q[2];
         detail::assign_point_from_index<0>(segment2, q[0]);
         detail::assign_point_from_index<1>(segment2, q[1]);
 

--- a/include/boost/geometry/algorithms/detail/closest_points/utilities.hpp
+++ b/include/boost/geometry/algorithms/detail/closest_points/utilities.hpp
@@ -57,8 +57,8 @@ using creturn_t = typename strategy::distance::services::return_type
             <
                 distance_strategy_t<Geometry1, Geometry2, Strategies>
             >::type,
-        typename point_type<Geometry1>::type,
-        typename point_type<Geometry2>::type
+        point_type_t<Geometry1>,
+        point_type_t<Geometry2>
     >::type;
 
 

--- a/include/boost/geometry/algorithms/detail/convex_hull/interface.hpp
+++ b/include/boost/geometry/algorithms/detail/convex_hull/interface.hpp
@@ -213,7 +213,7 @@ struct convex_hull
         detail::convex_hull::input_geometry_proxy<Geometry> in_proxy(geometry);
         detail::convex_hull::graham_andrew
             <
-                typename point_type<Geometry>::type
+                point_type_t<Geometry>
             >::apply(in_proxy, out, strategy);
     }
 };
@@ -234,7 +234,7 @@ struct convex_hull<Box, box_tag>
         static bool const Reverse
             = geometry::point_order<OutputGeometry>::value == counterclockwise;
 
-        std::array<typename point_type<OutputGeometry>::type, 4> arr;
+        std::array<point_type_t<OutputGeometry>, 4> arr;
         // TODO: This assigns only 2d cooridnates!
         //       And it is also used in box_view<>!
         geometry::detail::assign_box_corners_oriented<Reverse>(box, arr);

--- a/include/boost/geometry/algorithms/detail/covered_by/implementation.hpp
+++ b/include/boost/geometry/algorithms/detail/covered_by/implementation.hpp
@@ -65,7 +65,7 @@ struct geometry_covered_by_box
     template <typename Geometry, typename Box, typename Strategy>
     static inline bool apply(Geometry const& geometry, Box const& box, Strategy const& strategy)
     {
-        using point_type = typename point_type<Geometry>::type;
+        using point_type = point_type_t<Geometry>;
         using mutable_point_type = typename helper_geometry<point_type>::type;
         using box_type = model::box<mutable_point_type>;
 

--- a/include/boost/geometry/algorithms/detail/disjoint/linear_areal.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/linear_areal.hpp
@@ -71,8 +71,7 @@ struct disjoint_no_intersections_policy
     template <typename Strategy>
     static inline bool apply(Geometry1 const& g1, Geometry2 const& g2, Strategy const& strategy)
     {
-        using point_type = typename point_type<Geometry1>::type;
-        typename helper_geometry<point_type>::type p;
+        typename helper_geometry<point_type_t<Geometry1>>::type p;
         geometry::point_on_border(p, g1);
 
         return ! geometry::covered_by(p, g2, strategy);
@@ -183,7 +182,7 @@ public:
             return false;
         }
 
-        typename point_type<Segment>::type p;
+        point_type_t<Segment> p;
         detail::assign_point_from_index<0>(segment, p);
 
         return ! geometry::covered_by(p, polygon, strategy);
@@ -219,7 +218,7 @@ struct disjoint_segment_areal<Segment, Ring, ring_tag>
             return false;
         }
 
-        typename point_type<Segment>::type p;
+        point_type_t<Segment> p;
         detail::assign_point_from_index<0>(segment, p);
 
         return ! geometry::covered_by(p, ring, strategy);

--- a/include/boost/geometry/algorithms/detail/disjoint/linear_linear.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/linear_linear.hpp
@@ -55,14 +55,12 @@ struct disjoint_segment
     static inline bool apply(Segment1 const& segment1, Segment2 const& segment2,
                              Strategy const& strategy)
     {
-        typedef typename point_type<Segment1>::type point_type;
-
-        typedef segment_intersection_points<point_type> intersection_return_type;
-
-        typedef policies::relate::segments_intersection_points
+        using point_type = point_type_t<Segment1>;
+        using intersection_return_type = segment_intersection_points<point_type>;
+        using intersection_policy = policies::relate::segments_intersection_points
             <
                 intersection_return_type
-            > intersection_policy;
+            >;
 
         detail::segment_as_subrange<Segment1> sub_range1(segment1);
         detail::segment_as_subrange<Segment2> sub_range2(segment2);

--- a/include/boost/geometry/algorithms/detail/disjoint/linear_segment_or_box.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/linear_segment_or_box.hpp
@@ -86,7 +86,7 @@ struct disjoint_range_segment_or_box
                              SegmentOrBox const& segment_or_box,
                              Strategy const& strategy)
     {
-        using point_type = typename point_type<Range>::type;
+        using point_type = point_type_t<Range>;
         using range_segment = typename geometry::model::referring_segment<point_type const>;
 
         detail::closed_view<Range const> const view(range);

--- a/include/boost/geometry/algorithms/detail/disjoint/multipoint_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/multipoint_geometry.hpp
@@ -254,7 +254,7 @@ public:
         // should be passed, where envelope would be lazily calculated when needed the first time
         geometry::partition
             <
-                geometry::model::box<typename point_type<MultiPoint>::type>
+                geometry::model::box<point_type_t<MultiPoint>>
             >::apply(multipoint, segment_range(linear), visitor,
                      expand_box_point<Strategy>(strategy),
                      overlaps_box_point<Strategy>(strategy),
@@ -282,9 +282,9 @@ public:
                              SingleGeometry const& single_geometry,
                              Strategy const& strategy)
     {
-        typedef typename point_type<MultiPoint>::type point1_type;
-        typedef typename point_type<SingleGeometry>::type point2_type;
-        typedef model::box<point2_type> box2_type;
+        using point1_type = point_type_t<MultiPoint>;
+        using point2_type = point_type_t<SingleGeometry>;
+        using box2_type = model::box<point2_type>;
 
         box2_type box2;
         geometry::envelope(single_geometry, box2, strategy);
@@ -424,11 +424,11 @@ public:
     template <typename Strategy>
     static inline bool apply(MultiPoint const& multi_point, MultiGeometry const& multi_geometry, Strategy const& strategy)
     {
-        typedef typename point_type<MultiPoint>::type point1_type;
-        typedef typename point_type<MultiGeometry>::type point2_type;
-        typedef model::box<point1_type> box1_type;
-        typedef model::box<point2_type> box2_type;
-        typedef std::pair<box2_type, std::size_t> box_pair_type;
+        using point1_type = point_type_t<MultiPoint>;
+        using point2_type = point_type_t<MultiGeometry>;
+        using box1_type = model::box<point1_type>;
+        using box2_type = model::box<point2_type>;
+        using box_pair_type = std::pair<box2_type, std::size_t>;
 
         std::size_t count2 = boost::size(multi_geometry);
         std::vector<box_pair_type> boxes(count2);

--- a/include/boost/geometry/algorithms/detail/disjoint/segment_box.hpp
+++ b/include/boost/geometry/algorithms/detail/disjoint/segment_box.hpp
@@ -84,8 +84,7 @@ struct disjoint_segment_box_sphere_or_spheroid
                              DisjointPointBoxStrategy const& disjoint_point_box_strategy,
                              DisjointBoxBoxStrategy const& disjoint_box_box_strategy)
     {
-        typedef typename point_type<Segment>::type segment_point;
-        segment_point vertex;
+        point_type_t<Segment> vertex;
         return apply(segment, box, vertex,
                      azimuth_strategy,
                      normalize_strategy,
@@ -112,13 +111,13 @@ struct disjoint_segment_box_sphere_or_spheroid
     {
         assert_dimension_equal<Segment, Box>();
 
-        typedef typename point_type<Segment>::type segment_point_type;
+        using segment_point_type = point_type_t<Segment>;
 
         segment_point_type p0, p1;
         geometry::detail::assign_point_from_index<0>(segment, p0);
         geometry::detail::assign_point_from_index<1>(segment, p1);
 
-        //vertex not computed here
+        // Vertex is not computed here
         disjoint_info disjoint_return_value = disjoint_info::disjoint_no_vertex;
 
         // Simplest cases first

--- a/include/boost/geometry/algorithms/detail/distance/geometry_to_segment_or_box.hpp
+++ b/include/boost/geometry/algorithms/detail/distance/geometry_to_segment_or_box.hpp
@@ -81,20 +81,16 @@ template
 class geometry_to_segment_or_box
 {
 private:
-    typedef typename point_type<SegmentOrBox>::type segment_or_box_point;
-
-    typedef distance::strategy_t<Geometry, SegmentOrBox, Strategies> strategy_type;
-
-    typedef detail::closest_feature::point_to_point_range
+    using segment_or_box_point = point_type_t<SegmentOrBox>;
+    using strategy_type = distance::strategy_t<Geometry, SegmentOrBox, Strategies>;
+    using point_to_point_range = detail::closest_feature::point_to_point_range
         <
-            typename point_type<Geometry>::type,
+            point_type_t<Geometry>,
             std::vector<segment_or_box_point>,
             segment_or_box_point_range_closure<SegmentOrBox>::value
-        > point_to_point_range;
-
-    typedef detail::closest_feature::geometry_to_range geometry_to_range;
-
-    typedef distance::creturn_t<Geometry, SegmentOrBox, Strategies> comparable_return_type;
+        >;
+    using geometry_to_range = detail::closest_feature::geometry_to_range;
+    using comparable_return_type = distance::creturn_t<Geometry, SegmentOrBox, Strategies>;
 
     // assign the new minimum value for an iterator of the point range
     // of a segment or a box
@@ -320,7 +316,7 @@ public:
             :
             dispatch::distance
                 <
-                    typename point_type<MultiPoint>::type,
+                    point_type_t<MultiPoint>,
                     SegmentOrBox,
                     Strategies
                 >::apply(*it_min, segment_or_box, strategies);

--- a/include/boost/geometry/algorithms/detail/distance/linear_to_linear.hpp
+++ b/include/boost/geometry/algorithms/detail/distance/linear_to_linear.hpp
@@ -47,7 +47,7 @@ struct linear_to_linear
         {
             return dispatch::distance
                 <
-                    typename point_type<Linear1>::type,
+                    point_type_t<Linear1>,
                     Linear2,
                     Strategies
                 >::apply(*points_begin(linear1), linear2, strategies);
@@ -57,7 +57,7 @@ struct linear_to_linear
         {
             return dispatch::distance
                 <
-                    typename point_type<Linear2>::type,
+                    point_type_t<Linear2>,
                     Linear1,
                     Strategies
                 >::apply(*points_begin(linear2), linear1, strategies);

--- a/include/boost/geometry/algorithms/detail/distance/point_to_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/distance/point_to_geometry.hpp
@@ -100,7 +100,7 @@ struct point_to_segment
     static inline auto apply(Point const& point, Segment const& segment,
                              Strategies const& strategies)
     {
-        typename point_type<Segment>::type p[2];
+        point_type_t<Segment> p[2];
         geometry::detail::assign_point_from_index<0>(segment, p[0]);
         geometry::detail::assign_point_from_index<1>(segment, p[1]);
 
@@ -117,7 +117,7 @@ struct point_to_segment<Point, Segment, Strategy, false>
     static inline auto apply(Point const& point, Segment const& segment,
                              Strategy const& strategy)
     {
-        typename point_type<Segment>::type p[2];
+        point_type_t<Segment> p[2];
         geometry::detail::assign_point_from_index<0>(segment, p[0]);
         geometry::detail::assign_point_from_index<1>(segment, p[1]);
 

--- a/include/boost/geometry/algorithms/detail/distance/segment_to_box.hpp
+++ b/include/boost/geometry/algorithms/detail/distance/segment_to_box.hpp
@@ -82,17 +82,16 @@ template
 class segment_to_box_2D_generic
 {
 private:
-    typedef typename point_type<Segment>::type segment_point;
-    typedef typename point_type<Box>::type box_point;
+    using segment_point = point_type_t<Segment>;
+    using box_point = point_type_t<Box>;
+    using ps_strategy_type = distance::strategy_t<box_point, Segment, Strategies>;
 
-    typedef distance::strategy_t<box_point, Segment, Strategies> ps_strategy_type;
-
-    typedef detail::closest_feature::point_to_point_range
+    using point_to_point_range = detail::closest_feature::point_to_point_range
         <
             segment_point,
             std::vector<box_point>,
             open
-        > point_to_point_range;
+        >;
 
 public:
     // TODO: Or should the return type be defined by sb_strategy_type?
@@ -187,15 +186,15 @@ template
 class segment_to_box_2D_generic<Segment, Box, Strategies, true> // Use both PointSegment and PointBox strategies
 {
 private:
-    typedef typename point_type<Segment>::type segment_point;
-    typedef typename point_type<Box>::type box_point;
+    using segment_point = point_type_t<Segment>;
+    using box_point = point_type_t<Box>;
 
-    typedef distance::strategy_t<box_point, Segment, Strategies> ps_strategy_type;
-    typedef distance::strategy_t<segment_point, Box, Strategies> pb_strategy_type;
+    using ps_strategy_type = distance::strategy_t<box_point, Segment, Strategies>;
+    using pb_strategy_type = distance::strategy_t<segment_point, Box, Strategies>;
 
 public:
     // TODO: Or should the return type be defined by sb_strategy_type?
-    typedef distance::return_t<box_point, Segment, Strategies> return_type;
+    using return_type = distance::return_t<box_point, Segment, Strategies>;
 
     static inline return_type apply(Segment const& segment,
                                     Box const& box,
@@ -732,8 +731,8 @@ public:
                                     Box const& box,
                                     Strategies const& strategies)
     {
-        typedef typename point_type<Segment>::type segment_point;
-        typedef typename point_type<Box>::type box_point;
+        using segment_point = point_type_t<Segment>;
+        using box_point = point_type_t<Box>;
 
         segment_point p[2];
         detail::assign_point_from_index<0>(segment, p[0]);

--- a/include/boost/geometry/algorithms/detail/distance/segment_to_segment.hpp
+++ b/include/boost/geometry/algorithms/detail/distance/segment_to_segment.hpp
@@ -59,11 +59,11 @@ public:
             return 0;
         }
 
-        typename point_type<Segment1>::type p[2];
+        point_type_t<Segment1> p[2];
         detail::assign_point_from_index<0>(segment1, p[0]);
         detail::assign_point_from_index<1>(segment1, p[1]);
 
-        typename point_type<Segment2>::type q[2];
+        point_type_t<Segment2> q[2];
         detail::assign_point_from_index<0>(segment2, q[0]);
         detail::assign_point_from_index<1>(segment2, q[1]);
 

--- a/include/boost/geometry/algorithms/detail/distance/strategy_utils.hpp
+++ b/include/boost/geometry/algorithms/detail/distance/strategy_utils.hpp
@@ -35,8 +35,8 @@ template <typename Geometry1, typename Geometry2, typename Strategies>
 using return_t = typename strategy::distance::services::return_type
     <
         strategy_t<Geometry1, Geometry2, Strategies>,
-        typename point_type<Geometry1>::type,
-        typename point_type<Geometry2>::type
+        point_type_t<Geometry1>,
+        point_type_t<Geometry2>
     >::type;
 
 
@@ -51,8 +51,8 @@ template <typename Geometry1, typename Geometry2, typename Strategies>
 using creturn_t = typename strategy::distance::services::return_type
     <
         cstrategy_t<Geometry1, Geometry2, Strategies>,
-        typename point_type<Geometry1>::type,
-        typename point_type<Geometry2>::type
+        point_type_t<Geometry1>,
+        point_type_t<Geometry2>
     >::type;
 
 

--- a/include/boost/geometry/algorithms/detail/envelope/segment.hpp
+++ b/include/boost/geometry/algorithms/detail/envelope/segment.hpp
@@ -70,7 +70,7 @@ struct envelope_segment
     static inline void apply(Segment const& segment, Box& mbr,
                              Strategy const& strategy)
     {
-        typename point_type<Segment>::type p[2];
+        point_type_t<Segment> p[2];
         detail::assign_point_from_index<0>(segment, p[0]);
         detail::assign_point_from_index<1>(segment, p[1]);
 

--- a/include/boost/geometry/algorithms/detail/equals/collect_vectors.hpp
+++ b/include/boost/geometry/algorithms/detail/equals/collect_vectors.hpp
@@ -344,7 +344,7 @@ struct box_collect_vectors
 
     static inline void apply(Collection& collection, Box const& box)
     {
-        typename point_type<Box>::type lower_left, lower_right,
+        point_type_t<Box> lower_left, lower_right,
             upper_left, upper_right;
         geometry::detail::assign_box_corners(box, lower_left, lower_right,
             upper_left, upper_right);
@@ -365,7 +365,7 @@ struct box_collect_vectors<Box, Collection, spherical_equatorial_tag>
 {
     static inline void apply(Collection& collection, Box const& box)
     {
-        typename point_type<Box>::type lower_left, lower_right,
+        point_type_t<Box> lower_left, lower_right,
                 upper_left, upper_right;
         geometry::detail::assign_box_corners(box, lower_left, lower_right,
                 upper_left, upper_right);

--- a/include/boost/geometry/algorithms/detail/has_self_intersections.hpp
+++ b/include/boost/geometry/algorithms/detail/has_self_intersections.hpp
@@ -70,12 +70,12 @@ inline bool has_self_intersections(Geometry const& geometry,
         Strategy const& strategy,
         bool throw_on_self_intersection = true)
 {
-    typedef typename point_type<Geometry>::type point_type;
-    typedef turn_info
+    using point_type = point_type_t<Geometry>;
+    using turn_info = turn_info
     <
         point_type,
         typename segment_ratio_type<point_type>::type
-    > turn_info;
+    >;
     std::deque<turn_info> turns;
     detail::disjoint::disjoint_interrupt_policy policy;
 

--- a/include/boost/geometry/algorithms/detail/intersection/multi.hpp
+++ b/include/boost/geometry/algorithms/detail/intersection/multi.hpp
@@ -173,8 +173,7 @@ struct clip_multi_linestring
             Box const& box,
             OutputIterator out, Strategy const& )
     {
-        typedef typename point_type<LinestringOut>::type point_type;
-        strategy::intersection::liang_barsky<Box, point_type> lb_strategy;
+        strategy::intersection::liang_barsky<Box, point_type_t<LinestringOut>> lb_strategy;
         for (auto it = boost::begin(multi_linestring); it != boost::end(multi_linestring); ++it)
         {
             out = detail::intersection::clip_range_with_box

--- a/include/boost/geometry/algorithms/detail/is_simple/debug_print_boundary_points.hpp
+++ b/include/boost/geometry/algorithms/detail/is_simple/debug_print_boundary_points.hpp
@@ -65,10 +65,7 @@ struct debug_boundary_points_printer<MultiLinestring, multi_linestring_tag>
 {
     static inline void apply(MultiLinestring const& multilinestring)
     {
-        typedef typename point_type<MultiLinestring>::type point_type;
-        typedef std::vector<point_type> point_vector;
-
-        point_vector boundary_points;
+        std::vector<point_type_t<MultiLinestring>> boundary_points;
         for (auto it = boost::begin(multilinestring); it != boost::end(multilinestring); ++it)
         {
             if ( boost::size(*it) > 1

--- a/include/boost/geometry/algorithms/detail/is_simple/linear.hpp
+++ b/include/boost/geometry/algorithms/detail/is_simple/linear.hpp
@@ -187,22 +187,19 @@ private:
 template <typename Linear, typename Strategy>
 inline bool has_self_intersections(Linear const& linear, Strategy const& strategy)
 {
-    typedef typename point_type<Linear>::type point_type;
-
-    // compute self turns
-    typedef detail::overlay::turn_info<point_type> turn_info;
-
-    std::deque<turn_info> turns;
-
-    typedef detail::overlay::get_turn_info
+    using point_type = point_type_t<Linear>;
+    using turn_info = detail::overlay::turn_info<point_type>;
+    using turn_policy = detail::overlay::get_turn_info
         <
             detail::disjoint::assign_disjoint_policy
-        > turn_policy;
-
-    typedef is_acceptable_turn
+        >;
+    using is_acceptable_turn_type = is_acceptable_turn
         <
             Linear, Strategy
-        > is_acceptable_turn_type;
+        >;
+
+    // Compute self turns
+    std::deque<turn_info> turns;
 
     is_acceptable_turn_type predicate(linear, strategy);
     detail::overlay::predicate_based_interrupt_policy

--- a/include/boost/geometry/algorithms/detail/is_simple/multipoint.hpp
+++ b/include/boost/geometry/algorithms/detail/is_simple/multipoint.hpp
@@ -47,7 +47,7 @@ struct is_simple_multipoint
     {
         typedef geometry::less
             <
-                typename point_type<MultiPoint>::type,
+                point_type_t<MultiPoint>,
                 -1,
                 Strategy
             > less_type;

--- a/include/boost/geometry/algorithms/detail/is_valid/has_valid_self_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/has_valid_self_turns.hpp
@@ -44,14 +44,14 @@ template
 class has_valid_self_turns
 {
 private:
-    typedef typename point_type<Geometry>::type point_type;
+    using point_type = point_type_t<Geometry>;
 
 public:
-    typedef detail::overlay::turn_info
+    using turn_type = detail::overlay::turn_info
         <
             point_type,
             typename segment_ratio_type<point_type>::type
-        > turn_type;
+        >;
 
     // returns true if all turns are valid
     template <typename Turns, typename VisitPolicy, typename Strategy>

--- a/include/boost/geometry/algorithms/detail/is_valid/multipolygon.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/multipolygon.hpp
@@ -103,8 +103,8 @@ private:
             }
         }
 
-        typedef geometry::model::box<typename point_type<MultiPolygon>::type> box_type;
-        typedef typename base::template partition_item<PolygonIterator, box_type> item_type;
+        using box_type = geometry::model::box<point_type_t<MultiPolygon>>;
+        using item_type = typename base::template partition_item<PolygonIterator, box_type>;
 
         // put polygon iterators without turns in a vector
         std::vector<item_type> polygon_iterators;
@@ -123,7 +123,7 @@ private:
 
         geometry::partition
             <
-                geometry::model::box<typename point_type<MultiPolygon>::type>
+                geometry::model::box<point_type_t<MultiPolygon>>
             >::apply(polygon_iterators, item_visitor,
                      typename base::template expand_box<Strategy>(strategy),
                      typename base::template overlaps_box<Strategy>(strategy));

--- a/include/boost/geometry/algorithms/detail/is_valid/polygon.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/polygon.hpp
@@ -305,8 +305,8 @@ protected:
             ring_indices.insert(tit->operations[1].seg_id.ring_index);
         }
 
-        typedef geometry::model::box<typename point_type<Polygon>::type> box_type;
-        typedef partition_item<RingIterator, box_type> item_type;
+        using box_type = geometry::model::box<point_type_t<Polygon>>;
+        using item_type = partition_item<RingIterator, box_type>;
 
         // put iterators for interior rings without turns in a vector
         std::vector<item_type> ring_iterators;

--- a/include/boost/geometry/algorithms/detail/is_valid/segment.hpp
+++ b/include/boost/geometry/algorithms/detail/is_valid/segment.hpp
@@ -49,7 +49,7 @@ struct is_valid<Segment, segment_tag>
     {
         boost::ignore_unused(visitor);
 
-        typename point_type<Segment>::type p[2];
+        point_type_t<Segment> p[2];
         detail::assign_point_from_index<0>(segment, p[0]);
         detail::assign_point_from_index<1>(segment, p[1]);
 

--- a/include/boost/geometry/algorithms/detail/overlay/clip_linestring.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/clip_linestring.hpp
@@ -191,7 +191,7 @@ OutputIterator clip_range_with_box(Box const& b, Range const& range,
         return out;
     }
 
-    typedef typename point_type<OutputLinestring>::type point_type;
+    using point_type = point_type_t<OutputLinestring>;
 
     OutputLinestring line_out;
 

--- a/include/boost/geometry/algorithms/detail/overlay/copy_segment_point.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/copy_segment_point.hpp
@@ -115,7 +115,7 @@ struct copy_segment_point_box
             SegmentIdentifier const& seg_id, signed_size_type offset,
             PointOut& point)
     {
-        std::array<typename point_type<Box>::type, 4> bp;
+        std::array<point_type_t<Box>, 4> bp;
         assign_box_corners_oriented<Reverse>(box, bp);
 
         signed_size_type const target = circular_offset(4, seg_id.segment_index, offset);

--- a/include/boost/geometry/algorithms/detail/overlay/copy_segments.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/copy_segments.hpp
@@ -225,7 +225,7 @@ struct copy_segments_box
             : 5 - index + to_index + 1;
 
         // Create array of points, the fifth one closes it
-        std::array<typename point_type<Box>::type, 5> bp;
+        std::array<point_type_t<Box>, 5> bp;
         assign_box_corners_oriented<Reverse>(box, bp);
         bp[4] = bp[0];
 

--- a/include/boost/geometry/algorithms/detail/overlay/get_intersection_points.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/get_intersection_points.hpp
@@ -98,8 +98,8 @@ inline void get_intersection_points(Geometry1 const& geometry1,
 
     typedef detail::get_intersection_points::get_turn_without_info
                         <
-                            typename point_type<Geometry1>::type,
-                            typename point_type<Geometry2>::type,
+                            point_type_t<Geometry1>,
+                            point_type_t<Geometry2>,
                             typename boost::range_value<Turns>::type
                         > TurnPolicy;
 

--- a/include/boost/geometry/algorithms/detail/overlay/intersection_insert.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/intersection_insert.hpp
@@ -79,16 +79,14 @@ struct intersection_segment_segment_point
             OutputIterator out,
             Strategy const& strategy)
     {
-        typedef typename point_type<PointOut>::type point_type;
-
-        // Get the intersection point (or two points)
-        typedef segment_intersection_points<point_type> intersection_return_type;
-
-        typedef policies::relate::segments_intersection_points
+        using point_type = point_type_t<PointOut>;
+        using intersection_return_type = segment_intersection_points<point_type>;
+        using policy_type = policies::relate::segments_intersection_points
             <
                 intersection_return_type
-            > policy_type;
+            >;
 
+        // Get the intersection point (or two points)
         detail::segment_as_subrange<Segment1> sub_range1(segment1);
         detail::segment_as_subrange<Segment2> sub_range2(segment2);
 
@@ -286,10 +284,7 @@ struct intersection_of_linestring_with_areal
                 GeometryOut, linestring_tag, linestring_tag
             > linear;
 
-        typedef typename point_type
-            <
-                typename linear::type
-            >::type point_type;
+        using point_type = point_type_t<typename linear::type>;
 
         typedef geometry::segment_ratio
             <
@@ -632,8 +627,7 @@ struct intersection_insert
             Box const& box,
             OutputIterator out, Strategy const& )
     {
-        typedef typename point_type<GeometryOut>::type point_type;
-        strategy::intersection::liang_barsky<Box, point_type> lb_strategy;
+        strategy::intersection::liang_barsky<Box, point_type_t<GeometryOut>> lb_strategy;
         return detail::intersection::clip_range_with_box
             <GeometryOut>(box, linestring, out, lb_strategy);
     }
@@ -713,8 +707,7 @@ struct intersection_insert
     {
         geometry::segment_view<Segment> range(segment);
 
-        typedef typename point_type<GeometryOut>::type point_type;
-        strategy::intersection::liang_barsky<Box, point_type> lb_strategy;
+        strategy::intersection::liang_barsky<Box, point_type_t<GeometryOut>> lb_strategy;
         return detail::intersection::clip_range_with_box
             <GeometryOut>(box, range, out, lb_strategy);
     }

--- a/include/boost/geometry/algorithms/detail/relate/boundary_checker.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/boundary_checker.hpp
@@ -150,7 +150,7 @@ inline void copy_boundary_points_of_mls(MultiLinestring const& mls, Strategy con
 template <typename Geometry, typename Strategy>
 class boundary_checker<Geometry, Strategy, multi_linestring_tag>
 {
-    using point_type = typename point_type<Geometry>::type;
+    using point_type = point_type_t<Geometry>;
     using mutable_point_type = typename helper_geometry<point_type>::type;
 
 public:

--- a/include/boost/geometry/algorithms/detail/relate/multi_point_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/multi_point_geometry.hpp
@@ -182,8 +182,7 @@ struct multi_point_single_geometry
                              Result & result,
                              Strategy const& strategy)
     {
-        typedef typename point_type<SingleGeometry>::type point2_type;
-        typedef model::box<point2_type> box2_type;
+        using box2_type = model::box<point_type_t<SingleGeometry>> ;
 
         box2_type box2;
         geometry::envelope(single_geometry, box2, strategy);
@@ -402,11 +401,9 @@ class multi_point_multi_geometry_ii_ib
     };
 
 public:
-    typedef typename point_type<MultiPoint>::type point1_type;
-    typedef typename point_type<MultiGeometry>::type point2_type;
-    typedef model::box<point1_type> box1_type;
-    typedef model::box<point2_type> box2_type;
-    typedef std::pair<box2_type, std::size_t> box_pair_type;
+    using box1_type = model::box<point_type_t<MultiPoint>>;
+    using box2_type = model::box<point_type_t<MultiGeometry>>;
+    using box_pair_type = std::pair<box2_type, std::size_t>;
 
     template <typename Result, typename Strategy>
     static inline void apply(MultiPoint const& multi_point,
@@ -439,12 +436,10 @@ public:
 template <typename MultiPoint, typename MultiGeometry, bool Transpose>
 struct multi_point_multi_geometry_ii_ib_ie
 {
-    typedef typename point_type<MultiPoint>::type point1_type;
-    typedef typename point_type<MultiGeometry>::type point2_type;
-    typedef model::box<point1_type> box1_type;
-    typedef model::box<point2_type> box2_type;
-    typedef std::pair<box2_type, std::size_t> box_pair_type;
-    typedef std::vector<box_pair_type> boxes_type;
+    using box1_type = model::box<point_type_t<MultiPoint>>;
+    using box2_type = model::box<point_type_t<MultiGeometry>>;
+    using box_pair_type = std::pair<box2_type, std::size_t>;
+    using boxes_type = std::vector<box_pair_type>;
 
     template <typename Result, typename Strategy>
     static inline void apply(MultiPoint const& multi_point,
@@ -532,9 +527,7 @@ struct multi_point_multi_geometry
                              Result & result,
                              Strategy const& strategy)
     {
-        typedef typename point_type<MultiGeometry>::type point2_type;
-        typedef model::box<point2_type> box2_type;
-        typedef std::pair<box2_type, std::size_t> box_pair_type;
+        using box_pair_type = std::pair<model::box<point_type_t<MultiGeometry>>, std::size_t>;
 
         std::size_t count2 = boost::size(multi_geometry);
         std::vector<box_pair_type> boxes(count2);

--- a/include/boost/geometry/algorithms/detail/sections/sectionalize.hpp
+++ b/include/boost/geometry/algorithms/detail/sections/sectionalize.hpp
@@ -634,7 +634,7 @@ struct sectionalize_box
                 Strategy const& strategy,
                 ring_identifier const& ring_id, std::size_t max_count)
     {
-        using point_type = typename point_type<Box>::type;
+        using point_type = point_type_t<Box>;
 
         assert_dimension<Box, 2>();
 

--- a/include/boost/geometry/algorithms/detail/within/multi_point.hpp
+++ b/include/boost/geometry/algorithms/detail/within/multi_point.hpp
@@ -122,12 +122,8 @@ struct multi_point_single_geometry
                              LinearOrAreal const& linear_or_areal,
                              Strategy const& strategy)
     {
-        //typedef typename boost::range_value<MultiPoint>::type point1_type;
-        typedef typename point_type<LinearOrAreal>::type point2_type;
-        typedef model::box<point2_type> box2_type;
-
         // Create envelope of geometry
-        box2_type box;
+        model::box<point_type_t<LinearOrAreal>> box;
         geometry::envelope(linear_or_areal, box, strategy);
         geometry::detail::expand_by_epsilon(box);
 
@@ -170,16 +166,17 @@ struct multi_point_multi_geometry
                              LinearOrAreal const& linear_or_areal,
                              Strategy const& strategy)
     {
-        typedef typename point_type<LinearOrAreal>::type point2_type;
-        typedef model::box<point2_type> box2_type;
+        using point2_type = point_type_t<LinearOrAreal>;
+        using box2_type = model::box<point2_type>;
+        using box_pair_type = std::pair<box2_type, std::size_t>;
+        using box_pair_vector = std::vector<box_pair_type>;
+
         static const bool is_linear = util::is_linear<LinearOrAreal>::value;
 
         // TODO: box pairs could be constructed on the fly, inside the rtree
 
         // Prepare range of envelopes and ids
         std::size_t count2 = boost::size(linear_or_areal);
-        typedef std::pair<box2_type, std::size_t> box_pair_type;
-        typedef std::vector<box_pair_type> box_pair_vector;
         box_pair_vector boxes(count2);
         for (std::size_t i = 0 ; i < count2 ; ++i)
         {
@@ -245,7 +242,7 @@ struct multi_point_multi_geometry
                     }
                     else
                     {
-                        found_boundary = true;    
+                        found_boundary = true;
                     }
                 }
                 else

--- a/include/boost/geometry/algorithms/discrete_frechet_distance.hpp
+++ b/include/boost/geometry/algorithms/discrete_frechet_distance.hpp
@@ -76,8 +76,8 @@ struct linestring_linestring
     {
         typedef typename distance_result
             <
-                typename point_type<Linestring1>::type,
-                typename point_type<Linestring2>::type,
+                point_type_t<Linestring1>,
+                point_type_t<Linestring2>,
                 Strategies
             >::type result_type;
         typedef typename boost::range_size<Linestring1>::type size_type1;

--- a/include/boost/geometry/algorithms/discrete_hausdorff_distance.hpp
+++ b/include/boost/geometry/algorithms/discrete_hausdorff_distance.hpp
@@ -59,29 +59,29 @@ namespace detail { namespace discrete_hausdorff_distance
 struct point_range
 {
     template <typename Point, typename Range, typename Strategies>
-    static inline auto apply(Point const& pnt, Range const& rng,
+    static inline auto apply(Point const& pnt, Range const& range,
                              Strategies const& strategies)
     {
         typedef typename distance_result
             <
                 Point,
-                typename point_type<Range>::type,
+                point_type_t<Range>,
                 Strategies
             >::type result_type;
 
         typedef typename boost::range_size<Range>::type size_type;
 
-        boost::geometry::detail::throw_on_empty_input(rng);
+        boost::geometry::detail::throw_on_empty_input(range);
 
         auto const strategy = strategies.distance(dummy_point(), dummy_point());
 
-        size_type const n = boost::size(rng);
+        size_type const n = boost::size(range);
         result_type dis_min = 0;
         bool is_dis_min_set = false;
 
         for (size_type i = 0 ; i < n ; i++)
         {
-            result_type dis_temp = strategy.apply(pnt, range::at(rng, i));
+            result_type dis_temp = strategy.apply(pnt, range::at(range, i));
             if (! is_dis_min_set || dis_temp < dis_min)
             {
                 dis_min = dis_temp;
@@ -100,8 +100,8 @@ struct range_range
     {
         typedef typename distance_result
             <
-                typename point_type<Range1>::type,
-                typename point_type<Range2>::type,
+                point_type_t<Range1>,
+                point_type_t<Range2>,
                 Strategies
             >::type result_type;
 
@@ -115,8 +115,8 @@ struct range_range
 
 #ifdef BOOST_GEOMETRY_ENABLE_SIMILARITY_RTREE
         namespace bgi = boost::geometry::index;
-        typedef typename point_type<Range1>::type point_t;
-        typedef bgi::rtree<point_t, bgi::linear<4> > rtree_type;
+        using point_t = point_type_t<Range1>;
+        using rtree_type = bgi::rtree<point_t, bgi::linear<4> >;
         rtree_type rtree(boost::begin(r2), boost::end(r2));
         point_t res;
 #endif
@@ -141,27 +141,27 @@ struct range_range
 
 struct range_multi_range
 {
-    template <typename Range, typename Multi_range, typename Strategies>
-    static inline auto apply(Range const& rng, Multi_range const& mrng,
+    template <typename Range, typename MultiRange, typename Strategies>
+    static inline auto apply(Range const& range, MultiRange const& multi_range,
                              Strategies const& strategies)
     {
         typedef typename distance_result
             <
-                typename point_type<Range>::type,
-                typename point_type<Multi_range>::type,
+                point_type_t<Range>,
+                point_type_t<MultiRange>,
                 Strategies
             >::type result_type;
-        typedef typename boost::range_size<Multi_range>::type size_type;
+        typedef typename boost::range_size<MultiRange>::type size_type;
 
-        boost::geometry::detail::throw_on_empty_input(rng);
-        boost::geometry::detail::throw_on_empty_input(mrng);
+        boost::geometry::detail::throw_on_empty_input(range);
+        boost::geometry::detail::throw_on_empty_input(multi_range);
 
-        size_type b = boost::size(mrng);
+        size_type b = boost::size(multi_range);
         result_type haus_dis = 0;
 
         for (size_type j = 0 ; j < b ; j++)
         {
-            result_type dis_max = range_range::apply(rng, range::at(mrng, j), strategies);
+            result_type dis_max = range_range::apply(range, range::at(multi_range, j), strategies);
             if (dis_max > haus_dis)
             {
                 haus_dis = dis_max;
@@ -175,27 +175,27 @@ struct range_multi_range
 
 struct multi_range_multi_range
 {
-    template <typename Multi_Range1, typename Multi_range2, typename Strategies>
-    static inline auto apply(Multi_Range1 const& mrng1, Multi_range2 const& mrng2,
+    template <typename MultiRange1, typename MultiRange2, typename Strategies>
+    static inline auto apply(MultiRange1 const& multi_range1, MultiRange2 const& multi_range2,
                              Strategies const& strategies)
     {
         typedef typename distance_result
             <
-                typename point_type<Multi_Range1>::type,
-                typename point_type<Multi_range2>::type,
+                point_type_t<MultiRange1>,
+                point_type_t<MultiRange2>,
                 Strategies
             >::type result_type;
-        typedef typename boost::range_size<Multi_Range1>::type size_type;
+        typedef typename boost::range_size<MultiRange1>::type size_type;
 
-        boost::geometry::detail::throw_on_empty_input(mrng1);
-        boost::geometry::detail::throw_on_empty_input(mrng2);
+        boost::geometry::detail::throw_on_empty_input(multi_range1);
+        boost::geometry::detail::throw_on_empty_input(multi_range2);
 
-        size_type n = boost::size(mrng1);
+        size_type n = boost::size(multi_range1);
         result_type haus_dis = 0;
 
         for (size_type i = 0 ; i < n ; i++)
         {
-            result_type dis_max = range_multi_range::apply(range::at(mrng1, i), mrng2, strategies);
+            result_type dis_max = range_multi_range::apply(range::at(multi_range1, i), multi_range2, strategies);
             if (dis_max > haus_dis)
             {
                 haus_dis = dis_max;

--- a/include/boost/geometry/algorithms/for_each.hpp
+++ b/include/boost/geometry/algorithms/for_each.hpp
@@ -117,7 +117,7 @@ struct fe_point_type
     typedef util::transcribe_const_t
         <
             Range,
-            typename point_type<Range>::type
+            point_type_t<Range>
         > type;
 };
 

--- a/include/boost/geometry/algorithms/length.hpp
+++ b/include/boost/geometry/algorithms/length.hpp
@@ -64,8 +64,7 @@ struct segment_length
     static inline typename default_length_result<Segment>::type
     apply(Segment const& segment, Strategies const& strategies)
     {
-        typedef typename point_type<Segment>::type point_type;
-        point_type p1, p2;
+        point_type_t<Segment> p1, p2;
         geometry::detail::assign_point_from_index<0>(segment, p1);
         geometry::detail::assign_point_from_index<1>(segment, p2);
         return strategies.distance(p1, p2).apply(p1, p2);

--- a/include/boost/geometry/algorithms/remove_spikes.hpp
+++ b/include/boost/geometry/algorithms/remove_spikes.hpp
@@ -68,9 +68,7 @@ struct range_remove_spikes
     template <typename Range, typename SideStrategy>
     static inline void apply(Range& range, SideStrategy const& strategy)
     {
-        typedef typename point_type<Range>::type point_type;
-
-        std::size_t n = boost::size(range);
+        std::size_t const n = boost::size(range);
         std::size_t const min_num_points = core_detail::closure::minimum_ring_size
             <
                 geometry::closure<Range>::value
@@ -80,7 +78,7 @@ struct range_remove_spikes
             return;
         }
 
-        std::vector<point_type> cleaned;
+        std::vector<point_type_t<Range>> cleaned;
         cleaned.reserve(n);
 
         for (auto const& p : range)

--- a/include/boost/geometry/algorithms/simplify.hpp
+++ b/include/boost/geometry/algorithms/simplify.hpp
@@ -1078,7 +1078,7 @@ inline void simplify_insert(Geometry const& geometry, OutputIterator out,
 {
     // Concept: output point type = point type of input geometry
     concepts::check<Geometry const>();
-    concepts::check<typename point_type<Geometry>::type>();
+    concepts::check<point_type_t<Geometry>>();
 
     simplify_insert(geometry, out, max_distance, default_strategy());
 }

--- a/include/boost/geometry/algorithms/transform.hpp
+++ b/include/boost/geometry/algorithms/transform.hpp
@@ -70,8 +70,8 @@ struct transform_box
     static inline bool apply(Box1 const& b1, Box2& b2,
                 Strategy const& strategy)
     {
-        typedef typename point_type<Box1>::type point_type1;
-        typedef typename point_type<Box2>::type point_type2;
+        using point_type1 = point_type_t<Box1>;
+        using point_type2 = point_type_t<Box2>;
 
         point_type1 lower_left, upper_right;
         geometry::detail::assign::assign_box_2d_corner<min_corner, min_corner>(
@@ -83,7 +83,7 @@ struct transform_box
         if (strategy.apply(lower_left, p1) && strategy.apply(upper_right, p2))
         {
             // Create a valid box and therefore swap if necessary
-            typedef typename coordinate_type<point_type2>::type coordinate_type;
+            using coordinate_type = coordinate_type_t<point_type2>;
             coordinate_type x1 = geometry::get<0>(p1)
                     , y1  = geometry::get<1>(p1)
                     , x2  = geometry::get<0>(p2)
@@ -109,14 +109,11 @@ struct transform_box_or_segment
     static inline bool apply(Geometry1 const& source, Geometry2& target,
                 Strategy const& strategy)
     {
-        typedef typename point_type<Geometry1>::type point_type1;
-        typedef typename point_type<Geometry2>::type point_type2;
-
-        point_type1 source_point[2];
+        point_type_t<Geometry1> source_point[2];
         geometry::detail::assign_point_from_index<0>(source, source_point[0]);
         geometry::detail::assign_point_from_index<1>(source, source_point[1]);
 
-        point_type2 target_point[2];
+        point_type_t<Geometry2> target_point[2];
         if (strategy.apply(source_point[0], target_point[0])
             && strategy.apply(source_point[1], target_point[1]))
         {
@@ -158,7 +155,7 @@ struct transform_polygon
     static inline bool apply(Polygon1 const& poly1, Polygon2& poly2,
                 Strategy const& strategy)
     {
-        typedef typename point_type<Polygon2>::type point2_type;
+        using point2_type = point_type_t<Polygon2>;
 
         geometry::clear(poly2);
 
@@ -198,20 +195,20 @@ struct transform_polygon
 };
 
 
-template <typename Point1, typename Point2>
+template <typename Geometry1, typename Geometry2>
 struct select_strategy
 {
-    typedef typename strategy::transform::services::default_strategy
+    using type = typename strategy::transform::services::default_strategy
         <
-            cs_tag_t<Point1>,
-            cs_tag_t<Point2>,
-            typename coordinate_system<Point1>::type,
-            typename coordinate_system<Point2>::type,
-            dimension<Point1>::type::value,
-            dimension<Point2>::type::value,
-            typename point_type<Point1>::type,
-            typename point_type<Point2>::type
-        >::type type;
+            cs_tag_t<Geometry1>,
+            cs_tag_t<Geometry2>,
+            coordinate_system_t<Geometry1>,
+            coordinate_system_t<Geometry2>,
+            dimension<Geometry1>::value,
+            dimension<Geometry2>::value,
+            point_type_t<Geometry1>,
+            point_type_t<Geometry2>
+        >::type;
 };
 
 struct transform_range
@@ -220,11 +217,9 @@ struct transform_range
     static inline bool apply(Range1 const& range1,
             Range2& range2, Strategy const& strategy)
     {
-        typedef typename point_type<Range2>::type point_type;
-
-        // Should NOT be done here!
+        // "clear" should NOT be done here!
         // geometry::clear(range2);
-        return transform_range_out<point_type>(range1,
+        return transform_range_out<point_type_t<Range2>>(range1,
                 range::back_inserter(range2), strategy);
     }
 };

--- a/include/boost/geometry/geometries/concepts/box_concept.hpp
+++ b/include/boost/geometry/geometries/concepts/box_concept.hpp
@@ -34,8 +34,7 @@ template <typename Geometry>
 class Box
 {
 #ifndef DOXYGEN_NO_CONCEPT_MEMBERS
-    typedef typename point_type<Geometry>::type point_type;
-
+    using point_type = point_type_t<Geometry>;
 
     template
     <
@@ -80,8 +79,8 @@ template <typename Geometry>
 class ConstBox
 {
 #ifndef DOXYGEN_NO_CONCEPT_MEMBERS
-    typedef typename point_type<Geometry>::type point_type;
-    typedef typename coordinate_type<Geometry>::type coordinate_type;
+    using point_type = point_type_t<Geometry>;
+    using coordinate_type = coordinate_type_t<Geometry>;
 
     template
     <

--- a/include/boost/geometry/geometries/concepts/linestring_concept.hpp
+++ b/include/boost/geometry/geometries/concepts/linestring_concept.hpp
@@ -39,7 +39,7 @@ template <typename Geometry>
 class Linestring
 {
 #ifndef DOXYGEN_NO_CONCEPT_MEMBERS
-    typedef typename point_type<Geometry>::type point_type;
+    using point_type = point_type_t<Geometry>;
 
     BOOST_CONCEPT_ASSERT( (concepts::Point<point_type>) );
     BOOST_CONCEPT_ASSERT( (boost::RandomAccessRangeConcept<Geometry>) );
@@ -68,7 +68,7 @@ template <typename Geometry>
 class ConstLinestring
 {
 #ifndef DOXYGEN_NO_CONCEPT_MEMBERS
-    typedef typename point_type<Geometry>::type point_type;
+    using point_type = point_type_t<Geometry>;
 
     BOOST_CONCEPT_ASSERT( (concepts::ConstPoint<point_type>) );
     //BOOST_CONCEPT_ASSERT( (boost::RandomAccessRangeConcept<Geometry>) );

--- a/include/boost/geometry/geometries/concepts/polygon_concept.hpp
+++ b/include/boost/geometry/geometries/concepts/polygon_concept.hpp
@@ -53,8 +53,8 @@ class Polygon
     typedef typename traits::interior_const_type<polygon_type>::type interior_const_type;
     typedef typename traits::interior_mutable_type<polygon_type>::type interior_mutable_type;
 
-    typedef typename point_type<PolygonType>::type point_type;
-    typedef typename ring_type<PolygonType>::type ring_type;
+    using point_type = point_type_t<PolygonType>;
+    using ring_type = ring_type_t<PolygonType>;
 
     BOOST_CONCEPT_ASSERT( (concepts::Point<point_type>) );
     BOOST_CONCEPT_ASSERT( (concepts::Ring<ring_type>) );
@@ -102,8 +102,8 @@ class ConstPolygon
     typedef typename traits::ring_const_type<const_polygon_type>::type ring_const_type;
     typedef typename traits::interior_const_type<const_polygon_type>::type interior_const_type;
 
-    typedef typename point_type<const_polygon_type>::type point_type;
-    typedef typename ring_type<const_polygon_type>::type ring_type;
+    using point_type = point_type_t<const_polygon_type>;
+    using ring_type = ring_type_t<const_polygon_type>;
 
     BOOST_CONCEPT_ASSERT( (concepts::ConstPoint<point_type>) );
     BOOST_CONCEPT_ASSERT( (concepts::ConstRing<ring_type>) );

--- a/include/boost/geometry/geometries/concepts/ring_concept.hpp
+++ b/include/boost/geometry/geometries/concepts/ring_concept.hpp
@@ -38,7 +38,7 @@ template <typename Geometry>
 class Ring
 {
 #ifndef DOXYGEN_NO_CONCEPT_MEMBERS
-    typedef typename point_type<Geometry>::type point_type;
+    using point_type = point_type_t<Geometry>;
 
     BOOST_CONCEPT_ASSERT( (concepts::Point<point_type>) );
     BOOST_CONCEPT_ASSERT( (boost::RandomAccessRangeConcept<Geometry>) );
@@ -67,7 +67,7 @@ template <typename Geometry>
 class ConstRing
 {
 #ifndef DOXYGEN_NO_CONCEPT_MEMBERS
-    typedef typename point_type<Geometry>::type point_type;
+    using point_type = point_type_t<Geometry>;
 
     BOOST_CONCEPT_ASSERT( (concepts::ConstPoint<point_type>) );
     BOOST_CONCEPT_ASSERT( (boost::RandomAccessRangeConcept<Geometry>) );

--- a/include/boost/geometry/geometries/concepts/segment_concept.hpp
+++ b/include/boost/geometry/geometries/concepts/segment_concept.hpp
@@ -36,7 +36,7 @@ template <typename Geometry>
 class Segment
 {
 #ifndef DOXYGEN_NO_CONCEPT_MEMBERS
-    typedef typename point_type<Geometry>::type point_type;
+    using point_type = point_type_t<Geometry>;
 
     BOOST_CONCEPT_ASSERT( (concepts::Point<point_type>) );
 
@@ -80,8 +80,8 @@ template <typename Geometry>
 class ConstSegment
 {
 #ifndef DOXYGEN_NO_CONCEPT_MEMBERS
-    typedef typename point_type<Geometry>::type point_type;
-    typedef typename coordinate_type<Geometry>::type coordinate_type;
+    using point_type = point_type_t<Geometry>;
+    using coordinate_type = coordinate_type_t<Geometry>;
 
     BOOST_CONCEPT_ASSERT( (concepts::ConstPoint<point_type>) );
 

--- a/include/boost/geometry/geometries/helper_geometry.hpp
+++ b/include/boost/geometry/geometries/helper_geometry.hpp
@@ -87,7 +87,7 @@ struct helper_geometry<Box, NewCoordinateType, NewUnits, box_tag>
         <
             typename helper_geometry
                 <
-                    typename point_type<Box>::type, NewCoordinateType, NewUnits
+                    point_type_t<Box>, NewCoordinateType, NewUnits
                 >::type
         >;
 };
@@ -100,7 +100,7 @@ struct helper_geometry<Linestring, NewCoordinateType, NewUnits, linestring_tag>
         <
             typename helper_geometry
                 <
-                    typename point_type<Linestring>::type, NewCoordinateType, NewUnits
+                    point_type_t<Linestring>, NewCoordinateType, NewUnits
                 >::type
         >;
 };
@@ -112,7 +112,7 @@ struct helper_geometry<Ring, NewCoordinateType, NewUnits, ring_tag>
         <
             typename helper_geometry
                 <
-                    typename point_type<Ring>::type, NewCoordinateType, NewUnits
+                    point_type_t<Ring>, NewCoordinateType, NewUnits
                 >::type,
             point_order<Ring>::value != counterclockwise,
             closure<Ring>::value != open

--- a/include/boost/geometry/index/detail/algorithms/bounds.hpp
+++ b/include/boost/geometry/index/detail/algorithms/bounds.hpp
@@ -186,9 +186,9 @@ struct covered_by_bounds<Geometry, Bounds, segment_tag, box_tag>
 {
     static inline bool apply(Geometry const& g, Bounds & b)
     {
-        typedef typename point_type<Geometry>::type point_type;
-        typedef geometry::model::box<point_type> bounds_type;
-        typedef index::detail::bounded_view<Geometry, bounds_type, default_strategy> view_type;
+        using point_type = point_type_t<Geometry>;
+        using bounds_type = geometry::model::box<point_type>;
+        using view_type = index::detail::bounded_view<Geometry, bounds_type, default_strategy>;
 
         return geometry::covered_by(view_type(g, default_strategy()), b);
     }
@@ -196,9 +196,9 @@ struct covered_by_bounds<Geometry, Bounds, segment_tag, box_tag>
     template <typename Strategy>
     static inline bool apply(Geometry const& g, Bounds & b, Strategy const& strategy)
     {
-        typedef typename point_type<Geometry>::type point_type;
-        typedef geometry::model::box<point_type> bounds_type;
-        typedef index::detail::bounded_view<Geometry, bounds_type, Strategy> view_type;
+        using point_type = point_type_t<Geometry>;
+        using bounds_type = geometry::model::box<point_type>;
+        using view_type = index::detail::bounded_view<Geometry, bounds_type, Strategy>;
 
         return geometry::covered_by(view_type(g, strategy), b, strategy);
     }

--- a/include/boost/geometry/index/detail/algorithms/path_intersection.hpp
+++ b/include/boost/geometry/index/detail/algorithms/path_intersection.hpp
@@ -52,12 +52,11 @@ struct path_intersection
 template <typename Indexable, typename Segment>
 struct path_intersection<Indexable, Segment, box_tag, segment_tag>
 {
-    typedef typename default_distance_result<typename point_type<Segment>::type>::type comparable_distance_type;
+    using comparable_distance_type = typename default_distance_result<point_type_t<Segment>>::type;
 
     static inline bool apply(Indexable const& b, Segment const& segment, comparable_distance_type & comparable_distance)
     {
-        typedef typename point_type<Segment>::type point_type;
-        point_type p1, p2;
+        point_type_t<Segment> p1, p2;
         geometry::detail::assign_point_from_index<0>(segment, p1);
         geometry::detail::assign_point_from_index<1>(segment, p2);
         return index::detail::segment_intersection(b, p1, p2, comparable_distance);
@@ -67,7 +66,7 @@ struct path_intersection<Indexable, Segment, box_tag, segment_tag>
 template <typename Indexable, typename Linestring>
 struct path_intersection<Indexable, Linestring, box_tag, linestring_tag>
 {
-    typedef typename default_length_result<Linestring>::type comparable_distance_type;
+    using comparable_distance_type = typename default_length_result<Linestring>::type;
 
     static inline bool apply(Indexable const& b, Linestring const& path, comparable_distance_type & comparable_distance)
     {

--- a/include/boost/geometry/index/detail/bounded_view.hpp
+++ b/include/boost/geometry/index/detail/bounded_view.hpp
@@ -241,7 +241,7 @@ struct tag< index::detail::bounded_view<Geometry, Box, Strategy, Tag, box_tag> >
 template <typename Geometry, typename Box, typename Strategy, typename Tag>
 struct point_type< index::detail::bounded_view<Geometry, Box, Strategy, Tag, box_tag> >
 {
-    typedef typename point_type<Box>::type type;
+    using type = point_type_t<Box>;
 };
 
 template <typename Geometry, typename Box, typename Strategy, typename Tag, std::size_t Dimension>

--- a/include/boost/geometry/io/dsv/write.hpp
+++ b/include/boost/geometry/io/dsv/write.hpp
@@ -226,7 +226,7 @@ struct dsv_poly
 template <typename Geometry, std::size_t Index>
 struct dsv_per_index
 {
-    typedef typename point_type<Geometry>::type point_type;
+    using type = point_type_t<Geometry>;
 
     template <typename Char, typename Traits>
     static inline void apply(std::basic_ostream<Char, Traits>& os,
@@ -245,7 +245,7 @@ struct dsv_per_index
 template <typename Geometry>
 struct dsv_indexed
 {
-    typedef typename point_type<Geometry>::type point_type;
+    using type = point_type_t<Geometry>;
 
     template <typename Char, typename Traits>
     static inline void apply(std::basic_ostream<Char, Traits>& os,

--- a/include/boost/geometry/io/wkt/read.hpp
+++ b/include/boost/geometry/io/wkt/read.hpp
@@ -786,7 +786,7 @@ struct box_parser
             BOOST_THROW_EXCEPTION(read_wkt_exception("Should start with 'POLYGON' or 'BOX'", wkt));
         }
 
-        using point_type = typename point_type<Box>::type;
+        using point_type = point_type_t<Box>;
         std::vector<point_type> points;
         container_inserter<point_type>::apply(it, end, wkt, std::back_inserter(points));
 
@@ -855,7 +855,7 @@ struct segment_parser
             BOOST_THROW_EXCEPTION(read_wkt_exception("Should start with 'LINESTRING' or 'SEGMENT'", wkt));
         }
 
-        using point_type = typename point_type<Segment>::type;
+        using point_type = point_type_t<Segment>;
         std::vector<point_type> points;
         container_inserter<point_type>::apply(it, end, wkt, std::back_inserter(points));
 

--- a/include/boost/geometry/io/wkt/write.hpp
+++ b/include/boost/geometry/io/wkt/write.hpp
@@ -254,7 +254,7 @@ struct wkt_multi
 template <typename Box>
 struct wkt_box
 {
-    using point_type = typename point_type<Box>::type;
+    using point_type = point_type_t<Box>;
 
     template <typename Char, typename Traits>
     static inline void apply(std::basic_ostream<Char, Traits>& os,
@@ -298,7 +298,7 @@ struct wkt_box
 template <typename Segment>
 struct wkt_segment
 {
-    using point_type = typename point_type<Segment>::type;
+    using point_type = point_type_t<Segment>;
 
     template <typename Char, typename Traits>
     static inline void apply(std::basic_ostream<Char, Traits>& os,

--- a/include/boost/geometry/strategies/agnostic/point_in_box_by_side.hpp
+++ b/include/boost/geometry/strategies/agnostic/point_in_box_by_side.hpp
@@ -85,7 +85,7 @@ inline bool point_in_box_by_side(Point const& point, Box const& box,
     // Create (counterclockwise) array of points, the fifth one closes it
     // Every point should be on the LEFT side (=1), or ON the border (=0),
     // So >= 1 or >= 0
-    std::array<typename point_type<Box>::type, 5> bp;
+    std::array<point_type_t<Box>, 5> bp;
     geometry::detail::assign_box_corners_oriented<true>(box, bp);
     bp[4] = bp[0];
 

--- a/include/boost/geometry/strategies/cartesian/centroid_average.hpp
+++ b/include/boost/geometry/strategies/cartesian/centroid_average.hpp
@@ -118,7 +118,7 @@ struct default_strategy
     typedef average
         <
             Point,
-            typename point_type<Geometry>::type
+            point_type_t<Geometry>
         > type;
 };
 

--- a/include/boost/geometry/strategies/cartesian/centroid_bashein_detmer.hpp
+++ b/include/boost/geometry/strategies/cartesian/centroid_bashein_detmer.hpp
@@ -247,7 +247,7 @@ struct default_strategy<cartesian_tag, areal_tag, 2, Point, Geometry>
     typedef bashein_detmer
         <
             Point,
-            typename point_type<Geometry>::type
+            point_type_t<Geometry>
         > type;
 };
 

--- a/include/boost/geometry/strategies/cartesian/centroid_weighted_length.hpp
+++ b/include/boost/geometry/strategies/cartesian/centroid_weighted_length.hpp
@@ -165,7 +165,7 @@ struct default_strategy
     typedef weighted_length
         <
             Point,
-            typename point_type<Geometry>::type
+            point_type_t<Geometry>
         > type;
 };
 

--- a/include/boost/geometry/strategies/cartesian/disjoint_segment_box.hpp
+++ b/include/boost/geometry/strategies/cartesian/disjoint_segment_box.hpp
@@ -257,12 +257,12 @@ struct segment_box
     {
         assert_dimension_equal<Segment, Box>();
 
-        typedef typename util::calculation_type::geometric::binary
+        using relative_distance_type = typename util::calculation_type::geometric::binary
             <
                 Segment, Box, void
-            >::type relative_distance_type;
+            >::type;
 
-        typedef typename point_type<Segment>::type segment_point_type;
+        using segment_point_type = point_type_t<Segment>;
         segment_point_type p0, p1;
         geometry::detail::assign_point_from_index<0>(segment, p0);
         geometry::detail::assign_point_from_index<1>(segment, p1);

--- a/include/boost/geometry/strategies/cartesian/distance_pythagoras_box_box.hpp
+++ b/include/boost/geometry/strategies/cartesian/distance_pythagoras_box_box.hpp
@@ -118,9 +118,9 @@ public :
     apply(Box1 const& box1, Box2 const& box2)
     {
         BOOST_CONCEPT_ASSERT
-            ( (concepts::ConstPoint<typename point_type<Box1>::type>) );
+            ( (concepts::ConstPoint<point_type_t<Box1>>) );
         BOOST_CONCEPT_ASSERT
-            ( (concepts::ConstPoint<typename point_type<Box2>::type>) );
+            ( (concepts::ConstPoint<point_type_t<Box2>>) );
 
         // Calculate distance using Pythagoras
         // (Leave comment above for Doxygen)

--- a/include/boost/geometry/strategies/cartesian/distance_pythagoras_point_box.hpp
+++ b/include/boost/geometry/strategies/cartesian/distance_pythagoras_point_box.hpp
@@ -115,7 +115,7 @@ public :
     {
         BOOST_CONCEPT_ASSERT( (concepts::ConstPoint<Point>) );
         BOOST_CONCEPT_ASSERT
-            ( (concepts::ConstPoint<typename point_type<Box>::type>) );
+            ( (concepts::ConstPoint<point_type_t<Box>>) );
 
         // Calculate distance using Pythagoras
         // (Leave comment above for Doxygen)

--- a/include/boost/geometry/strategies/comparable_distance_result.hpp
+++ b/include/boost/geometry/strategies/comparable_distance_result.hpp
@@ -78,8 +78,8 @@ struct comparable_distance_result
     : strategy::distance::services::return_type
         <
             typename comparable_distance_strategy_type<Geometry1, Geometry2, Strategy>::type,
-            typename point_type<Geometry1>::type,
-            typename point_type<Geometry2>::type
+            point_type_t<Geometry1>,
+            point_type_t<Geometry2>
         >
 {};
 

--- a/include/boost/geometry/strategies/disjoint.hpp
+++ b/include/boost/geometry/strategies/disjoint.hpp
@@ -61,7 +61,7 @@ template <typename MultiPoint, typename Box>
 struct default_strategy<MultiPoint, Box, multi_point_tag, box_tag, 0, 2>
     : strategy::covered_by::services::default_strategy
         <
-            typename point_type<MultiPoint>::type,
+            point_type_t<MultiPoint>,
             Box
         >
 {};
@@ -70,7 +70,7 @@ template <typename Box, typename MultiPoint>
 struct default_strategy<Box, MultiPoint, box_tag, multi_point_tag, 2, 0>
     : strategy::covered_by::services::default_strategy
         <
-            typename point_type<MultiPoint>::type,
+            point_type_t<MultiPoint>,
             Box
         >
 {};

--- a/include/boost/geometry/strategies/distance_result.hpp
+++ b/include/boost/geometry/strategies/distance_result.hpp
@@ -83,8 +83,8 @@ struct distance_result
     : strategy::distance::services::return_type
         <
             typename distance_result_strategy_type<Geometry1, Geometry2, Strategy>::type,
-            typename point_type<Geometry1>::type,
-            typename point_type<Geometry2>::type
+            point_type_t<Geometry1>,
+            point_type_t<Geometry2>
         >
 {};
 

--- a/include/boost/geometry/strategies/geographic/distance_cross_track_box_box.hpp
+++ b/include/boost/geometry/strategies/geographic/distance_cross_track_box_box.hpp
@@ -83,8 +83,8 @@ public:
     struct return_type : services::return_type
             <
                 typename distance_ps_strategy::type,
-                typename point_type<Box1>::type,
-                typename point_type<Box2>::type
+                point_type_t<Box1>,
+                point_type_t<Box2>
             >
     {};
 
@@ -105,8 +105,8 @@ public:
                 (concepts::PointSegmentDistanceStrategy
                     <
                         Strategy,
-                        typename point_type<Box1>::type,
-                        typename point_type<Box2>::type
+                        point_type_t<Box1>,
+                        point_type_t<Box2>
                     >)
             );
 #endif
@@ -208,8 +208,8 @@ public:
         result_from_distance
             <
                 Strategy,
-                typename point_type<Box1>::type,
-                typename point_type<Box2>::type
+                point_type_t<Box1>,
+                point_type_t<Box2>
             >::apply(strategy, distance);
     }
 };

--- a/include/boost/geometry/strategies/geographic/distance_cross_track_point_box.hpp
+++ b/include/boost/geometry/strategies/geographic/distance_cross_track_point_box.hpp
@@ -69,7 +69,7 @@ public:
     template <typename Point, typename Box>
     struct return_type
         : services::return_type<typename distance_ps_strategy::type,
-                                Point, typename point_type<Box>::type>
+                                Point, point_type_t<Box>>
     {};
 
     //constructor
@@ -88,7 +88,7 @@ public:
             (
                 (concepts::PointSegmentDistanceStrategy
                     <
-                        Strategy, Point, typename point_type<Box>::type
+                        Strategy, Point, point_type_t<Box>
                     >)
             );
 #endif
@@ -190,7 +190,7 @@ public:
     {
         result_from_distance
             <
-                Strategy, P, typename point_type<Box>::type
+                Strategy, P, point_type_t<Box>
             >::apply(strategy, distance);
     }
 };

--- a/include/boost/geometry/strategies/spherical/disjoint_segment_box.hpp
+++ b/include/boost/geometry/strategies/spherical/disjoint_segment_box.hpp
@@ -54,9 +54,7 @@ struct segment_box_spherical
     template <typename Segment, typename Box>
     static inline bool apply(Segment const& segment, Box const& box)
     {
-        typedef typename point_type<Segment>::type segment_point_type;
-        typedef typename coordinate_type<segment_point_type>::type CT;
-        geometry::strategy::azimuth::spherical<CT> azimuth_strategy;
+        geometry::strategy::azimuth::spherical<coordinate_type_t<point_type_t<Segment>>> azimuth_strategy;
 
         return geometry::detail::disjoint::disjoint_segment_box_sphere_or_spheroid
                 <

--- a/include/boost/geometry/strategies/spherical/distance_cross_track_box_box.hpp
+++ b/include/boost/geometry/strategies/spherical/distance_cross_track_box_box.hpp
@@ -87,8 +87,8 @@ public :
         // this method assumes that the coordinates of the point and
         // the box are normalized
 
-        typedef typename point_type<Box1>::type box_point_type1;
-        typedef typename point_type<Box2>::type box_point_type2;
+        using box_point_type1 = point_type_t<Box1>;
+        using box_point_type2 = point_type_t<Box2>;
 
         box_point_type1 bottom_left1, bottom_right1, top_left1, top_right1;
         geometry::detail::assign_box_corners(box1,
@@ -277,8 +277,8 @@ public:
     template <typename Box1, typename Box2>
     struct return_type
         : services::return_type<Strategy,
-                                typename point_type<Box1>::type,
-                                typename point_type<Box2>::type>
+                                point_type_t<Box1>,
+                                point_type_t<Box2>>
     {};
 
     typedef typename Strategy::radius_type radius_type;
@@ -338,8 +338,8 @@ public:
                 (concepts::PointDistanceStrategy
                     <
                         Strategy,
-                        typename point_type<Box1>::type,
-                        typename point_type<Box2>::type
+                        point_type_t<Box1>,
+                        point_type_t<Box2>
                     >)
             );
 #endif
@@ -429,8 +429,8 @@ public:
         return result_from_distance
             <
                 Strategy,
-                typename point_type<Box1>::type,
-                typename point_type<Box2>::type
+                point_type_t<Box1>,
+                point_type_t<Box2>
             >::apply(s, distance);
     }
 };
@@ -455,7 +455,7 @@ struct default_strategy
                     typename default_strategy
                         <
                             point_tag, point_tag,
-                            typename point_type<Box1>::type, typename point_type<Box2>::type,
+                            point_type_t<Box1>, point_type_t<Box2>,
                             spherical_equatorial_tag, spherical_equatorial_tag
                         >::type,
                     Strategy

--- a/include/boost/geometry/strategies/spherical/distance_cross_track_point_box.hpp
+++ b/include/boost/geometry/strategies/spherical/distance_cross_track_point_box.hpp
@@ -65,7 +65,7 @@ public :
         // this method assumes that the coordinates of the point and
         // the box are normalized
 
-        typedef typename point_type<Box>::type box_point_type;
+        using box_point_type = point_type_t<Box>;
 
         box_point_type bottom_left, bottom_right, top_left, top_right;
         geometry::detail::assign_box_corners(box,
@@ -83,7 +83,7 @@ public :
         ReturnType const pi = math::pi<ReturnType>();
         ReturnType const two_pi = math::two_pi<ReturnType>();
 
-        typedef typename point_type<Box>::type box_point_type;
+        using box_point_type = point_type_t<Box>;
 
         // First check if the point is within the band defined by the
         // minimum and maximum longitude of the box; if yes, determine
@@ -205,7 +205,7 @@ class cross_track_point_box
 public:
     template <typename Point, typename Box>
     struct return_type
-        : services::return_type<Strategy, Point, typename point_type<Box>::type>
+        : services::return_type<Strategy, Point, point_type_t<Box>>
     {};
 
     typedef typename Strategy::radius_type radius_type;
@@ -266,7 +266,7 @@ public:
             (
                 (concepts::PointDistanceStrategy
                     <
-                        Strategy, Point, typename point_type<Box>::type
+                        Strategy, Point, point_type_t<Box>
                     >)
             );
 #endif
@@ -354,7 +354,7 @@ public:
 
         return result_from_distance
             <
-                Strategy, P, typename point_type<Box>::type
+                Strategy, P, point_type_t<Box>
             >::apply(s, distance);
     }
 };
@@ -379,7 +379,7 @@ struct default_strategy
                     typename default_strategy
                         <
                             point_tag, point_tag,
-                            Point, typename point_type<Box>::type,
+                            Point, point_type_t<Box>,
                             spherical_equatorial_tag, spherical_equatorial_tag
                         >::type,
                     Strategy

--- a/include/boost/geometry/strategy/relate.hpp
+++ b/include/boost/geometry/strategy/relate.hpp
@@ -95,11 +95,7 @@ struct default_intersection_strategy
 
 template <typename PointLike, typename Geometry>
 struct default_point_in_geometry_strategy
-    : point_in_geometry::services::default_strategy
-        <
-            typename point_type<PointLike>::type,
-            Geometry
-        >
+    : point_in_geometry::services::default_strategy<point_type_t<PointLike>, Geometry>
 {};
 
 } // namespace detail

--- a/include/boost/geometry/strategy/spherical/envelope_multipoint.hpp
+++ b/include/boost/geometry/strategy/spherical/envelope_multipoint.hpp
@@ -210,8 +210,8 @@ public:
     template <typename MultiPoint, typename Box>
     static inline void apply(MultiPoint const& multipoint, Box& mbr)
     {
-        typedef typename point_type<MultiPoint>::type point_type;
-        typedef typename coordinate_type<MultiPoint>::type coordinate_type;
+        using point_type = point_type_t<MultiPoint>;
+        using coordinate_type = coordinate_type_t<MultiPoint>;
         typedef math::detail::constants_on_spheroid
             <
                 coordinate_type,

--- a/include/boost/geometry/strategy/spherical/envelope_point.hpp
+++ b/include/boost/geometry/strategy/spherical/envelope_point.hpp
@@ -52,7 +52,7 @@ struct spherical_point
         Point normalized_point;
         strategy::normalize::spherical_point::apply(point, normalized_point);
 
-        typename point_type<Box>::type box_point;
+        point_type_t<Box> box_point;
 
         // transform units of input point to units of a box point
         geometry::detail::envelope::transform_units(normalized_point, box_point);

--- a/include/boost/geometry/strategy/spherical/expand_point.hpp
+++ b/include/boost/geometry/strategy/spherical/expand_point.hpp
@@ -61,15 +61,14 @@ struct point_loop_on_spheroid
     template <typename Box, typename Point>
     static inline void apply(Box& box, Point const& point)
     {
-        typedef typename point_type<Box>::type box_point_type;
-        typedef typename coordinate_type<Box>::type box_coordinate_type;
-        typedef typename geometry::detail::cs_angular_units<Box>::type units_type;
-
-        typedef math::detail::constants_on_spheroid
+        using box_point_type = point_type_t<Box>;
+        using box_coordinate_type = coordinate_type_t<Box>;
+        using units_type = typename geometry::detail::cs_angular_units<Box>::type;
+        using constants = math::detail::constants_on_spheroid
             <
                 box_coordinate_type,
                 units_type
-            > constants;
+            >;
 
         // normalize input point and input box
         Point p_normalized;

--- a/include/boost/geometry/util/is_inverse_spheroidal_coordinates.hpp
+++ b/include/boost/geometry/util/is_inverse_spheroidal_coordinates.hpp
@@ -25,8 +25,8 @@ namespace boost { namespace geometry
 template <typename Box>
 bool is_inverse_spheroidal_coordinates(Box const& box)
 {
-    typedef typename point_type<Box>::type point_type;
-    typedef typename coordinate_type<point_type>::type bound_type;
+    using point_type = point_type_t<Box>;
+    using bound_type = coordinate_type_t<point_type>;
 
     bound_type const high = util::bounds<bound_type>::highest();
     bound_type const low = util::bounds<bound_type>::lowest();

--- a/test/algorithms/similarity/test_frechet_distance.hpp
+++ b/test/algorithms/similarity/test_frechet_distance.hpp
@@ -28,8 +28,8 @@ void test_frechet_distance(Geometry1 const& geometry1,Geometry2 const& geometry2
     using namespace bg;
     typedef typename distance_result
         <
-            typename point_type<Geometry1>::type,
-            typename point_type<Geometry2>::type
+            point_type_t<Geometry1>,
+            point_type_t<Geometry2>
         >::type result_type;
     result_type h_distance = bg::discrete_frechet_distance(geometry1,geometry2);
 
@@ -81,8 +81,8 @@ void test_frechet_distance(Geometry1 const& geometry1,Geometry2 const& geometry2
     using namespace bg;
     typedef typename distance_result
         <
-            typename point_type<Geometry1>::type,
-            typename point_type<Geometry2>::type,
+            point_type_t<Geometry1>,
+            point_type_t<Geometry2>,
             Strategy
         >::type result_type;
     result_type h_distance = bg::discrete_frechet_distance(geometry1,geometry2,strategy);

--- a/test/robustness/common/make_square_polygon.hpp
+++ b/test/robustness/common/make_square_polygon.hpp
@@ -16,8 +16,8 @@ inline void make_square_polygon(Polygon& polygon, Generator& generator, Settings
 {
     using namespace boost::geometry;
 
-    typedef typename point_type<Polygon>::type point_type;
-    typedef typename coordinate_type<Polygon>::type coordinate_type;
+    using point_type = point_type_t<Polygon>;
+    using coordinate_type = coordinate_type_t<Polygon>;
 
     coordinate_type x, y;
     x = generator();

--- a/test/robustness/overlay/linear_areal/recursive_polygons_linear_areal.cpp
+++ b/test/robustness/overlay/linear_areal/recursive_polygons_linear_areal.cpp
@@ -77,8 +77,8 @@ inline void make_random_linestring(Linestring& line, Generator& generator, Setti
 {
     using namespace boost::geometry;
 
-    typedef typename point_type<Linestring>::type point_type;
-    typedef typename coordinate_type<Linestring>::type coordinate_type;
+    using point_type = point_type_t<Linestring>;
+    using coordinate_type = coordinate_type_t<Linestring>;
 
     coordinate_type x, y;
     x = generator();


### PR DESCRIPTION
This PR
* changes `typename point_type<X>::type` to `point_type_t<X>`
* at those places, use `using` i/o `typedef`
* in lines immediately before / after that, also use `using`
* sometimes also change to `coordinate_type_t` there (but that is not consistently)

I also verified `clang-tidy` with its usage `modernize-use-using` but that is not giving the desired results at this moment.

Clang tidy can, with its option `modernize-use-using`, replace `typedef` with `using. It sometimes works well, but:

* it can replace `typedef differential_quantities<CT, EnableReducedLength, EnableGeodesicScale, 1> quantities` with `using quantities = int` which is plainly wrong
* it can replace `typedef typename boost::range_value<Range const>::type point_t` with `using point_t = typename boost::range_value<const Range>::type` which moves the const to left, and that is not what is in our conventions
* it removes any newline and changes neatly formatted long typedefs into a very long one-lined using clause.

Therefore I decided to **not** use it. So this commit changes to `point_type_t`, plus `using`. A next might change to `coordinate_type_t` plus `using` and then we can change the rest manually, or semi-automatically (still using clang-tidy but judge per change) 