### PR TITLE
test: verify failures and remove some rescaling remainings

### DIFF
--- a/test/algorithms/buffer/buffer_countries.cpp
+++ b/test/algorithms/buffer/buffer_countries.cpp
@@ -210,10 +210,6 @@ int test_main(int, char* [])
     test_all<false, bg::model::point<default_test_type, 2, bg::cs::cartesian> >();
 #endif
 
-#if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(BG_NO_FAILURES, 2, BG_NO_FAILURES);
-#endif
-
     return 0;
 }
 

--- a/test/algorithms/buffer/buffer_linestring.cpp
+++ b/test/algorithms/buffer/buffer_linestring.cpp
@@ -218,10 +218,8 @@ void test_all()
     // Having flat end
     test_one<linestring, polygon>("for_collinear", for_collinear, join_round, end_flat, 68.561, 2.0);
     test_one<linestring, polygon>("for_collinear", for_collinear, join_miter, end_flat, 72, 2.0);
-#if defined(BOOST_GEOMETRY_TEST_FAILURES)
     test_one<linestring, polygon>("for_collinear2", for_collinear2, join_round, end_flat, 74.387, 2.0);
     test_one<linestring, polygon>("for_collinear2", for_collinear2, join_miter, end_flat, 78.0, 2.0);
-#endif
 
     test_one<linestring, polygon>("curve", curve, join_round, end_flat, 58.1944, 5.0, settings, 3.0);
     test_one<linestring, polygon>("curve", curve, join_miter, end_flat, 58.7371, 5.0, settings, 3.0);
@@ -468,10 +466,6 @@ int test_main(int, char* [])
 
 #if ! defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE)
     test_invalid<true, bg::model::point<long double, 2, bg::cs::cartesian> >();
-#endif
-
-#if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(4, 11, 3);
 #endif
 
     return 0;

--- a/test/algorithms/buffer/buffer_linestring_aimes.cpp
+++ b/test/algorithms/buffer/buffer_linestring_aimes.cpp
@@ -257,11 +257,6 @@ void test_aimes()
         double const aimes_width = width / 1000000.0;
         for (int i = 0; i < n; i++)
         {
-#if defined(BOOST_GEOMETRY_TEST_FAILURES)
-            // There are 4 false positives
-            bool const possible_invalid = width == 18 && (i == 75 || i == 80 || i == 140);
-            settings.set_test_validity(! possible_invalid);
-#endif
             std::ostringstream name;
             try
             {
@@ -293,12 +288,6 @@ int test_main(int, char* [])
     BoostGeometryWriteTestConfiguration();
 
     test_aimes<bg::model::point<default_test_type, 2, bg::cs::cartesian> >();
-
-#if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    // Type float is not supported for these cases.
-    // Type double has (judging the svg) 4 false negatives for validity
-    BoostGeometryWriteExpectedFailures(0, 0, 0);
-#endif
 
     return 0;
 }

--- a/test/algorithms/buffer/buffer_multi_linestring.cpp
+++ b/test/algorithms/buffer/buffer_multi_linestring.cpp
@@ -195,18 +195,12 @@ void test_all()
     test_one<multi_linestring_type, polygon>("mysql_23023665_1_20",
             mysql_23023665_1, join_round32, end_flat, 1, 1, 350.1135, 2.0);
 
-#if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    {
-        // Cases (railway roads) still failing
-        ut_settings settings(10.0, false);
-        test_one<multi_linestring_type, polygon>("ticket_13444_1",
-                ticket_13444, join_round32, end_round32, 3, 0, 11801.7832, 1.0, settings);
-        test_one<multi_linestring_type, polygon>("ticket_13444_3",
-                ticket_13444, join_round32, end_round32, 3, 1, 34132.0882, 3.0, settings);
-        test_one<multi_linestring_type, polygon>("ticket_13444_5",
-                ticket_13444, join_round32, end_round32, 2, 1, 50525.1110, 5.0, settings);
-    }
-#endif
+    test_one<multi_linestring_type, polygon>("ticket_13444_1",
+            ticket_13444, join_round32, end_round32, 3, 0, 11799.2681, 1.0);
+    test_one<multi_linestring_type, polygon>("ticket_13444_3",
+            ticket_13444, join_round32, end_round32, 3, 1, 34132.0882, 3.0);
+    test_one<multi_linestring_type, polygon>("ticket_13444_5",
+            ticket_13444, join_round32, end_round32, 2, 1, 50525.1110, 5.0);
 
     {
         // This issue was detected for CCW order and only CW is tested by default.
@@ -234,8 +228,5 @@ int test_main(int, char* [])
     test_all<false, bg::model::point<default_test_type, 2, bg::cs::cartesian> >();
 #endif
 
-#if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(6, 9, 3);
-#endif
     return 0;
 }

