### PR TITLE
Replace boost type_traits with stl type_traits.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,6 @@ target_link_libraries(boost_geometry
     Boost::throw_exception
     Boost::tokenizer
     Boost::tuple
-    Boost::type_traits
     Boost::utility
     Boost::variant
 )

--- a/build.jam
+++ b/build.jam
@@ -38,7 +38,6 @@ constant boost_dependencies :
     /boost/throw_exception//boost_throw_exception
     /boost/tokenizer//boost_tokenizer
     /boost/tuple//boost_tuple
-    /boost/type_traits//boost_type_traits
     /boost/variant//boost_variant
     /boost/variant2//boost_variant2 ;
 

--- a/doc/src/docutils/tools/support_status/support_status.cpp
+++ b/doc/src/docutils/tools/support_status/support_status.cpp
@@ -14,10 +14,10 @@
 #include <iostream>
 #include <fstream>
 #include <sstream>
+#include <type_traits>
 
 #include <boost/mpl/for_each.hpp>
 #include <boost/mpl/vector.hpp>
-#include <boost/type_traits/is_base_of.hpp>
 
 #define BOOST_GEOMETRY_IMPLEMENTATION_STATUS_BUILD true
 #include <boost/geometry/core/cs.hpp>
@@ -145,7 +145,7 @@ struct do_unary_test
 
     void operator()()
     {
-        if (boost::is_base_of<boost::geometry::nyi::not_implemented_tag, Dispatcher<G> >::type::value)
+        if (std::is_base_of<boost::geometry::nyi::not_implemented_tag, Dispatcher<G> >::type::value)
         {
             m_outputter.nyi();
         }
@@ -167,7 +167,7 @@ struct do_binary_test
     template <typename G1>
     void operator()(G1)
     {
-        if (boost::is_base_of<boost::geometry::nyi::not_implemented_tag, Dispatcher<G1, G2> >::type::value)
+        if (std::is_base_of<boost::geometry::nyi::not_implemented_tag, Dispatcher<G1, G2> >::type::value)
         {
             m_outputter.nyi();
         }

--- a/extensions/example/experimental/geometry_of.cpp
+++ b/extensions/example/experimental/geometry_of.cpp
@@ -10,12 +10,11 @@
 #include <vector>
 #include <string>
 #include <iostream>
-
+#include <type_traits>
 
 
 #include <boost/proto/core.hpp>
 #include <boost/proto/transform.hpp>
-#include <boost/type_traits/add_reference.hpp>
 
 #include <boost/mpl/assert.hpp>
 
@@ -40,7 +39,7 @@ struct append_point : proto::callable
 
     template<typename This, typename Geometry, typename T1, typename T2>
     struct result<This(Geometry, T1, T2)>
-        : boost::add_reference<Geometry>
+        : std::add_reference<Geometry>
     {};
 
     template<typename Geometry, typename T1, typename T2>

--- a/include/boost/geometry/extensions/gis/io/shapelib/shape_reader.hpp
+++ b/include/boost/geometry/extensions/gis/io/shapelib/shape_reader.hpp
@@ -14,7 +14,6 @@
 
 
 #include <boost/noncopyable.hpp>
-#include <boost/type_traits/promote.hpp>
 
 #include <boost/geometry/extensions/gis/io/shapelib/shp_read_object.hpp>
 

--- a/include/boost/geometry/index/detail/serialization.hpp
+++ b/include/boost/geometry/index/detail/serialization.hpp
@@ -14,8 +14,7 @@
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_SERIALIZATION_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_SERIALIZATION_HPP
 
-#include <boost/type_traits/alignment_of.hpp>
-#include <boost/type_traits/aligned_storage.hpp>
+#include <type_traits>
 
 #include <boost/serialization/serialization.hpp>
 #include <boost/serialization/split_member.hpp>
@@ -65,10 +64,10 @@ public:
     }
     T * address()
     {
-        return static_cast<T*>(m_storage.address());
+        return static_cast<void*>(&m_storage);
     }
 private:
-    boost::aligned_storage<sizeof(T), boost::alignment_of<T>::value> m_storage;
+    std::aligned_storage<sizeof(T), std::alignment_of<T>::value> m_storage;
 };
 
 // TODO - save and load item_version? see: collections_load_imp and collections_save_imp

--- a/include/boost/geometry/index/detail/varray.hpp
+++ b/include/boost/geometry/index/detail/varray.hpp
@@ -14,6 +14,8 @@
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_VARRAY_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_VARRAY_HPP
 
+#include <type_traits>
+
 // TODO - REMOVE/CHANGE
 #include <boost/container/detail/config_begin.hpp>
 #include <boost/container/detail/workaround.hpp>
@@ -28,9 +30,6 @@
 // or boost/detail/iterator.hpp ?
 #include <boost/iterator/reverse_iterator.hpp>
 #include <boost/iterator/iterator_concepts.hpp>
-
-#include <boost/type_traits/alignment_of.hpp>
-#include <boost/type_traits/aligned_storage.hpp>
 
 #include <boost/geometry/core/static_assert.hpp>
 
@@ -159,9 +158,9 @@ class varray
         typename vt::size_type, std::integral_constant<std::size_t, Capacity>
     );
 
-    typedef boost::aligned_storage<
+    typedef std::aligned_storage<
         sizeof(Value[Capacity]),
-        boost::alignment_of<Value[Capacity]>::value
+        std::alignment_of<Value[Capacity]>::value
     > aligned_storage_type;
 
     template <typename V, std::size_t C>
@@ -1031,7 +1030,7 @@ public:
             ++m_size; // update end
             sv::move_backward(position, this->end() - 2, this->end() - 1);          // may throw
 
