### PR TITLE
fix: avoid warnings for coordinate conversions and unused parameters

### DIFF
--- a/include/boost/geometry/algorithms/detail/overlay/check_enrich.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/check_enrich.hpp
@@ -21,6 +21,7 @@
 #include <cstddef>
 #include <vector>
 
+#include <boost/core/ignore_unused.hpp>
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 #include <boost/range/value_type.hpp>
@@ -66,6 +67,8 @@ inline void display(MetaTurn const& meta_turn, const char* reason = "")
         //<< " -> " << op_index
         << " " << reason
         << std::endl;
+#else
+boost::ignore_unused(meta_turn, reason);
 #endif
 }
 

--- a/include/boost/geometry/strategies/geographic/distance_cross_track_box_box.hpp
+++ b/include/boost/geometry/strategies/geographic/distance_cross_track_box_box.hpp
@@ -189,8 +189,7 @@ private:
 
 public:
     template <typename T>
-    static inline return_type apply(this_strategy const& strategy,
-                                    T const& distance)
+    static inline return_type apply(this_strategy const& , T const& distance)
     {
         return static_cast<return_type>(distance);
     }

--- a/include/boost/geometry/util/promote_integral.hpp
+++ b/include/boost/geometry/util/promote_integral.hpp
@@ -11,10 +11,10 @@
 #ifndef BOOST_GEOMETRY_UTIL_PROMOTE_INTEGRAL_HPP
 #define BOOST_GEOMETRY_UTIL_PROMOTE_INTEGRAL_HPP
 
-// For now deactivate the use of multiprecision integers
-// TODO: activate it later
+// Uncommenting this macro will use Boost.Multiprecision's cpp_int<> as a last resort
+// TODO (#1380): change this to BOOST_GEOMETRY_PROMOTE_INTEGER_TO_BOOST_MULTI_PRECISION
+// to be able to let users actively choose to use Boost.Multiprecision, but not enable it by default
 #define BOOST_GEOMETRY_NO_MULTIPRECISION_INTEGER
-
 
 #include <climits>
 #include <cstddef>


### PR DESCRIPTION
Fixes: #629

This was a long standing warning where we were pinged about several times.

I think this is the best solution at the moment. However, it solves one case. There is the message:

>This pattern of select_most_precise<double,...> is pretty common, and I have found the same warning being produced in other parts of boost that do the same thing when using with std::int64_t.

I cannot fix all of that now, it first have to wait at least for the big improvement in intersections.

Then we probably should fix it in `select_most_precise` itself.

Please give me your opinions.

If possible it should be included in `1.88`