--- a/test/algorithms/buffer/buffer_multi_point.cpp
+++ b/test/algorithms/buffer/buffer_multi_point.cpp
@@ -51,10 +51,11 @@ void test_all()
     test_one<multi_point_type, polygon>("simplex3", simplex, join, end_flat, 44.5619, 3.0);
 
     test_one<multi_point_type, polygon>("three1", three, join, end_flat, 3.0 * expectation, 1.0);
-#if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    // fails in CCW mode
-    test_one<multi_point_type, polygon>("three2", three, join, end_flat, 36.7528, 2.0);
-#endif
+    {
+        // Is reported as invalid for in CCW mode: test validity only for clockwise
+        ut_settings const settings(ut_settings::default_tolerance, Clockwise);
+        test_one<multi_point_type, polygon>("three2", three, join, end_flat, 36.7528, 2.0, settings);
+    }
     test_one<multi_point_type, polygon>("three19", three, join, end_flat, 33.6857, 1.9);
     test_one<multi_point_type, polygon>("three21", three, join, end_flat, 39.6337, 2.1);
     test_one<multi_point_type, polygon>("three3", three, join, end_flat, 65.5243, 3.0);
@@ -218,10 +219,6 @@ int test_main(int, char* [])
     test_many_points_per_circle<bg::model::point<double, 2, bg::cs::cartesian> >();
 #else
     std::cout << "Skipping some tests in debug or unknown mode" << std::endl;
-#endif
-
-#if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(BG_NO_FAILURES);
 #endif
 
     return 0;

--- a/test/algorithms/buffer/buffer_multi_polygon.cpp
+++ b/test/algorithms/buffer/buffer_multi_polygon.cpp
@@ -683,9 +683,5 @@ int test_main(int, char* [])
     test_all<true, bg::model::point<mp_test_type, 2, bg::cs::cartesian> >();
 #endif
 
-#if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(1, 3, 3);
-#endif
-
     return 0;
 }

--- a/test/algorithms/buffer/buffer_point.cpp
+++ b/test/algorithms/buffer/buffer_point.cpp
@@ -40,9 +40,5 @@ int test_main(int, char* [])
     test_all<false, bg::model::point<default_test_type, 2, bg::cs::cartesian> >();
 #endif
 
-#if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(BG_NO_FAILURES);
-#endif
-
     return 0;
 }

--- a/test/algorithms/buffer/buffer_polygon.cpp
+++ b/test/algorithms/buffer/buffer_polygon.cpp
@@ -955,10 +955,6 @@ int test_main(int, char* [])
     test_mixed<dpoint, dpoint, true, true, false, true>();
 #endif
 
-#if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(1, 9, 1);
-#endif
-
     test_different();
 
     return 0;

