### PR TITLE
Fix several strategies (add getters, fix compilation error and warning)

### DIFF
--- a/include/boost/geometry/strategies/cartesian.hpp
+++ b/include/boost/geometry/strategies/cartesian.hpp
@@ -1,5 +1,7 @@
 // Boost.Geometry
 
+// Copyright (c) 2025 Adam Wulkiewicz, Lodz, Poland.
+
 // Copyright (c) 2020-2021, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -14,6 +16,8 @@
 #include <boost/geometry/strategies/area/cartesian.hpp>
 #include <boost/geometry/strategies/azimuth/cartesian.hpp>
 #include <boost/geometry/strategies/buffer/cartesian.hpp>
+#include <boost/geometry/strategies/centroid/cartesian.hpp>
+#include <boost/geometry/strategies/closest_points/cartesian.hpp>
 #include <boost/geometry/strategies/convex_hull/cartesian.hpp>
 #include <boost/geometry/strategies/distance/cartesian.hpp>
 #include <boost/geometry/strategies/envelope/cartesian.hpp>
@@ -36,7 +40,8 @@ namespace strategies
 template <typename CalculationType = void>
 class cartesian
     // derived from the umbrella strategy defining the most strategies
-    : public strategies::index::cartesian<CalculationType>
+    : public strategies::closest_points::cartesian<CalculationType>
+    , public strategies::centroid::detail::cartesian<CalculationType>
 {
 public:
 

--- a/include/boost/geometry/strategies/centroid/cartesian.hpp
+++ b/include/boost/geometry/strategies/centroid/cartesian.hpp
@@ -1,5 +1,7 @@
 // Boost.Geometry
 
+// Copyright (c) 2025 Adam Wulkiewicz, Lodz, Poland.
+
 // Copyright (c) 2021, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -27,9 +29,12 @@ namespace boost { namespace geometry
 namespace strategies { namespace centroid
 {
 
+#ifndef DOXYGEN_NO_DETAIL
+namespace detail
+{
+
 template <typename CalculationType = void>
 struct cartesian
-    : public strategies::detail::cartesian_base
 {
     template <typename Geometry>
     static auto centroid(Geometry const&,
@@ -75,6 +80,17 @@ struct cartesian
         return strategy::centroid::not_applicable_strategy();
     }
 };
+
+
+} // namespace detail
+#endif // DOXYGEN_NO_DETAIL
+
+
+template <typename CalculationType = void>
+struct cartesian
+    : public strategies::detail::cartesian_base
+    , public strategies::centroid::detail::cartesian<CalculationType>
+{};
 
 
 namespace services

--- a/include/boost/geometry/strategies/centroid/geographic.hpp
+++ b/include/boost/geometry/strategies/centroid/geographic.hpp
@@ -1,5 +1,7 @@
 // Boost.Geometry
 
+// Copyright (c) 2025 Adam Wulkiewicz, Lodz, Poland.
+
 // Copyright (c) 2021, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -22,24 +24,13 @@ namespace boost { namespace geometry
 namespace strategies { namespace centroid
 {
 
-template
-<
-    typename FormulaPolicy = strategy::andoyer,
-    typename Spheroid = srs::spheroid<double>,
-    typename CalculationType = void
->
-class geographic
-    : public strategies::detail::geographic_base<Spheroid>
+#ifndef DOXYGEN_NO_DETAIL
+namespace detail
 {
-    using base_t = strategies::detail::geographic_base<Spheroid>;
 
+class geographic
+{
 public:
-    geographic() = default;
-
-    explicit geographic(Spheroid const& spheroid)
-        : base_t(spheroid)
-    {}
-
     // TODO: Box and Segment should have proper strategies.
     template <typename Geometry, typename Point>
     static auto centroid(Geometry const&, Point const&,
@@ -52,6 +43,32 @@ public:
         return strategy::centroid::not_applicable_strategy();
     }
 };
+
+
+} // namespace detail
+#endif // DOXYGEN_NO_DETAIL
+
+
+template
+<
+    typename FormulaPolicy = strategy::andoyer,
+    typename Spheroid = srs::spheroid<double>,
+    typename CalculationType = void
+>
+class geographic
+    : public strategies::detail::geographic_base<Spheroid>
+    , public strategies::centroid::detail::geographic
+{
+    using base_t = strategies::detail::geographic_base<Spheroid>;
+
+public:
+    geographic() = default;
+
+    explicit geographic(Spheroid const& spheroid)
+        : base_t(spheroid)
+    {}
+};
+
 
 namespace services
 {

--- a/include/boost/geometry/strategies/centroid/spherical.hpp
+++ b/include/boost/geometry/strategies/centroid/spherical.hpp
@@ -1,5 +1,7 @@
 // Boost.Geometry
 
+// Copyright (c) 2025 Adam Wulkiewicz, Lodz, Poland.
+
 // Copyright (c) 2021, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -22,18 +24,13 @@ namespace boost { namespace geometry
 namespace strategies { namespace centroid
 {
 
-template
-<
-    typename CalculationType = void
->
-class spherical
-    : public strategies::detail::spherical_base<void>
+#ifndef DOXYGEN_NO_DETAIL
+namespace detail
 {
-    using base_t = strategies::detail::spherical_base<void>;
 
+class spherical
+{
 public:
-    spherical() = default;
-
     // TODO: Box and Segment should have proper strategies.
     template <typename Geometry, typename Point>
     static auto centroid(Geometry const&, Point const&,
@@ -45,6 +42,20 @@ public:
     {
         return strategy::centroid::not_applicable_strategy();
     }
+};
+
+
+} // namespace detail
+#endif // DOXYGEN_NO_DETAIL
+
+
+template <typename CalculationType = void>
+class spherical
+    : public strategies::detail::spherical_base<void>
+    , public strategies::centroid::detail::spherical
+{
+public:
+    spherical() = default;
 };
 
 

--- a/include/boost/geometry/strategies/geographic.hpp
+++ b/include/boost/geometry/strategies/geographic.hpp
@@ -1,5 +1,7 @@
 // Boost.Geometry
 
+// Copyright (c) 2025 Adam Wulkiewicz, Lodz, Poland.
+
 // Copyright (c) 2020-2021, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -14,6 +16,8 @@
 #include <boost/geometry/strategies/area/geographic.hpp>
 #include <boost/geometry/strategies/azimuth/geographic.hpp>
 #include <boost/geometry/strategies/buffer/geographic.hpp>
+#include <boost/geometry/strategies/centroid/geographic.hpp>
+#include <boost/geometry/strategies/closest_points/geographic.hpp>
 #include <boost/geometry/strategies/convex_hull/geographic.hpp>
 #include <boost/geometry/strategies/distance/geographic.hpp>
 #include <boost/geometry/strategies/envelope/geographic.hpp>
@@ -41,9 +45,10 @@ template
 >
 class geographic
     // derived from the umbrella strategy defining the most strategies
-    : public index::geographic<FormulaPolicy, Spheroid, CalculationType>
+    : public strategies::closest_points::geographic<FormulaPolicy, Spheroid, CalculationType>
+    , public strategies::centroid::detail::geographic
 {
-    using base_t = index::geographic<FormulaPolicy, Spheroid, CalculationType>;
+    using base_t = strategies::closest_points::geographic<FormulaPolicy, Spheroid, CalculationType>;
 
 public:
     geographic() = default;

--- a/include/boost/geometry/strategies/geographic/distance_cross_track.hpp
+++ b/include/boost/geometry/strategies/geographic/distance_cross_track.hpp
@@ -1,6 +1,6 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2023 Adam Wulkiewicz, Lodz, Poland.
+// Copyright (c) 2023-2025 Adam Wulkiewicz, Lodz, Poland.
 
 // Copyright (c) 2016-2022, Oracle and/or its affiliates.
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
@@ -697,10 +697,13 @@ protected:
         point p2 = point(lon2, lat2);
         point p3 = point(lon3, lat3);
 
-        geometry::strategy::distance::cross_track<CT> cross_track(earth_radius);
+        using haversine_t = geometry::strategy::distance::haversine<CT>;
+        using cross_track_t = geometry::strategy::distance::cross_track<void, haversine_t>;
+
+        cross_track_t cross_track(earth_radius);
         CT s34_sph = cross_track.apply(p3, p1, p2);
 
-        geometry::strategy::distance::haversine<CT> str(earth_radius);
+        haversine_t str(earth_radius);
         CT s13_sph = str.apply(p1, p3);
 
         //CT s14 = acos( cos(s13/earth_radius) / cos(s34/earth_radius) ) * earth_radius;

--- a/include/boost/geometry/strategies/geographic/distance_cross_track.hpp
+++ b/include/boost/geometry/strategies/geographic/distance_cross_track.hpp
@@ -273,7 +273,7 @@ private:
                 pl_lat = res14.lat2;
             }
 
-            CT new_distance = inverse_distance_type::apply(lon3, lat3, res14.lon2, res14.lat2,
+            CT const new_distance = inverse_distance_type::apply(lon3, lat3, res14.lon2, res14.lat2,
                 spheroid).distance;
 
             dist_improve = new_distance != result.distance;
@@ -346,8 +346,8 @@ private:
             // g4 is the angle between segment (p1,p2) and segment (p3,p4)
             // that meet on p4 (GEO)
 
-            CT a4 = inverse_dist_azimuth_type::apply(res14.lon2, res14.lat2,
-                                                     lon2, lat2, spheroid).azimuth;
+            CT const a4 = inverse_dist_azimuth_type::apply(res14.lon2, res14.lat2,
+                                                           lon2, lat2, spheroid).azimuth;
             res34 = inverse_distance_azimuth_quantities_type::apply(res14.lon2, res14.lat2,
                                                                     lon3, lat3, spheroid);
             g4 = res34.azimuth - a4;
@@ -527,8 +527,8 @@ protected:
         CT lat1 = la1;
         CT lon2 = lo2;
         CT lat2 = la2;
-        CT lon3 = lo3;
-        CT lat3 = la3;
+        CT const lon3 = lo3;
+        CT const lat3 = la3;
 
         if (lon1 > lon2)
         {
@@ -549,14 +549,14 @@ protected:
         //segment on equator
         //Note: antipodal points on equator does not define segment on equator
         //but pass by the pole
-        CT diff = geometry::math::longitude_distance_signed<geometry::radian>(lon1, lon2);
+        CT const diff = geometry::math::longitude_distance_signed<geometry::radian>(lon1, lon2);
 
         using meridian_inverse = typename formula::meridian_inverse<CT>;
 
-        bool meridian_not_crossing_pole =
+        bool const meridian_not_crossing_pole =
             meridian_inverse::meridian_not_crossing_pole(lat1, lat2, diff);
 
-        bool meridian_crossing_pole =
+        bool const meridian_crossing_pole =
             meridian_inverse::meridian_crossing_pole(diff);
 
         if (math::equals(lat1, c0) && math::equals(lat2, c0)
@@ -596,18 +596,18 @@ protected:
 #ifdef BOOST_GEOMETRY_DEBUG_GEOGRAPHIC_CROSS_TRACK
             std::cout << "Meridian segment crossing pole" << std::endl;
 #endif
-            CT sign_non_zero = lat3 >= c0 ? 1 : -1;
+            CT const sign_non_zero = lat3 >= c0 ? 1 : -1;
 
-            auto res13 = apply(lon1, lat1, lon1, half_pi * sign_non_zero, lon3, lat3, spheroid);
+            auto const res13 = apply(lon1, lat1, lon1, half_pi * sign_non_zero, lon3, lat3, spheroid);
 
-            auto res23 = apply(lon2, lat2, lon2, half_pi * sign_non_zero, lon3, lat3, spheroid);
+            auto const res23 = apply(lon2, lat2, lon2, half_pi * sign_non_zero, lon3, lat3, spheroid);
 
             return (res13.distance) < (res23.distance) ? res13 : res23;
         }
 
-        auto res12 = inverse_dist_azimuth_reverse_type::apply(lon1, lat1, lon2, lat2, spheroid);
+        auto const res12 = inverse_dist_azimuth_reverse_type::apply(lon1, lat1, lon2, lat2, spheroid);
 
-        auto res13 = inverse_dist_azimuth_type::apply(lon1, lat1, lon3, lat3, spheroid);
+        auto const res13 = inverse_dist_azimuth_type::apply(lon1, lat1, lon3, lat3, spheroid);
 
         if (geometry::math::equals(res12.distance, c0))
         {
@@ -616,14 +616,14 @@ protected:
             std::cout << "distance between points="
                       << res13.distance << std::endl;
 #endif
-            auto res = meridian_inverse::apply(lon1, lat1, lon3, lat3, spheroid);
+            auto const res = meridian_inverse::apply(lon1, lat1, lon3, lat3, spheroid);
 
             return non_iterative_case(lon3, lat3, lon1, lat2,
                 res.meridian ? res.distance : res13.distance);
         }
 
         // Compute a12 (GEO)
-        CT a312 = res13.azimuth - res12.azimuth;
+        CT const a312 = res13.azimuth - res12.azimuth;
 
         // TODO: meridian case optimization
         if (geometry::math::equals(a312, c0) && meridian_not_crossing_pole)
@@ -640,7 +640,7 @@ protected:
             }
         }
 
-        CT projection1 = cos( a312 ) * res13.distance / res12.distance;
+        CT const projection1 = cos( a312 ) * res13.distance / res12.distance;
 
 #ifdef BOOST_GEOMETRY_DEBUG_GEOGRAPHIC_CROSS_TRACK
         std::cout << "a1=" << res12.azimuth * math::r2d<CT>() << std::endl;
@@ -661,10 +661,10 @@ protected:
             return non_iterative_case(lon3, lat3, lon1, lat1, spheroid);
         }
 
-        auto res23 = inverse_dist_azimuth_type::apply(lon2, lat2, lon3, lat3, spheroid);
+        auto const res23 = inverse_dist_azimuth_type::apply(lon2, lat2, lon3, lat3, spheroid);
 
-        CT a321 = res23.azimuth - res12.reverse_azimuth + pi;
-        CT projection2 = cos( a321 ) * res23.distance / res12.distance;
+        CT const a321 = res23.azimuth - res12.reverse_azimuth + pi;
+        CT const projection2 = cos( a321 ) * res23.distance / res12.distance;
 
 #ifdef BOOST_GEOMETRY_DEBUG_GEOGRAPHIC_CROSS_TRACK
         std::cout << "a21=" << res12.reverse_azimuth * math::r2d<CT>()
@@ -693,28 +693,28 @@ protected:
                 geometry::cs::spherical_equatorial<geometry::radian>
             >;
 
-        point p1 = point(lon1, lat1);
-        point p2 = point(lon2, lat2);
-        point p3 = point(lon3, lat3);
+        point const p1(lon1, lat1);
+        point const p2(lon2, lat2);
+        point const p3(lon3, lat3);
 
         using haversine_t = geometry::strategy::distance::haversine<CT>;
         using cross_track_t = geometry::strategy::distance::cross_track<void, haversine_t>;
 
-        cross_track_t cross_track(earth_radius);
-        CT s34_sph = cross_track.apply(p3, p1, p2);
+        cross_track_t const cross_track(earth_radius);
+        CT const s34_sph = cross_track.apply(p3, p1, p2);
 
-        haversine_t str(earth_radius);
-        CT s13_sph = str.apply(p1, p3);
+        haversine_t const str(earth_radius);
+        CT const s13_sph = str.apply(p1, p3);
 
         //CT s14 = acos( cos(s13/earth_radius) / cos(s34/earth_radius) ) * earth_radius;
-        CT cos_frac = cos(s13_sph / earth_radius) / cos(s34_sph / earth_radius);
-        CT s14_sph = cos_frac >= 1 ? CT(0)
+        CT const cos_frac = cos(s13_sph / earth_radius) / cos(s34_sph / earth_radius);
+        CT const s14_sph = cos_frac >= 1 ? CT(0)
             : cos_frac <= -1 ? pi * earth_radius
             : acos(cos_frac) * earth_radius;
 
         CT const a12_sph = geometry::formula::spherical_azimuth<>(lon1, lat1, lon2, lat2);
 
-        auto res = geometry::formula::spherical_direct<true, false>(lon1, lat1,
+        auto const res = geometry::formula::spherical_direct<true, false>(lon1, lat1,
             s14_sph, a12_sph, srs::sphere<CT>(earth_radius));
 
         // this is what postgis (version 2.5) returns
@@ -737,7 +737,7 @@ protected:
         }
         else
         {
-            CT s14_start = geometry::strategy::distance::geographic
+            CT const s14_start = geometry::strategy::distance::geographic
                 <
                     FormulaPolicy,
                     Spheroid,

--- a/include/boost/geometry/strategies/geographic/distance_cross_track_box_box.hpp
+++ b/include/boost/geometry/strategies/geographic/distance_cross_track_box_box.hpp
@@ -1,5 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
+// Copyright (c) 2025 Adam Wulkiewicz, Lodz, Poland.
+
 // Copyright (c) 2017-2021, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
@@ -133,67 +135,52 @@ private :
 namespace services
 {
 
-template <typename Strategy, typename Spheroid, typename CalculationType>
-struct tag<geographic_cross_track_box_box<Strategy, Spheroid, CalculationType> >
+template <typename FormulaPolicy, typename Spheroid, typename CalculationType>
+struct tag<geographic_cross_track_box_box<FormulaPolicy, Spheroid, CalculationType> >
 {
     typedef strategy_tag_distance_box_box type;
 };
 
 
-template <typename Strategy, typename Spheroid, typename CalculationType, typename Box1, typename Box2>
-struct return_type<geographic_cross_track_box_box<Strategy, Spheroid, CalculationType>, Box1, Box2>
+template <typename FormulaPolicy, typename Spheroid, typename CalculationType, typename Box1, typename Box2>
+struct return_type<geographic_cross_track_box_box<FormulaPolicy, Spheroid, CalculationType>, Box1, Box2>
     : geographic_cross_track_box_box
         <
-            Strategy, Spheroid, CalculationType
+            FormulaPolicy, Spheroid, CalculationType
         >::template return_type<Box1, Box2>
 {};
 
-template <typename Strategy, typename Spheroid, typename Box1, typename Box2>
-struct return_type<geographic_cross_track_box_box<Strategy, Spheroid>, Box1, Box2>
-    : geographic_cross_track_box_box
-        <
-            Strategy, Spheroid
-        >::template return_type<Box1, Box2>
-{};
 
-template <typename Strategy, typename Box1, typename Box2>
-struct return_type<geographic_cross_track_box_box<Strategy>, Box1, Box2>
-    : geographic_cross_track_box_box
-        <
-            Strategy
-        >::template return_type<Box1, Box2>
-{};
-
-template <typename Strategy, typename Spheroid, typename CalculationType>
-struct comparable_type<geographic_cross_track_box_box<Strategy, Spheroid, CalculationType> >
+template <typename FormulaPolicy, typename Spheroid, typename CalculationType>
+struct comparable_type<geographic_cross_track_box_box<FormulaPolicy, Spheroid, CalculationType> >
 {
     typedef geographic_cross_track_box_box
         <
-            typename comparable_type<Strategy>::type, Spheroid, CalculationType
+            FormulaPolicy, Spheroid, CalculationType
         > type;
 };
 
 
-template <typename Strategy, typename Spheroid, typename CalculationType>
-struct get_comparable<geographic_cross_track_box_box<Strategy, Spheroid, CalculationType> >
+template <typename FormulaPolicy, typename Spheroid, typename CalculationType>
+struct get_comparable<geographic_cross_track_box_box<FormulaPolicy, Spheroid, CalculationType> >
 {
 public:
-    static inline geographic_cross_track_box_box<Strategy, Spheroid, CalculationType>
-    apply(geographic_cross_track_box_box<Strategy, Spheroid, CalculationType> const& str)
+    static inline geographic_cross_track_box_box<FormulaPolicy, Spheroid, CalculationType>
+    apply(geographic_cross_track_box_box<FormulaPolicy, Spheroid, CalculationType> const& str)
     {
         return str;
     }
 };
 
 
-template <typename Strategy, typename Spheroid, typename CalculationType, typename Box1, typename Box2>
+template <typename FormulaPolicy, typename Spheroid, typename CalculationType, typename Box1, typename Box2>
 struct result_from_distance
     <
-        geographic_cross_track_box_box<Strategy, Spheroid, CalculationType>, Box1, Box2
+        geographic_cross_track_box_box<FormulaPolicy, Spheroid, CalculationType>, Box1, Box2
     >
 {
 private:
-    typedef geographic_cross_track_box_box<Strategy, Spheroid, CalculationType> this_strategy;
+    typedef geographic_cross_track_box_box<FormulaPolicy, Spheroid, CalculationType> this_strategy;
 
     typedef typename this_strategy::template return_type
         <
@@ -205,12 +192,7 @@ public:
     static inline return_type apply(this_strategy const& strategy,
                                     T const& distance)
     {
-        result_from_distance
-            <
-                Strategy,
-                point_type_t<Box1>,
-                point_type_t<Box2>
-            >::apply(strategy, distance);
+        return static_cast<return_type>(distance);
     }
 };
 

--- a/include/boost/geometry/strategies/index/cartesian.hpp
+++ b/include/boost/geometry/strategies/index/cartesian.hpp
@@ -1,5 +1,7 @@
 // Boost.Geometry
 
+// Copyright (c) 2025 Adam Wulkiewicz, Lodz, Poland.
+
 // Copyright (c) 2020-2021, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -11,9 +13,9 @@
 #define BOOST_GEOMETRY_STRATEGIES_INDEX_CARTESIAN_HPP
 
 
+#include <boost/geometry/strategies/centroid/cartesian.hpp>
 #include <boost/geometry/strategies/distance/cartesian.hpp>
 #include <boost/geometry/strategies/index/services.hpp>
-
 
 
 namespace boost { namespace geometry { namespace strategies { namespace index
@@ -22,6 +24,7 @@ namespace boost { namespace geometry { namespace strategies { namespace index
 template <typename CalculationType = void>
 class cartesian
     : public distance::cartesian<CalculationType>
+    , public strategies::centroid::detail::cartesian<CalculationType>
 {};
 
 

--- a/include/boost/geometry/strategies/index/geographic.hpp
+++ b/include/boost/geometry/strategies/index/geographic.hpp
@@ -1,5 +1,7 @@
 // Boost.Geometry
 
+// Copyright (c) 2025 Adam Wulkiewicz, Lodz, Poland.
+
 // Copyright (c) 2020-2021, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -11,6 +13,7 @@
 #define BOOST_GEOMETRY_STRATEGIES_INDEX_GEOGRAPHIC_HPP
 
 
+#include <boost/geometry/strategies/centroid/geographic.hpp>
 #include <boost/geometry/strategies/distance/geographic.hpp>
 #include <boost/geometry/strategies/index/services.hpp>
 
@@ -26,6 +29,7 @@ template
 >
 class geographic
     : public distance::geographic<FormulaPolicy, Spheroid, CalculationType>
+    , public strategies::centroid::detail::geographic
 {
     typedef distance::geographic<FormulaPolicy, Spheroid, CalculationType> base_t;
 

--- a/include/boost/geometry/strategies/index/spherical.hpp
+++ b/include/boost/geometry/strategies/index/spherical.hpp
@@ -1,5 +1,7 @@
 // Boost.Geometry
 
+// Copyright (c) 2025 Adam Wulkiewicz, Lodz, Poland.
+
 // Copyright (c) 2020-2021, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -11,6 +13,7 @@
 #define BOOST_GEOMETRY_STRATEGIES_INDEX_SPHERICAL_HPP
 
 
+#include <boost/geometry/strategies/centroid/spherical.hpp>
 #include <boost/geometry/strategies/distance/spherical.hpp>
 #include <boost/geometry/strategies/index/services.hpp>
 
@@ -28,6 +31,7 @@ namespace detail
 template <typename RadiusTypeOrSphere, typename CalculationType>
 class spherical
     : public strategies::distance::detail::spherical<RadiusTypeOrSphere, CalculationType>
+    , public strategies::centroid::detail::spherical
 {
     using base_t = strategies::distance::detail::spherical<RadiusTypeOrSphere, CalculationType>;
 

--- a/include/boost/geometry/strategies/spherical.hpp
+++ b/include/boost/geometry/strategies/spherical.hpp
@@ -1,5 +1,7 @@
 // Boost.Geometry
 
+// Copyright (c) 2025 Adam Wulkiewicz, Lodz, Poland.
+
 // Copyright (c) 2020-2021, Oracle and/or its affiliates.
 
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -14,6 +16,8 @@
 #include <boost/geometry/strategies/area/spherical.hpp>
 #include <boost/geometry/strategies/azimuth/spherical.hpp>
 #include <boost/geometry/strategies/buffer/spherical.hpp>
+#include <boost/geometry/strategies/centroid/spherical.hpp>
+#include <boost/geometry/strategies/closest_points/spherical.hpp>
 #include <boost/geometry/strategies/convex_hull/spherical.hpp>
 #include <boost/geometry/strategies/distance/spherical.hpp>
 #include <boost/geometry/strategies/envelope/spherical.hpp>
@@ -40,9 +44,10 @@ template
 >
 class spherical
     // derived from the umbrella strategy defining the most strategies
-    : public strategies::index::detail::spherical<RadiusTypeOrSphere, CalculationType>
+    : public strategies::closest_points::spherical<RadiusTypeOrSphere, CalculationType>
+    , public strategies::centroid::detail::spherical
 {
-    using base_t = strategies::index::detail::spherical<RadiusTypeOrSphere, CalculationType>;
+    using base_t = strategies::closest_points::spherical<RadiusTypeOrSphere, CalculationType>;
 
 public:
     spherical() = default;

--- a/include/boost/geometry/strategies/spherical/distance_cross_track_box_box.hpp
+++ b/include/boost/geometry/strategies/spherical/distance_cross_track_box_box.hpp
@@ -48,14 +48,14 @@ class cross_track_box_box_generic
 public :
 
     template <typename Point1, typename Point2, typename PPStrategy, typename PSStrategy>
-    ReturnType static inline diagonal_case(Point1 topA,
-                                           Point2 topB,
-                                           Point1 bottomA,
-                                           Point2 bottomB,
+    static inline ReturnType diagonal_case(Point1 const& topA,
+                                           Point2 const& topB,
+                                           Point1 const& bottomA,
+                                           Point2 const& bottomB,
                                            bool north_shortest,
                                            bool non_overlap,
-                                           PPStrategy pp_strategy,
-                                           PSStrategy ps_strategy)
+                                           PPStrategy const& pp_strategy,
+                                           PSStrategy const& ps_strategy)
     {
         if (north_shortest && non_overlap)
         {
@@ -80,10 +80,10 @@ public :
             typename PPStrategy,
             typename PSStrategy
     >
-    ReturnType static inline apply (Box1 const& box1,
-                                    Box2 const& box2,
-                                    PPStrategy pp_strategy,
-                                    PSStrategy ps_strategy)
+    static inline ReturnType apply(Box1 const& box1,
+                                   Box2 const& box2,
+                                   PPStrategy const& pp_strategy,
+                                   PSStrategy const& ps_strategy)
     {
 
         // this method assumes that the coordinates of the point and

--- a/include/boost/geometry/strategies/spherical/distance_cross_track_box_box.hpp
+++ b/include/boost/geometry/strategies/spherical/distance_cross_track_box_box.hpp
@@ -1,5 +1,7 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
+// Copyright (c) 2025 Adam Wulkiewicz, Lodz, Poland.
+
 // Copyright (c) 2016-2020 Oracle and/or its affiliates.
 // Contributed and/or modified by Vissarion Fisikopoulos, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
@@ -45,11 +47,11 @@ class cross_track_box_box_generic
 {
 public :
 
-    template <typename Point, typename PPStrategy, typename PSStrategy>
-    ReturnType static inline diagonal_case(Point topA,
-                                           Point topB,
-                                           Point bottomA,
-                                           Point bottomB,
+    template <typename Point1, typename Point2, typename PPStrategy, typename PSStrategy>
+    ReturnType static inline diagonal_case(Point1 topA,
+                                           Point2 topB,
+                                           Point1 bottomA,
+                                           Point2 bottomB,
                                            bool north_shortest,
                                            bool non_overlap,
                                            PPStrategy pp_strategy,


### PR DESCRIPTION
The getters are missing for `centroid` and `closest_points` in `index` and global umbrella strategies preventing them to be passed to these algorithms and rtree.

I divided centroid into detail part and official part derived from base. It works for now because centroid doesn't have proper strategies for spherical and geographic. After they are added and e.g. geographic one uses `Formula` and `Spheroid` we'll probably have to implement this differently.