### PR TITLE
Retire ubuntu 20.04

### DIFF
--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -4,7 +4,7 @@
 # Copyright (c) 2020 Mateusz Loskot <mateusz@loskot.net>
 # Copyright (c) 2020-2021 Adam Wulkiewicz, Lodz, Poland
 #
-# Copyright (c) 2022-2023 Oracle and/or its affiliates.
+# Copyright (c) 2022-2025 Oracle and/or its affiliates.
 # Contributed and/or modified by Vissarion Fysikopoulos, on behalf of Oracle
 #
 # Use, modification and distribution is subject to the Boost Software License,
@@ -25,9 +25,6 @@ jobs:
       fail-fast: false
       matrix:
         b2_toolset: [
-          clang-3.9,
-          clang-4.0,
-          clang-5.0,
           clang-6.0,
           clang-7,
           clang-8,
@@ -40,41 +37,29 @@ jobs:
         ]
 
         include:
-          - b2_toolset: clang-3.9
-            b2_cxxstd: 14
-            version: "3.9"
-            os: ubuntu-20.04
-          - b2_toolset: clang-4.0
-            b2_cxxstd: 14
-            version: "4.0"
-            os: ubuntu-20.04
-          - b2_toolset: clang-5.0
-            b2_cxxstd: 14
-            version: "5.0"
-            os: ubuntu-20.04
           - b2_toolset: clang-6.0
             b2_cxxstd: 14
             version: "6.0"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - b2_toolset: clang-7
             b2_cxxstd: 14,17
             version: "7"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - b2_toolset: clang-8
             b2_cxxstd: 14,17
             version: "8"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - b2_toolset: clang-9
             # At some point compilation started to fail with 2a from unknown reason
             # It may have something to do with the std library
             #b2_cxxstd: 14,17,2a
             b2_cxxstd: 14,17
             version: "9"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - b2_toolset: clang-10
             b2_cxxstd: 14,17,2a
             version: "10"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - b2_toolset: clang-11
             b2_cxxstd: 14,17,2a
             version: "11"
@@ -126,14 +111,11 @@ jobs:
 
       - name: Install
         run: |
-          # Required for compilers not available in ubuntu 20.04
+          # Required for compilers not available in ubuntu 22.04
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
-          sudo add-apt-repository "deb http://dk.archive.ubuntu.com/ubuntu/ xenial main"
-          sudo add-apt-repository "deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe"
-          sudo add-apt-repository "deb http://dk.archive.ubuntu.com/ubuntu/ bionic main"
-          sudo add-apt-repository "deb http://dk.archive.ubuntu.com/ubuntu/ bionic universe"
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo add-apt-repository "deb http://dk.archive.ubuntu.com/ubuntu/ focal main"
+          sudo add-apt-repository "deb http://dk.archive.ubuntu.com/ubuntu/ focal universe"
           sudo apt -q -y update
           sudo apt -q -y install clang-${{ matrix.version }} g++-multilib
 
@@ -171,8 +153,6 @@ jobs:
       fail-fast: false
       matrix:
         b2_toolset: [
-          gcc-5,
-          gcc-6,
           gcc-7,
           gcc-8,
           gcc-9,
@@ -181,26 +161,18 @@ jobs:
         ]
 
         include:
-          - b2_toolset: gcc-5
-            b2_cxxstd: 14
-            version: "5"
-            os: ubuntu-20.04
-          - b2_toolset: gcc-6
-            b2_cxxstd: 14
-            version: "6"
-            os: ubuntu-20.04
           - b2_toolset: gcc-7
             b2_cxxstd: 14,17
             version: "7"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - b2_toolset: gcc-8
             b2_cxxstd: 14,17
             version: "8"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - b2_toolset: gcc-9
             b2_cxxstd: 14,17,2a
             version: "9"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - b2_toolset: gcc-10
             b2_cxxstd: 14,17,2a
             version: "10"
@@ -245,14 +217,11 @@ jobs:
 
       - name: Install
         run: |
-          # Required for compilers not available in ubuntu 20.04
+          # Required for compilers not available in ubuntu 22.04
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
-          sudo add-apt-repository "deb http://dk.archive.ubuntu.com/ubuntu/ xenial main"
-          sudo add-apt-repository "deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe"
-          sudo add-apt-repository "deb http://dk.archive.ubuntu.com/ubuntu/ bionic main"
-          sudo add-apt-repository "deb http://dk.archive.ubuntu.com/ubuntu/ bionic universe"
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo add-apt-repository "deb http://dk.archive.ubuntu.com/ubuntu/ focal main"
+          sudo add-apt-repository "deb http://dk.archive.ubuntu.com/ubuntu/ focal universe"
           sudo apt -q -y update
           sudo apt -q -y install g++-${{ matrix.version }} g++-${{ matrix.version }}-multilib
 


### PR DESCRIPTION
Retire ubuntu 20.04 from github actions. This force us to also remove clang versions > 6 and gcc < 7, since it is not straightforward to install them in ubuntu 22.04. In particular, if one tries to import the ubuntu 18 (bionic) archives then `apt install` reaches an impossible situation when trying to install older versions (e.g. clang 5.0) due to unmet dependencies.  