--- a/test/algorithms/buffer/test_buffer.hpp
+++ b/test/algorithms/buffer/test_buffer.hpp
@@ -123,7 +123,8 @@ template<> struct EndTestProperties<boost::geometry::strategy::buffer::end_flat>
 
 struct ut_settings : public ut_base_settings
 {
-    explicit ut_settings(double tol = 0.01, bool val = true, int points = 88)
+    static constexpr double default_tolerance = 0.01;
+    explicit ut_settings(double tol = default_tolerance, bool val = true, int points = 88)
         : ut_base_settings(val)
         , tolerance(tol)
         , points_per_circle(points)

--- a/test/algorithms/check_validity.hpp
+++ b/test/algorithms/check_validity.hpp
@@ -16,7 +16,7 @@
 #include <boost/geometry/algorithms/is_valid.hpp>
 
 template<typename Geometry>
-inline bool input_is_valid(std::string const& case_id, std::string const& subcase,
+inline bool is_input_valid(std::string const& case_id, std::string const& subcase,
                          Geometry const& geometry)
 {
     std::string message;
@@ -42,8 +42,8 @@ inline bool is_output_valid(Geometry const& geometry,
     bool result = bg::is_valid(geometry, message);
     if (! result && ignore_validity_on_invalid_input)
     {
-        if (! input_is_valid(case_id, "a", g1)
-            || ! input_is_valid(case_id, "b", g2))
+        if (! is_input_valid(case_id, "a", g1)
+            || ! is_input_valid(case_id, "b", g2))
         {
             // Because input is invalid, output validity is ignored
             result = true;

--- a/test/algorithms/set_operations/difference/difference.cpp
+++ b/test/algorithms/set_operations/difference/difference.cpp
@@ -34,15 +34,6 @@
 namespace
 {
 
-// Change compiler defines to constexpr bools
-// to make conditions more readable
-// and to always compile all code.
-#if defined(BOOST_GEOMETRY_TEST_FAILURES)
-constexpr bool test_failures = true;
-#else
-constexpr bool test_failures = false;
-#endif
-
 #if defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE)
 constexpr bool test_only_one_type = true;
 #else
@@ -95,16 +86,10 @@ void test_all()
         1, 5, 8.0,
         1, 5, 8.0);
 
-    {
-        // It reports self-intersections for symmetric difference
-        ut_settings settings;
-        settings.sym_difference = false;
-        test_one<polygon, polygon, polygon>("star_comb_15",
-            star_comb_15[0], star_comb_15[1],
-            30, -1, 227.658275102812,
-            30, -1, 480.485775259312,
-            settings);
-    }
+    test_one<polygon, polygon, polygon>("star_comb_15",
+        star_comb_15[0], star_comb_15[1],
+        30, -1, 227.658275102812,
+        30, -1, 480.485775259312);
 
     test_one<polygon, polygon, polygon>("new_hole",
         new_hole[0], new_hole[1],
@@ -173,31 +158,20 @@ void test_all()
         4, 20, 11.533333,
         5, 26, 29.783333);
 
-    {
-        ut_settings settings;
-        settings.validity_of_sym = true;
-        test_one<polygon, polygon, polygon>("intersect_holes_intersect_and_disjoint",
-            intersect_holes_intersect_and_disjoint[0], intersect_holes_intersect_and_disjoint[1],
-            2, 16, 15.75,
-            3, 17, 6.75,
-            settings);
+    test_one<polygon, polygon, polygon>("intersect_holes_intersect_and_disjoint",
+        intersect_holes_intersect_and_disjoint[0], intersect_holes_intersect_and_disjoint[1],
+        2, 16, 15.75,
+        3, 17, 6.75);
 
-        test_one<polygon, polygon, polygon>("intersect_holes_intersect_and_touch",
-            intersect_holes_intersect_and_touch[0], intersect_holes_intersect_and_touch[1],
-            3, 21, 16.25,
-            3, 17, 6.25,
-            settings);
-    }
+    test_one<polygon, polygon, polygon>("intersect_holes_intersect_and_touch",
+        intersect_holes_intersect_and_touch[0], intersect_holes_intersect_and_touch[1],
+        3, 21, 16.25,
+        3, 17, 6.25);
 
-    {
-        ut_settings settings;
-        settings.percentage = 0.01;
-        test_one<polygon, polygon, polygon>("intersect_holes_new_ring",
-            intersect_holes_new_ring[0], intersect_holes_new_ring[1],
-            3, 15, 9.8961,
-            4, 25, 121.8961,
-            settings);
-    }
+    test_one<polygon, polygon, polygon>("intersect_holes_new_ring",
+        intersect_holes_new_ring[0], intersect_holes_new_ring[1],
+        3, 15, 9.8961,
+        4, 25, 121.8961);
 
     test_one<polygon, polygon, polygon>("first_within_hole_of_second",
         first_within_hole_of_second[0], first_within_hole_of_second[1],
@@ -209,14 +183,10 @@ void test_all()
         2, 14, 16.0,
         2, 10, 6.0);
 
-    {
-        ut_settings settings;
-        test_one<polygon, polygon, polygon>("intersect_holes_intersect",
-            intersect_holes_intersect[0], intersect_holes_intersect[1],
-            2, 16, 15.75,
-            2, 12, 5.75,
-            settings);
-    }
+    test_one<polygon, polygon, polygon>("intersect_holes_intersect",
+        intersect_holes_intersect[0], intersect_holes_intersect[1],
+        2, 16, 15.75,
+        2, 12, 5.75);
 
     test_one<polygon, polygon, polygon>(
             "case4", case_4[0], case_4[1],
@@ -279,11 +249,9 @@ void test_all()
     TEST_DIFFERENCE(case_precision_9, optional(), optional_sliver(), 1, 59.0, count_set(1, 2));
     TEST_DIFFERENCE_WITH(case_precision_10, optional(), optional_sliver(), 1, 59, count_set(1, 2), ut_settings(0.001));
 
-    if BOOST_GEOMETRY_CONSTEXPR(test_failures)
-    {
-        // Fails (since rescaling is turned off)
-        TEST_DIFFERENCE(case_precision_11, optional(), optional_sliver(), 1, 59.0, count_set(1, 2));
-    }
+    // Sym Difference fails (since rescaling is turned off)
+    TEST_DIFFERENCE_WITH(case_precision_11, optional(), optional_sliver(), 1, 59.0, count_set(1, 2),
+                         ut_settings(ut_settings::default_tolerance, true, BG_IF_TEST_FAILURES));
 
     TEST_DIFFERENCE(case_precision_12, 1, 12.0, 0, 0.0, 1);
     TEST_DIFFERENCE_WITH(case_precision_13, 1, 12, 0, 0.0, 1, ut_settings(0.001));
@@ -330,23 +298,25 @@ void test_all()
             count_set(1, 2), settings);
     }
 
-    /*** TODO: self-tangencies for difference
-    test_one<polygon, polygon, polygon>("wrapped_a",
-        wrapped[0], wrapped[1],
-        3, 1, 61,
-        1, 0, 13);
+    {
+        ut_settings settings(ut_settings::default_tolerance, false);
+        test_one<polygon, polygon, polygon>("wrapped_0_1",
+            wrapped[0], wrapped[1],
+            1, 1, 1.0,
+            1, 0, 15.0,
+            1, settings);
+    }
 
-    test_one<polygon, polygon, polygon>("wrapped_b",
+    test_one<polygon, polygon, polygon>("wrapped_0_2",
         wrapped[0], wrapped[2],
-        3, 1, 61,
-        1, 0, 13);
-    ***/
+        1, 1, 1.0,
+        1, 0, 15.0,
+        1);
 
     {
         ut_settings settings;
         settings.percentage = 0.1;
-        settings.set_test_validity(false);
-        settings.sym_difference = false;
+        settings.validity_of_sym = false;
 
         // Isovist - the # output polygons differ per compiler/pointtype, (very) small
         // rings might be discarded. We check area only
@@ -374,21 +344,15 @@ void test_all()
     }
 
     {
-        ut_settings settings;
-        settings.set_test_validity(true);
-
-        // Output polygons for sym difference might be combined
-        expectation_limits a{138.5312, 138.6924};
-        expectation_limits b{210.5312, 211.8594};
+        expectation_limits const a{138.5312, 138.6924};
+        expectation_limits const b{210.5312, 211.8594};
         test_one<polygon, polygon, polygon>("geos_2",
             geos_2[0], geos_2[1],
             1, -1, a,
             1, -1, b,
-            {1, 2}, -1, a + b,
-            settings);
+            {1, 2}, -1, a + b);
     }
 
-    // Output polygons for sym difference might be combined
     test_one<polygon, polygon, polygon>("geos_3",
         geos_3[0], geos_3[1],
         1, -1, 16211128.5,
@@ -418,15 +382,10 @@ void test_all()
         1, 58456.4964294434,
         1);
 
-    {
-      ut_settings settings(0.0001, false);
-      // Symmetric difference should output one polygon
-      // Using rescaling, it currently outputs two.
-      TEST_DIFFERENCE_WITH(ggl_list_20110820_christophe,
-          1, 2.8570121719168924,
-          1, 64.498061986388564,
-          count_set(1, 2), settings);
-    }
+    TEST_DIFFERENCE(ggl_list_20110820_christophe,
+        1, 2.8570121719168924,
+        1, 64.498061986388564,
+        count_set(1, 2));
 
     test_one<polygon, polygon, polygon>("ggl_list_20120717_volker",
         ggl_list_20120717_volker[0], ggl_list_20120717_volker[1],
@@ -439,28 +398,19 @@ void test_all()
     // sql server gives: 6.62295817619452E-05
     // PostGIS gives: 0.0 (no output)
     // Boost.Geometry gave results depending on FP-type, and compiler, and operating system.
-    // With rescaling results are equal w.r.t. compiler/FP type,
-    // however, some long spikes are still generated in the resulting difference
-    // Without rescaling there is no output, like PostGIS
+    // To be verified if some long spikes are still generated in the results
     test_one<polygon, polygon, polygon>("ggl_list_20110627_phillip",
         ggl_list_20110627_phillip[0], ggl_list_20110627_phillip[1],
         optional(), -1,
         optional_sliver(0.00013),
         1, -1, expectation_limits(3577.4096, 3577.415),
-        tolerance(0.01)
-        );
+        tolerance(0.01));
 
-    {
-        // With rescaling, difference of output a-b and a sym b is invalid
-        ut_settings settings;
-        settings.set_test_validity(true);
-        settings.validity_of_sym = true;
-        TEST_DIFFERENCE_WITH(ggl_list_20190307_matthieu_1,
-                count_set(1, 2), 0.18461532,
-                count_set(1, 2), 0.617978,
-                count_set(3, 4), settings);
-        TEST_DIFFERENCE_WITH(ggl_list_20190307_matthieu_2, 2, 12.357152, 0, 0.0, 2, settings);
-    }
+    TEST_DIFFERENCE(ggl_list_20190307_matthieu_1,
+            count_set(1, 2), 0.18461532,
+            count_set(1, 2), 0.617978,
+            count_set(3, 4));
+    TEST_DIFFERENCE(ggl_list_20190307_matthieu_2, 2, 12.357152, 0, 0.0, 2);
 
     // Ticket 8310, one should be completely subtracted from the other.
     test_one<polygon, polygon, polygon>("ticket_8310a",
@@ -494,14 +444,11 @@ void test_all()
                     count_set(1, 6), 20.096189,
                     count_set(1, 6));
 
-    if BOOST_GEOMETRY_CONSTEXPR(test_failures)
-    {
-        // Without rescaling the second case (labeled "b") produces no output.
-        test_one<polygon, polygon, polygon>("ticket_10108_a",
-                ticket_10108_a[0], ticket_10108_a[1],
-                1, 4,  {0.0145036, 0.0145037},
-                1, 4,  0.029019232);
-    }
+    test_one<polygon, polygon, polygon>("ticket_10108_a",
+            ticket_10108_a[0], ticket_10108_a[1],
+            1, 4, {0.0145036, 0.0145037},
+            1, 4, 0.029019232,
+            1);
 
     test_one<polygon, polygon, polygon>("ticket_10108_b",
             ticket_10108_b[0], ticket_10108_b[1],
@@ -570,7 +517,7 @@ void test_all()
         {
             using mp = bg::model::multi_polygon<polygon>;
 
-            static std::string const clip = "POLYGON((2 2,4 4))";
+            std::string const clip = "POLYGON((2 2,4 4))";
 
             test_one<polygon, box, mp>("simplex_multi_box_mp",
                 clip, case_multi_simplex[0],
@@ -590,16 +537,10 @@ void test_all()
                     optional(), optional_sliver(1.0e-5),
                     count_set(1, 2));
 
-    {
-        ut_settings settings;
-        settings.set_test_validity(false);
-        settings.validity_false_negative_a = true;
-        TEST_DIFFERENCE_WITH(issue_838,
-            count_set(1, 2), expectation_limits(0.000026, 0.0002823),
-            count_set(1, 2), expectation_limits(0.67257, 0.67499),
-            count_set(2, 3, 4),
-            settings);
-    }
+    TEST_DIFFERENCE(issue_838,
+        count_set(1, 2), expectation_limits(0.000026, 0.0002823),
+        count_set(1, 2), expectation_limits(0.67257, 0.67499),
+        count_set(2, 3, 4));
 
     {
         // The symmetric difference is invalid for ccw
@@ -612,7 +553,7 @@ void test_all()
     TEST_DIFFERENCE(issue_876b, 1, 6114.18234, 1, 4754.29449, count_set(1, 2));
 
     {
-        // Results are still invalid
+        // Results are reported as invalid
         ut_settings settings;
         settings.set_test_validity(false);
         settings.validity_of_sym = false;
@@ -721,13 +662,6 @@ int test_main(int, char* [])
     {
         test_all<bg::model::d2::point_xy<float>, true>();
     }
-
-#if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    // Not yet fully tested for float and long double.
-    // The difference algorithm can generate (additional) slivers
-    // Many of the failures are self-intersection points.
-    BoostGeometryWriteExpectedFailures(5, 17, 10);
-#endif
 
     return 0;
 }

--- a/test/algorithms/set_operations/difference/difference_multi.cpp
+++ b/test/algorithms/set_operations/difference/difference_multi.cpp
@@ -23,17 +23,11 @@
 
 #include <boost/geometry/io/wkt/read.hpp>
 
-// Convenience macros (points are not checked)
+// Convenience macros (not using number of points, they are not checked anymore)
 #define TEST_DIFFERENCE(caseid, clips1, area1, clips2, area2, clips3) \
     (test_one<Polygon, MultiPolygon, MultiPolygon>) \
     ( #caseid, caseid[0], caseid[1], clips1, -1, area1, clips2, -1, area2, \
                 clips3, -1, area1 + area2)
-
-#define TEST_DIFFERENCE_IGNORE(caseid, clips1, area1, clips2, area2, clips3) \
-    { ut_settings ignore_validity; ignore_validity.set_test_validity(false); \
-    (test_one<Polygon, MultiPolygon, MultiPolygon>) \
-    ( #caseid, caseid[0], caseid[1], clips1, -1, area1, clips2, -1, area2, \
-                clips3, -1, area1 + area2, ignore_validity); }
 
 #define TEST_DIFFERENCE_WITH(index1, index2, caseid, clips1, area1, \
                 clips2, area2, clips3) \
@@ -106,18 +100,11 @@ void test_areal()
     // A should have 3 clips, B should have 5 clips
     TEST_DIFFERENCE(case_126_multi, 4, 16.0, 5, 27.0, 9);
 
-    {
-        ut_settings settings;
-
-        settings.sym_difference = true;
-
-        test_one<Polygon, MultiPolygon, MultiPolygon>("case_108_multi",
-            case_108_multi[0], case_108_multi[1],
-                7, 32, 5.5,
-                4, 24, 9.75,
-                7, 45, 15.25,
-                settings);
-    }
+    test_one<Polygon, MultiPolygon, MultiPolygon>("case_108_multi",
+        case_108_multi[0], case_108_multi[1],
+            7, 32, 5.5,
+            4, 24, 9.75,
+            7, 45, 15.25);
 
     // Ticket on GGL list 2011/10/25
     // to mix polygon/multipolygon in call to difference
@@ -154,19 +141,7 @@ void test_areal()
 
     TEST_DIFFERENCE(bug_21155501, 1, 3.758937, 1, 1.78e-15, 1);
 
-#if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    {
-        // With rescaling, it is complete but invalid
-        // Without rescaling, one ring is missing (for a and s)
-        ut_settings settings;
-        settings.set_test_validity(true);
-        settings.validity_of_sym = true;
-        TEST_DIFFERENCE_WITH(0, 1, ticket_9081,
-                             2, 0.0907392476356186,
-                             4, 0.126018011439877,
-                             count_set(3, 4));
-    }
-#endif
+    TEST_DIFFERENCE(ticket_9081, 2, 0.0907392476356186, 4, 0.126018011439877, count_set(3, 4));
 
     TEST_DIFFERENCE(ticket_12503, 46, 920.625, 4, 7.625, 50);
 
@@ -178,9 +153,7 @@ void test_areal()
         TEST_DIFFERENCE_WITH(0, 1, issue_630_a, 0, expectation_limits(0.0), 1, (expectation_limits(2.023, 2.2004)), 1);
         TEST_DIFFERENCE_WITH(0, 1, issue_630_b, 1, 0.0056089, 2, 1.498976, 3);
         TEST_DIFFERENCE_WITH(0, 1, issue_630_c, 0, 0, 1, 1.493367, 1);
-        // Symmetrical difference fails without get_clusters
-        settings.sym_difference = BG_IF_TEST_FAILURES;
-        TEST_DIFFERENCE_WITH(0, 1, issue_643, 1, expectation_limits(76.5385), optional(), optional_sliver(1.0e-6), 1);
+        TEST_DIFFERENCE_WITH(0, 1, issue_643, 1, expectation_limits(76.5385), optional(), optional_sliver(1.0e-6), 2);
     }
 
     // Cases below go (or went) wrong in either a ( [0] - [1] ) or b ( [1] - [0] )
@@ -418,7 +391,7 @@ template <typename Polygon, typename MultiPolygon>
 void test_specific_areal()
 {
     {
-        // Spikes in a-b and b-a, failure in symmetric difference
+        // Spikes in a-b and b-a, causing invalidity
         ut_settings settings;
         settings.sym_difference = false;
         settings.set_test_validity(false);
@@ -506,12 +479,6 @@ int test_main(int, char* [])
 
 #if ! defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE)
     test_all<bg::model::d2::point_xy<float> >();
-#endif
-
-#if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    // Not yet fully tested for float.
-    // The difference algorithm can generate (additional) slivers
-    BoostGeometryWriteExpectedFailures(11, 21, 7);
 #endif
 
     return 0;

--- a/test/algorithms/set_operations/difference/test_difference.hpp
+++ b/test/algorithms/set_operations/difference/test_difference.hpp
@@ -79,7 +79,9 @@ struct ut_settings : ut_base_settings
     bool validity_false_negative_b = false;
     bool validity_false_negative_sym = false;
 
-    explicit ut_settings(double p = 0.0001, bool validity = true, bool sd = true)
+    static constexpr double default_tolerance = 0.0001;
+
+    explicit ut_settings(double p = default_tolerance, bool validity = true, bool sd = true)
         : ut_base_settings(validity)
         , percentage(p)
         , sym_difference(sd)
@@ -215,7 +217,6 @@ std::string test_difference(std::string const& caseid, G1 const& g1, G2 const& g
 #if ! defined(BOOST_GEOMETRY_NO_BOOST_TEST)
     if (settings.test_validity_of_diff(dtype))
     {
-        // std::cout << bg::dsv(result) << std::endl;
         typedef bg::model::multi_polygon<OutputType> result_type;
         std::string message;
         bool const valid = check_validity<result_type>::apply(result, caseid, g1, g2, message);

--- a/test/algorithms/set_operations/intersection/intersection.cpp
+++ b/test/algorithms/set_operations/intersection/intersection.cpp
@@ -51,11 +51,6 @@ BOOST_GEOMETRY_REGISTER_LINESTRING_TEMPLATED(std::vector)
     (test_one<Polygon, Polygon, Polygon>) \
     ( #caseid "_rev", caseid[1], caseid[0], clips, points, area)
 
-#define TEST_INTERSECTION_IGNORE(caseid, clips, points, area) \
-    { ut_settings ignore_validity; ignore_validity.set_test_validity(false); \
-    (test_one<Polygon, Polygon, Polygon>) \
-    ( #caseid, caseid[0], caseid[1], clips, points, area, ignore_validity); }
-
 #define TEST_INTERSECTION_WITH(caseid, index1, index2, \
      clips, points, area, settings) \
     (test_one<Polygon, Polygon, Polygon>) \
@@ -178,14 +173,9 @@ void test_areal()
         pie_2_3_23_0[0], pie_2_3_23_0[1],
         1, 4, 163292.679042133, ut_settings(0.1));
 
-#if defined(BOOST_GEOMETRY_TEST_FAILURES)
     TEST_INTERSECTION(isovist, 1, 19, expectation_limits(88.19202, 88.19206));
-#else
-    // Reported as invalid
-    TEST_INTERSECTION_IGNORE(isovist, 1, 19, expectation_limits(88.19202, 88.19206));
-#endif
 
-    TEST_INTERSECTION_IGNORE(geos_1, 1, -1, expectation_limits(3454, 3462));
+    TEST_INTERSECTION(geos_1, 1, -1, expectation_limits(3454, 3462));
 
     // Can, in some cases, create small slivers
     // In some cases: 1.430511474609375e-05 (clang/gcc on Xubuntu using b2)
@@ -847,12 +837,6 @@ int test_main(int, char* [])
 
     test_pointer_version();
     test_rational<bg::model::d2::point_xy<boost::rational<int> > >();
-#endif
-
-#if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    // llb_touch generates a polygon with 1 point and is therefore invalid everywhere
-    // TODO: this should be easy to fix
-    BoostGeometryWriteExpectedFailures(2, 7, 1);
 #endif
 
     return 0;

--- a/test/algorithms/set_operations/intersection/intersection_multi.cpp
+++ b/test/algorithms/set_operations/intersection/intersection_multi.cpp
@@ -484,10 +484,6 @@ int test_main(int, char* [])
     test_all<bg::model::d2::point_xy<float> >();
 #endif
 
-#if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(1, 2, 1);
-#endif
-
     return 0;
 }
 

--- a/test/algorithms/set_operations/union/union.cpp
+++ b/test/algorithms/set_operations/union/union.cpp
@@ -370,20 +370,11 @@ void test_areal()
         ggl_list_20110716_enrico[0], ggl_list_20110716_enrico[1],
         1, 1, 15, 129904.197692871);
 
-    {
-        ut_settings settings;
-        settings.set_test_validity(BG_IF_TEST_FAILURES);
-        TEST_UNION_WITH(ggl_list_20110820_christophe, count_set(1, 2), 0, -1, 67.3550722317627);
-    }
+    TEST_UNION(ggl_list_20110820_christophe, count_set(1, 2), 0, -1, 67.3550722317627);
 
-    {
-        // SQL Server gives: 313.360374193241
-        // PostGIS gives:    313.360364623393
-        // Without rescaling, it is creates an invalidity for double
-        ut_settings settings;
-        settings.set_test_validity(false);
-        TEST_UNION_WITH(isovist, 1, 0, -1, 313.36036462);
-    }
+    // SQL Server gives: 313.360374193241
+    // PostGIS gives:    313.360364623393
+    TEST_UNION(isovist, 1, 0, -1, 313.36036462);
 
     TEST_UNION(ggl_list_20190307_matthieu_1, 1, 1, -1, 0.83773);
     TEST_UNION(ggl_list_20190307_matthieu_2, 1, 0, -1, 16.0);
@@ -430,14 +421,7 @@ void test_areal()
     TEST_UNION_REV(issue_566_a, 1, 0, -1, 214.3728);
     TEST_UNION_REV(issue_566_b, 1, 0, -1, 214.3728);
 
-    {
-        // With rescaling, the input (was already an output of a previous step)
-        // is somehow considered as invalid. Output is also invalid.
-        // Without rescaling, the same input is considered as valid
-        ut_settings settings;
-        settings.ignore_validity_on_invalid_input = false;
-        TEST_UNION_WITH(issue_690, 2, 0, -1, 25492.0505);
-    }
+    TEST_UNION(issue_690, 2, 0, -1, 25492.0505);
 
     TEST_UNION(issue_838, 1, 0, -1, expectation_limits(1.3333, 1.33785));
     TEST_UNION_REV(issue_838, 1, 0, -1, expectation_limits(1.3333, 1.33785));
@@ -668,10 +652,6 @@ int test_main(int, char* [])
     test_all<bg::model::d2::point_xy<float>, true>();
     test_all<bg::model::d2::point_xy<long double>, true>();
     test_all<bg::model::d2::point_xy<mp_test_type>, true>();
-#endif
-
-#if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(1, 2, 0);
 #endif
 
     return 0;

--- a/test/algorithms/set_operations/union/union_multi.cpp
+++ b/test/algorithms/set_operations/union/union_multi.cpp
@@ -392,16 +392,9 @@ void test_areal()
          ggl_list_20140212_sybren[0], ggl_list_20140212_sybren[1],
          2, bg_if_mp<ct>(1, 0), -1, 0.002471626);
 
-    {
-        // Generates either 4 or 3 output polygons
-        // With rescaling the result is invalid.
-        ut_settings settings;
-        settings.set_test_validity(true);
-        test_one<Polygon, MultiPolygon, MultiPolygon>("ticket_9081",
-            ticket_9081[0], ticket_9081[1],
-            3, 0, -1, 0.2187385,
-            settings);
-    }
+    test_one<Polygon, MultiPolygon, MultiPolygon>("ticket_9081",
+        ticket_9081[0], ticket_9081[1],
+        3, 0, -1, 0.2187385);
 
     test_one<Polygon, MultiPolygon, MultiPolygon>("ticket_10803",
         ticket_10803[0], ticket_10803[1],
@@ -490,10 +483,6 @@ int test_main(int, char* [])
     test_all<bg::model::d2::point_xy<mp_test_type>, true, true>();
 
     test_specific<bg::model::d2::point_xy<int>, false, false>();
-#endif
-
-#if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    BoostGeometryWriteExpectedFailures(0, 1, 0);
 #endif
 
     return 0;

--- a/test/geometry_test_common.hpp
+++ b/test/geometry_test_common.hpp
@@ -213,32 +213,4 @@ inline void BoostGeometryWriteTestConfiguration()
     std::cout << std::endl;
 }
 
-#ifdef BOOST_GEOMETRY_TEST_FAILURES
-#define BG_NO_FAILURES 0
-inline void BoostGeometryWriteExpectedFailures(std::size_t for_double,
-                                               std::size_t for_float,
-                                               std::size_t for_extended)
-{
-    std::size_t const expected
-        = if_typed<default_test_type, double>(for_double,
-              if_typed<default_test_type, float>(for_float,
-                  for_extended));
-
-    boost::ignore_unused(expected, for_double, for_float, for_extended);
-
-
-#if defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE) && defined(BOOST_GEOMETRY_TEST_ONLY_ONE_ORDER)
-    std::cout << "Expected: " << expected << " error(s)" << std::endl;
-#else
-    std::cout << std::endl;
-#endif
-}
-
-inline void BoostGeometryWriteExpectedFailures(std::size_t for_double = BG_NO_FAILURES)
-{
-    BoostGeometryWriteExpectedFailures(for_double, for_double, for_double);
-}
-
-#endif
-
 #endif // GEOMETRY_TEST_GEOMETRY_TEST_COMMON_HPP


### PR DESCRIPTION
This PR:

* removes `BoostGeometryWriteExpectedFailures` (it was to compare rescaling with / without)
* verifies failing tests
* where not failing anymore, removes the defines or conditions

There were several tests which now succeeds. I didn't bisect them, but it is good to have them enabled now for future PR's.