### PR TITLE
test: divide rtree_with_strategies test into multiple files

### DIFF
--- a/index/test/rtree/Jamfile
+++ b/index/test/rtree/Jamfile
@@ -9,6 +9,7 @@
 build-project exceptions ;
 build-project interprocess ;
 build-project generated ;
+build-project strategies ;
 
 test-suite boost-geometry-index-rtree
     :
@@ -19,6 +20,5 @@ test-suite boost-geometry-index-rtree
     [ run rtree_move_pack.cpp ]
     [ run rtree_non_cartesian.cpp ]
     [ run rtree_values.cpp ]
-    [ compile rtree_with_strategies.cpp ]
     [ compile-fail rtree_values_invalid.cpp ]
     ;

--- a/index/test/rtree/strategies/CMakeLists.txt
+++ b/index/test/rtree/strategies/CMakeLists.txt
@@ -7,16 +7,15 @@
 # http://www.boost.org/LICENSE_1_0.txt)
 
 foreach(item IN ITEMS
-    rtree_contains_point
-    rtree_epsilon
-    rtree_insert_remove
-    rtree_intersects_geom
-    rtree_move_pack
-    rtree_non_cartesian
-    rtree_values
-    #compile-fail rtree_values_invalid
+    rtree_with_strategies_b_l
+    rtree_with_strategies_b_q
+    rtree_with_strategies_b_r
+    rtree_with_strategies_p_l
+    rtree_with_strategies_p_q
+    rtree_with_strategies_p_r
+    rtree_with_strategies_s_l
+    rtree_with_strategies_s_q
+    rtree_with_strategies_s_r
   )
   boost_geometry_add_unit_test("index" ${item})
 endforeach()
-
-add_subdirectory(strategies)

--- a/index/test/rtree/strategies/Jamfile
+++ b/index/test/rtree/strategies/Jamfile
@@ -1,0 +1,20 @@
+# Boost.Geometry Index
+#
+# Copyright (c) 2025 Adam Wulkiewicz, Lodz, Poland.
+#
+# Use, modification and distribution is subject to the Boost Software License,
+# Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+test-suite boost-geometry-index-rtree-strategies
+    :
+    [ compile rtree_with_strategies_b_l.cpp ]
+    [ compile rtree_with_strategies_b_q.cpp ]
+    [ compile rtree_with_strategies_b_r.cpp ]
+    [ compile rtree_with_strategies_p_l.cpp ]
+    [ compile rtree_with_strategies_p_q.cpp ]
+    [ compile rtree_with_strategies_p_r.cpp ]
+    [ compile rtree_with_strategies_s_l.cpp ]
+    [ compile rtree_with_strategies_s_q.cpp ]
+    [ compile rtree_with_strategies_s_r.cpp ]
+    ;

--- a/index/test/rtree/strategies/rtree_with_strategies.hpp
+++ b/index/test/rtree/strategies/rtree_with_strategies.hpp
@@ -7,6 +7,9 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+#ifndef BOOST_GEOMETRY_INDEX_TEST_RTREE_STRATEGIES_HPP
+#define BOOST_GEOMETRY_INDEX_TEST_RTREE_STRATEGIES_HPP
+
 #include <vector>
 
 #define BOOST_GEOMETRY_INDEX_DETAIL_EXPERIMENTAL_PREDICATES
@@ -132,7 +135,7 @@ void test_strategies()
 }
 
 template <typename Value, typename Params>
-void test_params()
+void test_rtree()
 {
     test_strategies<Value, Params, bg::strategies::index::cartesian<>>();
     test_strategies<Value, Params, bg::strategies::cartesian<>>();
@@ -142,19 +145,4 @@ void test_params()
     test_strategies<Value, Params, bg::strategies::geographic<>>();
 }
 
-template <typename Value>
-void test_value()
-{
-    test_params<Value, bgi::linear<4>>();
-    test_params<Value, bgi::quadratic<4>>();
-    test_params<Value, bgi::rstar<4>>();
-}
-
-int test_main(int, char* [])
-{
-    test_value<point>();
-    test_value<box>();
-    test_value<segment>();
-
-    return 0;
-}
+#endif // BOOST_GEOMETRY_INDEX_TEST_RTREE_STRATEGIES_HPP

--- a/index/test/rtree/strategies/rtree_with_strategies_b_l.cpp
+++ b/index/test/rtree/strategies/rtree_with_strategies_b_l.cpp
@@ -1,0 +1,17 @@
+// Boost.Geometry Index
+// Unit Test
+
+// Copyright (c) 2025 Adam Wulkiewicz, Lodz, Poland.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "rtree_with_strategies.hpp"
+
+int test_main(int, char* [])
+{
+    test_rtree<box, bgi::linear<4>>();
+
+    return 0;
+}

