### PR TITLE
chore: update retired ubuntu 20.04

### DIFF
--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -43,38 +43,38 @@ jobs:
           - b2_toolset: clang-3.9
             b2_cxxstd: 14
             version: "3.9"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - b2_toolset: clang-4.0
             b2_cxxstd: 14
             version: "4.0"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - b2_toolset: clang-5.0
             b2_cxxstd: 14
             version: "5.0"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - b2_toolset: clang-6.0
             b2_cxxstd: 14
             version: "6.0"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - b2_toolset: clang-7
             b2_cxxstd: 14,17
             version: "7"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - b2_toolset: clang-8
             b2_cxxstd: 14,17
             version: "8"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - b2_toolset: clang-9
             # At some point compilation started to fail with 2a from unknown reason
             # It may have something to do with the std library
             #b2_cxxstd: 14,17,2a
             b2_cxxstd: 14,17
             version: "9"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - b2_toolset: clang-10
             b2_cxxstd: 14,17,2a
             version: "10"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - b2_toolset: clang-11
             b2_cxxstd: 14,17,2a
             version: "11"
@@ -184,23 +184,23 @@ jobs:
           - b2_toolset: gcc-5
             b2_cxxstd: 14
             version: "5"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - b2_toolset: gcc-6
             b2_cxxstd: 14
             version: "6"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - b2_toolset: gcc-7
             b2_cxxstd: 14,17
             version: "7"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - b2_toolset: gcc-8
             b2_cxxstd: 14,17
             version: "8"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - b2_toolset: gcc-9
             b2_cxxstd: 14,17,2a
             version: "9"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - b2_toolset: gcc-10
             b2_cxxstd: 14,17,2a
             version: "10"


### PR DESCRIPTION
second try