### PR TITLE
Relax half period check in spheroidal normalization

### DIFF
--- a/include/boost/geometry/strategies/normalize.hpp
+++ b/include/boost/geometry/strategies/normalize.hpp
@@ -1,7 +1,8 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2015-2020, Oracle and/or its affiliates.
+// Copyright (c) 2015-2025, Oracle and/or its affiliates.
 
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 // Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
@@ -123,7 +124,7 @@ struct assign_loop<1, DimensionCount>
 template <typename PointIn, typename PointOut, bool IsEquatorial = true>
 struct normalize_point
 {
-    static inline void apply(PointIn const& point_in, PointOut& point_out)
+    static inline void apply(PointIn const& point_in, PointOut& point_out, bool exact = true)
     {
         using in_coordinate_type = coordinate_type_t<PointIn>;
 
@@ -135,7 +136,7 @@ struct normalize_point
                 typename geometry::detail::cs_angular_units<PointIn>::type,
                 IsEquatorial,
                 in_coordinate_type
-            >(longitude, latitude);
+            >(longitude, latitude, exact);
 
         assign_loop
             <
@@ -221,13 +222,13 @@ struct cartesian_box
 struct spherical_point
 {
     template <typename PointIn, typename PointOut>
-    static inline void apply(PointIn const& point_in, PointOut& point_out)
+    static inline void apply(PointIn const& point_in, PointOut& point_out, bool exact = true)
     {
         detail::normalize_point
             <
                 PointIn, PointOut,
                 (! std::is_same<cs_tag_t<PointIn>, spherical_polar_tag>::value)
-            >::apply(point_in, point_out);
+            >::apply(point_in, point_out, exact);
     }
 };
 

--- a/include/boost/geometry/strategies/spherical/point_in_point.hpp
+++ b/include/boost/geometry/strategies/spherical/point_in_point.hpp
@@ -68,8 +68,8 @@ private:
     {
         static inline bool apply(Point1 const& point1, Point2 const& point2)
         {
-            typedef typename helper_geometry<Point1>::type helper_point_type1;
-            typedef typename helper_geometry<Point2>::type helper_point_type2;
+            using helper_point_type1 = typename helper_geometry<Point1>::type;
+            using helper_point_type2 = typename helper_geometry<Point2>::type;
 
             helper_point_type1 point1_normalized;
             bool const exact_normalized = false;
@@ -89,11 +89,11 @@ private:
     {
         static inline bool apply(Point1 const& point1, Point2 const& point2)
         {
-            typedef typename geometry::select_most_precise
+            using calculation_type = typename geometry::select_most_precise
                 <
                     typename fp_coordinate_type<Point1>::type,
                     typename fp_coordinate_type<Point2>::type
-                >::type calculation_type;
+                >::type;
 
             typename helper_geometry
                 <
@@ -151,7 +151,7 @@ namespace services
 template <typename PointLike1, typename PointLike2, typename Tag1, typename Tag2>
 struct default_strategy<PointLike1, PointLike2, Tag1, Tag2, pointlike_tag, pointlike_tag, spherical_tag, spherical_tag>
 {
-    typedef strategy::within::spherical_point_point type;
+    using type = strategy::within::spherical_point_point;
 };
 
 } // namespace services
@@ -168,7 +168,7 @@ namespace strategy { namespace covered_by { namespace services
 template <typename PointLike1, typename PointLike2, typename Tag1, typename Tag2>
 struct default_strategy<PointLike1, PointLike2, Tag1, Tag2, pointlike_tag, pointlike_tag, spherical_tag, spherical_tag>
 {
-    typedef strategy::within::spherical_point_point type;
+    using type = strategy::within::spherical_point_point;
 };
 
 }}} // namespace strategy::covered_by::services

--- a/include/boost/geometry/strategies/spherical/point_in_point.hpp
+++ b/include/boost/geometry/strategies/spherical/point_in_point.hpp
@@ -5,11 +5,12 @@
 // Copyright (c) 2009-2015 Mateusz Loskot, London, UK.
 // Copyright (c) 2013-2015 Adam Wulkiewicz, Lodz, Poland
 
-// This file was modified by Oracle on 2013-2020.
-// Modifications copyright (c) 2013-2020, Oracle and/or its affiliates.
+// This file was modified by Oracle on 2013-2025.
+// Modifications copyright (c) 2013-2025, Oracle and/or its affiliates.
 
-// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
+// Contributed and/or modified by Adam Wulkiewicz, on behalf of Oracle
 
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
@@ -71,9 +72,10 @@ private:
             typedef typename helper_geometry<Point2>::type helper_point_type2;
 
             helper_point_type1 point1_normalized;
-            strategy::normalize::spherical_point::apply(point1, point1_normalized);
+            bool const exact_normalized = false;
+            strategy::normalize::spherical_point::apply(point1, point1_normalized, exact_normalized);
             helper_point_type2 point2_normalized;
-            strategy::normalize::spherical_point::apply(point2, point2_normalized);
+            strategy::normalize::spherical_point::apply(point2, point2_normalized, exact_normalized);
 
             return point_point_generic
                 <

--- a/include/boost/geometry/util/normalize_spheroidal_coordinates.hpp
+++ b/include/boost/geometry/util/normalize_spheroidal_coordinates.hpp
@@ -152,11 +152,7 @@ struct constants_on_spheroid<CoordinateType, degree, false>
 template <typename Units, typename CoordinateType>
 inline CoordinateType latitude_convert_ep(CoordinateType const& lat)
 {
-    typedef math::detail::constants_on_spheroid
-            <
-                CoordinateType,
-                Units
-            > constants;
+    using constants = math::detail::constants_on_spheroid<CoordinateType, Units>;
 
     return constants::quarter_period() - lat;
 }
@@ -165,31 +161,21 @@ inline CoordinateType latitude_convert_ep(CoordinateType const& lat)
 template <typename Units, bool IsEquatorial, typename T>
 static bool is_latitude_pole(T const& lat)
 {
-    typedef math::detail::constants_on_spheroid
-        <
-            T,
-            Units
-        > constants;
+    using constants = math::detail::constants_on_spheroid<T, Units>;
 
     return math::equals(math::abs(IsEquatorial
                                     ? lat
                                     : math::latitude_convert_ep<Units>(lat)),
                         constants::quarter_period());
-
 }
 
 
 template <typename Units, typename T>
 static bool is_longitude_antimeridian(T const& lon)
 {
-    typedef math::detail::constants_on_spheroid
-        <
-            T,
-            Units
-        > constants;
+    using constants = math::detail::constants_on_spheroid<T, Units>;
 
     return math::equals(math::abs(lon), constants::half_period());
-
 }
 
 
@@ -219,7 +205,7 @@ struct latitude_convert_if_polar<Units, false>
 template <typename Units, typename CoordinateType, bool IsEquatorial = true>
 class normalize_spheroidal_coordinates
 {
-    typedef constants_on_spheroid<CoordinateType, Units> constants;
+    using constants = constants_on_spheroid<CoordinateType, Units>;
 
 protected:
     static inline CoordinateType normalize_up(CoordinateType const& value)
@@ -324,7 +310,7 @@ public:
 template <typename Units, typename CoordinateType>
 inline void normalize_angle_loop(CoordinateType& angle)
 {
-    typedef constants_on_spheroid<CoordinateType, Units> constants;
+    using constants = constants_on_spheroid<CoordinateType, Units>;
     CoordinateType const pi = constants::half_period();
     CoordinateType const two_pi = constants::period();
     while (angle > pi)
@@ -336,7 +322,7 @@ inline void normalize_angle_loop(CoordinateType& angle)
 template <typename Units, typename CoordinateType>
 inline void normalize_angle_cond(CoordinateType& angle)
 {
-    typedef constants_on_spheroid<CoordinateType, Units> constants;
+    using constants = constants_on_spheroid<CoordinateType, Units>;
     CoordinateType const pi = constants::half_period();
     CoordinateType const two_pi = constants::period();
     if (angle > pi)
@@ -462,10 +448,7 @@ template <typename Units, typename CoordinateType>
 inline CoordinateType longitude_distance_unsigned(CoordinateType const& longitude1,
                                                   CoordinateType const& longitude2)
 {
-    typedef math::detail::constants_on_spheroid
-        <
-            CoordinateType, Units
-        > constants;
+    using constants = math::detail::constants_on_spheroid<CoordinateType, Units>;
 
     CoordinateType const c0 = 0;
     CoordinateType diff = longitude_distance_signed<Units>(longitude1, longitude2);

--- a/include/boost/geometry/util/rational.hpp
+++ b/include/boost/geometry/util/rational.hpp
@@ -101,16 +101,16 @@ struct coordinate_cast<rational<T> >
 template <typename T1, typename T2>
 struct select_most_precise<boost::rational<T1>, boost::rational<T2> >
 {
-    typedef typename boost::rational
+    using type = typename boost::rational
         <
             typename select_most_precise<T1, T2>::type
-        > type;
+        > ;
 };
 
 template <typename T>
 struct select_most_precise<boost::rational<T>, double>
 {
-    typedef typename boost::rational<T> type;
+    using type = typename boost::rational<T>;
 };
 
 namespace util

--- a/test/algorithms/equals/equals_on_spheroid.cpp
+++ b/test/algorithms/equals/equals_on_spheroid.cpp
@@ -130,7 +130,7 @@ struct test_point_point_with_height
 template <typename P>
 void test_segment_segment(std::string const& header)
 {
-    typedef bgm::segment<P> seg;
+    using seg = bgm::segment<P>;
 
     std::string const str = header + "-";
 
@@ -159,7 +159,7 @@ void test_segment_segment(std::string const& header)
 
 BOOST_AUTO_TEST_CASE( equals_point_point_se )
 {
-    typedef bg::cs::spherical_equatorial<bg::degree> cs_type;
+    using cs_type = bg::cs::spherical_equatorial<bg::degree>;
 
     test_point_point<bgm::point<int, 2, cs_type> >::apply("se");
     test_point_point<bgm::point<double, 2, cs_type> >::apply("se");
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE( equals_point_point_radian )
 
 BOOST_AUTO_TEST_CASE( equals_point_point_with_height_se )
 {
-    typedef bg::cs::spherical_equatorial<bg::degree> cs_type;
+    using cs_type = bg::cs::spherical_equatorial<bg::degree>;
 
     test_point_point<bgm::point<int, 3, cs_type> >::apply("seh");
     test_point_point<bgm::point<double, 3, cs_type> >::apply("seh");
@@ -226,7 +226,7 @@ BOOST_AUTO_TEST_CASE( equals_point_point_with_height_se )
 
 BOOST_AUTO_TEST_CASE( equals_point_point_geo )
 {
-    typedef bg::cs::geographic<bg::degree> cs_type;
+    using cs_type = bg::cs::geographic<bg::degree>;
 
     test_point_point<bgm::point<int, 2, cs_type> >::apply("geo");
     test_point_point<bgm::point<double, 2, cs_type> >::apply("geo");
@@ -246,7 +246,7 @@ BOOST_AUTO_TEST_CASE( equals_point_point_geo )
 
 BOOST_AUTO_TEST_CASE( equals_segment_segment_se )
 {
-    typedef bg::cs::spherical_equatorial<bg::degree> cs_type;
+    using cs_type = bg::cs::spherical_equatorial<bg::degree>;
 
     test_segment_segment<bgm::point<int, 2, cs_type> >("se");
     test_segment_segment<bgm::point<double, 2, cs_type> >("se");
@@ -255,7 +255,7 @@ BOOST_AUTO_TEST_CASE( equals_segment_segment_se )
 
 BOOST_AUTO_TEST_CASE( equals_segment_segment_geo )
 {
-    typedef bg::cs::geographic<bg::degree> cs_type;
+    using cs_type = bg::cs::geographic<bg::degree>;
 
     test_segment_segment<bgm::point<int, 2, cs_type> >("geo");
     test_segment_segment<bgm::point<double, 2, cs_type> >("geo");

--- a/test/algorithms/equals/equals_on_spheroid.cpp
+++ b/test/algorithms/equals/equals_on_spheroid.cpp
@@ -1,7 +1,8 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 // Unit test
 
-// Copyright (c) 2015, Oracle and/or its affiliates.
+// Copyright (c) 2015-2025, Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 
 // Licensed under the Boost Software License version 1.0.
 // http://www.boost.org/users/license.html
@@ -174,6 +175,33 @@ BOOST_AUTO_TEST_CASE( equals_point_point_se )
         <
             bgm::point<double, 2, cs_type>, bgm::point<long double, 2, cs_type>
         >::apply("se");
+}
+
+template <typename T>
+std::string to_string_with_precision(const T value, const int precision = 15)
+{
+    std::ostringstream out;
+    out << std::fixed << std::setprecision(precision) << value;
+    return out.str();
+}
+
+void test_pp_rad(double half_pi)
+{
+    using cs_radian = bg::cs::spherical_equatorial<bg::radian>;
+    using P = bgm::point<double, 2, cs_radian>;
+
+    test_geometry<P, P>("ser_pp_half_pi",
+                        "POINT(" + to_string_with_precision(-half_pi)  + " 0)",
+                        "POINT(" + to_string_with_precision(half_pi)  + " 0)", true);
+}
+
+BOOST_AUTO_TEST_CASE( equals_point_point_radian )
+{
+    test_pp_rad(bg::math::d2r<float>() * 180);
+    // half pi value with less accuracy
+    test_pp_rad(-3.14159265358979);
+    // convert from degrees to radians with constant from epsg 4326 (WGS84)
+    test_pp_rad(0.017453292519943278 * 180);
 }
 
 BOOST_AUTO_TEST_CASE( equals_point_point_with_height_se )

--- a/test/algorithms/overlay/get_turns_linear_linear_geo.cpp
+++ b/test/algorithms/overlay/get_turns_linear_linear_geo.cpp
@@ -24,7 +24,7 @@ void test_radian()
     boost::geometry::strategies::relate::geographic<> wgs84(sph_wgs84);
 
     test_geometry<ls, mls>(
-        "LINESTRING(0 0, -3.14159265358979 0)",
+        "LINESTRING(0 0,-3.14159265358979 0)",
         "MULTILINESTRING((-2.1467549799530232 -0.12217304763960295,"
                          "-2.5481807079117185 -0.90757121103705041,"
                          "-2.6529004630313784 0.85521133347722067,"

--- a/test/algorithms/set_operations/difference/difference_linear_linear.cpp
+++ b/test/algorithms/set_operations/difference/difference_linear_linear.cpp
@@ -27,11 +27,12 @@
 #include <boost/geometry/geometries/multi_linestring.hpp>
 #include <boost/geometry/algorithms/difference.hpp>
 
-typedef bg::model::point<double,2,bg::cs::cartesian>  point_type;
-typedef bg::model::segment<point_type>                segment_type;
-typedef bg::model::linestring<point_type>             linestring_type;
-typedef bg::model::multi_linestring<linestring_type>  multi_linestring_type;
-
+using point_type = bg::model::point<double,2,bg::cs::cartesian>;
+using segment_type = bg::model::segment<point_type>;
+using linestring_type = bg::model::linestring<point_type>;
+using multi_linestring_type = bg::model::multi_linestring<linestring_type>;
+using L = linestring_type;
+using ML = multi_linestring_type;
 
 
 //===========================================================================
@@ -47,10 +48,7 @@ BOOST_AUTO_TEST_CASE( test_difference_linestring_linestring )
     std::cout << std::endl;
 #endif
 
-    typedef linestring_type L;
-    typedef multi_linestring_type ML;
-
-    typedef test_difference_of_geometries<L, L, ML> tester;
+    using tester = test_difference_of_geometries<L, L, ML>;
 
     tester::apply
         (from_wkt<L>("LINESTRING(0 0,1 1,2 1,3 2)"),
@@ -566,10 +564,7 @@ BOOST_AUTO_TEST_CASE( test_difference_linestring_multilinestring )
     std::cout << std::endl;
 #endif
 
-    typedef linestring_type L;
-    typedef multi_linestring_type ML;
-
-    typedef test_difference_of_geometries<L, ML, ML> tester;
+    using tester = test_difference_of_geometries<L, ML, ML>;
 
     // disjoint linestrings
     tester::apply
@@ -790,10 +785,7 @@ BOOST_AUTO_TEST_CASE( test_difference_multilinestring_linestring )
     std::cout << std::endl;
 #endif
 
-    typedef linestring_type L;
-    typedef multi_linestring_type ML;
-
-    typedef test_difference_of_geometries<ML, L, ML> tester;
+    using tester = test_difference_of_geometries<ML, L, ML>;
 
     // disjoint linestrings
     tester::apply
@@ -875,9 +867,7 @@ BOOST_AUTO_TEST_CASE( test_difference_multilinestring_multilinestring )
     std::cout << std::endl;
 #endif
 
-    typedef multi_linestring_type ML;
-
-    typedef test_difference_of_geometries<ML, ML, ML> tester;
+    using tester = test_difference_of_geometries<ML, ML, ML>;
 
     // disjoint linestrings
     tester::apply
@@ -1167,9 +1157,7 @@ BOOST_AUTO_TEST_CASE( test_difference_ml_ml_degenerate )
     std::cout << std::endl;
 #endif
 
-    typedef multi_linestring_type ML;
-
-    typedef test_difference_of_geometries<ML, ML, ML> tester;
+    using tester = test_difference_of_geometries<ML, ML, ML>;
 
     // the following test cases concern linestrings with duplicate
     // points and possibly linestrings with zero length.
@@ -1254,9 +1242,7 @@ BOOST_AUTO_TEST_CASE( test_difference_ml_ml_spikes )
     std::cout << std::endl;
 #endif
 
-    typedef multi_linestring_type ML;
-
-    typedef test_difference_of_geometries<ML, ML, ML> tester;
+    using tester = test_difference_of_geometries<ML, ML, ML>;
 
     // the following test cases concern linestrings with spikes
 
@@ -1446,9 +1432,9 @@ BOOST_AUTO_TEST_CASE( test_difference_ml_ml_spikes )
 
 BOOST_AUTO_TEST_CASE( test_difference_ls_mls_geo_rad )
 {
-    typedef bg::model::point<double, 2, bg::cs::geographic<bg::radian> > pt;
-    typedef bg::model::linestring<pt> ls;
-    typedef bg::model::multi_linestring<ls> mls;
+    using pt = bg::model::point<double, 2, bg::cs::geographic<bg::radian>>;
+    using ls = bg::model::linestring<pt>;
+    using mls = bg::model::multi_linestring<ls>;
 
     bg::srs::spheroid<double> sph_wgs84(6378137.0, 6356752.3142451793);
     boost::geometry::strategy::intersection::geographic_segments<> wgs84(sph_wgs84);

--- a/test/algorithms/set_operations/difference/difference_linear_linear.cpp
+++ b/test/algorithms/set_operations/difference/difference_linear_linear.cpp
@@ -1,10 +1,11 @@
 // Boost.Geometry (aka GGL, Generic Geometry Library)
 
-// Copyright (c) 2014-2015, Oracle and/or its affiliates.
+// Copyright (c) 2014-2025, Oracle and/or its affiliates.
 
 // Licensed under the Boost Software License version 1.0.
 // http://www.boost.org/users/license.html
 
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 // Contributed and/or modified by Menelaos Karavelas, on behalf of Oracle
 
 #include <iostream>
@@ -1160,7 +1161,7 @@ BOOST_AUTO_TEST_CASE( test_difference_ml_ml_degenerate )
 {
 #ifdef BOOST_GEOMETRY_TEST_DEBUG
     std::cout << std::endl << std::endl << std::endl;
-    std::cout << "*** MULTILINESTRING / MULTILINESTRING DIFFERENCE" 
+    std::cout << "*** MULTILINESTRING / MULTILINESTRING DIFFERENCE"
               << " (DEGENERATE) ***"
               << std::endl;
     std::cout << std::endl;
@@ -1247,7 +1248,7 @@ BOOST_AUTO_TEST_CASE( test_difference_ml_ml_spikes )
 {
 #ifdef BOOST_GEOMETRY_TEST_DEBUG
     std::cout << std::endl << std::endl << std::endl;
-    std::cout << "*** MULTILINESTRING / MULTILINESTRING DIFFERENCE" 
+    std::cout << "*** MULTILINESTRING / MULTILINESTRING DIFFERENCE"
               << " (WITH SPIKES) ***"
               << std::endl;
     std::cout << std::endl;
@@ -1452,7 +1453,7 @@ BOOST_AUTO_TEST_CASE( test_difference_ls_mls_geo_rad )
     bg::srs::spheroid<double> sph_wgs84(6378137.0, 6356752.3142451793);
     boost::geometry::strategy::intersection::geographic_segments<> wgs84(sph_wgs84);
 
-    ls g1 = from_wkt<ls>("LINESTRING(0 0, -3.14159265358979 0)");
+    ls g1 = from_wkt<ls>("LINESTRING(0 0,-3.14159265358979 0)");
     mls g2 = from_wkt<mls>("MULTILINESTRING((-2.1467549799530232 -0.12217304763960295,"
                                             "-2.5481807079117185 -0.90757121103705041,"
                                             "-2.6529004630313784 0.85521133347722067,"

--- a/test/util/rational.cpp
+++ b/test/util/rational.cpp
@@ -5,6 +5,10 @@
 // Copyright (c) 2008-2012 Bruno Lalande, Paris, France.
 // Copyright (c) 2009-2012 Mateusz Loskot, London, UK.
 
+// This file was modified by Oracle on 2025.
+// Modifications copyright (c) 2025 Oracle and/or its affiliates.
+// Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
+
 // Parts of Boost.Geometry are redesigned from Geodan's Geographic Library
 // (geolib/GGL), copyright (c) 1995-2010 Geodan, Amsterdam, the Netherlands.
 
@@ -46,7 +50,6 @@ template <typename T>
 void test_bounds()
 {
     using coordinate_t = boost::rational<T>;
-    using point_t = bg::model::point<coordinate_t, 2, bg::cs::cartesian>;
 
     auto const lowest = bg::util::bounds<coordinate_t>::lowest();
     auto const highest = bg::util::bounds<coordinate_t>::highest();


### PR DESCRIPTION
Currently when points (180,0) and (-180,0) are tested for equality (in spherical or geographic systems) we are getting the expected result which is true. 

However, if the points are in radians instead of degrees the accuracy of the representation of pi/2 or the conversion from 180 degrees to radians could result in wrong results of equals (see added tests in this PR for details). 

This PR fixes this issue by relaxing conditions in normalization of spheroidal coordinates.