--- a/index/test/rtree/strategies/rtree_with_strategies_b_q.cpp
+++ b/index/test/rtree/strategies/rtree_with_strategies_b_q.cpp
@@ -1,0 +1,17 @@
+// Boost.Geometry Index
+// Unit Test
+
+// Copyright (c) 2025 Adam Wulkiewicz, Lodz, Poland.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "rtree_with_strategies.hpp"
+
+int test_main(int, char* [])
+{
+    test_rtree<box, bgi::quadratic<4>>();
+
+    return 0;
+}

--- a/index/test/rtree/strategies/rtree_with_strategies_b_r.cpp
+++ b/index/test/rtree/strategies/rtree_with_strategies_b_r.cpp
@@ -1,0 +1,17 @@
+// Boost.Geometry Index
+// Unit Test
+
+// Copyright (c) 2025 Adam Wulkiewicz, Lodz, Poland.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "rtree_with_strategies.hpp"
+
+int test_main(int, char* [])
+{
+    test_rtree<box, bgi::rstar<4>>();
+
+    return 0;
+}

--- a/index/test/rtree/strategies/rtree_with_strategies_p_l.cpp
+++ b/index/test/rtree/strategies/rtree_with_strategies_p_l.cpp
@@ -1,0 +1,17 @@
+// Boost.Geometry Index
+// Unit Test
+
+// Copyright (c) 2025 Adam Wulkiewicz, Lodz, Poland.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "rtree_with_strategies.hpp"
+
+int test_main(int, char* [])
+{
+    test_rtree<point, bgi::linear<4>>();
+
+    return 0;
+}

--- a/index/test/rtree/strategies/rtree_with_strategies_p_q.cpp
+++ b/index/test/rtree/strategies/rtree_with_strategies_p_q.cpp
@@ -1,0 +1,17 @@
+// Boost.Geometry Index
+// Unit Test
+
+// Copyright (c) 2025 Adam Wulkiewicz, Lodz, Poland.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "rtree_with_strategies.hpp"
+
+int test_main(int, char* [])
+{
+    test_rtree<point, bgi::quadratic<4>>();
+
+    return 0;
+}

--- a/index/test/rtree/strategies/rtree_with_strategies_p_r.cpp
+++ b/index/test/rtree/strategies/rtree_with_strategies_p_r.cpp
@@ -1,0 +1,17 @@
+// Boost.Geometry Index
+// Unit Test
+
+// Copyright (c) 2025 Adam Wulkiewicz, Lodz, Poland.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "rtree_with_strategies.hpp"
+
+int test_main(int, char* [])
+{
+    test_rtree<point, bgi::rstar<4>>();
+
+    return 0;
+}

--- a/index/test/rtree/strategies/rtree_with_strategies_s_l.cpp
+++ b/index/test/rtree/strategies/rtree_with_strategies_s_l.cpp
@@ -1,0 +1,17 @@
+// Boost.Geometry Index
+// Unit Test
+
+// Copyright (c) 2025 Adam Wulkiewicz, Lodz, Poland.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "rtree_with_strategies.hpp"
+
+int test_main(int, char* [])
+{
+    test_rtree<segment, bgi::linear<4>>();
+    
+    return 0;
+}

--- a/index/test/rtree/strategies/rtree_with_strategies_s_q.cpp
+++ b/index/test/rtree/strategies/rtree_with_strategies_s_q.cpp
@@ -1,0 +1,17 @@
+// Boost.Geometry Index
+// Unit Test
+
+// Copyright (c) 2025 Adam Wulkiewicz, Lodz, Poland.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "rtree_with_strategies.hpp"
+
+int test_main(int, char* [])
+{
+    test_rtree<segment, bgi::quadratic<4>>();
+    
+    return 0;
+}

--- a/index/test/rtree/strategies/rtree_with_strategies_s_r.cpp
+++ b/index/test/rtree/strategies/rtree_with_strategies_s_r.cpp
@@ -1,0 +1,17 @@
+// Boost.Geometry Index
+// Unit Test
+
+// Copyright (c) 2025 Adam Wulkiewicz, Lodz, Poland.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "rtree_with_strategies.hpp"
+
+int test_main(int, char* [])
+{
+    test_rtree<segment, bgi::rstar<4>>();
+
+    return 0;
+}


### PR DESCRIPTION
Trying to fix: https://github.com/boostorg/geometry/issues/1371