-            aligned_storage<sizeof(value_type), alignment_of<value_type>::value> temp_storage;
+            std::aligned_storage<sizeof(value_type), std::alignment_of<value_type>::value> temp_storage;
             value_type* val_p = static_cast<value_type*>(temp_storage.address());
             sv::construct(dti(), val_p, std::forward<Args>(args)...);               // may throw
             sv::scoped_destructor<value_type> d(val_p);
@@ -1536,9 +1535,9 @@ private:
         namespace sv = varray_detail;
         for (; first_sm != last_sm ; ++first_sm, ++first_la)
         {
-            boost::aligned_storage<
+            std::aligned_storage<
                 sizeof(value_type),
-                boost::alignment_of<value_type>::value
+                std::alignment_of<value_type>::value
             > temp_storage;
             value_type* temp_ptr = reinterpret_cast<value_type*>(temp_storage.address());
 
@@ -1729,12 +1728,12 @@ private:
 
     pointer ptr()
     {
-        return pointer(static_cast<Value*>(m_storage.address()));
+        return pointer(static_cast<void*>(&m_storage));
     }
 
     const_pointer ptr() const
     {
-        return const_pointer(static_cast<const Value*>(m_storage.address()));
+        return const_pointer(static_cast<const void*>(&m_storage));
     }
 
     size_type m_size;

--- a/include/boost/geometry/srs/projections/str_cast.hpp
+++ b/include/boost/geometry/srs/projections/str_cast.hpp
@@ -11,10 +11,11 @@
 #ifndef BOOST_GEOMETRY_SRS_PROJECTIONS_STR_CAST_HPP
 #define BOOST_GEOMETRY_SRS_PROJECTIONS_STR_CAST_HPP
 
+#include <type_traits>
+
 #include <boost/config.hpp>
 #include <boost/geometry/core/exception.hpp>
 #include <boost/throw_exception.hpp>
-#include <boost/type_traits/remove_cv.hpp>
 
 namespace boost { namespace geometry
 {
@@ -116,7 +117,7 @@ struct str_cast_traits_generic
         char * str_end = (char*)(void*)str;
         T res = str_cast_traits_strtox
                     <
-                        typename boost::remove_cv<T>::type
+                        typename std::remove_cv<T>::type
                     >::apply(str, &str_end);
         if (str_end == str)
         {

--- a/test/util/compress_variant.cpp
+++ b/test/util/compress_variant.cpp
@@ -12,13 +12,13 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+#include <type_traits>
 
 #include <boost/test/included/test_exec_monitor.hpp>
 #include <boost/geometry/util/compress_variant.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/mpl/equal.hpp>
 #include <boost/mpl/vector.hpp>
-#include <boost/type_traits/is_same.hpp>
 #include <boost/variant/variant.hpp>
 
 
@@ -43,7 +43,7 @@ template <typename Variant, typename ExpectedType>
 void test_single_type_result()
 {
     BOOST_MPL_ASSERT((
-        boost::is_same<
+        std::is_same<
             typename boost::geometry::compress_variant<Variant>::type,
             ExpectedType
         >

--- a/test/util/is_implemented.cpp
+++ b/test/util/is_implemented.cpp
@@ -10,6 +10,7 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+#include <type_traits>
 
 #include <geometry_test_common.hpp>
 
@@ -23,7 +24,6 @@
 
 #include <boost/geometry/util/is_implemented.hpp>
 
-#include <boost/type_traits/is_same.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/mpl/bool.hpp>
 

--- a/test/util/rational.cpp
+++ b/test/util/rational.cpp
@@ -46,7 +46,6 @@ template <typename T>
 void test_bounds()
 {
     using coordinate_t = boost::rational<T>;
-    using point_t = bg::model::point<coordinate_t, 2, bg::cs::cartesian>;
 
     auto const lowest = bg::util::bounds<coordinate_t>::lowest();
     auto const highest = bg::util::bounds<coordinate_t>::highest();

--- a/test/util/transform_variant.cpp
+++ b/test/util/transform_variant.cpp
@@ -12,6 +12,7 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+#include <type_traits>
 
 #include <boost/test/included/test_exec_monitor.hpp>
 #include <boost/geometry/util/transform_variant.hpp>
@@ -19,7 +20,6 @@
 #include <boost/mpl/equal.hpp>
 #include <boost/mpl/placeholders.hpp>
 #include <boost/mpl/vector.hpp>
-#include <boost/type_traits.hpp>
 #include <boost/variant/variant.hpp>
 
 using boost::mpl::placeholders::_;
@@ -42,7 +42,7 @@ int test_main(int, char* [])
     // Transform Variant to Variant
     typedef boost::geometry::transform_variant<
         boost::variant<int, float, long>,
-        boost::add_pointer<_>
+        std::add_pointer<_>
     >::type transformed1;
 
     check<boost::mpl::vector<int*, float*, long*> >(transformed1());
@@ -50,7 +50,7 @@ int test_main(int, char* [])
     // Transform Sequence to Variant (without inserter)
     typedef boost::geometry::transform_variant<
         boost::mpl::vector<int, float, long>,
-        boost::add_pointer<_>
+        std::add_pointer<_>
     >::type transformed2;
 
     check<boost::mpl::vector<int*, float*, long*> >(transformed2());
@@ -58,7 +58,7 @@ int test_main(int, char* [])
     // Transform Sequence to Variant (with inserter)
     typedef boost::geometry::transform_variant<
         boost::mpl::vector<int, float, long>,
-        boost::add_pointer<_>,
+        std::add_pointer<_>,
         boost::mpl::back_inserter<boost::mpl::vector0<> >
     >::type transformed3;
 


### PR DESCRIPTION
With C++14, is possible to replace **Boost.TypeTraits** library usages with standard `type_traits`. This PR removes direct **Boost.TypeTraits** dependency in **Geometry** module.