### PR TITLE
experimental: use clang-format for buffer and graph

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,24 @@
+---
+BasedOnStyle: LLVM
+---
+Language: Cpp
+
+AlwaysBreakAfterReturnType: None
+AlwaysBreakTemplateDeclarations: true
+AllowShortBlocksOnASingleLine: Always
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortLambdasOnASingleLine: true
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: Allman
+BinPackArguments: false
+BinPackParameters: false
+ColumnLimit: 100
+CompactNamespaces: true
+IndentCaseLabels: true
+IndentWidth: 4
+PackConstructorInitializers: NextLine
+PointerAlignment: Left
+QualifierAlignment: Right
+SpaceAfterLogicalNot: true
+SpaceAfterTemplateKeyword: true

--- a/include/boost/geometry/algorithms/detail/buffer/buffer_box.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/buffer_box.hpp
@@ -11,16 +11,19 @@
 
 #include <cstddef>
 
+#include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
-#include <boost/geometry/core/access.hpp>
 
-
-namespace boost { namespace geometry
+namespace boost
+{
+namespace geometry
 {
 
 #ifndef DOXYGEN_NO_DETAIL
-namespace detail { namespace buffer
+namespace detail
+{
+namespace buffer
 {
 
 template <typename BoxIn, typename BoxOut, typename T, std::size_t C, std::size_t D, std::size_t N>
@@ -43,7 +46,7 @@ struct box_loop<BoxIn, BoxOut, T, C, N, N>
 };
 
 // Extends a box with the same amount in all directions
-template<typename BoxIn, typename BoxOut, typename T>
+template <typename BoxIn, typename BoxOut, typename T>
 inline void buffer_box(BoxIn const& box_in, T const& distance, BoxOut& box_out)
 {
     assert_dimension_equal<BoxIn, BoxOut>();
@@ -54,9 +57,11 @@ inline void buffer_box(BoxIn const& box_in, T const& distance, BoxOut& box_out)
     box_loop<BoxIn, BoxOut, T, max_corner, 0, N>::apply(box_in, distance, box_out);
 }
 
-}} // namespace detail::buffer
+} // namespace buffer
+} // namespace detail
 #endif // DOXYGEN_NO_DETAIL
 
-}} // namespace boost::geometry
+} // namespace geometry
+} // namespace boost
 
 #endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_BUFFER_BUFFER_BOX_HPP

--- a/include/boost/geometry/algorithms/detail/buffer/buffer_inserter.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/buffer_inserter.hpp
@@ -26,9 +26,9 @@
 #include <boost/range/size.hpp>
 #include <boost/range/value_type.hpp>
 
-#include <boost/geometry/algorithms/detail/direction_code.hpp>
 #include <boost/geometry/algorithms/detail/buffer/buffered_piece_collection.hpp>
 #include <boost/geometry/algorithms/detail/buffer/line_line_intersection.hpp>
+#include <boost/geometry/algorithms/detail/direction_code.hpp>
 
 #include <boost/geometry/algorithms/num_interior_rings.hpp>
 #include <boost/geometry/algorithms/simplify.hpp>
@@ -51,12 +51,15 @@
 
 #include <boost/geometry/views/detail/closed_clockwise_view.hpp>
 
-
-namespace boost { namespace geometry
+namespace boost
+{
+namespace geometry
 {
 
 #ifndef DOXYGEN_NO_DETAIL
-namespace detail { namespace buffer
+namespace detail
+{
+namespace buffer
 {
 
 template <typename RangeIn, typename DistanceStrategy, typename RangeOut, typename Strategies>
@@ -76,12 +79,11 @@ inline void simplify_input(RangeIn const& range,
     // It also gets rid of duplicate points
 
     geometry::detail::simplify::simplify_range<2>::apply(range,
-        simplified, distance.simplify_distance(),
-        detail::simplify::douglas_peucker(),
-        strategies);
-
+                                                         simplified,
+                                                         distance.simplify_distance(),
+                                                         detail::simplify::douglas_peucker(),
+                                                         strategies);
 }
-
 
 template <typename RingOutput>
 struct buffer_range
@@ -89,144 +91,149 @@ struct buffer_range
     using output_point_type = point_type_t<RingOutput>;
     using coordinate_type = coordinate_type_t<RingOutput>;
 
-    template
-    <
-        typename Collection,
-        typename Point,
-        typename DistanceStrategy,
-        typename SegmentStrategy,
-        typename JoinStrategy,
-        typename EndStrategy,
-        typename Strategies
-    >
-    static inline
-    void add_join(Collection& collection,
-            Point const& penultimate_input,
-            Point const& previous_input,
-            output_point_type const& prev_perp1,
-            output_point_type const& prev_perp2,
-            Point const& input,
-            output_point_type const& perp1,
-            output_point_type const& perp2,
-            geometry::strategy::buffer::buffer_side_selector side,
-            DistanceStrategy const& distance,
-            SegmentStrategy const& segment_strategy,
-            JoinStrategy const& join_strategy,
-            EndStrategy const& end_strategy,
-            Strategies const& strategies)
+    template <typename Collection,
+              typename Point,
+              typename DistanceStrategy,
+              typename SegmentStrategy,
+              typename JoinStrategy,
+              typename EndStrategy,
+              typename Strategies>
+    static inline void add_join(Collection& collection,
+                                Point const& penultimate_input,
+                                Point const& previous_input,
+                                output_point_type const& prev_perp1,
+                                output_point_type const& prev_perp2,
+                                Point const& input,
+                                output_point_type const& perp1,
+                                output_point_type const& perp2,
+                                geometry::strategy::buffer::buffer_side_selector side,
+                                DistanceStrategy const& distance,
+                                SegmentStrategy const& segment_strategy,
+                                JoinStrategy const& join_strategy,
+                                EndStrategy const& end_strategy,
+                                Strategies const& strategies)
     {
         geometry::strategy::buffer::join_selector const join
-                = get_join_type(penultimate_input, previous_input, input,
-                                strategies);
+            = get_join_type(penultimate_input, previous_input, input, strategies);
 
-        switch(join)
+        switch (join)
         {
-            case geometry::strategy::buffer::join_continue :
+            case geometry::strategy::buffer::join_continue:
                 // No join, we get two consecutive sides
                 break;
-            case geometry::strategy::buffer::join_concave :
-                {
-                    std::vector<output_point_type> range_out;
-                    range_out.push_back(prev_perp2);
-                    range_out.push_back(previous_input);
-                    collection.add_piece(geometry::strategy::buffer::buffered_concave, previous_input, range_out);
+            case geometry::strategy::buffer::join_concave:
+            {
+                std::vector<output_point_type> range_out;
+                range_out.push_back(prev_perp2);
+                range_out.push_back(previous_input);
+                collection.add_piece(
+                    geometry::strategy::buffer::buffered_concave, previous_input, range_out);
 
-                    range_out.clear();
-                    range_out.push_back(previous_input);
-                    range_out.push_back(perp1);
-                    collection.add_piece(geometry::strategy::buffer::buffered_concave, previous_input, range_out);
-                }
-                break;
-            case geometry::strategy::buffer::join_spike :
+                range_out.clear();
+                range_out.push_back(previous_input);
+                range_out.push_back(perp1);
+                collection.add_piece(
+                    geometry::strategy::buffer::buffered_concave, previous_input, range_out);
+            }
+            break;
+            case geometry::strategy::buffer::join_spike:
+            {
+                // For linestrings, only add spike at one side to avoid
+                // duplicates
+                std::vector<output_point_type> range_out;
+                end_strategy.apply(penultimate_input,
+                                   prev_perp2,
+                                   previous_input,
+                                   perp1,
+                                   side,
+                                   distance,
+                                   range_out);
+                collection.add_endcap(end_strategy, range_out, previous_input);
+                collection.set_current_ring_concave();
+            }
+            break;
+            case geometry::strategy::buffer::join_convex:
+            {
+                // The corner is convex, we create a join
+                // TODO (future) - avoid a separate vector, add the piece directly
+                output_point_type intersection_point;
+                if (line_line_intersection::apply(prev_perp1,
+                                                  prev_perp2,
+                                                  perp1,
+                                                  perp2,
+                                                  previous_input,
+                                                  segment_strategy.equidistant(),
+                                                  intersection_point))
                 {
-                    // For linestrings, only add spike at one side to avoid
-                    // duplicates
                     std::vector<output_point_type> range_out;
-                    end_strategy.apply(penultimate_input, prev_perp2, previous_input, perp1, side, distance, range_out);
-                    collection.add_endcap(end_strategy, range_out, previous_input);
-                    collection.set_current_ring_concave();
-                }
-                break;
-            case geometry::strategy::buffer::join_convex :
-                {
-                    // The corner is convex, we create a join
-                    // TODO (future) - avoid a separate vector, add the piece directly
-                    output_point_type intersection_point;
-                    if (line_line_intersection::apply(prev_perp1, prev_perp2,
-                                                      perp1, perp2, previous_input,
-                                                      segment_strategy.equidistant(),
-                                                      intersection_point))
+                    if (join_strategy.apply(intersection_point,
+                                            previous_input,
+                                            prev_perp2,
+                                            perp1,
+                                            distance.apply(previous_input, input, side),
+                                            range_out))
                     {
-                        std::vector<output_point_type> range_out;
-                        if (join_strategy.apply(intersection_point,
-                                    previous_input, prev_perp2, perp1,
-                                    distance.apply(previous_input, input, side),
-                                    range_out))
-                        {
-                            collection.add_piece(geometry::strategy::buffer::buffered_join,
-                                    previous_input, range_out);
-                        }
+                        collection.add_piece(
+                            geometry::strategy::buffer::buffered_join, previous_input, range_out);
                     }
                 }
-                break;
+            }
+            break;
         }
     }
 
     // Returns true if collinear point p2 continues after p0 and p1.
     // If it turns back (spike), it returns false.
     static inline bool same_direction(output_point_type const& p0,
-            output_point_type const& p1,
-            output_point_type const& p2)
+                                      output_point_type const& p1,
+                                      output_point_type const& p2)
     {
         return direction_code<cs_tag_t<output_point_type>>(p0, p1, p2) == 1;
     }
 
     template <typename Strategies>
-    static inline geometry::strategy::buffer::join_selector get_join_type(
-            output_point_type const& p0,
-            output_point_type const& p1,
-            output_point_type const& p2,
-            Strategies const& strategies)
+    static inline geometry::strategy::buffer::join_selector
+    get_join_type(output_point_type const& p0,
+                  output_point_type const& p1,
+                  output_point_type const& p2,
+                  Strategies const& strategies)
     {
         int const side = strategies.side().apply(p0, p1, p2);
-        return side == -1 ? geometry::strategy::buffer::join_convex
-            :  side == 1  ? geometry::strategy::buffer::join_concave
-            :  same_direction(p0, p1, p2) ? geometry::strategy::buffer::join_continue
-            : geometry::strategy::buffer::join_spike;
+        return side == -1                   ? geometry::strategy::buffer::join_convex
+               : side == 1                  ? geometry::strategy::buffer::join_concave
+               : same_direction(p0, p1, p2) ? geometry::strategy::buffer::join_continue
+                                            : geometry::strategy::buffer::join_spike;
     }
 
-    template
-    <
-        typename Collection,
-        typename Iterator,
-        typename DistanceStrategy,
-        typename SegmentStrategy,
-        typename JoinStrategy,
-        typename EndStrategy,
-        typename Strategies
-    >
-    static inline geometry::strategy::buffer::result_code iterate(Collection& collection,
-                Iterator begin, Iterator end,
-                geometry::strategy::buffer::buffer_side_selector side,
-                DistanceStrategy const& distance_strategy,
-                SegmentStrategy const& segment_strategy,
-                JoinStrategy const& join_strategy,
-                EndStrategy const& end_strategy,
-                Strategies const& strategies,
-                bool linear,
-                output_point_type& first_p1,
-                output_point_type& first_p2,
-                output_point_type& last_p1,
-                output_point_type& last_p2)
+    template <typename Collection,
+              typename Iterator,
+              typename DistanceStrategy,
+              typename SegmentStrategy,
+              typename JoinStrategy,
+              typename EndStrategy,
+              typename Strategies>
+    static inline geometry::strategy::buffer::result_code
+    iterate(Collection& collection,
+            Iterator begin,
+            Iterator end,
+            geometry::strategy::buffer::buffer_side_selector side,
+            DistanceStrategy const& distance_strategy,
+            SegmentStrategy const& segment_strategy,
+            JoinStrategy const& join_strategy,
+            EndStrategy const& end_strategy,
+            Strategies const& strategies,
+            bool linear,
+            output_point_type& first_p1,
+            output_point_type& first_p2,
+            output_point_type& last_p1,
+            output_point_type& last_p2)
     {
         boost::ignore_unused(segment_strategy);
 
-        using point_type = typename std::iterator_traits
-        <
-            Iterator
-        >::value_type;
+        using point_type = typename std::iterator_traits<Iterator>::value_type;
 
-        point_type second_point, penultimate_point, ultimate_point; // last two points from begin/end
+        point_type second_point, penultimate_point,
+            ultimate_point; // last two points from begin/end
 
         /*
          * last.p1    last.p2  these are the "previous (last) perpendicular points"
@@ -247,9 +254,10 @@ struct buffer_range
 
         bool const mark_flat
             = linear
-                && end_strategy.get_piece_type() == geometry::strategy::buffer::buffered_flat_end;
+              && end_strategy.get_piece_type() == geometry::strategy::buffer::buffered_flat_end;
 
-        geometry::strategy::buffer::result_code result = geometry::strategy::buffer::result_no_output;
+        geometry::strategy::buffer::result_code result
+            = geometry::strategy::buffer::result_no_output;
         bool first = true;
 
         Iterator it = begin;
@@ -261,8 +269,7 @@ struct buffer_range
         {
             generated_side.clear();
             geometry::strategy::buffer::result_code error_code
-                = segment_strategy.apply(*prev, *it, side,
-                                distance_strategy, generated_side);
+                = segment_strategy.apply(*prev, *it, side, distance_strategy, generated_side);
 
             if (error_code == geometry::strategy::buffer::result_no_output)
             {
@@ -282,16 +289,24 @@ struct buffer_range
 
             if (! first)
             {
-                 add_join(collection,
-                        penultimate_point,
-                        *prev, last_p1, last_p2,
-                        *it, generated_side.front(), generated_side.back(),
-                        side,
-                        distance_strategy, segment_strategy, join_strategy, end_strategy,
-                        strategies);
+                add_join(collection,
+                         penultimate_point,
+                         *prev,
+                         last_p1,
+                         last_p2,
+                         *it,
+                         generated_side.front(),
+                         generated_side.back(),
+                         side,
+                         distance_strategy,
+                         segment_strategy,
+                         join_strategy,
+                         end_strategy,
+                         strategies);
             }
 
-            collection.add_side_piece(*prev, *it, generated_side, first, distance_strategy.empty(side));
+            collection.add_side_piece(
+                *prev, *it, generated_side, first, distance_strategy.empty(side));
 
             if (first && mark_flat)
             {
@@ -321,39 +336,35 @@ struct buffer_range
     }
 };
 
-template
-<
-    typename Multi,
-    typename PolygonOutput,
-    typename Policy
->
+template <typename Multi, typename PolygonOutput, typename Policy>
 struct buffer_multi
 {
-    template
-    <
-        typename Collection,
-        typename DistanceStrategy,
-        typename SegmentStrategy,
-        typename JoinStrategy,
-        typename EndStrategy,
-        typename PointStrategy,
-        typename Strategies
-    >
+    template <typename Collection,
+              typename DistanceStrategy,
+              typename SegmentStrategy,
+              typename JoinStrategy,
+              typename EndStrategy,
+              typename PointStrategy,
+              typename Strategies>
     static inline void apply(Multi const& multi,
-            Collection& collection,
-            DistanceStrategy const& distance_strategy,
-            SegmentStrategy const& segment_strategy,
-            JoinStrategy const& join_strategy,
-            EndStrategy const& end_strategy,
-            PointStrategy const& point_strategy,
-            Strategies const& strategies)
+                             Collection& collection,
+                             DistanceStrategy const& distance_strategy,
+                             SegmentStrategy const& segment_strategy,
+                             JoinStrategy const& join_strategy,
+                             EndStrategy const& end_strategy,
+                             PointStrategy const& point_strategy,
+                             Strategies const& strategies)
     {
         for (auto it = boost::begin(multi); it != boost::end(multi); ++it)
         {
-            Policy::apply(*it, collection,
-                distance_strategy, segment_strategy,
-                join_strategy, end_strategy, point_strategy,
-                strategies);
+            Policy::apply(*it,
+                          collection,
+                          distance_strategy,
+                          segment_strategy,
+                          join_strategy,
+                          end_strategy,
+                          point_strategy,
+                          strategies);
         }
     }
 };
@@ -362,25 +373,27 @@ struct visit_pieces_default_policy
 {
     template <typename Collection>
     static inline void apply(Collection const&, int)
-    {}
+    {
+    }
 
     template <typename Turns, typename Cluster, typename Connections>
     inline void visit_cluster_connections(signed_size_type cluster_id,
-            Turns const& turns, Cluster const& cluster, Connections const& connections) {}
-
+                                          Turns const& turns,
+                                          Cluster const& cluster,
+                                          Connections const& connections)
+    {
+    }
 };
 
-template
-<
-    typename OutputPointType,
-    typename Point,
-    typename Collection,
-    typename DistanceStrategy,
-    typename PointStrategy
->
-inline void buffer_point(Point const& point, Collection& collection,
-        DistanceStrategy const& distance_strategy,
-        PointStrategy const& point_strategy)
+template <typename OutputPointType,
+          typename Point,
+          typename Collection,
+          typename DistanceStrategy,
+          typename PointStrategy>
+inline void buffer_point(Point const& point,
+                         Collection& collection,
+                         DistanceStrategy const& distance_strategy,
+                         PointStrategy const& point_strategy)
 {
     collection.start_new_ring(false);
     std::vector<OutputPointType> range_out;
@@ -390,151 +403,139 @@ inline void buffer_point(Point const& point, Collection& collection,
     collection.finish_ring(geometry::strategy::buffer::result_normal);
 }
 
-
-}} // namespace detail::buffer
+} // namespace buffer
+} // namespace detail
 #endif // DOXYGEN_NO_DETAIL
-
 
 #ifndef DOXYGEN_NO_DISPATCH
 namespace dispatch
 {
 
-template
-<
-    typename Tag,
-    typename RingInput,
-    typename RingOutput
->
+template <typename Tag, typename RingInput, typename RingOutput>
 struct buffer_inserter
-{};
+{
+};
 
-
-
-template
-<
-    typename Point,
-    typename RingOutput
->
+template <typename Point, typename RingOutput>
 struct buffer_inserter<point_tag, Point, RingOutput>
 {
-    template
-    <
-        typename Collection,
-        typename DistanceStrategy,
-        typename SegmentStrategy,
-        typename JoinStrategy,
-        typename EndStrategy,
-        typename PointStrategy,
-        typename Strategies
-    >
-    static inline void apply(Point const& point, Collection& collection,
-            DistanceStrategy const& distance_strategy,
-            SegmentStrategy const& ,
-            JoinStrategy const& ,
-            EndStrategy const& ,
-            PointStrategy const& point_strategy,
-            Strategies const& )
+    template <typename Collection,
+              typename DistanceStrategy,
+              typename SegmentStrategy,
+              typename JoinStrategy,
+              typename EndStrategy,
+              typename PointStrategy,
+              typename Strategies>
+    static inline void apply(Point const& point,
+                             Collection& collection,
+                             DistanceStrategy const& distance_strategy,
+                             SegmentStrategy const&,
+                             JoinStrategy const&,
+                             EndStrategy const&,
+                             PointStrategy const& point_strategy,
+                             Strategies const&)
     {
-        detail::buffer::buffer_point
-        <
-            point_type_t<RingOutput>
-        >(point, collection, distance_strategy, point_strategy);
+        detail::buffer::buffer_point<point_type_t<RingOutput>>(
+            point, collection, distance_strategy, point_strategy);
     }
 };
 
 // Not a specialization, but called from specializations of ring and of polygon.
 // Calling code starts/finishes ring before/after apply
-template
-<
-    typename RingInput,
-    typename RingOutput
->
+template <typename RingInput, typename RingOutput>
 struct buffer_inserter_ring
 {
     using output_point_type = point_type_t<RingOutput>;
 
-    template
-    <
-        typename Collection,
-        typename Iterator,
-        typename DistanceStrategy,
-        typename SegmentStrategy,
-        typename JoinStrategy,
-        typename EndStrategy,
-        typename Strategies
-    >
-    static inline geometry::strategy::buffer::result_code iterate(Collection& collection,
-                Iterator begin, Iterator end,
-                geometry::strategy::buffer::buffer_side_selector side,
-                DistanceStrategy const& distance_strategy,
-                SegmentStrategy const& segment_strategy,
-                JoinStrategy const& join_strategy,
-                EndStrategy const& end_strategy,
-                Strategies const& strategies)
+    template <typename Collection,
+              typename Iterator,
+              typename DistanceStrategy,
+              typename SegmentStrategy,
+              typename JoinStrategy,
+              typename EndStrategy,
+              typename Strategies>
+    static inline geometry::strategy::buffer::result_code
+    iterate(Collection& collection,
+            Iterator begin,
+            Iterator end,
+            geometry::strategy::buffer::buffer_side_selector side,
+            DistanceStrategy const& distance_strategy,
+            SegmentStrategy const& segment_strategy,
+            JoinStrategy const& join_strategy,
+            EndStrategy const& end_strategy,
+            Strategies const& strategies)
     {
         output_point_type first_p1, first_p2, last_p1, last_p2;
 
         using buffer_range = detail::buffer::buffer_range<RingOutput>;
 
-        geometry::strategy::buffer::result_code result
-            = buffer_range::iterate(collection, begin, end,
-                side,
-                distance_strategy, segment_strategy, join_strategy, end_strategy,
-                strategies,
-                false, first_p1, first_p2, last_p1, last_p2);
+        geometry::strategy::buffer::result_code result = buffer_range::iterate(collection,
+                                                                               begin,
+                                                                               end,
+                                                                               side,
+                                                                               distance_strategy,
+                                                                               segment_strategy,
+                                                                               join_strategy,
+                                                                               end_strategy,
+                                                                               strategies,
+                                                                               false,
+                                                                               first_p1,
+                                                                               first_p2,
+                                                                               last_p1,
+                                                                               last_p2);
 
         // Generate closing join
         if (result == geometry::strategy::buffer::result_normal)
         {
             buffer_range::add_join(collection,
-                *(end - 2),
-                *(end - 1), last_p1, last_p2,
-                *(begin + 1), first_p1, first_p2,
-                side,
-                distance_strategy, segment_strategy, join_strategy, end_strategy,
-                strategies);
+                                   *(end - 2),
+                                   *(end - 1),
+                                   last_p1,
+                                   last_p2,
+                                   *(begin + 1),
+                                   first_p1,
+                                   first_p2,
+                                   side,
+                                   distance_strategy,
+                                   segment_strategy,
+                                   join_strategy,
+                                   end_strategy,
+                                   strategies);
         }
 
         // Buffer is closed automatically by last closing corner
         return result;
     }
 
-    template
-    <
-        typename Collection,
-        typename DistanceStrategy,
-        typename SegmentStrategy,
-        typename JoinStrategy,
-        typename EndStrategy,
-        typename PointStrategy,
-        typename Strategies
-    >
-    static inline geometry::strategy::buffer::result_code apply(RingInput const& ring,
-            Collection& collection,
-            DistanceStrategy const& distance,
-            SegmentStrategy const& segment_strategy,
-            JoinStrategy const& join_strategy,
-            EndStrategy const& end_strategy,
-            PointStrategy const& point_strategy,
-            Strategies const& strategies)
+    template <typename Collection,
+              typename DistanceStrategy,
+              typename SegmentStrategy,
+              typename JoinStrategy,
+              typename EndStrategy,
+              typename PointStrategy,
+              typename Strategies>
+    static inline geometry::strategy::buffer::result_code
+    apply(RingInput const& ring,
+          Collection& collection,
+          DistanceStrategy const& distance,
+          SegmentStrategy const& segment_strategy,
+          JoinStrategy const& join_strategy,
+          EndStrategy const& end_strategy,
+          PointStrategy const& point_strategy,
+          Strategies const& strategies)
     {
         // Use helper geometry to support non-mutable input Rings
-        using simplified_ring_t = model::ring
-            <
-                output_point_type,
-                point_order<RingInput>::value != counterclockwise,
-                closure<RingInput>::value != open
-            >;
+        using simplified_ring_t = model::ring<output_point_type,
+                                              point_order<RingInput>::value != counterclockwise,
+                                              closure<RingInput>::value != open>;
         simplified_ring_t simplified;
         detail::buffer::simplify_input(ring, distance, simplified, strategies);
 
         geometry::strategy::buffer::result_code code = geometry::strategy::buffer::result_no_output;
 
         std::size_t n = boost::size(simplified);
-        std::size_t const min_points = core_detail::closure::minimum_ring_size
-            <
-                geometry::closure<simplified_ring_t>::value
-            >::value;
+        std::size_t const min_points = core_detail::closure::minimum_ring_size<
+            geometry::closure<simplified_ring_t>::value>::value;
 
         if (n >= min_points)
         {
@@ -542,100 +543,99 @@ struct buffer_inserter_ring
             if (distance.negative())
             {
                 // Walk backwards (rings will be reversed afterwards)
-                code = iterate(collection, boost::rbegin(view), boost::rend(view),
-                        geometry::strategy::buffer::buffer_side_right,
-                        distance, segment_strategy, join_strategy, end_strategy,
-                        strategies);
+                code = iterate(collection,
+                               boost::rbegin(view),
+                               boost::rend(view),
+                               geometry::strategy::buffer::buffer_side_right,
+                               distance,
+                               segment_strategy,
+                               join_strategy,
+                               end_strategy,
+                               strategies);
             }
             else
             {
-                code = iterate(collection, boost::begin(view), boost::end(view),
-                        geometry::strategy::buffer::buffer_side_left,
-                        distance, segment_strategy, join_strategy, end_strategy,
-                        strategies);
+                code = iterate(collection,
+                               boost::begin(view),
+                               boost::end(view),
+                               geometry::strategy::buffer::buffer_side_left,
+                               distance,
+                               segment_strategy,
+                               join_strategy,
+                               end_strategy,
+                               strategies);
             }
         }
 
         if (code == geometry::strategy::buffer::result_no_output && n >= 1)
         {
             // Use point_strategy to buffer degenerated ring
-            detail::buffer::buffer_point<output_point_type>
-                (
-                    geometry::range::front(simplified),
-                    collection, distance, point_strategy
-                );
+            detail::buffer::buffer_point<output_point_type>(
+                geometry::range::front(simplified), collection, distance, point_strategy);
         }
         return code;
     }
 };
 
-
-template
-<
-    typename RingInput,
-    typename RingOutput
->
+template <typename RingInput, typename RingOutput>
 struct buffer_inserter<ring_tag, RingInput, RingOutput>
 {
-    template
-    <
-        typename Collection,
-        typename DistanceStrategy,
-        typename SegmentStrategy,
-        typename JoinStrategy,
-        typename EndStrategy,
-        typename PointStrategy,
-        typename Strategies
-    >
-    static inline geometry::strategy::buffer::result_code apply(RingInput const& ring,
-            Collection& collection,
-            DistanceStrategy const& distance,
-            SegmentStrategy const& segment_strategy,
-            JoinStrategy const& join_strategy,
-            EndStrategy const& end_strategy,
-            PointStrategy const& point_strategy,
-            Strategies const& strategies)
+    template <typename Collection,
+              typename DistanceStrategy,
+              typename SegmentStrategy,
+              typename JoinStrategy,
+              typename EndStrategy,
+              typename PointStrategy,
+              typename Strategies>
+    static inline geometry::strategy::buffer::result_code
+    apply(RingInput const& ring,
+          Collection& collection,
+          DistanceStrategy const& distance,
+          SegmentStrategy const& segment_strategy,
+          JoinStrategy const& join_strategy,
+          EndStrategy const& end_strategy,
+          PointStrategy const& point_strategy,
+          Strategies const& strategies)
     {
         collection.start_new_ring(distance.negative());
         geometry::strategy::buffer::result_code const code
             = buffer_inserter_ring<RingInput, RingOutput>::apply(ring,
-                collection, distance,
-                segment_strategy, join_strategy, end_strategy, point_strategy,
-                strategies);
+                                                                 collection,
+                                                                 distance,
+                                                                 segment_strategy,
+                                                                 join_strategy,
+                                                                 end_strategy,
+                                                                 point_strategy,
+                                                                 strategies);
         collection.finish_ring(code, ring, false, false);
         return code;
     }
 };
 
-template
-<
-    typename Linestring,
-    typename Polygon
->
+template <typename Linestring, typename Polygon>
 struct buffer_inserter<linestring_tag, Linestring, Polygon>
 {
     using output_ring_type = ring_type_t<Polygon>;
     using output_point_type = point_type_t<output_ring_type>;
 
-    template
-    <
-        typename Collection,
-        typename Iterator,
-        typename DistanceStrategy,
-        typename SegmentStrategy,
-        typename JoinStrategy,
-        typename EndStrategy,
-        typename Strategies
-    >
-    static inline geometry::strategy::buffer::result_code iterate(Collection& collection,
-                Iterator begin, Iterator end,
-                geometry::strategy::buffer::buffer_side_selector side,
-                DistanceStrategy const& distance_strategy,
-                SegmentStrategy const& segment_strategy,
-                JoinStrategy const& join_strategy,
-                EndStrategy const& end_strategy,
-                Strategies const& strategies,
-                output_point_type& first_p1)
+    template <typename Collection,
+              typename Iterator,
+              typename DistanceStrategy,
+              typename SegmentStrategy,
+              typename JoinStrategy,
+              typename EndStrategy,
+              typename Strategies>
+    static inline geometry::strategy::buffer::result_code
+    iterate(Collection& collection,
+            Iterator begin,
+            Iterator end,
+            geometry::strategy::buffer::buffer_side_selector side,
+            DistanceStrategy const& distance_strategy,
+            SegmentStrategy const& segment_strategy,
+            JoinStrategy const& join_strategy,
+            EndStrategy const& end_strategy,
+            Strategies const& strategies,
+            output_point_type& first_p1)
     {
         output_point_type const& ultimate_point = *(end - 1);
         output_point_type const& penultimate_point = *(end - 2);
@@ -653,9 +653,11 @@ struct buffer_inserter<linestring_tag, Linestring, Polygon>
         {
             std::vector<output_point_type> generated_side;
             geometry::strategy::buffer::result_code code
-                = segment_strategy.apply(ultimate_point, penultimate_point,
-                    geometry::strategy::buffer::buffer_side_right,
-                    distance_strategy, generated_side);
+                = segment_strategy.apply(ultimate_point,
+                                         penultimate_point,
+                                         geometry::strategy::buffer::buffer_side_right,
+                                         distance_strategy,
+                                         generated_side);
             if (code != geometry::strategy::buffer::result_normal)
             {
                 // No output or numerical error
@@ -668,39 +670,51 @@ struct buffer_inserter<linestring_tag, Linestring, Polygon>
 
         geometry::strategy::buffer::result_code result
             = detail::buffer::buffer_range<output_ring_type>::iterate(collection,
-                begin, end, side,
-                distance_strategy, segment_strategy, join_strategy, end_strategy,
-                strategies,
-                true, first_p1, first_p2, last_p1, last_p2);
+                                                                      begin,
+                                                                      end,
+                                                                      side,
+                                                                      distance_strategy,
+                                                                      segment_strategy,
+                                                                      join_strategy,
+                                                                      end_strategy,
+                                                                      strategies,
+                                                                      true,
+                                                                      first_p1,
+                                                                      first_p2,
+                                                                      last_p1,
+                                                                      last_p2);
 
         if (result == geometry::strategy::buffer::result_normal)
         {
             std::vector<output_point_type> range_out;
-            end_strategy.apply(penultimate_point, last_p2, ultimate_point, reverse_p1,
-                               side, distance_strategy, range_out);
+            end_strategy.apply(penultimate_point,
+                               last_p2,
+                               ultimate_point,
+                               reverse_p1,
+                               side,
+                               distance_strategy,
+                               range_out);
             collection.add_endcap(end_strategy, range_out, ultimate_point);
         }
         return result;
     }
 
-    template
-    <
-        typename Collection,
-        typename DistanceStrategy,
-        typename SegmentStrategy,
-        typename JoinStrategy,
-        typename EndStrategy,
-        typename PointStrategy,
-        typename Strategies
-    >
-    static inline geometry::strategy::buffer::result_code apply(Linestring const& linestring,
-            Collection& collection,
-            DistanceStrategy const& distance,
-            SegmentStrategy const& segment_strategy,
-            JoinStrategy const& join_strategy,
-            EndStrategy const& end_strategy,
-            PointStrategy const& point_strategy,
-            Strategies const& strategies)
+    template <typename Collection,
+              typename DistanceStrategy,
+              typename SegmentStrategy,
+              typename JoinStrategy,
+              typename EndStrategy,
+              typename PointStrategy,
+              typename Strategies>
+    static inline geometry::strategy::buffer::result_code
+    apply(Linestring const& linestring,
+          Collection& collection,
+          DistanceStrategy const& distance,
+          SegmentStrategy const& segment_strategy,
+          JoinStrategy const& join_strategy,
+          EndStrategy const& end_strategy,
+          PointStrategy const& point_strategy,
+          Strategies const& strategies)
     {
         // Use helper geometry to support non-mutable input Linestrings
         model::linestring<output_point_type> simplified;
@@ -713,230 +727,224 @@ struct buffer_inserter<linestring_tag, Linestring, Polygon>
             collection.start_new_ring(false);
             output_point_type first_p1;
             code = iterate(collection,
-                    boost::begin(simplified), boost::end(simplified),
-                    geometry::strategy::buffer::buffer_side_left,
-                    distance, segment_strategy, join_strategy, end_strategy,
-                    strategies,
-                    first_p1);
+                           boost::begin(simplified),
+                           boost::end(simplified),
+                           geometry::strategy::buffer::buffer_side_left,
+                           distance,
+                           segment_strategy,
+                           join_strategy,
+                           end_strategy,
+                           strategies,
+                           first_p1);
 
             if (code == geometry::strategy::buffer::result_normal)
             {
                 code = iterate(collection,
-                        boost::rbegin(simplified), boost::rend(simplified),
-                        geometry::strategy::buffer::buffer_side_right,
-                        distance, segment_strategy, join_strategy, end_strategy,
-                        strategies,
-                        first_p1);
+                               boost::rbegin(simplified),
+                               boost::rend(simplified),
+                               geometry::strategy::buffer::buffer_side_right,
+                               distance,
+                               segment_strategy,
+                               join_strategy,
+                               end_strategy,
+                               strategies,
+                               first_p1);
             }
             collection.finish_ring(code);
         }
         if (code == geometry::strategy::buffer::result_no_output && n >= 1)
         {
             // Use point_strategy to buffer degenerated linestring
-            detail::buffer::buffer_point<output_point_type>
-                (
-                    geometry::range::front(simplified),
-                    collection, distance, point_strategy
-                );
+            detail::buffer::buffer_point<output_point_type>(
+                geometry::range::front(simplified), collection, distance, point_strategy);
         }
         return code;
     }
 };
 
-
-template
-<
-    typename PolygonInput,
-    typename PolygonOutput
->
+template <typename PolygonInput, typename PolygonOutput>
 struct buffer_inserter<polygon_tag, PolygonInput, PolygonOutput>
 {
-private:
+  private:
     using input_ring_type = ring_type_t<PolygonInput>;
     using output_ring_type = ring_type_t<PolygonOutput>;
 
     using policy = buffer_inserter_ring<input_ring_type, output_ring_type>;
 
-    template
-    <
-        typename Iterator,
-        typename Collection,
-        typename DistanceStrategy,
-        typename SegmentStrategy,
-        typename JoinStrategy,
-        typename EndStrategy,
-        typename PointStrategy,
-        typename Strategies
-    >
-    static inline
-    void iterate(Iterator begin, Iterator end,
-            Collection& collection,
-            DistanceStrategy const& distance,
-            SegmentStrategy const& segment_strategy,
-            JoinStrategy const& join_strategy,
-            EndStrategy const& end_strategy,
-            PointStrategy const& point_strategy,
-            Strategies const& strategies,
-            bool is_interior)
+    template <typename Iterator,
+              typename Collection,
+              typename DistanceStrategy,
+              typename SegmentStrategy,
+              typename JoinStrategy,
+              typename EndStrategy,
+              typename PointStrategy,
+              typename Strategies>
+    static inline void iterate(Iterator begin,
+                               Iterator end,
+                               Collection& collection,
+                               DistanceStrategy const& distance,
+                               SegmentStrategy const& segment_strategy,
+                               JoinStrategy const& join_strategy,
+                               EndStrategy const& end_strategy,
+                               PointStrategy const& point_strategy,
+                               Strategies const& strategies,
+                               bool is_interior)
     {
         for (Iterator it = begin; it != end; ++it)
         {
             // For exterior rings, it deflates if distance is negative.
             // For interior rings, it is vice versa
-            bool const deflate = is_interior
-                    ? ! distance.negative()
-                    : distance.negative();
+            bool const deflate = is_interior ? ! distance.negative() : distance.negative();
 
             collection.start_new_ring(deflate);
-            geometry::strategy::buffer::result_code const code
-                    = policy::apply(*it, collection, distance, segment_strategy,
-                    join_strategy, end_strategy, point_strategy,
-                    strategies);
+            geometry::strategy::buffer::result_code const code = policy::apply(*it,
+                                                                               collection,
+                                                                               distance,
+                                                                               segment_strategy,
+                                                                               join_strategy,
+                                                                               end_strategy,
+                                                                               point_strategy,
+                                                                               strategies);
 
             collection.finish_ring(code, *it, is_interior, false);
         }
     }
 
-    template
-    <
-        typename InteriorRings,
-        typename Collection,
-        typename DistanceStrategy,
-        typename SegmentStrategy,
-        typename JoinStrategy,
-        typename EndStrategy,
-        typename PointStrategy,
-        typename Strategies
-    >
-    static inline
-    void apply_interior_rings(InteriorRings const& interior_rings,
-            Collection& collection,
-            DistanceStrategy const& distance,
-            SegmentStrategy const& segment_strategy,
-            JoinStrategy const& join_strategy,
-            EndStrategy const& end_strategy,
-            PointStrategy const& point_strategy,
-            Strategies const& strategies)
+    template <typename InteriorRings,
+              typename Collection,
+              typename DistanceStrategy,
+              typename SegmentStrategy,
+              typename JoinStrategy,
+              typename EndStrategy,
+              typename PointStrategy,
+              typename Strategies>
+    static inline void apply_interior_rings(InteriorRings const& interior_rings,
+                                            Collection& collection,
+                                            DistanceStrategy const& distance,
+                                            SegmentStrategy const& segment_strategy,
+                                            JoinStrategy const& join_strategy,
+                                            EndStrategy const& end_strategy,
+                                            PointStrategy const& point_strategy,
+                                            Strategies const& strategies)
     {
-        iterate(boost::begin(interior_rings), boost::end(interior_rings),
-            collection, distance, segment_strategy,
-            join_strategy, end_strategy, point_strategy,
-            strategies, true);
+        iterate(boost::begin(interior_rings),
+                boost::end(interior_rings),
+                collection,
+                distance,
+                segment_strategy,
+                join_strategy,
+                end_strategy,
+                point_strategy,
+                strategies,
+                true);
     }
 
-public:
-    template
-    <
-        typename Collection,
-        typename DistanceStrategy,
-        typename SegmentStrategy,
-        typename JoinStrategy,
-        typename EndStrategy,
-        typename PointStrategy,
-        typename Strategies
-    >
+  public:
+    template <typename Collection,
+              typename DistanceStrategy,
+              typename SegmentStrategy,
+              typename JoinStrategy,
+              typename EndStrategy,
+              typename PointStrategy,
+              typename Strategies>
     static inline void apply(PolygonInput const& polygon,
-            Collection& collection,
-            DistanceStrategy const& distance,
-            SegmentStrategy const& segment_strategy,
-            JoinStrategy const& join_strategy,
-            EndStrategy const& end_strategy,
-            PointStrategy const& point_strategy,
-            Strategies const& strategies)
+                             Collection& collection,
+                             DistanceStrategy const& distance,
+                             SegmentStrategy const& segment_strategy,
+                             JoinStrategy const& join_strategy,
+                             EndStrategy const& end_strategy,
+                             PointStrategy const& point_strategy,
+                             Strategies const& strategies)
     {
         {
             collection.start_new_ring(distance.negative());
 
             geometry::strategy::buffer::result_code const code
-                = policy::apply(exterior_ring(polygon), collection,
-                    distance, segment_strategy,
-                    join_strategy, end_strategy, point_strategy,
-                    strategies);
+                = policy::apply(exterior_ring(polygon),
+                                collection,
+                                distance,
+                                segment_strategy,
+                                join_strategy,
+                                end_strategy,
+                                point_strategy,
+                                strategies);
 
-            collection.finish_ring(code, exterior_ring(polygon), false,
-                    geometry::num_interior_rings(polygon) > 0u);
+            collection.finish_ring(
+                code, exterior_ring(polygon), false, geometry::num_interior_rings(polygon) > 0u);
         }
 
         apply_interior_rings(interior_rings(polygon),
-                collection, distance, segment_strategy,
-                join_strategy, end_strategy, point_strategy,
-                strategies);
+                             collection,
+                             distance,
+                             segment_strategy,
+                             join_strategy,
+                             end_strategy,
+                             point_strategy,
+                             strategies);
     }
 };
 
-
-template
-<
-    typename Multi,
-    typename PolygonOutput
->
+template <typename Multi, typename PolygonOutput>
 struct buffer_inserter<multi_tag, Multi, PolygonOutput>
-    : public detail::buffer::buffer_multi
-             <
-                Multi,
-                PolygonOutput,
-                dispatch::buffer_inserter
-                <
-                    typename single_tag_of<tag_t<Multi>>::type,
-                    typename boost::range_value<Multi const>::type,
-                    geometry::ring_type_t<PolygonOutput>
-                >
-            >
-{};
-
+    : public detail::buffer::buffer_multi<
+          Multi,
+          PolygonOutput,
+          dispatch::buffer_inserter<typename single_tag_of<tag_t<Multi>>::type,
+                                    typename boost::range_value<Multi const>::type,
+                                    geometry::ring_type_t<PolygonOutput>>>
+{
+};
 
 } // namespace dispatch
 #endif // DOXYGEN_NO_DISPATCH
 
 #ifndef DOXYGEN_NO_DETAIL
-namespace detail { namespace buffer
+namespace detail
+{
+namespace buffer
 {
 
-template
-<
-    typename GeometryOutput,
-    typename GeometryInput,
-    typename OutputIterator,
-    typename DistanceStrategy,
-    typename SegmentStrategy,
-    typename JoinStrategy,
-    typename EndStrategy,
-    typename PointStrategy,
-    typename Strategies,
-    typename VisitPiecesPolicy
->
-inline void buffer_inserter(GeometryInput const& geometry_input, OutputIterator out,
-        DistanceStrategy const& distance_strategy,
-        SegmentStrategy const& segment_strategy,
-        JoinStrategy const& join_strategy,
-        EndStrategy const& end_strategy,
-        PointStrategy const& point_strategy,
-        Strategies const& strategies,
-        VisitPiecesPolicy& visit_pieces_policy
-    )
+template <typename GeometryOutput,
+          typename GeometryInput,
+          typename OutputIterator,
+          typename DistanceStrategy,
+          typename SegmentStrategy,
+          typename JoinStrategy,
+          typename EndStrategy,
+          typename PointStrategy,
+          typename Strategies,
+          typename VisitPiecesPolicy>
+inline void buffer_inserter(GeometryInput const& geometry_input,
+                            OutputIterator out,
+                            DistanceStrategy const& distance_strategy,
+                            SegmentStrategy const& segment_strategy,
+                            JoinStrategy const& join_strategy,
+                            EndStrategy const& end_strategy,
+                            PointStrategy const& point_strategy,
+                            Strategies const& strategies,
+                            VisitPiecesPolicy& visit_pieces_policy)
 {
     boost::ignore_unused(visit_pieces_policy);
 
-    using collection_type = detail::buffer::buffered_piece_collection
-        <
-            geometry::ring_type_t<GeometryOutput>,
-            Strategies,
-            DistanceStrategy
-        >;
+    using collection_type
+        = detail::buffer::buffered_piece_collection<geometry::ring_type_t<GeometryOutput>,
+                                                    Strategies,
+                                                    DistanceStrategy>;
     collection_type collection(strategies, distance_strategy);
     collection_type const& const_collection = collection;
 
     static constexpr bool areal = util::is_areal<GeometryInput>::value;
 
-    dispatch::buffer_inserter
-        <
-            tag_cast_t<tag_t<GeometryInput>, multi_tag>,
-            GeometryInput,
-            GeometryOutput
-        >::apply(geometry_input, collection,
-                 distance_strategy, segment_strategy, join_strategy,
-                 end_strategy, point_strategy,
-                 strategies);
+    dispatch::buffer_inserter<tag_cast_t<tag_t<GeometryInput>, multi_tag>,
+                              GeometryInput,
+                              GeometryOutput>::apply(geometry_input,
+                                                     collection,
+                                                     distance_strategy,
+                                                     segment_strategy,
+                                                     join_strategy,
+                                                     end_strategy,
+                                                     point_strategy,
+                                                     strategies);
 
     collection.get_turns();
     if BOOST_GEOMETRY_CONSTEXPR (areal)
@@ -997,36 +1005,40 @@ inline void buffer_inserter(GeometryInput const& geometry_input, OutputIterator 
     visit_pieces_policy.apply(const_collection, 2);
 }
 
-template
-<
-    typename GeometryOutput,
-    typename GeometryInput,
-    typename OutputIterator,
-    typename DistanceStrategy,
-    typename SegmentStrategy,
-    typename JoinStrategy,
-    typename EndStrategy,
-    typename PointStrategy,
-    typename Strategies
->
-inline void buffer_inserter(GeometryInput const& geometry_input, OutputIterator out,
-        DistanceStrategy const& distance_strategy,
-        SegmentStrategy const& segment_strategy,
-        JoinStrategy const& join_strategy,
-        EndStrategy const& end_strategy,
-        PointStrategy const& point_strategy,
-        Strategies const& strategies)
+template <typename GeometryOutput,
+          typename GeometryInput,
+          typename OutputIterator,
+          typename DistanceStrategy,
+          typename SegmentStrategy,
+          typename JoinStrategy,
+          typename EndStrategy,
+          typename PointStrategy,
+          typename Strategies>
+inline void buffer_inserter(GeometryInput const& geometry_input,
+                            OutputIterator out,
+                            DistanceStrategy const& distance_strategy,
+                            SegmentStrategy const& segment_strategy,
+                            JoinStrategy const& join_strategy,
+                            EndStrategy const& end_strategy,
+                            PointStrategy const& point_strategy,
+                            Strategies const& strategies)
 {
     detail::buffer::visit_pieces_default_policy visitor;
-    buffer_inserter<GeometryOutput>(geometry_input, out,
-        distance_strategy, segment_strategy, join_strategy,
-        end_strategy, point_strategy,
-        strategies, visitor);
+    buffer_inserter<GeometryOutput>(geometry_input,
+                                    out,
+                                    distance_strategy,
+                                    segment_strategy,
+                                    join_strategy,
+                                    end_strategy,
+                                    point_strategy,
+                                    strategies,
+                                    visitor);
 }
 #endif // DOXYGEN_NO_DETAIL
+}
+} // namespace detail::buffer
 
-}} // namespace detail::buffer
-
-}} // namespace boost::geometry
+} // namespace geometry
+} // namespace boost
 
 #endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_BUFFER_BUFFER_INSERTER_HPP

--- a/include/boost/geometry/algorithms/detail/buffer/buffer_policies.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/buffer_policies.hpp
@@ -21,66 +21,67 @@
 #include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/point_type.hpp>
 
-#include <boost/geometry/algorithms/disjoint.hpp>
-#include <boost/geometry/algorithms/expand.hpp>
 #include <boost/geometry/algorithms/detail/overlay/traversal_info.hpp>
 #include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>
+#include <boost/geometry/algorithms/disjoint.hpp>
+#include <boost/geometry/algorithms/expand.hpp>
 
 #include <boost/geometry/strategies/buffer.hpp>
 
-
-namespace boost { namespace geometry
+namespace boost
+{
+namespace geometry
 {
 
-
 #ifndef DOXYGEN_NO_DETAIL
-namespace detail { namespace buffer
+namespace detail
+{
+namespace buffer
 {
 
 struct buffer_overlay_visitor
 {
-public :
+  public:
     template <typename Turns>
-    void visit_turns(int , Turns const& ) {}
+    void visit_turns(int, Turns const&)
+    {
+    }
 
     template <typename Clusters, typename Turns>
-    void visit_clusters(Clusters const& , Turns const& ) {}
+    void visit_clusters(Clusters const&, Turns const&)
+    {
+    }
 
     template <typename Turns, typename Turn, typename Operation>
-    void visit_traverse(Turns const& /*turns*/, Turn const& /*turn*/, Operation const& /*op*/, const char* /*header*/)
+    void visit_traverse(Turns const& /*turns*/,
+                        Turn const& /*turn*/,
+                        Operation const& /*op*/,
+                        char const* /*header*/)
     {
     }
 
     template <typename Rings>
-    void visit_generated_rings(Rings const& )
-    {}
+    void visit_generated_rings(Rings const&)
+    {
+    }
 };
-
 
 // Should follow traversal-turn-concept (enrichment, visit structure)
 // and adds index in piece vector to find it back
 template <typename Point, typename SegmentRatio>
-struct buffer_turn_operation
-    : public detail::overlay::traversal_turn_operation<Point, SegmentRatio>
+struct buffer_turn_operation : public detail::overlay::traversal_turn_operation<Point, SegmentRatio>
 {
     signed_size_type piece_index;
     signed_size_type index_in_ring;
 
-    inline buffer_turn_operation()
-        : piece_index(-1)
-        , index_in_ring(-1)
-    {}
+    inline buffer_turn_operation() : piece_index(-1), index_in_ring(-1) {}
 };
 
 // Version of turn_info for buffer with its turn index and other helper variables
 template <typename Point, typename SegmentRatio>
 struct buffer_turn_info
-    : public detail::overlay::turn_info
-        <
-            Point,
-            SegmentRatio,
-            buffer_turn_operation<Point, SegmentRatio>
-        >
+    : public detail::overlay::
+          turn_info<Point, SegmentRatio, buffer_turn_operation<Point, SegmentRatio>>
 {
     using point_type = Point;
 
@@ -95,19 +96,15 @@ struct buffer_turn_info
     signed_size_type count_in_original; // increased by +1 for in ext.ring, -1 for int.ring
 
     inline buffer_turn_info()
-        : turn_index(0)
-        , is_linear_end_point(false)
-        , within_original(false)
-        , count_in_original(0)
-    {}
+        : turn_index(0), is_linear_end_point(false), within_original(false), count_in_original(0)
+    {
+    }
 };
 
 template <typename Strategy>
 struct piece_get_box
 {
-    explicit piece_get_box(Strategy const& strategy)
-        : m_strategy(strategy)
-    {}
+    explicit piece_get_box(Strategy const& strategy) : m_strategy(strategy) {}
 
     template <typename Box, typename Piece>
     inline void apply(Box& total, Piece const& piece) const
@@ -116,8 +113,7 @@ struct piece_get_box
 
         if (piece.m_piece_border.m_has_envelope)
         {
-            geometry::expand(total, piece.m_piece_border.m_envelope,
-                             m_strategy);
+            geometry::expand(total, piece.m_piece_border.m_envelope, m_strategy);
         }
     }
 
@@ -127,9 +123,7 @@ struct piece_get_box
 template <typename Strategy>
 struct piece_overlaps_box
 {
-    explicit piece_overlaps_box(Strategy const& strategy)
-        : m_strategy(strategy)
-    {}
+    explicit piece_overlaps_box(Strategy const& strategy) : m_strategy(strategy) {}
 
     template <typename Box, typename Piece>
     inline bool apply(Box const& box, Piece const& piece) const
@@ -150,8 +144,8 @@ struct piece_overlaps_box
             return false;
         }
 
-        return ! geometry::detail::disjoint::disjoint_box_box(box, piece.m_piece_border.m_envelope,
-                                                              m_strategy);
+        return ! geometry::detail::disjoint::disjoint_box_box(
+            box, piece.m_piece_border.m_envelope, m_strategy);
     }
 
     Strategy const& m_strategy;
@@ -160,9 +154,7 @@ struct piece_overlaps_box
 template <typename Strategy>
 struct turn_get_box
 {
-    explicit turn_get_box(Strategy const& strategy)
-        : m_strategy(strategy)
-    {}
+    explicit turn_get_box(Strategy const& strategy) : m_strategy(strategy) {}
 
     template <typename Box, typename Turn>
     inline void apply(Box& total, Turn const& turn) const
@@ -177,25 +169,23 @@ struct turn_get_box
 template <typename Strategy>
 struct turn_overlaps_box
 {
-    explicit turn_overlaps_box(Strategy const& strategy)
-        : m_strategy(strategy)
-    {}
+    explicit turn_overlaps_box(Strategy const& strategy) : m_strategy(strategy) {}
 
     template <typename Box, typename Turn>
     inline bool apply(Box const& box, Turn const& turn) const
     {
         assert_coordinate_type_equal(turn.point, box);
-        return ! geometry::detail::disjoint::disjoint_point_box(turn.point, box,
-                                                                m_strategy);
+        return ! geometry::detail::disjoint::disjoint_point_box(turn.point, box, m_strategy);
     }
 
     Strategy const& m_strategy;
 };
 
-}} // namespace detail::buffer
+} // namespace buffer
+} // namespace detail
 #endif // DOXYGEN_NO_DETAIL
 
-
-}} // namespace boost::geometry
+} // namespace geometry
+} // namespace boost
 
 #endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_BUFFER_BUFFER_POLICIES_HPP

--- a/include/boost/geometry/algorithms/detail/buffer/buffered_piece_collection.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/buffered_piece_collection.hpp
@@ -37,44 +37,45 @@
 
 #include <boost/geometry/geometries/ring.hpp>
 
-#include <boost/geometry/algorithms/detail/overlay/graph/assign_side_counts.hpp>
-#include <boost/geometry/algorithms/detail/buffer/buffered_ring.hpp>
 #include <boost/geometry/algorithms/detail/buffer/buffer_policies.hpp>
-#include <boost/geometry/algorithms/detail/overlay/cluster_info.hpp>
-#include <boost/geometry/algorithms/detail/overlay/get_properties_ahead.hpp>
-#include <boost/geometry/algorithms/detail/overlay/handle_colocations.hpp>
+#include <boost/geometry/algorithms/detail/buffer/buffered_ring.hpp>
 #include <boost/geometry/algorithms/detail/buffer/get_piece_turns.hpp>
 #include <boost/geometry/algorithms/detail/buffer/piece_border.hpp>
-#include <boost/geometry/algorithms/detail/buffer/turn_in_piece_visitor.hpp>
 #include <boost/geometry/algorithms/detail/buffer/turn_in_original_visitor.hpp>
+#include <boost/geometry/algorithms/detail/buffer/turn_in_piece_visitor.hpp>
+#include <boost/geometry/algorithms/detail/overlay/cluster_info.hpp>
+#include <boost/geometry/algorithms/detail/overlay/get_properties_ahead.hpp>
+#include <boost/geometry/algorithms/detail/overlay/graph/assign_side_counts.hpp>
+#include <boost/geometry/algorithms/detail/overlay/handle_colocations.hpp>
 
 #include <boost/geometry/algorithms/detail/disjoint/point_box.hpp>
 #include <boost/geometry/algorithms/detail/overlay/add_rings.hpp>
 #include <boost/geometry/algorithms/detail/overlay/assign_parents.hpp>
-#include <boost/geometry/algorithms/detail/overlay/enrichment_info.hpp>
 #include <boost/geometry/algorithms/detail/overlay/enrich_intersection_points.hpp>
+#include <boost/geometry/algorithms/detail/overlay/enrichment_info.hpp>
 #include <boost/geometry/algorithms/detail/overlay/ring_properties.hpp>
 #include <boost/geometry/algorithms/detail/overlay/select_rings.hpp>
 #include <boost/geometry/algorithms/detail/overlay/traversal_info.hpp>
 #include <boost/geometry/algorithms/detail/overlay/traverse.hpp>
 #include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>
 #include <boost/geometry/algorithms/detail/partition.hpp>
-#include <boost/geometry/algorithms/detail/sections/sectionalize.hpp>
 #include <boost/geometry/algorithms/detail/sections/section_box_policies.hpp>
+#include <boost/geometry/algorithms/detail/sections/sectionalize.hpp>
 
+#include <boost/geometry/util/range.hpp>
 #include <boost/geometry/views/detail/closed_clockwise_view.hpp>
 #include <boost/geometry/views/enumerate_view.hpp>
-#include <boost/geometry/util/range.hpp>
 
-
-namespace boost { namespace geometry
+namespace boost
 {
-
+namespace geometry
+{
 
 #ifndef DOXYGEN_NO_DETAIL
-namespace detail { namespace buffer
+namespace detail
 {
-
+namespace buffer
+{
 
 /*
  *  Terminology
@@ -119,12 +120,7 @@ namespace detail { namespace buffer
  *
  */
 
-template
-<
-    typename Ring,
-    typename Strategy,
-    typename DistanceStrategy
->
+template <typename Ring, typename Strategy, typename DistanceStrategy>
 struct buffered_piece_collection
 {
     using point_type = geometry::point_type_t<Ring>;
@@ -135,28 +131,22 @@ struct buffered_piece_collection
 
     using box_type = geometry::model::box<point_type>;
 
-    using buffer_turn_info_type = buffer_turn_info
-    <
-        point_type,
-        typename segment_ratio_type<point_type>::type
-    >;
+    using buffer_turn_info_type
+        = buffer_turn_info<point_type, typename segment_ratio_type<point_type>::type>;
 
-    using buffer_turn_operation_type = buffer_turn_operation
-    <
-        point_type,
-        typename segment_ratio_type<point_type>::type
-    >;
+    using buffer_turn_operation_type
+        = buffer_turn_operation<point_type, typename segment_ratio_type<point_type>::type>;
 
     using turn_vector_type = std::vector<buffer_turn_info_type>;
 
-    using piece_border_type = piece_border<Ring, point_type> ;
+    using piece_border_type = piece_border<Ring, point_type>;
 
     struct piece
     {
         strategy::buffer::piece_type type;
         signed_size_type index;
 
-        signed_size_type left_index; // points to previous piece of same ring
+        signed_size_type left_index;  // points to previous piece of same ring
         signed_size_type right_index; // points to next piece of same ring
 
         // The next two members (1, 2) form together a complete clockwise ring
@@ -191,15 +181,15 @@ struct buffered_piece_collection
         point_type m_center;
 
         piece()
-            : type(strategy::buffer::piece_type_unknown)
-            , index(-1)
-            , left_index(-1)
-            , right_index(-1)
-            , beyond_last_segment_index(-1)
-            , offsetted_count(-1)
-            , is_flat_start(false)
-            , is_flat_end(false)
-            , is_deflated(false)
+            : type(strategy::buffer::piece_type_unknown),
+              index(-1),
+              left_index(-1),
+              right_index(-1),
+              beyond_last_segment_index(-1),
+              offsetted_count(-1),
+              is_flat_start(false),
+              is_flat_end(false),
+              is_deflated(false)
         {
         }
     };
@@ -209,17 +199,13 @@ struct buffered_piece_collection
         using sections_type = geometry::sections<box_type, 1>;
 
         // Creates an empty instance
-        inline original_ring()
-            : m_is_interior(false)
-            , m_has_interiors(false)
-        {}
+        inline original_ring() : m_is_interior(false), m_has_interiors(false) {}
 
         inline original_ring(clockwise_ring_type const& ring,
-                             bool is_interior, bool has_interiors,
+                             bool is_interior,
+                             bool has_interiors,
                              Strategy const& strategy)
-            : m_ring(ring)
-            , m_is_interior(is_interior)
-            , m_has_interiors(has_interiors)
+            : m_ring(ring), m_is_interior(is_interior), m_has_interiors(has_interiors)
         {
             geometry::envelope(m_ring, m_box, strategy);
 
@@ -228,10 +214,7 @@ struct buffered_piece_collection
             // in the optimization for within checks using winding strategy
             // and this strategy is scanning in x direction.
             using dimensions = std::integer_sequence<std::size_t, 0>;
-            geometry::sectionalize
-                <
-                    false, dimensions
-                >(m_ring, m_sections, strategy);
+            geometry::sectionalize<false, dimensions>(m_ring, m_sections, strategy);
         }
 
         clockwise_ring_type m_ring;
@@ -265,25 +248,21 @@ struct buffered_piece_collection
     sections_type monotonic_sections;
 
     // Define the clusters, mapping cluster_id -> turns
-    using cluster_type = std::map
-        <
-            signed_size_type,
-            detail::overlay::cluster_info
-        >;
+    using cluster_type = std::map<signed_size_type, detail::overlay::cluster_info>;
 
     cluster_type m_clusters;
 
     Strategy m_strategy;
     DistanceStrategy m_distance_strategy;
 
-    buffered_piece_collection(Strategy const& strategy,
-                              DistanceStrategy const& distance_strategy)
-        : m_first_piece_index(-1)
-        , m_deflate(false)
-        , m_has_deflated(false)
-        , m_strategy(strategy)
-        , m_distance_strategy(distance_strategy)
-    {}
+    buffered_piece_collection(Strategy const& strategy, DistanceStrategy const& distance_strategy)
+        : m_first_piece_index(-1),
+          m_deflate(false),
+          m_has_deflated(false),
+          m_strategy(strategy),
+          m_distance_strategy(distance_strategy)
+    {
+    }
 
     inline void check_linear_endpoints(buffer_turn_info_type& turn) const
     {
@@ -317,7 +296,8 @@ struct buffered_piece_collection
             }
             for (auto& op : turn.operations)
             {
-                if (op.enriched.get_next_turn_index() == static_cast<signed_size_type>(turn.turn_index)
+                if (op.enriched.get_next_turn_index()
+                        == static_cast<signed_size_type>(turn.turn_index)
                     && m_pieces[op.seg_id.piece_index].is_deflated)
                 {
                     // Keep traversable, but don't start here
@@ -330,22 +310,16 @@ struct buffered_piece_collection
     // Check if a turn is inside any of the originals
     inline void check_turn_in_original()
     {
-        turn_in_original_visitor
-            <
-                turn_vector_type,
-                Strategy
-            > visitor(m_turns, m_strategy);
+        turn_in_original_visitor<turn_vector_type, Strategy> visitor(m_turns, m_strategy);
 
-        geometry::partition
-            <
-                box_type,
-                include_turn_policy,
-                detail::partition::include_all_policy
-            >::apply(m_turns, original_rings, visitor,
-                     turn_get_box<Strategy>(m_strategy),
-                     turn_in_original_overlaps_box<Strategy>(m_strategy),
-                     original_get_box<Strategy>(m_strategy),
-                     original_overlaps_box<Strategy>(m_strategy));
+        geometry::partition<box_type, include_turn_policy, detail::partition::include_all_policy>::
+            apply(m_turns,
+                  original_rings,
+                  visitor,
+                  turn_get_box<Strategy>(m_strategy),
+                  turn_in_original_overlaps_box<Strategy>(m_strategy),
+                  original_get_box<Strategy>(m_strategy),
+                  original_overlaps_box<Strategy>(m_strategy));
 
         bool const deflate = m_distance_strategy.negative();
 
@@ -402,13 +376,13 @@ struct buffered_piece_collection
             {
                 if (pc.type != strategy::buffer::buffered_concave)
                 {
-                    border.set_offsetted(ring, pc.first_seg_id.segment_index,
-                                       pc.beyond_last_segment_index);
+                    border.set_offsetted(
+                        ring, pc.first_seg_id.segment_index, pc.beyond_last_segment_index);
                 }
 
                 // Calculate envelopes for piece borders
-                border.get_properties_of_border(pc.type == geometry::strategy::buffer::buffered_point,
-                                                pc.m_center, m_strategy);
+                border.get_properties_of_border(
+                    pc.type == geometry::strategy::buffer::buffered_point, pc.m_center, m_strategy);
                 if (! pc.is_flat_end && ! pc.is_flat_start)
                 {
                     border.get_properties_of_offsetted_ring_part(m_strategy);
@@ -423,23 +397,19 @@ struct buffered_piece_collection
 
         {
             // Calculate the turns
-            piece_turn_visitor
-                <
-                    piece_vector_type,
-                    buffered_ring_collection<buffered_ring<Ring> >,
-                    turn_vector_type,
-                    Strategy
-                > visitor(m_pieces, offsetted_rings, m_turns,
-                          m_strategy);
+            piece_turn_visitor<piece_vector_type,
+                               buffered_ring_collection<buffered_ring<Ring>>,
+                               turn_vector_type,
+                               Strategy>
+                visitor(m_pieces, offsetted_rings, m_turns, m_strategy);
 
             detail::sectionalize::enlarge_sections(monotonic_sections, m_strategy);
 
-            geometry::partition
-                <
-                    box_type
-                >::apply(monotonic_sections, visitor,
-                         detail::section::get_section_box<Strategy>(m_strategy),
-                         detail::section::overlaps_section_box<Strategy>(m_strategy));
+            geometry::partition<box_type>::apply(
+                monotonic_sections,
+                visitor,
+                detail::section::get_section_box<Strategy>(m_strategy),
+                detail::section::overlaps_section_box<Strategy>(m_strategy));
         }
 
         // This fixes the fact that sometimes wrong ix or xi turns are generated.
@@ -448,14 +418,18 @@ struct buffered_piece_collection
         // as long as they are removed before calculating turn indices.
         // It will also enhance performance a bit (no need to calculate point in original,
         // point in piece). Therefore we remove ii and xx as well.
-        m_turns.erase(std::remove_if(m_turns.begin(), m_turns.end(),
-            [](auto const& turn)
-            {
-                bool const is_ix = turn.combination(overlay::operation_intersection, overlay::operation_blocked);
-                bool const is_ii = turn.both(overlay::operation_intersection);
-                return is_ix || is_ii || turn.blocked();
-            }),
-            m_turns.end());
+        m_turns.erase(std::remove_if(m_turns.begin(),
+                                     m_turns.end(),
+                                     [](auto const& turn)
+                                     {
+                                         bool const is_ix
+                                             = turn.combination(overlay::operation_intersection,
+                                                                overlay::operation_blocked);
+                                         bool const is_ii
+                                             = turn.both(overlay::operation_intersection);
+                                         return is_ix || is_ii || turn.blocked();
+                                     }),
+                      m_turns.end());
 
         update_turn_administration();
     }
@@ -463,20 +437,20 @@ struct buffered_piece_collection
     inline void check_turn_in_pieces()
     {
         // Check if turns are inside pieces
-        turn_in_piece_visitor
-            <
-                geometry::cs_tag_t<point_type>,
-                turn_vector_type, piece_vector_type, DistanceStrategy, Strategy
-            > visitor(m_turns, m_pieces, m_distance_strategy, m_strategy);
+        turn_in_piece_visitor<geometry::cs_tag_t<point_type>,
+                              turn_vector_type,
+                              piece_vector_type,
+                              DistanceStrategy,
+                              Strategy>
+            visitor(m_turns, m_pieces, m_distance_strategy, m_strategy);
 
-        geometry::partition
-            <
-                box_type
-            >::apply(m_turns, m_pieces, visitor,
-                        turn_get_box<Strategy>(m_strategy),
-                        turn_overlaps_box<Strategy>(m_strategy),
-                        piece_get_box<Strategy>(m_strategy),
-                        piece_overlaps_box<Strategy>(m_strategy));
+        geometry::partition<box_type>::apply(m_turns,
+                                             m_pieces,
+                                             visitor,
+                                             turn_get_box<Strategy>(m_strategy),
+                                             turn_overlaps_box<Strategy>(m_strategy),
+                                             piece_get_box<Strategy>(m_strategy),
+                                             piece_overlaps_box<Strategy>(m_strategy));
     }
 
     inline void start_new_ring(bool deflate)
@@ -504,8 +478,7 @@ struct buffered_piece_collection
     {
         // Remove all created pieces for this ring, sections, last offsetted
         while (! m_pieces.empty()
-               && m_pieces.back().first_seg_id.multi_index
-               == current_segment_id.multi_index)
+               && m_pieces.back().first_seg_id.multi_index == current_segment_id.multi_index)
         {
             m_pieces.pop_back();
         }
@@ -516,8 +489,7 @@ struct buffered_piece_collection
         m_first_piece_index = -1;
     }
 
-    inline void update_last_point(point_type const& p,
-            buffered_ring<Ring>& ring)
+    inline void update_last_point(point_type const& p, buffered_ring<Ring>& ring)
     {
         // For the first point of a new piece, and there were already
         // points in the offsetted ring, for some piece types the first point
@@ -530,8 +502,7 @@ struct buffered_piece_collection
 
         BOOST_GEOMETRY_ASSERT(boost::size(m_pieces) > 0);
         if (! ring.empty()
-            && current_segment_id.segment_index
-                == m_pieces.back().first_seg_id.segment_index)
+            && current_segment_id.segment_index == m_pieces.back().first_seg_id.segment_index)
         {
             ring.back() = p;
         }
@@ -557,17 +528,15 @@ struct buffered_piece_collection
         }
 
         // Casted version
-        std::size_t const first_piece_index
-                = static_cast<std::size_t>(m_first_piece_index);
+        std::size_t const first_piece_index = static_cast<std::size_t>(m_first_piece_index);
         signed_size_type const last_piece_index
-                = static_cast<signed_size_type>(boost::size(m_pieces)) - 1;
+            = static_cast<signed_size_type>(boost::size(m_pieces)) - 1;
 
         if (first_piece_index < boost::size(m_pieces))
         {
             // If pieces were added,
             // reassign left-of-first and right-of-last
-            geometry::range::at(m_pieces, first_piece_index).left_index
-                    = last_piece_index;
+            geometry::range::at(m_pieces, first_piece_index).left_index = last_piece_index;
             geometry::range::back(m_pieces).right_index = m_first_piece_index;
         }
 
@@ -591,7 +560,8 @@ struct buffered_piece_collection
     template <typename InputRing>
     inline void finish_ring(strategy::buffer::result_code code,
                             InputRing const& input_ring,
-                            bool is_interior, bool has_interiors)
+                            bool is_interior,
+                            bool has_interiors)
     {
         if (! finish_ring(code))
         {
@@ -614,9 +584,7 @@ struct buffered_piece_collection
             }
 
             original_rings.back()
-                = original_ring(clockwise_ring,
-                    is_interior, has_interiors,
-                    m_strategy);
+                = original_ring(clockwise_ring, is_interior, has_interiors, m_strategy);
         }
     }
 
@@ -641,7 +609,7 @@ struct buffered_piece_collection
     //-------------------------------------------------------------------------
 
     inline piece& create_piece(strategy::buffer::piece_type type,
-            bool decrease_segment_index_by_one)
+                               bool decrease_segment_index_by_one)
     {
         if (type == strategy::buffer::buffered_concave)
         {
@@ -700,10 +668,9 @@ struct buffered_piece_collection
 
     inline void sectionalize(piece const& pc, buffered_ring<Ring> const& ring)
     {
-        using sectionalizer = geometry::detail::sectionalize::sectionalize_part
-        <
+        using sectionalizer = geometry::detail::sectionalize::sectionalize_part<
             std::integer_sequence<std::size_t, 0, 1> // x,y dimension
-        >;
+            >;
 
         // Create a ring-identifier. The source-index is the piece index
         // The multi_index is as in this collection (the ring), but not used here
@@ -711,21 +678,19 @@ struct buffered_piece_collection
         ring_identifier const ring_id(pc.index, pc.first_seg_id.multi_index, -1);
 
         sectionalizer::apply(monotonic_sections,
-            boost::begin(ring) + pc.first_seg_id.segment_index,
-            boost::begin(ring) + pc.beyond_last_segment_index,
-            m_strategy,
-            ring_id, 10);
+                             boost::begin(ring) + pc.first_seg_id.segment_index,
+                             boost::begin(ring) + pc.beyond_last_segment_index,
+                             m_strategy,
+                             ring_id,
+                             10);
     }
 
-    inline void finish_piece(piece& pc)
-    {
-        init_rescale_piece(pc);
-    }
+    inline void finish_piece(piece& pc) { init_rescale_piece(pc); }
 
     inline void finish_piece(piece& pc,
-                    point_type const& point1,
-                    point_type const& point2,
-                    point_type const& point3)
+                             point_type const& point1,
+                             point_type const& point2,
+                             point_type const& point3)
     {
         init_rescale_piece(pc);
         if (pc.offsetted_count == 0)
@@ -739,10 +704,10 @@ struct buffered_piece_collection
     }
 
     inline void finish_piece(piece& pc,
-                    point_type const& point1,
-                    point_type const& point2,
-                    point_type const& point3,
-                    point_type const& point4)
+                             point_type const& point1,
+                             point_type const& point2,
+                             point_type const& point3,
+                             point_type const& point4)
     {
         init_rescale_piece(pc);
 
@@ -776,8 +741,10 @@ struct buffered_piece_collection
         }
     }
 
-    inline void add_piece(strategy::buffer::piece_type type, point_type const& p,
-            point_type const& b1, point_type const& b2)
+    inline void add_piece(strategy::buffer::piece_type type,
+                          point_type const& p,
+                          point_type const& b1,
+                          point_type const& b2)
     {
         piece& pc = create_piece(type, false);
         add_point(b1);
@@ -786,8 +753,9 @@ struct buffered_piece_collection
     }
 
     template <typename Range>
-    inline void add_piece(strategy::buffer::piece_type type, Range const& range,
-            bool decrease_segment_index_by_one)
+    inline void add_piece(strategy::buffer::piece_type type,
+                          Range const& range,
+                          bool decrease_segment_index_by_one)
     {
         piece& pc = create_piece(type, decrease_segment_index_by_one);
 
@@ -799,8 +767,8 @@ struct buffered_piece_collection
     }
 
     template <typename Range>
-    inline void add_piece(strategy::buffer::piece_type type,
-            point_type const& p, Range const& range)
+    inline void
+    add_piece(strategy::buffer::piece_type type, point_type const& p, Range const& range)
     {
         piece& pc = create_piece(type, true);
 
@@ -817,14 +785,15 @@ struct buffered_piece_collection
 
     template <typename Range>
     inline void add_side_piece(point_type const& original_point1,
-            point_type const& original_point2,
-            Range const& range, bool is_first, bool is_empty)
+                               point_type const& original_point2,
+                               Range const& range,
+                               bool is_first,
+                               bool is_empty)
     {
         BOOST_GEOMETRY_ASSERT(boost::size(range) >= 2u);
 
-        auto const piece_type = is_empty
-            ? strategy::buffer::buffered_empty_side
-            : strategy::buffer::buffered_segment;
+        auto const piece_type
+            = is_empty ? strategy::buffer::buffered_empty_side : strategy::buffer::buffered_segment;
 
         piece& pc = create_piece(piece_type, ! is_first);
         add_range_to_piece(pc, range, is_first);
@@ -835,8 +804,8 @@ struct buffered_piece_collection
     }
 
     template <typename EndcapStrategy, typename Range>
-    inline void add_endcap(EndcapStrategy const& strategy, Range const& range,
-            point_type const& end_point)
+    inline void
+    add_endcap(EndcapStrategy const& strategy, Range const& range, point_type const& end_point)
     {
         boost::ignore_unused(strategy);
 
@@ -885,20 +854,14 @@ struct buffered_piece_collection
 
     //-------------------------------------------------------------------------
 
-    inline void handle_colocations()
-    {
-        detail::overlay::handle_colocations(m_turns, m_clusters);
-    }
+    inline void handle_colocations() { detail::overlay::handle_colocations(m_turns, m_clusters); }
 
     template <typename Visitor>
     inline void assign_side_counts(Visitor& visitor)
     {
         // Assign count_left, count_right and open_count
-        detail::overlay::assign_side_counts
-            <false, false, overlay_buffer>
-                (offsetted_rings, offsetted_rings,
-                    m_turns, m_clusters,
-                    m_strategy, visitor);
+        detail::overlay::assign_side_counts<false, false, overlay_buffer>(
+            offsetted_rings, offsetted_rings, m_turns, m_clusters, m_strategy, visitor);
 
         // Mark closed clusters as not traversable
         for (auto const& cluster : m_clusters)
@@ -945,8 +908,8 @@ struct buffered_piece_collection
         detail::overlay::enrich_turns<false, false, overlay_buffer>(
             m_turns, offsetted_rings, offsetted_rings, m_strategy);
 
-        detail::overlay::get_properties_ahead<false, false>(m_turns, m_clusters, offsetted_rings,
-            offsetted_rings, m_strategy);
+        detail::overlay::get_properties_ahead<false, false>(
+            m_turns, m_clusters, offsetted_rings, offsetted_rings, m_strategy);
     }
 
     // Discards all rings which do have not-OK intersection points only.
@@ -957,13 +920,17 @@ struct buffered_piece_collection
         {
             if (turn.is_traversable)
             {
-                offsetted_rings[turn.operations[0].seg_id.multi_index].has_accepted_intersections = true;
-                offsetted_rings[turn.operations[1].seg_id.multi_index].has_accepted_intersections = true;
+                offsetted_rings[turn.operations[0].seg_id.multi_index].has_accepted_intersections
+                    = true;
+                offsetted_rings[turn.operations[1].seg_id.multi_index].has_accepted_intersections
+                    = true;
             }
             else
             {
-                offsetted_rings[turn.operations[0].seg_id.multi_index].has_discarded_intersections = true;
-                offsetted_rings[turn.operations[1].seg_id.multi_index].has_discarded_intersections = true;
+                offsetted_rings[turn.operations[0].seg_id.multi_index].has_discarded_intersections
+                    = true;
+                offsetted_rings[turn.operations[1].seg_id.multi_index].has_discarded_intersections
+                    = true;
             }
         }
     }
@@ -982,7 +949,7 @@ struct buffered_piece_collection
             {
                 continue;
             }
-            if (detail::disjoint::disjoint_point_box(point, original.m_box,m_strategy))
+            if (detail::disjoint::disjoint_point_box(point, original.m_box, m_strategy))
             {
                 continue;
             }
@@ -1021,8 +988,7 @@ struct buffered_piece_collection
     {
         for (auto& ring : offsetted_rings)
         {
-            if (! ring.has_intersections()
-                && boost::size(ring) > 0u
+            if (! ring.has_intersections() && boost::size(ring) > 0u
                 && geometry::area(ring, m_strategy) < 0)
             {
                 if (! point_coveredby_original(geometry::range::front(ring)))
@@ -1048,22 +1014,23 @@ struct buffered_piece_collection
     template <typename PieceVisitor>
     inline void traverse(PieceVisitor const& piece_visitor)
     {
-        using traverser = detail::overlay::traverse
-            <
-                false, false,
-                buffered_ring_collection<buffered_ring<Ring> >,
-                buffered_ring_collection<buffered_ring<Ring > >,
-                overlay_buffer
-            >;
+        using traverser = detail::overlay::traverse<false,
+                                                    false,
+                                                    buffered_ring_collection<buffered_ring<Ring>>,
+                                                    buffered_ring_collection<buffered_ring<Ring>>,
+                                                    overlay_buffer>;
         std::map<ring_identifier, overlay::ring_turn_info> turn_info_per_ring;
 
         traversed_rings.clear();
         buffer_overlay_visitor visitor;
-        traverser::apply(offsetted_rings, offsetted_rings,
-                        m_strategy,
-                        m_turns, traversed_rings,
-                        turn_info_per_ring,
-                        m_clusters, visitor);
+        traverser::apply(offsetted_rings,
+                         offsetted_rings,
+                         m_strategy,
+                         m_turns,
+                         traversed_rings,
+                         turn_info_per_ring,
+                         m_clusters,
+                         visitor);
     }
 
     inline void reverse()
@@ -1084,14 +1051,9 @@ struct buffered_piece_collection
     template <typename GeometryOutput, typename OutputIterator>
     inline OutputIterator assign(OutputIterator out) const
     {
-        using area_result_type = typename geometry::area_result
-            <
-                buffered_ring<Ring>, Strategy
-            >::type;
-        using properties = detail::overlay::ring_properties
-            <
-                point_type, area_result_type
-            >;
+        using area_result_type =
+            typename geometry::area_result<buffered_ring<Ring>, Strategy>::type;
+        using properties = detail::overlay::ring_properties<point_type, area_result_type>;
 
         std::map<ring_identifier, properties> selected;
 
@@ -1102,8 +1064,7 @@ struct buffered_piece_collection
         for (auto const& enumerated : util::enumerate(offsetted_rings))
         {
             auto const& ring = enumerated.value;
-            if (! ring.has_intersections()
-                && ! ring.is_untouched_outside_original)
+            if (! ring.has_intersections() && ! ring.is_untouched_outside_original)
             {
                 properties const p = properties(ring, m_strategy);
                 if (p.valid)
@@ -1126,19 +1087,18 @@ struct buffered_piece_collection
             }
         }
 
-        detail::overlay::assign_parents<overlay_buffer>(offsetted_rings, traversed_rings,
-                selected, m_strategy);
-        return detail::overlay::add_rings<GeometryOutput>(selected, offsetted_rings, traversed_rings, out,
-                                                          m_strategy);
+        detail::overlay::assign_parents<overlay_buffer>(
+            offsetted_rings, traversed_rings, selected, m_strategy);
+        return detail::overlay::add_rings<GeometryOutput>(
+            selected, offsetted_rings, traversed_rings, out, m_strategy);
     }
-
 };
 
-
-}} // namespace detail::buffer
+} // namespace buffer
+} // namespace detail
 #endif // DOXYGEN_NO_DETAIL
 
-
-}} // namespace boost::geometry
+} // namespace geometry
+} // namespace boost
 
 #endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_BUFFER_BUFFERED_PIECE_COLLECTION_HPP

--- a/include/boost/geometry/algorithms/detail/buffer/buffered_ring.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/buffered_ring.hpp
@@ -13,15 +13,14 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_BUFFER_BUFFERED_RING
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_BUFFER_BUFFERED_RING
 
-
 #include <cstddef>
 
 #include <boost/range/size.hpp>
 #include <boost/range/value_type.hpp>
 
 #include <boost/geometry/core/assert.hpp>
-#include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/closure.hpp>
+#include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/core/point_order.hpp>
 #include <boost/geometry/core/point_type.hpp>
 
@@ -29,24 +28,27 @@
 
 #include <boost/geometry/algorithms/within.hpp>
 
-#include <boost/geometry/algorithms/detail/overlay/copy_segments.hpp>
 #include <boost/geometry/algorithms/detail/overlay/copy_segment_point.hpp>
+#include <boost/geometry/algorithms/detail/overlay/copy_segments.hpp>
 #include <boost/geometry/algorithms/detail/overlay/enrichment_info.hpp>
 #include <boost/geometry/algorithms/detail/overlay/get_ring.hpp>
 #include <boost/geometry/algorithms/detail/overlay/traversal_info.hpp>
 #include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>
 
-
-namespace boost { namespace geometry
+namespace boost
+{
+namespace geometry
 {
 
 #ifndef DOXYGEN_NO_DETAIL
-namespace detail { namespace buffer
+namespace detail
+{
+namespace buffer
 {
 
 struct buffered_ring_collection_tag : polygonal_tag, multi_tag
-{};
-
+{
+};
 
 template <typename Ring>
 struct buffered_ring : public Ring
@@ -57,11 +59,12 @@ struct buffered_ring : public Ring
     bool is_untouched_outside_original;
 
     inline buffered_ring()
-        : has_concave(false)
-        , has_accepted_intersections(false)
-        , has_discarded_intersections(false)
-        , is_untouched_outside_original(false)
-    {}
+        : has_concave(false),
+          has_accepted_intersections(false),
+          has_discarded_intersections(false),
+          is_untouched_outside_original(false)
+    {
+    }
 
     inline bool discarded() const
     {
@@ -79,8 +82,8 @@ struct buffered_ring_collection : public std::vector<Ring>
 {
 };
 
-}} // namespace detail::buffer
-
+} // namespace buffer
+} // namespace detail
 
 // Turn off concept checking (for now)
 namespace concepts
@@ -89,90 +92,72 @@ namespace concepts
 template <typename Geometry>
 struct concept_type<Geometry, geometry::detail::buffer::buffered_ring_collection_tag>
 {
-    struct dummy {};
+    struct dummy
+    {
+    };
     using type = dummy;
 };
 
-}
-
+} // namespace concepts
 
 #endif // DOXYGEN_NO_DETAIL
-
-
 
 // Register the types
 namespace traits
 {
 
-
 template <typename Ring>
-struct tag<geometry::detail::buffer::buffered_ring<Ring> >
+struct tag<geometry::detail::buffer::buffered_ring<Ring>>
 {
     using type = ring_tag;
 };
 
-
 template <typename Ring>
-struct point_order<geometry::detail::buffer::buffered_ring<Ring> >
+struct point_order<geometry::detail::buffer::buffered_ring<Ring>>
 {
     static const order_selector value = geometry::point_order<Ring>::value;
 };
 
-
 template <typename Ring>
-struct closure<geometry::detail::buffer::buffered_ring<Ring> >
+struct closure<geometry::detail::buffer::buffered_ring<Ring>>
 {
     static const closure_selector value = geometry::closure<Ring>::value;
 };
 
-
 template <typename Ring>
-struct point_type<geometry::detail::buffer::buffered_ring_collection<Ring> >
+struct point_type<geometry::detail::buffer::buffered_ring_collection<Ring>>
 {
     using type = geometry::point_type_t<Ring>;
 };
 
 template <typename Ring>
-struct tag<geometry::detail::buffer::buffered_ring_collection<Ring> >
+struct tag<geometry::detail::buffer::buffered_ring_collection<Ring>>
 {
     using type = geometry::detail::buffer::buffered_ring_collection_tag;
 };
 
-
 } // namespace traits
-
-
-
 
 namespace core_dispatch
 {
 
 template <typename Ring>
-struct ring_type
-<
-    detail::buffer::buffered_ring_collection_tag,
-    detail::buffer::buffered_ring_collection<Ring>
->
+struct ring_type<detail::buffer::buffered_ring_collection_tag,
+                 detail::buffer::buffered_ring_collection<Ring>>
 {
     using type = Ring;
 };
 
-
 // There is a specific tag, so this specialization cannot be placed in traits
 template <typename Ring>
 struct point_order<detail::buffer::buffered_ring_collection_tag,
-        geometry::detail::buffer::buffered_ring_collection
-        <
-            geometry::detail::buffer::buffered_ring<Ring>
-        > >
+                   geometry::detail::buffer::buffered_ring_collection<
+                       geometry::detail::buffer::buffered_ring<Ring>>>
 {
-    static const order_selector value
-        = core_dispatch::point_order<ring_tag, Ring>::value;
+    static const order_selector value = core_dispatch::point_order<ring_tag, Ring>::value;
 };
 
-
-}
-
+} // namespace core_dispatch
 
 template <>
 struct single_tag_of<detail::buffer::buffered_ring_collection_tag>
@@ -180,111 +165,79 @@ struct single_tag_of<detail::buffer::buffered_ring_collection_tag>
     using type = ring_tag;
 };
 
-
 namespace dispatch
 {
 
-template
-<
-    typename MultiRing,
-    bool Reverse,
-    typename SegmentIdentifier,
-    typename PointOut
->
-struct copy_segment_point
-    <
-        detail::buffer::buffered_ring_collection_tag,
-        MultiRing,
-        Reverse,
-        SegmentIdentifier,
-        PointOut
-    >
-    : detail::copy_segments::copy_segment_point_multi
-        <
-            MultiRing,
-            SegmentIdentifier,
-            PointOut,
-            detail::copy_segments::copy_segment_point_range
-                <
-                    typename boost::range_value<MultiRing>::type,
-                    Reverse,
-                    SegmentIdentifier,
-                    PointOut
-                >
-        >
-{};
+template <typename MultiRing, bool Reverse, typename SegmentIdentifier, typename PointOut>
+struct copy_segment_point<detail::buffer::buffered_ring_collection_tag,
+                          MultiRing,
+                          Reverse,
+                          SegmentIdentifier,
+                          PointOut>
+    : detail::copy_segments::copy_segment_point_multi<
+          MultiRing,
+          SegmentIdentifier,
+          PointOut,
+          detail::copy_segments::copy_segment_point_range<
+              typename boost::range_value<MultiRing>::type,
+              Reverse,
+              SegmentIdentifier,
+              PointOut>>
+{
+};
 
-
-template<bool Reverse>
-struct copy_segments
-    <
-        detail::buffer::buffered_ring_collection_tag,
-        Reverse
-    >
-    : detail::copy_segments::copy_segments_multi
-        <
-            detail::copy_segments::copy_segments_ring<Reverse>
-        >
-{};
+template <bool Reverse>
+struct copy_segments<detail::buffer::buffered_ring_collection_tag, Reverse>
+    : detail::copy_segments::copy_segments_multi<detail::copy_segments::copy_segments_ring<Reverse>>
+{
+};
 
 template <typename Point, typename MultiGeometry>
-struct within
-<
-    Point,
-    MultiGeometry,
-    point_tag,
-    detail::buffer::buffered_ring_collection_tag
->
+struct within<Point, MultiGeometry, point_tag, detail::buffer::buffered_ring_collection_tag>
 {
     template <typename Strategy>
-    static inline bool apply(Point const& point,
-                MultiGeometry const& multi, Strategy const& strategy)
+    static inline bool
+    apply(Point const& point, MultiGeometry const& multi, Strategy const& strategy)
     {
         return detail::within::point_in_geometry(point, multi, strategy) == 1;
     }
 };
 
-
 template <typename Geometry>
 struct is_empty<Geometry, detail::buffer::buffered_ring_collection_tag>
     : detail::is_empty::multi_is_empty<detail::is_empty::range_is_empty>
-{};
-
+{
+};
 
 template <typename Geometry>
 struct envelope<Geometry, detail::buffer::buffered_ring_collection_tag>
-    : detail::envelope::envelope_multi_range
-        <
-            detail::envelope::envelope_range
-        >
-{};
-
+    : detail::envelope::envelope_multi_range<detail::envelope::envelope_range>
+{
+};
 
 } // namespace dispatch
 
-namespace detail { namespace overlay
+namespace detail
+{
+namespace overlay
 {
 
-template<>
+template <>
 struct get_ring<detail::buffer::buffered_ring_collection_tag>
 {
-    template<typename MultiGeometry>
-    static inline ring_type_t<MultiGeometry> const& apply(
-                ring_identifier const& id,
-                MultiGeometry const& multi_ring)
+    template <typename MultiGeometry>
+    static inline ring_type_t<MultiGeometry> const& apply(ring_identifier const& id,
+                                                          MultiGeometry const& multi_ring)
     {
-        BOOST_GEOMETRY_ASSERT
-            (
-                id.multi_index >= 0
-                && id.multi_index < int(boost::size(multi_ring))
-            );
+        BOOST_GEOMETRY_ASSERT(id.multi_index >= 0 && id.multi_index < int(boost::size(multi_ring)));
         return get_ring<ring_tag>::apply(id, multi_ring[id.multi_index]);
     }
 };
 
-}}
+} // namespace overlay
+} // namespace detail
 
-
-}} // namespace boost::geometry
+} // namespace geometry
+} // namespace boost
 
 #endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_BUFFER_BUFFERED_RING

--- a/include/boost/geometry/algorithms/detail/buffer/get_piece_turns.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/get_piece_turns.hpp
@@ -20,21 +20,23 @@
 #include <boost/range/end.hpp>
 #include <boost/range/value_type.hpp>
 
-#include <boost/geometry/core/assert.hpp>
-#include <boost/geometry/algorithms/equals.hpp>
-#include <boost/geometry/algorithms/detail/disjoint/box_box.hpp>
-#include <boost/geometry/algorithms/detail/overlay/segment_identifier.hpp>
-#include <boost/geometry/algorithms/detail/overlay/get_turn_info.hpp>
-#include <boost/geometry/algorithms/detail/sections/section_functions.hpp>
 #include <boost/geometry/algorithms/detail/buffer/buffer_policies.hpp>
+#include <boost/geometry/algorithms/detail/disjoint/box_box.hpp>
+#include <boost/geometry/algorithms/detail/overlay/get_turn_info.hpp>
+#include <boost/geometry/algorithms/detail/overlay/segment_identifier.hpp>
+#include <boost/geometry/algorithms/detail/sections/section_functions.hpp>
+#include <boost/geometry/algorithms/equals.hpp>
+#include <boost/geometry/core/assert.hpp>
 
-
-namespace boost { namespace geometry
+namespace boost
+{
+namespace geometry
 {
 
-
 #ifndef DOXYGEN_NO_DETAIL
-namespace detail { namespace buffer
+namespace detail
+{
+namespace buffer
 {
 
 // Implements a unique_sub_range for a buffered piece,
@@ -47,12 +49,14 @@ struct unique_sub_range_from_piece
     using point_type = geometry::point_type_t<Ring const>;
 
     unique_sub_range_from_piece(Ring const& ring,
-                                iterator_type iterator_at_i, iterator_type iterator_at_j)
-        : m_ring(ring)
-        , m_iterator_at_i(iterator_at_i)
-        , m_iterator_at_j(iterator_at_j)
-        , m_point_retrieved(false)
-    {}
+                                iterator_type iterator_at_i,
+                                iterator_type iterator_at_j)
+        : m_ring(ring),
+          m_iterator_at_i(iterator_at_i),
+          m_iterator_at_j(iterator_at_j),
+          m_point_retrieved(false)
+    {
+    }
 
     static inline bool is_first_segment() { return false; }
     static inline bool is_last_segment() { return false; }
@@ -64,15 +68,14 @@ struct unique_sub_range_from_piece
         BOOST_GEOMETRY_ASSERT(index < size());
         switch (index)
         {
-            case 0 : return *m_iterator_at_i;
-            case 1 : return *m_iterator_at_j;
-            case 2 : return get_point_k();
-            default : return *m_iterator_at_i;
+            case 0: return *m_iterator_at_i;
+            case 1: return *m_iterator_at_j;
+            case 2: return get_point_k();
+            default: return *m_iterator_at_i;
         }
     }
 
-private :
-
+  private:
     inline point_type const& get_point_k() const
     {
         if (! m_point_retrieved)
@@ -113,13 +116,7 @@ private :
     mutable bool m_point_retrieved;
 };
 
-template
-<
-    typename Pieces,
-    typename Rings,
-    typename Turns,
-    typename Strategy
->
+template <typename Pieces, typename Rings, typename Turns, typename Strategy>
 class piece_turn_visitor
 {
     Pieces const& m_pieces;
@@ -135,8 +132,7 @@ class piece_turn_visitor
             return false;
         }
 
-        return piece1.index == piece2.left_index
-            || piece1.index == piece2.right_index;
+        return piece1.index == piece2.left_index || piece1.index == piece2.right_index;
     }
 
     template <typename Piece>
@@ -151,31 +147,32 @@ class piece_turn_visitor
     }
 
     template <std::size_t Dimension, typename Iterator, typename Box>
-    inline void move_begin_iterator(Iterator& it_begin, Iterator it_beyond,
-                                    signed_size_type& index, int dir,
+    inline void move_begin_iterator(Iterator& it_begin,
+                                    Iterator it_beyond,
+                                    signed_size_type& index,
+                                    int dir,
                                     Box const& this_bounding_box,
                                     Box const& other_bounding_box)
     {
-        for(; it_begin != it_beyond
-                && it_begin + 1 != it_beyond
-                && detail::section::preceding<Dimension>(dir, *(it_begin + 1),
-                                                         this_bounding_box,
-                                                         other_bounding_box);
-            ++it_begin, index++)
-        {}
+        for (; it_begin != it_beyond && it_begin + 1 != it_beyond
+               && detail::section::preceding<Dimension>(
+                   dir, *(it_begin + 1), this_bounding_box, other_bounding_box);
+             ++it_begin, index++)
+        {
+        }
     }
 
     template <std::size_t Dimension, typename Iterator, typename Box>
-    inline void move_end_iterator(Iterator it_begin, Iterator& it_beyond,
-                                  int dir, Box const& this_bounding_box,
+    inline void move_end_iterator(Iterator it_begin,
+                                  Iterator& it_beyond,
+                                  int dir,
+                                  Box const& this_bounding_box,
                                   Box const& other_bounding_box)
     {
-        while (it_beyond != it_begin
-            && it_beyond - 1 != it_begin
-            && it_beyond - 2 != it_begin)
+        while (it_beyond != it_begin && it_beyond - 1 != it_begin && it_beyond - 2 != it_begin)
         {
-            if (detail::section::exceeding<Dimension>(dir, *(it_beyond - 2),
-                        this_bounding_box, other_bounding_box))
+            if (detail::section::exceeding<Dimension>(
+                    dir, *(it_beyond - 2), this_bounding_box, other_bounding_box))
             {
                 --it_beyond;
             }
@@ -187,8 +184,10 @@ class piece_turn_visitor
     }
 
     template <typename Piece, typename Section>
-    inline void calculate_turns(Piece const& piece1, Piece const& piece2,
-        Section const& section1, Section const& section2)
+    inline void calculate_turns(Piece const& piece1,
+                                Piece const& piece2,
+                                Section const& section1,
+                                Section const& section2)
     {
         using ring_type = typename boost::range_value<Rings const>::type;
         using turn_type = typename boost::range_value<Turns const>::type;
@@ -219,24 +218,52 @@ class piece_turn_visitor
 
         // Set begin/end of monotonic ranges, in both x/y directions
         signed_size_type index1 = sec1_first_index;
-        move_begin_iterator<0>(it1_first, it1_beyond, index1,
-                    section1.directions[0], section1.bounding_box, section2.bounding_box);
-        move_end_iterator<0>(it1_first, it1_beyond,
-                    section1.directions[0], section1.bounding_box, section2.bounding_box);
-        move_begin_iterator<1>(it1_first, it1_beyond, index1,
-                    section1.directions[1], section1.bounding_box, section2.bounding_box);
-        move_end_iterator<1>(it1_first, it1_beyond,
-                    section1.directions[1], section1.bounding_box, section2.bounding_box);
+        move_begin_iterator<0>(it1_first,
+                               it1_beyond,
+                               index1,
+                               section1.directions[0],
+                               section1.bounding_box,
+                               section2.bounding_box);
+        move_end_iterator<0>(it1_first,
+                             it1_beyond,
+                             section1.directions[0],
+                             section1.bounding_box,
+                             section2.bounding_box);
+        move_begin_iterator<1>(it1_first,
+                               it1_beyond,
+                               index1,
+                               section1.directions[1],
+                               section1.bounding_box,
+                               section2.bounding_box);
+        move_end_iterator<1>(it1_first,
+                             it1_beyond,
+                             section1.directions[1],
+                             section1.bounding_box,
+                             section2.bounding_box);
 
         signed_size_type index2 = sec2_first_index;
-        move_begin_iterator<0>(it2_first, it2_beyond, index2,
-                    section2.directions[0], section2.bounding_box, section1.bounding_box);
-        move_end_iterator<0>(it2_first, it2_beyond,
-                    section2.directions[0], section2.bounding_box, section1.bounding_box);
-        move_begin_iterator<1>(it2_first, it2_beyond, index2,
-                    section2.directions[1], section2.bounding_box, section1.bounding_box);
-        move_end_iterator<1>(it2_first, it2_beyond,
-                    section2.directions[1], section2.bounding_box, section1.bounding_box);
+        move_begin_iterator<0>(it2_first,
+                               it2_beyond,
+                               index2,
+                               section2.directions[0],
+                               section2.bounding_box,
+                               section1.bounding_box);
+        move_end_iterator<0>(it2_first,
+                             it2_beyond,
+                             section2.directions[0],
+                             section2.bounding_box,
+                             section1.bounding_box);
+        move_begin_iterator<1>(it2_first,
+                               it2_beyond,
+                               index2,
+                               section2.directions[1],
+                               section2.bounding_box,
+                               section1.bounding_box);
+        move_end_iterator<1>(it2_first,
+                             it2_beyond,
+                             section2.directions[1],
+                             section2.bounding_box,
+                             section1.bounding_box);
 
         turn_type the_model;
         the_model.operations[0].piece_index = piece1.index;
@@ -244,9 +271,8 @@ class piece_turn_visitor
         the_model.operations[0].seg_id.segment_index = index1; // override
 
         auto it1 = it1_first;
-        for (auto prev1 = it1++;
-                it1 != it1_beyond;
-                prev1 = it1++, the_model.operations[0].seg_id.segment_index++)
+        for (auto prev1 = it1++; it1 != it1_beyond;
+             prev1 = it1++, the_model.operations[0].seg_id.segment_index++)
         {
             the_model.operations[1].piece_index = piece2.index;
             the_model.operations[1].seg_id = piece2.first_seg_id;
@@ -255,18 +281,16 @@ class piece_turn_visitor
             unique_sub_range_from_piece<ring_type> unique_sub_range1(ring1, prev1, it1);
 
             auto it2 = it2_first;
-            for (auto prev2 = it2++;
-                    it2 != it2_beyond;
-                    prev2 = it2++, the_model.operations[1].seg_id.segment_index++)
+            for (auto prev2 = it2++; it2 != it2_beyond;
+                 prev2 = it2++, the_model.operations[1].seg_id.segment_index++)
             {
                 unique_sub_range_from_piece<ring_type> unique_sub_range2(ring2, prev2, it2);
 
-                using turn_policy = detail::overlay::get_turn_info
-                    <
-                        detail::overlay::assign_policy_only_start_turns
-                    >;
+                using turn_policy = detail::overlay::get_turn_info<
+                    detail::overlay::assign_policy_only_start_turns>;
 
-                turn_policy::apply(unique_sub_range1, unique_sub_range2,
+                turn_policy::apply(unique_sub_range1,
+                                   unique_sub_range2,
                                    the_model,
                                    m_strategy,
                                    std::back_inserter(m_turns));
@@ -274,33 +298,27 @@ class piece_turn_visitor
         }
     }
 
-public:
-
+  public:
     piece_turn_visitor(Pieces const& pieces,
-            Rings const& ring_collection,
-            Turns& turns,
-            Strategy const& strategy)
-        : m_pieces(pieces)
-        , m_rings(ring_collection)
-        , m_turns(turns)
-        , m_strategy(strategy)
-    {}
+                       Rings const& ring_collection,
+                       Turns& turns,
+                       Strategy const& strategy)
+        : m_pieces(pieces), m_rings(ring_collection), m_turns(turns), m_strategy(strategy)
+    {
+    }
 
     template <typename Section>
-    inline bool apply(Section const& section1, Section const& section2,
-                    bool first = true)
+    inline bool apply(Section const& section1, Section const& section2, bool first = true)
     {
         boost::ignore_unused(first);
 
         auto const& piece1 = m_pieces[section1.ring_id.source_index];
         auto const& piece2 = m_pieces[section2.ring_id.source_index];
 
-        if ( piece1.index == piece2.index
-          || is_adjacent(piece1, piece2)
-          || is_on_same_convex_ring(piece1, piece2)
-          || detail::disjoint::disjoint_box_box(section1.bounding_box,
-                                                section2.bounding_box,
-                                                m_strategy) )
+        if (piece1.index == piece2.index || is_adjacent(piece1, piece2)
+            || is_on_same_convex_ring(piece1, piece2)
+            || detail::disjoint::disjoint_box_box(
+                section1.bounding_box, section2.bounding_box, m_strategy))
         {
             return true;
         }
@@ -311,11 +329,11 @@ public:
     }
 };
 
-
-}} // namespace detail::buffer
+} // namespace buffer
+} // namespace detail
 #endif // DOXYGEN_NO_DETAIL
 
-
-}} // namespace boost::geometry
+} // namespace geometry
+} // namespace boost
 
 #endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_BUFFER_GET_PIECE_TURNS_HPP

--- a/include/boost/geometry/algorithms/detail/buffer/implementation.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/implementation.hpp
@@ -36,7 +36,9 @@
 #include <boost/geometry/util/math.hpp>
 #include <boost/geometry/util/range.hpp>
 
-namespace boost { namespace geometry
+namespace boost
+{
+namespace geometry
 {
 
 #ifndef DOXYGEN_NO_DISPATCH
@@ -47,26 +49,22 @@ template <typename BoxIn, typename BoxOut>
 struct buffer_dc<BoxIn, BoxOut, box_tag, box_tag>
 {
     template <typename Distance>
-    static inline void apply(BoxIn const& box_in, BoxOut& box_out,
-                             Distance const& distance, Distance const& )
+    static inline void
+    apply(BoxIn const& box_in, BoxOut& box_out, Distance const& distance, Distance const&)
     {
         detail::buffer::buffer_box(box_in, distance, box_out);
     }
 };
 
-
 template <typename Input, typename Output, typename TagIn>
 struct buffer_all<Input, Output, TagIn, multi_polygon_tag>
 {
-    template
-    <
-        typename DistanceStrategy,
-        typename SideStrategy,
-        typename JoinStrategy,
-        typename EndStrategy,
-        typename PointStrategy,
-        typename Strategies
-    >
+    template <typename DistanceStrategy,
+              typename SideStrategy,
+              typename JoinStrategy,
+              typename EndStrategy,
+              typename PointStrategy,
+              typename Strategies>
     static inline void apply(Input const& geometry_in,
                              Output& geometry_out,
                              DistanceStrategy const& distance_strategy,
@@ -89,29 +87,25 @@ struct buffer_all<Input, Output, TagIn, multi_polygon_tag>
         geometry::buffer(box, box, distance_strategy.max_distance(join_strategy, end_strategy));
 
         detail::buffer::buffer_inserter<polygon_type>(geometry_in,
-                    range::back_inserter(geometry_out),
-                    distance_strategy,
-                    side_strategy,
-                    join_strategy,
-                    end_strategy,
-                    point_strategy,
-                    strategies);
+                                                      range::back_inserter(geometry_out),
+                                                      distance_strategy,
+                                                      side_strategy,
+                                                      join_strategy,
+                                                      end_strategy,
+                                                      point_strategy,
+                                                      strategies);
     }
 };
-
 
 template <typename Input, typename Output>
 struct buffer_all<Input, Output, geometry_collection_tag, multi_polygon_tag>
 {
-    template
-    <
-        typename DistanceStrategy,
-        typename SideStrategy,
-        typename JoinStrategy,
-        typename EndStrategy,
-        typename PointStrategy,
-        typename Strategies
-    >
+    template <typename DistanceStrategy,
+              typename SideStrategy,
+              typename JoinStrategy,
+              typename EndStrategy,
+              typename PointStrategy,
+              typename Strategies>
     static inline void apply(Input const& geometry_in,
                              Output& geometry_out,
                              DistanceStrategy const& distance_strategy,
@@ -128,39 +122,41 @@ struct buffer_all<Input, Output, geometry_collection_tag, multi_polygon_tag>
         // NOTE: This algorithm merges partial results iteratively.
         //   We could first gather all of the results and after that
         //   use some more optimal method like merge_elements().
-        detail::visit_breadth_first([&](auto const& g)
-        {
-            Output buffer_result;
-            buffer_all
-                <
-                    util::remove_cref_t<decltype(g)>, Output
-                >::apply(g, buffer_result, distance_strategy, side_strategy,
-                         join_strategy, end_strategy, point_strategy, strategies);
-
-            if (! geometry::is_empty(buffer_result))
+        detail::visit_breadth_first(
+            [&](auto const& g)
             {
-                Output union_result;
-                geometry::union_(geometry_out, buffer_result, union_result, strategies);
-                geometry_out = std::move(union_result);
-            }
+                Output buffer_result;
+                buffer_all<util::remove_cref_t<decltype(g)>, Output>::apply(g,
+                                                                            buffer_result,
+                                                                            distance_strategy,
+                                                                            side_strategy,
+                                                                            join_strategy,
+                                                                            end_strategy,
+                                                                            point_strategy,
+                                                                            strategies);
 
-            return true;
-        }, geometry_in);
+                if (! geometry::is_empty(buffer_result))
+                {
+                    Output union_result;
+                    geometry::union_(geometry_out, buffer_result, union_result, strategies);
+                    geometry_out = std::move(union_result);
+                }
+
+                return true;
+            },
+            geometry_in);
     }
 };
 
 template <typename Input, typename Output>
 struct buffer_all<Input, Output, geometry_collection_tag, geometry_collection_tag>
 {
-    template
-    <
-        typename DistanceStrategy,
-        typename SideStrategy,
-        typename JoinStrategy,
-        typename EndStrategy,
-        typename PointStrategy,
-        typename Strategies
-    >
+    template <typename DistanceStrategy,
+              typename SideStrategy,
+              typename JoinStrategy,
+              typename EndStrategy,
+              typename PointStrategy,
+              typename Strategies>
     static inline void apply(Input const& geometry_in,
                              Output& geometry_out,
                              DistanceStrategy const& distance_strategy,
@@ -173,17 +169,17 @@ struct buffer_all<Input, Output, geometry_collection_tag, geometry_collection_ta
         // NOTE: We could also allow returning GC containing only polygons.
         //   We'd have to wrap them in model::multi_polygon and then
         //   iteratively emplace_back() into the GC.
-        using mpo_t = typename util::sequence_find_if
-            <
-                typename traits::geometry_types<Output>::type,
-                util::is_multi_polygon
-            >::type;
+        using mpo_t = typename util::sequence_find_if<typename traits::geometry_types<Output>::type,
+                                                      util::is_multi_polygon>::type;
         mpo_t result;
-        buffer_all
-            <
-                Input, mpo_t
-            >::apply(geometry_in, result, distance_strategy, side_strategy,
-                     join_strategy, end_strategy, point_strategy, strategies);
+        buffer_all<Input, mpo_t>::apply(geometry_in,
+                                        result,
+                                        distance_strategy,
+                                        side_strategy,
+                                        join_strategy,
+                                        end_strategy,
+                                        point_strategy,
+                                        strategies);
         range::emplace_back(geometry_out, std::move(result));
     }
 };
@@ -191,13 +187,13 @@ struct buffer_all<Input, Output, geometry_collection_tag, geometry_collection_ta
 template <typename Input, typename Output, typename TagIn>
 struct buffer_all<Input, Output, TagIn, geometry_collection_tag>
     : buffer_all<Input, Output, geometry_collection_tag, geometry_collection_tag>
-{};
-
+{
+};
 
 } // namespace dispatch
 #endif // DOXYGEN_NO_DISPATCH
 
-}} // namespace boost::geometry
-
+} // namespace geometry
+} // namespace boost
 
 #endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_BUFFER_IMPLEMENTATION_HPP

--- a/include/boost/geometry/algorithms/detail/buffer/interface.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/interface.hpp
@@ -20,52 +20,45 @@
 
 #include <boost/geometry/algorithms/clear.hpp>
 #include <boost/geometry/algorithms/not_implemented.hpp>
-#include <boost/geometry/core/visit.hpp>
 #include <boost/geometry/core/tag.hpp>
+#include <boost/geometry/core/visit.hpp>
 #include <boost/geometry/geometries/adapted/boost_variant.hpp>
 #include <boost/geometry/geometries/concepts/check.hpp>
 #include <boost/geometry/strategies/buffer/services.hpp>
 #include <boost/geometry/util/type_traits_std.hpp>
 
-namespace boost { namespace geometry
+namespace boost
+{
+namespace geometry
 {
 
 #ifndef DOXYGEN_NO_DISPATCH
 namespace dispatch
 {
 
-template
-<
-    typename Input,
-    typename Output,
-    typename TagIn = tag_t<Input>,
-    typename TagOut = tag_t<Output>
->
+template <typename Input,
+          typename Output,
+          typename TagIn = tag_t<Input>,
+          typename TagOut = tag_t<Output>>
 struct buffer_dc : not_implemented<TagIn, TagOut>
-{};
+{
+};
 
-template
-<
-    typename Input,
-    typename Output,
-    typename TagIn = tag_t<Input>,
-    typename TagOut = tag_t<Output>
->
+template <typename Input,
+          typename Output,
+          typename TagIn = tag_t<Input>,
+          typename TagOut = tag_t<Output>>
 struct buffer_all : not_implemented<TagIn, TagOut>
-{};
+{
+};
 
 } // namespace dispatch
 #endif // DOXYGEN_NO_DISPATCH
 
-
 namespace resolve_dynamic
 {
 
-template
-<
-    typename Input,
-    typename TagIn = geometry::tag_t<Input>
->
+template <typename Input, typename TagIn = geometry::tag_t<Input>>
 struct buffer_dc
 {
     template <typename Output, typename Distance>
@@ -74,7 +67,8 @@ struct buffer_dc
                              Distance const& distance,
                              Distance const& chord_length)
     {
-        dispatch::buffer_dc<Input, Output>::apply(geometry_in, geometry_out, distance, chord_length);
+        dispatch::buffer_dc<Input, Output>::apply(
+            geometry_in, geometry_out, distance, chord_length);
     }
 };
 
@@ -87,33 +81,25 @@ struct buffer_dc<Input, dynamic_geometry_tag>
                              Distance const& distance,
                              Distance const& chord_length)
     {
-        traits::visit<Input>::apply([&](auto const& g)
-        {
-            dispatch::buffer_dc
-                <
-                    util::remove_cref_t<decltype(g)>, Output
-                >::apply(g, geometry_out, distance, chord_length);
-        }, geometry_in);
+        traits::visit<Input>::apply(
+            [&](auto const& g)
+            {
+                dispatch::buffer_dc<util::remove_cref_t<decltype(g)>, Output>::apply(
+                    g, geometry_out, distance, chord_length);
+            },
+            geometry_in);
     }
 };
 
-
-template
-<
-    typename Input,
-    typename TagIn = geometry::tag_t<Input>
->
+template <typename Input, typename TagIn = geometry::tag_t<Input>>
 struct buffer_all
 {
-    template
-    <
-        typename Output,
-        typename DistanceStrategy,
-        typename SideStrategy,
-        typename JoinStrategy,
-        typename EndStrategy,
-        typename PointStrategy
-    >
+    template <typename Output,
+              typename DistanceStrategy,
+              typename SideStrategy,
+              typename JoinStrategy,
+              typename EndStrategy,
+              typename PointStrategy>
     static inline void apply(Input const& geometry_in,
                              Output& geometry_out,
                              DistanceStrategy const& distance_strategy,
@@ -122,31 +108,28 @@ struct buffer_all
                              EndStrategy const& end_strategy,
                              PointStrategy const& point_strategy)
     {
-        typename strategies::buffer::services::default_strategy
-            <
-                Input
-            >::type strategies;
+        typename strategies::buffer::services::default_strategy<Input>::type strategies;
 
-        dispatch::buffer_all
-            <
-                Input, Output
-            >::apply(geometry_in, geometry_out, distance_strategy, side_strategy,
-                     join_strategy, end_strategy, point_strategy, strategies);
+        dispatch::buffer_all<Input, Output>::apply(geometry_in,
+                                                   geometry_out,
+                                                   distance_strategy,
+                                                   side_strategy,
+                                                   join_strategy,
+                                                   end_strategy,
+                                                   point_strategy,
+                                                   strategies);
     }
 };
 
 template <typename Input>
 struct buffer_all<Input, dynamic_geometry_tag>
 {
-    template
-    <
-        typename Output,
-        typename DistanceStrategy,
-        typename SideStrategy,
-        typename JoinStrategy,
-        typename EndStrategy,
-        typename PointStrategy
-    >
+    template <typename Output,
+              typename DistanceStrategy,
+              typename SideStrategy,
+              typename JoinStrategy,
+              typename EndStrategy,
+              typename PointStrategy>
     static inline void apply(Input const& geometry_in,
                              Output& geometry_out,
                              DistanceStrategy const& distance_strategy,
@@ -155,19 +138,22 @@ struct buffer_all<Input, dynamic_geometry_tag>
                              EndStrategy const& end_strategy,
                              PointStrategy const& point_strategy)
     {
-        traits::visit<Input>::apply([&](auto const& g)
-        {
-            buffer_all
-                <
-                    util::remove_cref_t<decltype(g)>
-                >::apply(g, geometry_out, distance_strategy, side_strategy,
-                         join_strategy, end_strategy, point_strategy);
-        }, geometry_in);
+        traits::visit<Input>::apply(
+            [&](auto const& g)
+            {
+                buffer_all<util::remove_cref_t<decltype(g)>>::apply(g,
+                                                                    geometry_out,
+                                                                    distance_strategy,
+                                                                    side_strategy,
+                                                                    join_strategy,
+                                                                    end_strategy,
+                                                                    point_strategy);
+            },
+            geometry_in);
     }
 };
 
 } // namespace resolve_dynamic
-
 
 /*!
 \brief \brief_calc{buffer}
@@ -179,13 +165,16 @@ struct buffer_all<Input, dynamic_geometry_tag>
 \param geometry_in \param_geometry
 \param geometry_out \param_geometry
 \param distance The distance to be used for the buffer
-\param chord_length (optional) The length of the chord's in the generated arcs around points or bends
+\param chord_length (optional) The length of the chord's in the generated arcs around points or
+bends
 
 \qbk{[include reference/algorithms/buffer.qbk]}
  */
 template <typename Input, typename Output, typename Distance>
-inline void buffer(Input const& geometry_in, Output& geometry_out,
-                   Distance const& distance, Distance const& chord_length = -1)
+inline void buffer(Input const& geometry_in,
+                   Output& geometry_out,
+                   Distance const& distance,
+                   Distance const& chord_length = -1)
 {
     concepts::check<Input const>();
     concepts::check<Output>();
@@ -207,8 +196,8 @@ inline void buffer(Input const& geometry_in, Output& geometry_out,
 \return \return_calc{buffer}
  */
 template <typename Output, typename Input, typename Distance>
-inline Output return_buffer(Input const& geometry, Distance const& distance,
-                            Distance const& chord_length = -1)
+inline Output
+return_buffer(Input const& geometry, Distance const& distance, Distance const& chord_length = -1)
 {
     concepts::check<Input const>();
     concepts::check<Output>();
@@ -243,16 +232,13 @@ inline Output return_buffer(Input const& geometry, Distance const& distance,
 \qbk{distinguish,with strategies}
 \qbk{[include reference/algorithms/buffer_with_strategies.qbk]}
  */
-template
-<
-    typename GeometryIn,
-    typename GeometryOut,
-    typename DistanceStrategy,
-    typename SideStrategy,
-    typename JoinStrategy,
-    typename EndStrategy,
-    typename PointStrategy
->
+template <typename GeometryIn,
+          typename GeometryOut,
+          typename DistanceStrategy,
+          typename SideStrategy,
+          typename JoinStrategy,
+          typename EndStrategy,
+          typename PointStrategy>
 inline void buffer(GeometryIn const& geometry_in,
                    GeometryOut& geometry_out,
                    DistanceStrategy const& distance_strategy,
@@ -266,14 +252,16 @@ inline void buffer(GeometryIn const& geometry_in,
 
     geometry::clear(geometry_out);
 
-    resolve_dynamic::buffer_all
-        <
-            GeometryIn, GeometryOut
-        >::apply(geometry_in, geometry_out, distance_strategy, side_strategy,
-                 join_strategy, end_strategy, point_strategy);
+    resolve_dynamic::buffer_all<GeometryIn, GeometryOut>::apply(geometry_in,
+                                                                geometry_out,
+                                                                distance_strategy,
+                                                                side_strategy,
+                                                                join_strategy,
+                                                                end_strategy,
+                                                                point_strategy);
 }
 
-
-}} // namespace boost::geometry
+} // namespace geometry
+} // namespace boost
 
 #endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_BUFFER_INTERFACE_HPP

--- a/include/boost/geometry/algorithms/detail/buffer/line_line_intersection.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/line_line_intersection.hpp
@@ -13,12 +13,15 @@
 #include <boost/geometry/arithmetic/infinite_line_functions.hpp>
 #include <boost/geometry/util/math.hpp>
 
-namespace boost { namespace geometry
+namespace boost
+{
+namespace geometry
 {
 
-
 #ifndef DOXYGEN_NO_DETAIL
-namespace detail { namespace buffer
+namespace detail
+{
+namespace buffer
 {
 
 struct line_line_intersection
@@ -33,9 +36,13 @@ struct line_line_intersection
     }
 
     template <typename Point>
-    static bool
-    apply(Point const& pi, Point const& pj, Point const& qi, Point const& qj,
-          Point const& vertex, bool equidistant, Point& ip)
+    static bool apply(Point const& pi,
+                      Point const& pj,
+                      Point const& qi,
+                      Point const& qj,
+                      Point const& vertex,
+                      bool equidistant,
+                      Point& ip)
     {
         // Calculates ip (below) by either intersecting p (pi, pj)
         // with q (qi, qj) or by taking a point between pj and qi (b) and
@@ -70,8 +77,8 @@ struct line_line_intersection
         auto const q = detail::make::make_infinite_line<ct>(qi, qj);
 
         using line = decltype(p);
-        using arithmetic::determinant;
         using arithmetic::assign_intersection_point;
+        using arithmetic::determinant;
 
         // The denominator is the determinant of (a,b) values of lines p q
         // | pa pa |
@@ -85,16 +92,15 @@ struct line_line_intersection
             auto const r = detail::make::make_infinite_line<ct>(vertex, between);
             auto const denominator_pr = determinant<line, &line::a, &line::b>(p, r);
 
-            if (math::equals(denominator_pq, zero)
-                && math::equals(denominator_pr, zero))
+            if (math::equals(denominator_pq, zero) && math::equals(denominator_pr, zero))
             {
                 // Degenerate case (for example when length results in <inf>)
                 return false;
             }
 
             ip = geometry::math::abs(denominator_pq) > geometry::math::abs(denominator_pr)
-                 ? assign_intersection_point<Point>(p, q, denominator_pq)
-                 : assign_intersection_point<Point>(p, r, denominator_pr);
+                     ? assign_intersection_point<Point>(p, q, denominator_pq)
+                     : assign_intersection_point<Point>(p, r, denominator_pr);
         }
         else
         {
@@ -109,12 +115,11 @@ struct line_line_intersection
     }
 };
 
-
-}} // namespace detail::buffer
+} // namespace buffer
+} // namespace detail
 #endif // DOXYGEN_NO_DETAIL
 
-
-}} // namespace boost::geometry
-
+} // namespace geometry
+} // namespace boost
 
 #endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_BUFFER_LINE_LINE_INTERSECTION_HPP

--- a/include/boost/geometry/algorithms/detail/buffer/piece_border.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/piece_border.hpp
@@ -14,7 +14,6 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_BUFFER_PIECE_BORDER_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_BUFFER_PIECE_BORDER_HPP
 
-
 #include <array>
 
 #include <boost/core/addressof.hpp>
@@ -25,23 +24,25 @@
 
 #include <boost/geometry/algorithms/assign.hpp>
 #include <boost/geometry/algorithms/comparable_distance.hpp>
-#include <boost/geometry/algorithms/equals.hpp>
-#include <boost/geometry/algorithms/expand.hpp>
 #include <boost/geometry/algorithms/detail/buffer/buffer_policies.hpp>
 #include <boost/geometry/algorithms/detail/expand_by_epsilon.hpp>
-#include <boost/geometry/strategies/cartesian/turn_in_ring_winding.hpp>
+#include <boost/geometry/algorithms/equals.hpp>
+#include <boost/geometry/algorithms/expand.hpp>
 #include <boost/geometry/geometries/box.hpp>
 #include <boost/geometry/geometries/segment.hpp>
+#include <boost/geometry/strategies/cartesian/turn_in_ring_winding.hpp>
 
-
-namespace boost { namespace geometry
+namespace boost
+{
+namespace geometry
 {
 
 #ifndef DOXYGEN_NO_DETAIL
 namespace detail
 {
 template <typename It, typename T, typename Compare>
-inline bool get_range_around(It begin, It end, T const& value, Compare const& compare, It& lower, It& upper)
+inline bool
+get_range_around(It begin, It end, T const& value, Compare const& compare, It& lower, It& upper)
 {
     lower = end;
     upper = end;
@@ -83,10 +84,11 @@ inline bool get_range_around(It begin, It end, T const& value, Compare const& co
     return true;
 }
 
-}
+} // namespace detail
 
-
-namespace detail { namespace buffer
+namespace detail
+{
+namespace buffer
 {
 
 //! Contains the border of the piece, consisting of 4 parts:
@@ -105,7 +107,8 @@ struct piece_border
 {
     using coordinate_type = geometry::coordinate_type_t<Point>;
     using radius_type = typename default_comparable_distance_result<Point>::type;
-    using state_type = typename geometry::strategy::buffer::turn_in_ring_winding<coordinate_type>::state_type;
+    using state_type =
+        typename geometry::strategy::buffer::turn_in_ring_winding<coordinate_type>::state_type;
 
     bool m_reversed;
 
@@ -135,17 +138,17 @@ struct piece_border
     radius_type m_max_comparable_radius;
 
     piece_border()
-        : m_reversed(false)
-        , m_ring(NULL)
-        , m_begin(0)
-        , m_end(0)
-        , m_original_size(0)
-        , m_has_envelope(false)
-        , m_is_convex(false)
-        , m_is_monotonic_increasing(false)
-        , m_is_monotonic_decreasing(false)
-        , m_min_comparable_radius(0)
-        , m_max_comparable_radius(0)
+        : m_reversed(false),
+          m_ring(NULL),
+          m_begin(0),
+          m_end(0),
+          m_original_size(0),
+          m_has_envelope(false),
+          m_is_convex(false),
+          m_is_monotonic_increasing(false),
+          m_is_monotonic_decreasing(false),
+          m_min_comparable_radius(0),
+          m_max_comparable_radius(0)
     {
     }
 
@@ -157,12 +160,9 @@ struct piece_border
         {
             return result;
         }
-        std::copy(m_ring->begin() + m_begin,
-                  m_ring->begin() + m_end,
-                  std::back_inserter(result));
-        std::copy(m_originals.begin(),
-                  m_originals.begin() + m_original_size,
-                  std::back_inserter(result));
+        std::copy(m_ring->begin() + m_begin, m_ring->begin() + m_end, std::back_inserter(result));
+        std::copy(
+            m_originals.begin(), m_originals.begin() + m_original_size, std::back_inserter(result));
         // Add the closing point
         result.push_back(*(m_ring->begin() + m_begin));
 
@@ -170,8 +170,8 @@ struct piece_border
     }
 
     template <typename Strategy>
-    void get_properties_of_border(bool is_point_buffer, Point const& center,
-                                  Strategy const& strategy)
+    void
+    get_properties_of_border(bool is_point_buffer, Point const& center, Strategy const& strategy)
     {
         m_has_envelope = calculate_envelope(m_envelope, strategy);
         if (m_has_envelope)
@@ -222,15 +222,16 @@ struct piece_border
             return false;
         }
         expand_envelope(envelope, m_ring->begin() + m_begin, m_ring->begin() + m_end, strategy);
-        expand_envelope(envelope, m_originals.begin(), m_originals.begin() + m_original_size, strategy);
+        expand_envelope(
+            envelope, m_originals.begin(), m_originals.begin() + m_original_size, strategy);
         return true;
     }
-
 
     // Whatever the return value, the state should be checked.
     template <typename TurnPoint, typename State>
     bool point_on_piece(TurnPoint const& point,
-                        bool one_sided, bool is_linear_end_point,
+                        bool one_sided,
+                        bool is_linear_end_point,
                         State& state) const
     {
         if (ring_or_original_empty())
@@ -250,43 +251,40 @@ struct piece_border
 
         // For onesided buffers, or turns colocated with linear end points,
         // the place on the ring is changed to offsetted (because of colocation)
-        geometry::strategy::buffer::place_on_ring_type const por_original
-            = adapted_place_on_ring(geometry::strategy::buffer::place_on_ring_original,
-                                    one_sided, is_linear_end_point);
+        geometry::strategy::buffer::place_on_ring_type const por_original = adapted_place_on_ring(
+            geometry::strategy::buffer::place_on_ring_original, one_sided, is_linear_end_point);
         geometry::strategy::buffer::place_on_ring_type const por_from_offsetted
             = adapted_place_on_ring(geometry::strategy::buffer::place_on_ring_from_offsetted,
-                                    one_sided, is_linear_end_point);
+                                    one_sided,
+                                    is_linear_end_point);
         geometry::strategy::buffer::place_on_ring_type const por_to_offsetted
             = adapted_place_on_ring(geometry::strategy::buffer::place_on_ring_to_offsetted,
-                                    one_sided, is_linear_end_point);
+                                    one_sided,
+                                    is_linear_end_point);
 
         bool continue_processing = true;
         if (m_original_size == 1)
         {
             // One point. Walk from last offsetted to point, and from point to first offsetted
-            continue_processing = step(point, offsetted_back, m_originals[0],
-                                       tir, por_from_offsetted, state)
-                               && step(point, m_originals[0], offsetted_front,
-                                       tir, por_to_offsetted, state);
+            continue_processing
+                = step(point, offsetted_back, m_originals[0], tir, por_from_offsetted, state)
+                  && step(point, m_originals[0], offsetted_front, tir, por_to_offsetted, state);
         }
         else if (m_original_size == 2)
         {
             // Two original points. Walk from last offsetted point to first original point,
             // then along original, then from second oginal to first offsetted point
-            continue_processing = step(point, offsetted_back, m_originals[0],
-                                       tir, por_from_offsetted, state)
-                               && step(point, m_originals[0], m_originals[1],
-                                       tir, por_original, state)
-                               && step(point, m_originals[1], offsetted_front,
-                                       tir, por_to_offsetted, state);
+            continue_processing
+                = step(point, offsetted_back, m_originals[0], tir, por_from_offsetted, state)
+                  && step(point, m_originals[0], m_originals[1], tir, por_original, state)
+                  && step(point, m_originals[1], offsetted_front, tir, por_to_offsetted, state);
         }
 
         if (continue_processing)
         {
             // Check the offsetted ring (in rounded joins, these might be
             // several segments)
-            walk_offsetted(point, m_ring->begin() + m_begin, m_ring->begin() + m_end,
-                           tir, state);
+            walk_offsetted(point, m_ring->begin() + m_begin, m_ring->begin() + m_end, tir, state);
         }
 
         return true;
@@ -298,25 +296,22 @@ struct piece_border
         return m_ring == NULL || m_begin >= m_end || m_original_size == 0;
     }
 
-private :
-
+  private:
     static geometry::strategy::buffer::place_on_ring_type
-        adapted_place_on_ring(geometry::strategy::buffer::place_on_ring_type target,
-                              bool one_sided, bool is_linear_end_point)
+    adapted_place_on_ring(geometry::strategy::buffer::place_on_ring_type target,
+                          bool one_sided,
+                          bool is_linear_end_point)
     {
         return one_sided || is_linear_end_point
-               ? geometry::strategy::buffer::place_on_ring_offsetted
-               : target;
+                   ? geometry::strategy::buffer::place_on_ring_offsetted
+                   : target;
     }
 
-    template
-    <
-        typename TurnPoint, typename Iterator,
-        typename TiRStrategy,
-        typename State
-    >
-    bool walk_offsetted(TurnPoint const& point, Iterator begin, Iterator end,
-                        TiRStrategy const & strategy,
+    template <typename TurnPoint, typename Iterator, typename TiRStrategy, typename State>
+    bool walk_offsetted(TurnPoint const& point,
+                        Iterator begin,
+                        Iterator end,
+                        TiRStrategy const& strategy,
                         State& state) const
     {
         Iterator it = begin;
@@ -338,10 +333,14 @@ private :
             }
         }
 
-        for (Iterator previous = it++ ; it != beyond ; ++previous, ++it )
+        for (Iterator previous = it++; it != beyond; ++previous, ++it)
         {
-            if (! step(point, *previous, *it, strategy,
-                       geometry::strategy::buffer::place_on_ring_offsetted, state))
+            if (! step(point,
+                       *previous,
+                       *it,
+                       strategy,
+                       geometry::strategy::buffer::place_on_ring_offsetted,
+                       state))
             {
                 return false;
             }
@@ -350,9 +349,12 @@ private :
     }
 
     template <typename TurnPoint, typename TiRStrategy, typename State>
-    bool step(TurnPoint const& point, Point const& p1, Point const& p2,
+    bool step(TurnPoint const& point,
+              Point const& p1,
+              Point const& p2,
               TiRStrategy const& strategy,
-              geometry::strategy::buffer::place_on_ring_type place_on_ring, State& state) const
+              geometry::strategy::buffer::place_on_ring_type place_on_ring,
+              State& state) const
     {
         return strategy.apply(point, p1, p2, place_on_ring, m_is_convex, state);
     }
@@ -403,16 +405,25 @@ private :
 
         // Verify the offsetted range (from the second point on), the original,
         // and loop through the first two points of the offsetted range
-        bool const result = is_convex(previous, current, m_ring->begin() + m_begin + 2, m_ring->begin() + m_end, strategy)
-            && is_convex(previous, current, m_originals.begin(), m_originals.begin() + m_original_size, strategy)
-            && is_convex(previous, current, offsetted_front, strategy)
-            && is_convex(previous, current, offsetted_second, strategy);
+        bool const result = is_convex(previous,
+                                      current,
+                                      m_ring->begin() + m_begin + 2,
+                                      m_ring->begin() + m_end,
+                                      strategy)
+                            && is_convex(previous,
+                                         current,
+                                         m_originals.begin(),
+                                         m_originals.begin() + m_original_size,
+                                         strategy)
+                            && is_convex(previous, current, offsetted_front, strategy)
+                            && is_convex(previous, current, offsetted_second, strategy);
 
         return result;
     }
 
     template <typename It, typename Strategy>
-    bool is_convex(Point& previous, Point& current, It begin, It end, Strategy const& strategy) const
+    bool
+    is_convex(Point& previous, Point& current, It begin, It end, Strategy const& strategy) const
     {
         for (It it = begin; it != end; ++it)
         {
@@ -425,7 +436,8 @@ private :
     }
 
     template <typename Strategy>
-    bool is_convex(Point& previous, Point& current, Point const& next, Strategy const& strategy) const
+    bool
+    is_convex(Point& previous, Point& current, Point const& next, Strategy const& strategy) const
     {
         int const side = strategy.side().apply(previous, current, next);
         if (side == 1)
@@ -500,13 +512,13 @@ private :
             first = false;
         }
     }
-
 };
 
-}} // namespace detail::buffer
+} // namespace buffer
+} // namespace detail
 #endif // DOXYGEN_NO_DETAIL
 
-
-}} // namespace boost::geometry
+} // namespace geometry
+} // namespace boost
 
 #endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_BUFFER_PIECE_BORDER_HPP

--- a/include/boost/geometry/algorithms/detail/buffer/turn_in_original_visitor.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/turn_in_original_visitor.hpp
@@ -14,33 +14,31 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_BUFFER_TURN_IN_ORIGINAL_VISITOR
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_BUFFER_TURN_IN_ORIGINAL_VISITOR
 
-
 #include <boost/core/ignore_unused.hpp>
 #include <boost/range/size.hpp>
 
-#include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/algorithms/detail/buffer/buffer_policies.hpp>
 #include <boost/geometry/algorithms/detail/disjoint/interface.hpp>
 #include <boost/geometry/algorithms/expand.hpp>
+#include <boost/geometry/core/coordinate_type.hpp>
 #include <boost/geometry/strategies/agnostic/point_in_poly_winding.hpp>
 #include <boost/geometry/strategies/buffer.hpp>
 
-
-namespace boost { namespace geometry
+namespace boost
 {
-
+namespace geometry
+{
 
 #ifndef DOXYGEN_NO_DETAIL
-namespace detail { namespace buffer
+namespace detail
 {
-
+namespace buffer
+{
 
 template <typename Strategy>
 struct original_get_box
 {
-    explicit original_get_box(Strategy const& strategy)
-        : m_strategy(strategy)
-    {}
+    explicit original_get_box(Strategy const& strategy) : m_strategy(strategy) {}
 
     template <typename Box, typename Original>
     inline void apply(Box& total, Original const& original) const
@@ -55,16 +53,13 @@ struct original_get_box
 template <typename Strategy>
 struct original_overlaps_box
 {
-    explicit original_overlaps_box(Strategy const& strategy)
-        : m_strategy(strategy)
-    {}
+    explicit original_overlaps_box(Strategy const& strategy) : m_strategy(strategy) {}
 
     template <typename Box, typename Original>
     inline bool apply(Box const& box, Original const& original) const
     {
         assert_coordinate_type_equal(box, original.m_box);
-        return ! detail::disjoint::disjoint_box_box(box, original.m_box,
-                                                    m_strategy);
+        return ! detail::disjoint::disjoint_box_box(box, original.m_box, m_strategy);
     }
 
     Strategy const& m_strategy;
@@ -82,9 +77,7 @@ struct include_turn_policy
 template <typename Strategy>
 struct turn_in_original_overlaps_box
 {
-    explicit turn_in_original_overlaps_box(Strategy const& strategy)
-        : m_strategy(strategy)
-    {}
+    explicit turn_in_original_overlaps_box(Strategy const& strategy) : m_strategy(strategy) {}
 
     template <typename Box, typename Turn>
     inline bool apply(Box const& box, Turn const& turn) const
@@ -95,8 +88,7 @@ struct turn_in_original_overlaps_box
             return false;
         }
 
-        return ! geometry::detail::disjoint::disjoint_point_box(
-                    turn.point, box, m_strategy);
+        return ! geometry::detail::disjoint::disjoint_point_box(turn.point, box, m_strategy);
     }
 
     Strategy const& m_strategy;
@@ -104,15 +96,9 @@ struct turn_in_original_overlaps_box
 
 //! Check if specified is in range of specified iterators
 //! Return value of strategy (true if we can bail out)
-template
-<
-    typename Strategy,
-    typename State,
-    typename Point,
-    typename Iterator
->
-inline bool point_in_range(Strategy& strategy, State& state,
-        Point const& point, Iterator begin, Iterator end)
+template <typename Strategy, typename State, typename Point, typename Iterator>
+inline bool
+point_in_range(Strategy& strategy, State& state, Point const& point, Iterator begin, Iterator end)
 {
     boost::ignore_unused(strategy);
 
@@ -128,18 +114,18 @@ inline bool point_in_range(Strategy& strategy, State& state,
     return true;
 }
 
-template
-<
-    typename Strategy,
-    typename State,
-    typename Point,
-    typename CoordinateType,
-    typename Iterator
->
-inline bool point_in_section(Strategy& strategy, State& state,
-        Point const& point, CoordinateType const& point_x,
-        Iterator begin, Iterator end,
-        int direction)
+template <typename Strategy,
+          typename State,
+          typename Point,
+          typename CoordinateType,
+          typename Iterator>
+inline bool point_in_section(Strategy& strategy,
+                             State& state,
+                             Point const& point,
+                             CoordinateType const& point_x,
+                             Iterator begin,
+                             Iterator end,
+                             int direction)
 {
     if (direction == 0)
     {
@@ -175,9 +161,9 @@ inline bool point_in_section(Strategy& strategy, State& state,
     return true;
 }
 
-
 template <typename Point, typename Original, typename PointInGeometryStrategy>
-inline int point_in_original(Point const& point, Original const& original,
+inline int point_in_original(Point const& point,
+                             Original const& original,
                              PointInGeometryStrategy const& strategy)
 {
     typename PointInGeometryStrategy::state_type state;
@@ -188,8 +174,7 @@ inline int point_in_original(Point const& point, Original const& original,
         // There are no sections, or it does not profit to walk over sections
         // instead of over points. Boundary of 16 is arbitrary but can influence
         // performance
-        point_in_range(strategy, state, point,
-                original.m_ring.begin(), original.m_ring.end());
+        point_in_range(strategy, state, point, original.m_ring.begin(), original.m_ring.end());
         return strategy.result(state);
     }
 
@@ -198,16 +183,18 @@ inline int point_in_original(Point const& point, Original const& original,
     // Walk through all monotonic sections of this original
     for (auto const& section : original.m_sections)
     {
-        if (! section.duplicate
-            && section.begin_index < section.end_index
+        if (! section.duplicate && section.begin_index < section.end_index
             && point_x >= geometry::get<min_corner, 0>(section.bounding_box)
             && point_x <= geometry::get<max_corner, 0>(section.bounding_box))
         {
             // x-coordinate of point overlaps with section
-            if (! point_in_section(strategy, state, point, point_x,
-                    boost::begin(original.m_ring) + section.begin_index,
-                    boost::begin(original.m_ring) + section.end_index + 1,
-                    section.directions[0]))
+            if (! point_in_section(strategy,
+                                   state,
+                                   point,
+                                   point_x,
+                                   boost::begin(original.m_ring) + section.begin_index,
+                                   boost::begin(original.m_ring) + section.end_index + 1,
+                                   section.directions[0]))
             {
                 // We're probably on the boundary
                 break;
@@ -218,15 +205,14 @@ inline int point_in_original(Point const& point, Original const& original,
     return strategy.result(state);
 }
 
-
 template <typename Turns, typename Strategy>
 class turn_in_original_visitor
 {
-public:
+  public:
     turn_in_original_visitor(Turns& turns, Strategy const& strategy)
-        : m_mutable_turns(turns)
-        , m_strategy(strategy)
-    {}
+        : m_mutable_turns(turns), m_strategy(strategy)
+    {
+    }
 
     template <typename Turn, typename Original>
     inline bool apply(Turn const& turn, Original const& original)
@@ -249,8 +235,8 @@ public:
             return true;
         }
 
-        int const code = point_in_original(turn.point, original,
-                                           m_strategy.relate(turn.point, original.m_ring));
+        int const code = point_in_original(
+            turn.point, original, m_strategy.relate(turn.point, original.m_ring));
 
         if (code == -1)
         {
@@ -285,16 +271,16 @@ public:
         return true;
     }
 
-private :
+  private:
     Turns& m_mutable_turns;
     Strategy const& m_strategy;
 };
 
-
-}} // namespace detail::buffer
+} // namespace buffer
+} // namespace detail
 #endif // DOXYGEN_NO_DETAIL
 
-
-}} // namespace boost::geometry
+} // namespace geometry
+} // namespace boost
 
 #endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_BUFFER_TURN_IN_ORIGINAL_VISITOR

--- a/include/boost/geometry/algorithms/detail/buffer/turn_in_piece_visitor.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/turn_in_piece_visitor.hpp
@@ -19,33 +19,34 @@
 
 #include <boost/geometry/algorithms/comparable_distance.hpp>
 #include <boost/geometry/algorithms/covered_by.hpp>
-#include <boost/geometry/algorithms/detail/disjoint/point_box.hpp>
-#include <boost/geometry/algorithms/detail/disjoint/box_box.hpp>
-#include <boost/geometry/algorithms/detail/dummy_geometries.hpp>
 #include <boost/geometry/algorithms/detail/buffer/buffer_policies.hpp>
+#include <boost/geometry/algorithms/detail/disjoint/box_box.hpp>
+#include <boost/geometry/algorithms/detail/disjoint/point_box.hpp>
+#include <boost/geometry/algorithms/detail/dummy_geometries.hpp>
 #include <boost/geometry/geometries/box.hpp>
 
-
-namespace boost { namespace geometry
+namespace boost
+{
+namespace geometry
 {
 
 #ifndef DOXYGEN_NO_DETAIL
 
-namespace detail { namespace buffer
+namespace detail
+{
+namespace buffer
 {
 
-template
-<
-    typename CsTag,
-    typename Turns,
-    typename Pieces,
-    typename DistanceStrategy,
-    typename UmbrellaStrategy
+template <typename CsTag,
+          typename Turns,
+          typename Pieces,
+          typename DistanceStrategy,
+          typename UmbrellaStrategy
 
->
+          >
 class turn_in_piece_visitor
 {
-    Turns& m_turns; // because partition is currently operating on const input only
+    Turns& m_turns;         // because partition is currently operating on const input only
     Pieces const& m_pieces; // to check for piece-type
     DistanceStrategy const& m_distance_strategy; // to check if point is on original or one_sided
     UmbrellaStrategy const& m_umbrella_strategy;
@@ -81,29 +82,28 @@ class turn_in_piece_visitor
     inline bool is_one_sided(NumericType const& left, NumericType const& right) const
     {
         static NumericType const zero = 0;
-        return geometry::math::equals(left, zero)
-            || geometry::math::equals(right, zero);
+        return geometry::math::equals(left, zero) || geometry::math::equals(right, zero);
     }
 
     template <typename Point>
     inline bool has_zero_distance_at(Point const& point) const
     {
-        return is_one_sided(m_distance_strategy.apply(point, point,
-                strategy::buffer::buffer_side_left),
-            m_distance_strategy.apply(point, point,
-                strategy::buffer::buffer_side_right));
+        return is_one_sided(
+            m_distance_strategy.apply(point, point, strategy::buffer::buffer_side_left),
+            m_distance_strategy.apply(point, point, strategy::buffer::buffer_side_right));
     }
 
-public:
-
-    inline turn_in_piece_visitor(Turns& turns, Pieces const& pieces,
+  public:
+    inline turn_in_piece_visitor(Turns& turns,
+                                 Pieces const& pieces,
                                  DistanceStrategy const& distance_strategy,
                                  UmbrellaStrategy const& umbrella_strategy)
-        : m_turns(turns)
-        , m_pieces(pieces)
-        , m_distance_strategy(distance_strategy)
-        , m_umbrella_strategy(umbrella_strategy)
-    {}
+        : m_turns(turns),
+          m_pieces(pieces),
+          m_distance_strategy(distance_strategy),
+          m_umbrella_strategy(umbrella_strategy)
+    {
+    }
 
     template <typename Turn, typename Piece>
     inline bool apply(Turn const& turn, Piece const& piece)
@@ -148,8 +148,8 @@ public:
             // Optimization for a buffer around points: if distance from center
             // is not between min/max radius, it is either inside or outside,
             // and more expensive checks are not necessary.
-            auto const d = geometry::comparable_distance(piece.m_center, turn.point,
-                                                         m_umbrella_strategy);
+            auto const d
+                = geometry::comparable_distance(piece.m_center, turn.point, m_umbrella_strategy);
 
             if (d < border.m_min_comparable_radius)
             {
@@ -168,8 +168,7 @@ public:
         bool const one_sided = has_zero_distance_at(turn.point);
 
         typename Border::state_type state;
-        if (! border.point_on_piece(turn.point, one_sided,
-                                    turn.is_linear_end_point, state))
+        if (! border.point_on_piece(turn.point, one_sided, turn.is_linear_end_point, state))
         {
             return true;
         }
@@ -184,11 +183,11 @@ public:
     }
 };
 
-
-}} // namespace detail::buffer
+} // namespace buffer
+} // namespace detail
 #endif // DOXYGEN_NO_DETAIL
 
-
-}} // namespace boost::geometry
+} // namespace geometry
+} // namespace boost
 
 #endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_BUFFER_TURN_IN_PIECE_VISITOR_HPP

--- a/include/boost/geometry/algorithms/detail/overlay/graph/adapt_operations.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/graph/adapt_operations.hpp
@@ -9,22 +9,26 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_ADAPT_OPERATIONS_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_ADAPT_OPERATIONS_HPP
 
-#include <boost/geometry/algorithms/detail/signed_size_type.hpp>
 #include <boost/geometry/algorithms/detail/overlay/debug_turn_info.hpp>
 #include <boost/geometry/algorithms/detail/overlay/overlay_type.hpp>
 #include <boost/geometry/algorithms/detail/overlay/turn_operation_id.hpp>
+#include <boost/geometry/algorithms/detail/signed_size_type.hpp>
 
-namespace boost { namespace geometry
+namespace boost
+{
+namespace geometry
 {
 
 #ifndef DOXYGEN_NO_DETAIL
-namespace detail { namespace overlay
+namespace detail
+{
+namespace overlay
 {
 
 // Changes the operation of a UU turn, following a UX turn, to X (blocked)
 // under certain conditions, such that it is not followed
-// ADAPT: still necessary for just 2 cases. It should be possible to fix it in get_turn_info instead.
-// It happens in issue_1100_rev (union) and in ticket_10108 (sym diff)
+// ADAPT: still necessary for just 2 cases. It should be possible to fix it in get_turn_info
+// instead. It happens in issue_1100_rev (union) and in ticket_10108 (sym diff)
 //
 // Situation sketch (issue_1100 reversed - the non reversed version does not need the workaround).
 //
@@ -59,18 +63,14 @@ void block_ux_uu_workaround(Turns& turns)
     for (std::size_t turn_index = 0; turn_index < turns.size(); turn_index++)
     {
         auto const& turn = turns[turn_index];
-        if (turn.is_clustered()
-            || turn.discarded
-            || turn.is_self()
+        if (turn.is_clustered() || turn.discarded || turn.is_self()
             || ! turn.combination(operation_blocked, operation_union))
         {
             continue;
         }
 
-        auto const blocked_index = get_op_index(turn, [](auto const& op)
-            {
-                return op.operation == operation_blocked;
-            });
+        auto const blocked_index
+            = get_op_index(turn, [](auto const& op) { return op.operation == operation_blocked; });
 
         auto const& blocked_op = turn.operations[blocked_index];
         auto const next_index = blocked_op.enriched.travels_to_ip_index;
@@ -88,10 +88,10 @@ void block_ux_uu_workaround(Turns& turns)
             continue;
         }
 
-        int const same_source_index = get_op_index(next_turn, [&](auto const& op)
-            {
-                return op.seg_id.source_index == blocked_op.seg_id.source_index;
-            });
+        int const same_source_index
+            = get_op_index(next_turn,
+                           [&](auto const& op)
+                           { return op.seg_id.source_index == blocked_op.seg_id.source_index; });
 
         if (same_source_index < 0)
         {
@@ -112,9 +112,11 @@ void block_ux_uu_workaround(Turns& turns)
     }
 }
 
-}} // namespace detail::overlay
+} // namespace overlay
+} // namespace detail
 #endif // DOXYGEN_NO_DETAIL
 
-}} // namespace boost::geometry
+} // namespace geometry
+} // namespace boost
 
 #endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_ADAPT_OPERATIONS_HPP

--- a/include/boost/geometry/algorithms/detail/overlay/graph/assign_counts.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/graph/assign_counts.hpp
@@ -14,11 +14,15 @@
 #include <boost/geometry/algorithms/detail/overlay/overlay_type.hpp>
 #include <boost/geometry/algorithms/detail/overlay/turn_operation_id.hpp>
 
-namespace boost { namespace geometry
+namespace boost
+{
+namespace geometry
 {
 
 #ifndef DOXYGEN_NO_DETAIL
-namespace detail { namespace overlay
+namespace detail
+{
+namespace overlay
 {
 
 template <typename Turns, typename Clusters>
@@ -26,8 +30,9 @@ void assign_clustered_self_counts(Turns& turns, Clusters const& clusters)
 {
     auto is_self_cluster = [&turns](auto const& cinfo)
     {
-        return std::all_of(cinfo.turn_indices.cbegin(), cinfo.turn_indices.cend(),
-            [&](auto index) { return turns[index].is_self(); });
+        return std::all_of(cinfo.turn_indices.cbegin(),
+                           cinfo.turn_indices.cend(),
+                           [&](auto index) { return turns[index].is_self(); });
     };
 
     for (auto const& cluster : clusters)
@@ -75,29 +80,34 @@ void assign_counts(Turn& turn)
     {
         for (auto& op : turn.operations)
         {
-            if (op.operation == op1.first) { assign(op.enriched, op1.second); }
-            else if (op.operation == op2.first) { assign(op.enriched, op2.second); }
+            if (op.operation == op1.first)
+            {
+                assign(op.enriched, op1.second);
+            }
+            else if (op.operation == op2.first)
+            {
+                assign(op.enriched, op2.second);
+            }
         }
     };
 
     auto assign_left_for = [&turn, &assign_for](counts_per_op_t const& op1, counts_per_op_t op2)
-    {
-        assign_for(op1, op2, [](auto& enriched, auto count) { enriched.count_left = count; });
-    };
+    { assign_for(op1, op2, [](auto& enriched, auto count) { enriched.count_left = count; }); };
 
     auto assign_right_for = [&turn, &assign_for](counts_per_op_t const& op1, counts_per_op_t op2)
-    {
-        assign_for(op1, op2, [](auto& enriched, auto count) { enriched.count_right = count; });
+    { assign_for(op1, op2, [](auto& enriched, auto count) { enriched.count_right = count; }); };
+
+    auto assign_left_incoming_for = [&turn, &assign_for](counts_per_op_t const& op1,
+                                                         counts_per_op_t op2) {
+        assign_for(
+            op1, op2, [](auto& enriched, auto count) { enriched.count_left_incoming = count; });
     };
 
-    auto assign_left_incoming_for = [&turn, &assign_for](counts_per_op_t const& op1, counts_per_op_t op2)
+    auto assign_right_incoming_for
+        = [&turn, &assign_for](counts_per_op_t const& op1, counts_per_op_t op2)
     {
-        assign_for(op1, op2, [](auto& enriched, auto count) { enriched.count_left_incoming = count; });
-    };
-
-    auto assign_right_incoming_for = [&turn, &assign_for](counts_per_op_t const& op1, counts_per_op_t op2)
-    {
-        assign_for(op1, op2, [](auto& enriched, auto count) { enriched.count_right_incoming = count; });
+        assign_for(
+            op1, op2, [](auto& enriched, auto count) { enriched.count_right_incoming = count; });
     };
 
     if (turn.combination(operation_intersection, operation_union))
@@ -154,9 +164,11 @@ void assign_unclustered_counts(Turns& turns)
     }
 }
 
-}} // namespace detail::overlay
+} // namespace overlay
+} // namespace detail
 #endif // DOXYGEN_NO_DETAIL
 
-}} // namespace boost::geometry
+} // namespace geometry
+} // namespace boost
 
 #endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_ASSIGN_COUNTS_HPP

--- a/include/boost/geometry/algorithms/detail/overlay/graph/assign_side_counts.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/graph/assign_side_counts.hpp
@@ -9,40 +9,46 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_ASSIGN_SIDE_COUNTS_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_ASSIGN_SIDE_COUNTS_HPP
 
-#include <boost/geometry/algorithms/detail/overlay/graph/assign_counts.hpp>
 #include <boost/geometry/algorithms/detail/overlay/graph/assign_clustered_counts.hpp>
+#include <boost/geometry/algorithms/detail/overlay/graph/assign_counts.hpp>
 #include <boost/geometry/algorithms/detail/overlay/handle_self_turns.hpp>
 
-namespace boost { namespace geometry
+namespace boost
+{
+namespace geometry
 {
 
 #ifndef DOXYGEN_NO_DETAIL
-namespace detail { namespace overlay
+namespace detail
+{
+namespace overlay
 {
 
-template
-<
-    bool Reverse1,
-    bool Reverse2,
-    overlay_type OverlayType,
-    typename Geometry1,
-    typename Geometry2,
-    typename Turns,
-    typename Clusters,
-    typename IntersectionStrategy,
-    typename Visitor
->
-void assign_side_counts(Geometry1 const& geometry1, Geometry2 const& geometry2,
-        Turns& turns, Clusters& clusters,
-        IntersectionStrategy const& intersection_strategy, Visitor& visitor)
+template <bool Reverse1,
+          bool Reverse2,
+          overlay_type OverlayType,
+          typename Geometry1,
+          typename Geometry2,
+          typename Turns,
+          typename Clusters,
+          typename IntersectionStrategy,
+          typename Visitor>
+void assign_side_counts(Geometry1 const& geometry1,
+                        Geometry2 const& geometry2,
+                        Turns& turns,
+                        Clusters& clusters,
+                        IntersectionStrategy const& intersection_strategy,
+                        Visitor& visitor)
 {
-    clustered_count_handler
-        <
-            Reverse1, Reverse2, OverlayType,
-            Geometry1, Geometry2,
-            Turns, Clusters,
-            IntersectionStrategy
-        > processor(geometry1, geometry2, turns, clusters, intersection_strategy);
+    clustered_count_handler<Reverse1,
+                            Reverse2,
+                            OverlayType,
+                            Geometry1,
+                            Geometry2,
+                            Turns,
+                            Clusters,
+                            IntersectionStrategy>
+        processor(geometry1, geometry2, turns, clusters, intersection_strategy);
 
     processor.apply(visitor);
 
@@ -55,9 +61,11 @@ void assign_side_counts(Geometry1 const& geometry1, Geometry2 const& geometry2,
     assign_unclustered_counts(turns);
 }
 
-}} // namespace detail::overlay
+} // namespace overlay
+} // namespace detail
 #endif // DOXYGEN_NO_DETAIL
 
-}} // namespace boost::geometry
+} // namespace geometry
+} // namespace boost
 
 #endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_ASSIGN_SIDE_COUNTS_HPP

--- a/include/boost/geometry/algorithms/detail/overlay/graph/debug_graph.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/graph/debug_graph.hpp
@@ -11,31 +11,41 @@
 
 #include <boost/geometry/core/access.hpp>
 
-#include <ostream>
 #include <iostream>
+#include <ostream>
 
-#include <boost/graph/graph_traits.hpp>
 #include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/graph_traits.hpp>
 
-namespace boost { namespace geometry
+namespace boost
+{
+namespace geometry
 {
 
 #ifndef DOXYGEN_NO_DETAIL
-namespace detail { namespace overlay
+namespace detail
+{
+namespace overlay
 {
 
 // For debug purposes only
-template <typename Turns, typename Clusters, typename Graph, typename Components, typename VertexMap>
-void write_graph_viz(std::ostream& out, Turns const& turns, Clusters const& clusters,
-    Graph const& g, Components const& component, VertexMap const& vertex_map,
-    bool use_absolute_position = true)
+template <typename Turns,
+          typename Clusters,
+          typename Graph,
+          typename Components,
+          typename VertexMap>
+void write_graph_viz(std::ostream& out,
+                     Turns const& turns,
+                     Clusters const& clusters,
+                     Graph const& g,
+                     Components const& component,
+                     VertexMap const& vertex_map,
+                     bool use_absolute_position = true)
 {
     out << "graph A {\n  node[shape=\"circle\"]\n";
 
     auto add_pos = [&](auto const& point)
-    {
-        out << ", pos=\"" << geometry::get<0>(point) << "," << geometry::get<1>(point) << "!\"";
-    };
+    { out << ", pos=\"" << geometry::get<0>(point) << "," << geometry::get<1>(point) << "!\""; };
 
     // List all nodes
     for (auto const& vertex_pair : vertex_map)
@@ -85,28 +95,28 @@ void write_graph_viz(std::ostream& out, Turns const& turns, Clusters const& clus
         auto it_target = vertex_map.find(target_vertex);
         if (it_source == vertex_map.end() || it_target == vertex_map.end())
         {
-            std::cerr << "Edge not found FOR GRAPH_VIZ "
-                        << source_vertex << " -- " << target_vertex
-                        << std::endl;
+            std::cerr << "Edge not found FOR GRAPH_VIZ " << source_vertex << " -- " << target_vertex
+                      << std::endl;
             continue;
         }
         auto const source_node_id = it_source->second.node_id;
         auto const target_node_id = it_target->second.node_id;
 
         out << source_node_id << " -- " << target_node_id
-                  << "[label=\""
-                    //<< source_node_id << ".." << target_node_id << " ("
-                    << component[*ei]
-                    // << ")"
-                    << "\"]"
-                  << '\n';
+            << "[label=\""
+            //<< source_node_id << ".." << target_node_id << " ("
+            << component[*ei]
+            // << ")"
+            << "\"]" << '\n';
     }
     out << "}\n";
 }
 
-}} // namespace detail::overlay
+} // namespace overlay
+} // namespace detail
 #endif // DOXYGEN_NO_DETAIL
 
-}} // namespace boost::geometry
+} // namespace geometry
+} // namespace boost
 
 #endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_DEBUG_GRAPH_HPP

--- a/include/boost/geometry/algorithms/detail/overlay/graph/detect_biconnected_components.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/graph/detect_biconnected_components.hpp
@@ -12,16 +12,16 @@
 #include <map>
 #include <set>
 
-#include <boost/geometry/algorithms/detail/signed_size_type.hpp>
+#include <boost/geometry/algorithms/detail/overlay/graph/graph_util.hpp>
+#include <boost/geometry/algorithms/detail/overlay/graph/node_util.hpp>
 #include <boost/geometry/algorithms/detail/overlay/overlay_type.hpp>
 #include <boost/geometry/algorithms/detail/overlay/segment_identifier.hpp>
-#include <boost/geometry/algorithms/detail/overlay/graph/node_util.hpp>
-#include <boost/geometry/algorithms/detail/overlay/graph/graph_util.hpp>
+#include <boost/geometry/algorithms/detail/signed_size_type.hpp>
 
 #include <boost/geometry/algorithms/detail/overlay/graph/debug_graph.hpp>
 
-#include <boost/graph/biconnected_components.hpp>
 #include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/biconnected_components.hpp>
 
 #if ! defined(BOOST_GEOMETRY_OVERLAY_NO_THROW)
 #include <boost/geometry/core/exception.hpp>
@@ -32,11 +32,15 @@
 #include <fstream>
 #endif
 
-namespace boost { namespace geometry
+namespace boost
+{
+namespace geometry
 {
 
 #ifndef DOXYGEN_NO_DETAIL
-namespace detail { namespace overlay
+namespace detail
+{
+namespace overlay
 {
 
 struct vertex_info
@@ -75,8 +79,10 @@ struct state_type
     std::size_t extra_node_id{0};
 };
 
-inline void add_edge(signed_size_type source_node_id, signed_size_type target_node_id,
-        segment_identifier const& seg_id, state_type& state)
+inline void add_edge(signed_size_type source_node_id,
+                     signed_size_type target_node_id,
+                     segment_identifier const& seg_id,
+                     state_type& state)
 {
     // Insert the source and target node (turn or cluster)
     auto it_source = state.node_to_vertex_index.find(source_node_id);
@@ -159,15 +165,15 @@ void fill_vertex_map(Turns const& turns, Clusters const& clusters, state_type& s
 
 // Assigns biconnected components to turns
 template <typename Turns, typename Clusters, typename Graph, typename Components>
-void assign_biconnected_component_ids(Turns& turns, Clusters const& clusters, bool allow_closed,
-    Graph const& graph, Components const& component, state_type const& state)
+void assign_biconnected_component_ids(Turns& turns,
+                                      Clusters const& clusters,
+                                      bool allow_closed,
+                                      Graph const& graph,
+                                      Components const& component,
+                                      state_type const& state)
 {
     auto node_id_from_it = [&state](auto const& it)
-    {
-        return it->second.is_extra
-            ? it->second.original_node_id
-            : it->second.node_id;
-    };
+    { return it->second.is_extra ? it->second.original_node_id : it->second.node_id; };
 
     typename graph_traits<Graph>::edge_iterator ei, ei_end;
     for (boost::tie(ei, ei_end) = edges(graph); ei != ei_end; ++ei)
@@ -186,8 +192,8 @@ void assign_biconnected_component_ids(Turns& turns, Clusters const& clusters, bo
         auto const target_node_id = node_id_from_it(it_target);
         auto const edge_seg_id = state.edge_to_seg_id.at({source(*ei, graph), target(*ei, graph)});
 
-        auto const turn_indices = get_turn_indices_by_node_id(turns, clusters, source_node_id,
-            allow_closed);
+        auto const turn_indices
+            = get_turn_indices_by_node_id(turns, clusters, source_node_id, allow_closed);
 
         // Assign the component to all the operations
         // going from the source node to the target node.
@@ -208,7 +214,8 @@ void assign_biconnected_component_ids(Turns& turns, Clusters const& clusters, bo
                     op.enriched.component_id = static_cast<int>(component[*ei]);
                     if (turn.both(operation_continue))
                     {
-                        // For cc, always set both operations (only one of them is returned by get_node_id)
+                        // For cc, always set both operations (only one of them is returned by
+                        // get_node_id)
                         auto& other_op = turn.operations[1 - j];
                         other_op.enriched.component_id = op.enriched.component_id;
                     }
@@ -221,14 +228,11 @@ void assign_biconnected_component_ids(Turns& turns, Clusters const& clusters, bo
 template <operation_type TargetOperation, typename Turns, typename Clusters>
 void detect_biconnected_components(Turns& turns, Clusters const& clusters)
 {
-    using graph_t = boost::adjacency_list
-        <
-            boost::vecS,
-            boost::vecS,
-            boost::undirectedS,
-            boost::no_property,
-            boost::property<edge_component, std::size_t>
-        >;
+    using graph_t = boost::adjacency_list<boost::vecS,
+                                          boost::vecS,
+                                          boost::undirectedS,
+                                          boost::no_property,
+                                          boost::property<edge_component, std::size_t>>;
 
     // Mapping to add turns to vertices, count them, and then build the graph.
     // (It is convenient if the vertex index is the same as the turn index.
@@ -256,9 +260,8 @@ void detect_biconnected_components(Turns& turns, Clusters const& clusters)
     biconnected_components(graph, component);
     fix_components(component, graph);
 
-    assign_biconnected_component_ids(turns, clusters,
-        TargetOperation == operation_intersection,
-        graph, component, state);
+    assign_biconnected_component_ids(
+        turns, clusters, TargetOperation == operation_intersection, graph, component, state);
 
 #if defined(BOOST_GEOMETRY_DEBUG_TRAVERSE_GRAPH)
     {
@@ -268,9 +271,11 @@ void detect_biconnected_components(Turns& turns, Clusters const& clusters)
 #endif
 }
 
-}} // namespace detail::overlay
+} // namespace overlay
+} // namespace detail
 #endif // DOXYGEN_NO_DETAIL
 
-}} // namespace boost::geometry
+} // namespace geometry
+} // namespace boost
 
 #endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_DETECT_ARTICULATION_POINTS_HPP

--- a/include/boost/geometry/algorithms/detail/overlay/graph/fill_ring_turn_info_map.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/graph/fill_ring_turn_info_map.hpp
@@ -9,15 +9,19 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_FILL_RING_TURN_INFO_MAP_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_FILL_RING_TURN_INFO_MAP_HPP
 
-#include <boost/geometry/algorithms/detail/ring_identifier.hpp>
 #include <boost/geometry/algorithms/detail/overlay/get_ring.hpp>
 #include <boost/geometry/algorithms/detail/overlay/overlay_type.hpp>
+#include <boost/geometry/algorithms/detail/ring_identifier.hpp>
 
-namespace boost { namespace geometry
+namespace boost
+{
+namespace geometry
 {
 
 #ifndef DOXYGEN_NO_DETAIL
-namespace detail { namespace overlay
+namespace detail
+{
+namespace overlay
 {
 
 template <typename TurnInfoMap, typename Turns>
@@ -46,9 +50,11 @@ void update_ring_turn_info_map(TurnInfoMap& ring_turn_info_map, Turns const& tur
     }
 }
 
-}} // namespace detail::overlay
+} // namespace overlay
+} // namespace detail
 #endif // DOXYGEN_NO_DETAIL
 
-}} // namespace boost::geometry
+} // namespace geometry
+} // namespace boost
 
 #endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_FILL_RING_TURN_INFO_MAP_HPP

--- a/include/boost/geometry/algorithms/detail/overlay/graph/get_tois.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/graph/get_tois.hpp
@@ -9,23 +9,29 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_TOIS_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_TOIS_HPP
 
-#include <boost/geometry/algorithms/detail/signed_size_type.hpp>
-#include <boost/geometry/algorithms/detail/overlay/overlay_type.hpp>
-#include <boost/geometry/algorithms/detail/overlay/segment_identifier.hpp>
 #include <boost/geometry/algorithms/detail/overlay/graph/is_operation_included.hpp>
 #include <boost/geometry/algorithms/detail/overlay/graph/node_util.hpp>
+#include <boost/geometry/algorithms/detail/overlay/overlay_type.hpp>
+#include <boost/geometry/algorithms/detail/overlay/segment_identifier.hpp>
+#include <boost/geometry/algorithms/detail/signed_size_type.hpp>
 
-namespace boost { namespace geometry
+namespace boost
+{
+namespace geometry
 {
 
 #ifndef DOXYGEN_NO_DETAIL
-namespace detail { namespace overlay
+namespace detail
+{
+namespace overlay
 {
 
 template <operation_type TargetOperation, typename Turns, typename Clusters>
-void add_tois(Turns const& turns, Clusters const& clusters,
-        signed_size_type source_node_id, signed_size_type target_node_id,
-        set_of_tois& result)
+void add_tois(Turns const& turns,
+              Clusters const& clusters,
+              signed_size_type source_node_id,
+              signed_size_type target_node_id,
+              set_of_tois& result)
 {
     using is_included = is_operation_included<TargetOperation>;
 
@@ -53,8 +59,8 @@ void add_tois(Turns const& turns, Clusters const& clusters,
     }
     else if (source_node_id < 0 && target_node_id >= 0)
     {
-        const auto source_turn_indices = get_turn_indices_by_node_id(turns, clusters,
-                    source_node_id, allow_closed);
+        auto const source_turn_indices
+            = get_turn_indices_by_node_id(turns, clusters, source_node_id, allow_closed);
         for (auto source_turn_index : source_turn_indices)
         {
             get_tois_from_turns(source_turn_index, target_node_id);
@@ -62,8 +68,8 @@ void add_tois(Turns const& turns, Clusters const& clusters,
     }
     else if (source_node_id >= 0 && target_node_id < 0)
     {
-        const auto target_turn_indices = get_turn_indices_by_node_id(turns, clusters,
-                target_node_id, allow_closed);
+        auto const target_turn_indices
+            = get_turn_indices_by_node_id(turns, clusters, target_node_id, allow_closed);
         for (auto target_turn_index : target_turn_indices)
         {
             get_tois_from_turns(source_node_id, target_turn_index);
@@ -72,10 +78,10 @@ void add_tois(Turns const& turns, Clusters const& clusters,
     else
     {
         // Combine two sets together, quadratically
-        const auto source_turn_indices = get_turn_indices_by_node_id(turns, clusters,
-                source_node_id, allow_closed);
-        const auto target_turn_indices = get_turn_indices_by_node_id(turns, clusters,
-                target_node_id, allow_closed);
+        auto const source_turn_indices
+            = get_turn_indices_by_node_id(turns, clusters, source_node_id, allow_closed);
+        auto const target_turn_indices
+            = get_turn_indices_by_node_id(turns, clusters, target_node_id, allow_closed);
         for (auto source_turn_index : source_turn_indices)
         {
             for (auto target_turn_index : target_turn_indices)
@@ -91,19 +97,19 @@ void add_tois(Turns const& turns, Clusters const& clusters,
         // It is currently probably not worth to cache these cases, as these are rare cases.
         // In the bitset_grids robustness test, the clusters are small and the listings are like:
         //     quadratic: -5 -> -1 sizes 2 x 3 = 1
-        std::cout << "quadratic: "
-            << source_node_id << " -> " << target_node_id
-            << " sizes " << source_turn_indices.size() << " x " << target_turn_indices.size()
-            << " = " << result.size()
-            << std::endl;
+        std::cout << "quadratic: " << source_node_id << " -> " << target_node_id << " sizes "
+                  << source_turn_indices.size() << " x " << target_turn_indices.size() << " = "
+                  << result.size() << std::endl;
 #endif
     }
 }
 
 // Variant with one node
 template <operation_type TargetOperation, typename Turns, typename Clusters>
-set_of_tois get_tois(Turns const& turns, Clusters const& clusters,
-        signed_size_type source_node_id, signed_size_type target_node_id)
+set_of_tois get_tois(Turns const& turns,
+                     Clusters const& clusters,
+                     signed_size_type source_node_id,
+                     signed_size_type target_node_id)
 {
     set_of_tois result;
     add_tois<TargetOperation>(turns, clusters, source_node_id, target_node_id, result);
@@ -112,8 +118,10 @@ set_of_tois get_tois(Turns const& turns, Clusters const& clusters,
 
 // Variant with multiple target nodes
 template <operation_type TargetOperation, typename Turns, typename Clusters>
-set_of_tois get_tois(Turns const& turns, Clusters const& clusters,
-        signed_size_type source_node_id, std::set<signed_size_type> const& target_node_ids)
+set_of_tois get_tois(Turns const& turns,
+                     Clusters const& clusters,
+                     signed_size_type source_node_id,
+                     std::set<signed_size_type> const& target_node_ids)
 {
     set_of_tois result;
     for (auto const& target : target_node_ids)
@@ -123,9 +131,11 @@ set_of_tois get_tois(Turns const& turns, Clusters const& clusters,
     return result;
 }
 
-}} // namespace detail::overlay
+} // namespace overlay
+} // namespace detail
 #endif // DOXYGEN_NO_DETAIL
 
-}} // namespace boost::geometry
+} // namespace geometry
+} // namespace boost
 
 #endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GET_TOIS_HPP

--- a/include/boost/geometry/algorithms/detail/overlay/graph/graph_util.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/graph/graph_util.hpp
@@ -9,14 +9,18 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GRAPH_UTIL_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GRAPH_UTIL_HPP
 
-#include <boost/graph/biconnected_components.hpp>
 #include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/biconnected_components.hpp>
 
-namespace boost { namespace geometry
+namespace boost
+{
+namespace geometry
 {
 
 #ifndef DOXYGEN_NO_DETAIL
-namespace detail { namespace overlay
+namespace detail
+{
+namespace overlay
 {
 
 struct edge_component
@@ -54,9 +58,11 @@ void fix_components(Components& components, Graph const& g)
     }
 }
 
-}} // namespace detail::overlay
+} // namespace overlay
+} // namespace detail
 #endif // DOXYGEN_NO_DETAIL
 
-}} // namespace boost::geometry
+} // namespace geometry
+} // namespace boost
 
 #endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GRAPH_UTIL_HPP

--- a/include/boost/geometry/algorithms/detail/overlay/graph/is_operation_included.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/graph/is_operation_included.hpp
@@ -10,17 +10,22 @@
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GRAPH_IS_OPERATION_INCLUDED_HPP
 
 #include <boost/geometry/algorithms/detail/overlay/overlay_type.hpp>
-#include <boost/geometry/algorithms/detail/overlay/overlay_type.hpp>
 
-namespace boost { namespace geometry
+namespace boost
+{
+namespace geometry
 {
 
 #ifndef DOXYGEN_NO_DETAIL
-namespace detail { namespace overlay
+namespace detail
+{
+namespace overlay
 {
 
 template <operation_type target_operation>
-struct is_operation_included {};
+struct is_operation_included
+{
+};
 
 template <>
 struct is_operation_included<operation_intersection>
@@ -42,9 +47,11 @@ struct is_operation_included<operation_union>
     }
 };
 
-}} // namespace detail::overlay
+} // namespace overlay
+} // namespace detail
 #endif // DOXYGEN_NO_DETAIL
 
-}} // namespace boost::geometry
+} // namespace geometry
+} // namespace boost
 
 #endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GRAPH_IS_OPERATION_INCLUDED_HPP

--- a/include/boost/geometry/algorithms/detail/overlay/graph/is_target_operation.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/graph/is_target_operation.hpp
@@ -9,18 +9,22 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GRAPH_IS_TARGET_OPERATION_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GRAPH_IS_TARGET_OPERATION_HPP
 
-#include <boost/geometry/algorithms/detail/signed_size_type.hpp>
 #include <boost/geometry/algorithms/detail/overlay/overlay_type.hpp>
 #include <boost/geometry/algorithms/detail/overlay/turn_operation_id.hpp>
+#include <boost/geometry/algorithms/detail/signed_size_type.hpp>
 
 #include <set>
 #include <utility>
 
-namespace boost { namespace geometry
+namespace boost
+{
+namespace geometry
 {
 
 #ifndef DOXYGEN_NO_DETAIL
-namespace detail { namespace overlay
+namespace detail
+{
+namespace overlay
 {
 
 // For continue/continue cases where one of the targets
@@ -56,7 +60,7 @@ std::pair<bool, bool> is_cc_target_ahead(Turns const& turns, turn_operation_id c
     auto has_target = [](auto const& turn, signed_size_type target)
     {
         return turn.operations[0].enriched.travels_to_ip_index == target
-            || turn.operations[1].enriched.travels_to_ip_index == target;
+               || turn.operations[1].enriched.travels_to_ip_index == target;
     };
 
     bool const is_target_ahead_op = has_target(turns[target_op], target_other);
@@ -71,20 +75,20 @@ std::pair<bool, bool> is_cc_target_ahead(Turns const& turns, turn_operation_id c
 
 #if defined(BOOST_GEOMETRY_DEBUG_TRAVERSE_GRAPH)
     std::cout << "Decide for turn " << toi.turn_index << " " << toi.operation_index
-        << " targets: " << target_op
-        << " / " << target_other
-        << " clusters: " << turns[target_op].cluster_id
-        << " / " << turns[target_other].cluster_id
-        << " via " << std::boolalpha << is_target_ahead_op << " / " << is_target_ahead_other
-        << std::endl;
+              << " targets: " << target_op << " / " << target_other
+              << " clusters: " << turns[target_op].cluster_id << " / "
+              << turns[target_other].cluster_id << " via " << std::boolalpha << is_target_ahead_op
+              << " / " << is_target_ahead_other << std::endl;
 #endif
 
     return std::make_pair(true, is_target_ahead_op);
 }
 
 template <typename Operation>
-bool is_better_collinear_for_union(Operation const& op, Operation const& other_op,
-        turn_operation_id const& toi, turn_operation_id const& other_toi)
+bool is_better_collinear_for_union(Operation const& op,
+                                   Operation const& other_op,
+                                   turn_operation_id const& toi,
+                                   turn_operation_id const& other_toi)
 {
     // Continue, prefer the one having no polygon on the left
     if (op.enriched.count_left > 0 && other_op.enriched.count_left == 0)
@@ -124,18 +128,19 @@ bool is_better_collinear_for_union(Operation const& op, Operation const& other_o
     // For a right turn (-1), the one with the largest distance is preferred.
     // For collinear (0), it should not matter.
 
-    return
-        op.enriched.ahead_side == 1
-        ? op.enriched.ahead_distance_of_side_change
-            <= other_op.enriched.ahead_distance_of_side_change
-        : op.enriched.ahead_distance_of_side_change
-            >= other_op.enriched.ahead_distance_of_side_change;
+    return op.enriched.ahead_side == 1 ? op.enriched.ahead_distance_of_side_change
+                                             <= other_op.enriched.ahead_distance_of_side_change
+                                       : op.enriched.ahead_distance_of_side_change
+                                             >= other_op.enriched.ahead_distance_of_side_change;
 }
 
 // The same for intersection - but it needs turns for the same target ahead check.
 template <typename Operation, typename Turns>
-bool is_better_collinear_for_intersection(Operation const& op, Operation const& other_op,
-        turn_operation_id const& toi, turn_operation_id const& other_toi, Turns const& turns)
+bool is_better_collinear_for_intersection(Operation const& op,
+                                          Operation const& other_op,
+                                          turn_operation_id const& toi,
+                                          turn_operation_id const& other_toi,
+                                          Turns const& turns)
 {
     // Continue, prefer the one having no polygon on the left
     if (op.enriched.count_right < 2 && other_op.enriched.count_right >= 2)
@@ -154,18 +159,23 @@ bool is_better_collinear_for_intersection(Operation const& op, Operation const& 
     }
 
     return op.enriched.ahead_distance_of_side_change
-        <= other_op.enriched.ahead_distance_of_side_change;
+           <= other_op.enriched.ahead_distance_of_side_change;
 }
 
 template <operation_type Operation>
-struct is_better_collinear_target {};
+struct is_better_collinear_target
+{
+};
 
 template <>
 struct is_better_collinear_target<operation_union>
 {
     template <typename Operation, typename Turns>
-    static bool apply(Operation const& op, Operation const& other_op,
-        turn_operation_id const& toi, turn_operation_id const& other_toi, Turns const&)
+    static bool apply(Operation const& op,
+                      Operation const& other_op,
+                      turn_operation_id const& toi,
+                      turn_operation_id const& other_toi,
+                      Turns const&)
     {
         return is_better_collinear_for_union(op, other_op, toi, other_toi);
     }
@@ -175,8 +185,11 @@ template <>
 struct is_better_collinear_target<operation_intersection>
 {
     template <typename Operation, typename Turns>
-    static bool apply(Operation const& op, Operation const& other_op,
-        turn_operation_id const& toi, turn_operation_id const& other_toi, Turns const& turns)
+    static bool apply(Operation const& op,
+                      Operation const& other_op,
+                      turn_operation_id const& toi,
+                      turn_operation_id const& other_toi,
+                      Turns const& turns)
     {
         return is_better_collinear_for_intersection(op, other_op, toi, other_toi, turns);
     }
@@ -203,13 +216,14 @@ bool is_target_operation(Turns const& turns, turn_operation_id const& toi)
 
     turn_operation_id const other_toi{toi.turn_index, 1 - toi.operation_index};
     auto const& other_op = turn.operations[other_toi.operation_index];
-    return is_better_collinear_target<TargetOperation>
-        ::apply(op, other_op, toi, other_toi, turns);
+    return is_better_collinear_target<TargetOperation>::apply(op, other_op, toi, other_toi, turns);
 }
 
-}} // namespace detail::overlay
+} // namespace overlay
+} // namespace detail
 #endif // DOXYGEN_NO_DETAIL
 
-}} // namespace boost::geometry
+} // namespace geometry
+} // namespace boost
 
 #endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_GRAPH_IS_TARGET_OPERATION_HPP

--- a/include/boost/geometry/algorithms/detail/overlay/graph/node_util.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/graph/node_util.hpp
@@ -9,21 +9,25 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_NODE_UTIL_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_NODE_UTIL_HPP
 
-#include <boost/geometry/algorithms/detail/signed_size_type.hpp>
-#include <boost/geometry/algorithms/detail/overlay/overlay_type.hpp>
 #include <boost/geometry/algorithms/detail/overlay/graph/is_operation_included.hpp>
 #include <boost/geometry/algorithms/detail/overlay/graph/is_target_operation.hpp>
+#include <boost/geometry/algorithms/detail/overlay/overlay_type.hpp>
 #include <boost/geometry/algorithms/detail/overlay/segment_identifier.hpp>
 #include <boost/geometry/algorithms/detail/overlay/turn_operation_id.hpp>
+#include <boost/geometry/algorithms/detail/signed_size_type.hpp>
 
 #include <set>
 #include <tuple>
 
-namespace boost { namespace geometry
+namespace boost
+{
+namespace geometry
 {
 
 #ifndef DOXYGEN_NO_DETAIL
-namespace detail { namespace overlay
+namespace detail
+{
+namespace overlay
 {
 
 using set_of_tois = std::set<turn_operation_id>;
@@ -38,13 +42,15 @@ struct edge_info
     bool operator<(edge_info const& other) const
     {
         return std::tie(source_node_id, target_node_id, seg_id)
-             < std::tie(other.source_node_id, other.target_node_id, other.seg_id);
+               < std::tie(other.source_node_id, other.target_node_id, other.seg_id);
     }
 };
 
 template <typename Turns, typename Clusters>
-set_of_size_t get_turn_indices_by_cluster_id(Turns const& turns, Clusters const& clusters,
-        signed_size_type cluster_id, bool allow_closed)
+set_of_size_t get_turn_indices_by_cluster_id(Turns const& turns,
+                                             Clusters const& clusters,
+                                             signed_size_type cluster_id,
+                                             bool allow_closed)
 {
     set_of_size_t result;
     auto it = clusters.find(cluster_id);
@@ -76,8 +82,10 @@ signed_size_type get_node_id(Turns const& turns, std::size_t turn_index)
 }
 
 template <typename Turns, typename Clusters>
-set_of_size_t get_turn_indices_by_node_id(Turns const& turns, Clusters const& clusters,
-        signed_size_type node_id, bool allow_closed)
+set_of_size_t get_turn_indices_by_node_id(Turns const& turns,
+                                          Clusters const& clusters,
+                                          signed_size_type node_id,
+                                          bool allow_closed)
 {
     if (node_id < 0)
     {
@@ -101,17 +109,16 @@ set_of_size_t get_turn_indices_by_node_id(Turns const& turns, Clusters const& cl
 
 template <operation_type TargetOperation, typename Turns>
 void get_target_operations(Turns const& turns,
-                      typename Turns::value_type const& turn,
-                      std::size_t turn_index,
-                      signed_size_type source_node_id,
-                      std::set<edge_info>& edges)
+                           typename Turns::value_type const& turn,
+                           std::size_t turn_index,
+                           signed_size_type source_node_id,
+                           std::set<edge_info>& edges)
 {
     using is_included = is_operation_included<TargetOperation>;
     for (int j = 0; j < 2; j++)
     {
         auto const& op = turn.operations[j];
-        if (is_included::apply(op)
-            && is_target_operation<TargetOperation>(turns, {turn_index, j}))
+        if (is_included::apply(op) && is_target_operation<TargetOperation>(turns, {turn_index, j}))
         {
             auto const& target_node_id = get_node_id(turns, op.enriched.travels_to_ip_index);
             edges.insert({source_node_id, target_node_id, op.seg_id});
@@ -119,10 +126,10 @@ void get_target_operations(Turns const& turns,
     }
 }
 
-
 // Get the target nodes of a specific component_id only.
 template <operation_type TargetOperation, typename Turns, typename Clusters, typename Set>
-auto get_target_nodes(Turns const& turns, Clusters const& clusters,
+auto get_target_nodes(Turns const& turns,
+                      Clusters const& clusters,
                       Set const& turn_indices,
                       signed_size_type component_id)
 {
@@ -140,8 +147,7 @@ auto get_target_nodes(Turns const& turns, Clusters const& clusters,
         for (int j = 0; j < 2; j++)
         {
             auto const& op = turn.operations[j];
-            if (op.enriched.component_id == component_id
-                && is_included::apply(op)
+            if (op.enriched.component_id == component_id && is_included::apply(op)
                 && is_target_operation<TargetOperation>(turns, {turn_index, j}))
             {
                 result.insert(get_node_id(turns, op.enriched.travels_to_ip_index));
@@ -151,9 +157,11 @@ auto get_target_nodes(Turns const& turns, Clusters const& clusters,
     return result;
 }
 
-}} // namespace detail::overlay
+} // namespace overlay
+} // namespace detail
 #endif // DOXYGEN_NO_DETAIL
 
-}} // namespace boost::geometry
+} // namespace geometry
+} // namespace boost
 
 #endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_NODE_UTIL_HPP

--- a/include/boost/geometry/algorithms/detail/overlay/graph/select_edge.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/graph/select_edge.hpp
@@ -12,21 +12,25 @@
 #include <boost/core/ignore_unused.hpp>
 #include <boost/geometry/algorithms/detail/overlay/approximately_equals.hpp>
 #include <boost/geometry/algorithms/detail/overlay/copy_segment_point.hpp>
+#include <boost/geometry/algorithms/detail/overlay/graph/node_util.hpp>
+#include <boost/geometry/algorithms/detail/overlay/graph/select_toi_by_incoming.hpp>
 #include <boost/geometry/algorithms/detail/overlay/overlay_type.hpp>
 #include <boost/geometry/algorithms/detail/overlay/segment_identifier.hpp>
 #include <boost/geometry/algorithms/detail/overlay/turn_operation_id.hpp>
-#include <boost/geometry/algorithms/detail/overlay/graph/node_util.hpp>
-#include <boost/geometry/algorithms/detail/overlay/graph/select_toi_by_incoming.hpp>
 
 #if defined(BOOST_GEOMETRY_DEBUG_TRAVERSE_GRAPH)
 #include <boost/geometry/io/wkt/wkt.hpp>
 #endif
 
-namespace boost { namespace geometry
+namespace boost
+{
+namespace geometry
 {
 
 #ifndef DOXYGEN_NO_DETAIL
-namespace detail { namespace overlay
+namespace detail
+{
+namespace overlay
 {
 
 template <typename Point>
@@ -37,31 +41,26 @@ struct edge_and_side
     int side{0};
 };
 
-template
-<
-    bool Reverse1,
-    bool Reverse2,
-    overlay_type OverlayType,
-    typename Geometry1,
-    typename Geometry2,
-    typename Turns,
-    typename Clusters,
-    typename Strategy
->
+template <bool Reverse1,
+          bool Reverse2,
+          overlay_type OverlayType,
+          typename Geometry1,
+          typename Geometry2,
+          typename Turns,
+          typename Clusters,
+          typename Strategy>
 struct edge_selector
 {
-private:
+  private:
     static constexpr operation_type target_operation = operation_from_overlay<OverlayType>::value;
     using point_type = typename Turns::value_type::point_type;
     using edge_type = edge_and_side<point_type>;
     using edges_type = std::vector<edge_type>;
 
     // Use the coordinate type, but if it is too small (e.g. std::int16), use a double
-    using coor_type = typename geometry::select_most_precise
-        <
-            geometry::coordinate_type_t<point_type>,
-            double
-        >::type;
+    using coor_type =
+        typename geometry::select_most_precise<geometry::coordinate_type_t<point_type>,
+                                               double>::type;
 
     // Walks over a ring to get the point after the turn.
     // The turn can be located at the very end of a segment.
@@ -75,8 +74,8 @@ private:
         point_type point;
         do
         {
-            geometry::copy_segment_point<Reverse1, Reverse2>(m_geometry1, m_geometry2,
-                op.seg_id, offset, point);
+            geometry::copy_segment_point<Reverse1, Reverse2>(
+                m_geometry1, m_geometry2, op.seg_id, offset, point);
             ++offset;
         } while (approximately_equals(point, turn_point, tolerance) && offset < 10);
         return point;
@@ -125,25 +124,25 @@ private:
         return true;
     }
 
-    void report(const char* caption, edges_type const& edges,
-        point_type const& p1, point_type const& p2) const
+    void report(char const* caption,
+                edges_type const& edges,
+                point_type const& p1,
+                point_type const& p2) const
     {
 #if defined(BOOST_GEOMETRY_DEBUG_TRAVERSE_GRAPH)
-        std::cout << " *** Sorted edges " << caption
-        << " from " << geometry::wkt(p1) << " to " << geometry::wkt(p2)
-        << std::endl;
+        std::cout << " *** Sorted edges " << caption << " from " << geometry::wkt(p1) << " to "
+                  << geometry::wkt(p2) << std::endl;
         for (auto const& item : edges)
         {
             auto const& op = m_turns[item.toi.turn_index].operations[item.toi.operation_index];
-            std::cout << "  -> " << item.toi
-                << " to " << op.enriched.travels_to_ip_index
-                << " side: " << item.side
-                << std::endl;
+            std::cout << "  -> " << item.toi << " to " << op.enriched.travels_to_ip_index
+                      << " side: " << item.side << std::endl;
         }
 #endif
     }
 
-    turn_operation_id select_by_side(edges_type& edges, point_type const& p1, point_type const& p2) const
+    turn_operation_id
+    select_by_side(edges_type& edges, point_type const& p1, point_type const& p2) const
     {
         // Select point and calculate side for each edge
         auto const side_strategy = m_intersection_strategy.side();
@@ -158,10 +157,10 @@ private:
         // Right = -1 will come first. Left = 1 will come last.
         // This works for both union and intersection operations, because it should always
         // take the right turn (even in uu in buffer/union).
-        std::sort(edges.begin(), edges.end(), [](auto const& a, auto const& b)
-        {
-            return std::tie(a.side, a.toi) < std::tie(b.side, b.toi);
-        });
+        std::sort(edges.begin(),
+                  edges.end(),
+                  [](auto const& a, auto const& b)
+                  { return std::tie(a.side, a.toi) < std::tie(b.side, b.toi); });
 
         report("by side", edges, p1, p2);
 
@@ -173,10 +172,10 @@ private:
         if (edges.front().side != edges.back().side)
         {
             // Remove all edges with different side than the first
-            auto it = std::find_if(edges.begin() + 1, edges.end(), [&](auto const& item)
-            {
-                return item.side != edges.front().side;
-            });
+            auto it
+                = std::find_if(edges.begin() + 1,
+                               edges.end(),
+                               [&](auto const& item) { return item.side != edges.front().side; });
             edges.erase(it, edges.end());
         }
 
@@ -184,9 +183,7 @@ private:
         {
             // Select for collinearity (it makes no sense to sort on mutual side)
             auto compare = [&](edge_type const& a, edge_type const& b) -> bool
-            {
-                return select_collinear_target_edge(a, b);
-            };
+            { return select_collinear_target_edge(a, b); };
             std::sort(edges.begin(), edges.end(), compare);
             return edges.front().toi;
         }
@@ -206,24 +203,27 @@ private:
         return edges.front().toi;
     }
 
-public:
-
-    edge_selector(Geometry1 const& m_geometry1, Geometry2 const& m_geometry2,
-        Turns const& m_turns, Clusters const& clusters,
-        Strategy const& strategy)
-        : m_geometry1(m_geometry1)
-        , m_geometry2(m_geometry2)
-        , m_turns(m_turns)
-        , m_clusters(clusters)
-        , m_intersection_strategy(strategy)
-    {}
+  public:
+    edge_selector(Geometry1 const& m_geometry1,
+                  Geometry2 const& m_geometry2,
+                  Turns const& m_turns,
+                  Clusters const& clusters,
+                  Strategy const& strategy)
+        : m_geometry1(m_geometry1),
+          m_geometry2(m_geometry2),
+          m_turns(m_turns),
+          m_clusters(clusters),
+          m_intersection_strategy(strategy)
+    {
+    }
 
     // Select one operation which is the leftmost or rightmost operation.
     // p1 is the point before the current turn.
     // p2 is the current turn.
     // So (p1, p2) together define the direction of the segment.
     turn_operation_id select_target_edge(set_of_tois const& turn_operation_ids,
-            point_type const& p1, point_type const& p2) const
+                                         point_type const& p1,
+                                         point_type const& p2) const
     {
         if (turn_operation_ids.empty())
         {
@@ -267,17 +267,14 @@ public:
             auto const& turn1 = m_turns[edges[1].toi.turn_index];
             auto const& op0 = turn0.operations[edges[0].toi.operation_index];
             auto const& op1 = turn1.operations[edges[1].toi.operation_index];
-            if (op0.operation == operation_continue
-                && op1.operation == operation_continue
+            if (op0.operation == operation_continue && op1.operation == operation_continue
                 && op0.enriched.travels_to_ip_index == op1.enriched.travels_to_ip_index)
             {
                 return edges.front().toi;
             }
 
-            if (target_operation == operation_union
-                && turn0.is_clustered()
-                && op0.operation == operation_union
-                && op1.operation == operation_union
+            if (target_operation == operation_union && turn0.is_clustered()
+                && op0.operation == operation_union && op1.operation == operation_union
                 && op0.enriched.rank == op1.enriched.rank)
             {
                 // Because it is clustered, and all operations come from the same cluster,
@@ -290,8 +287,8 @@ public:
                     return result;
                 }
 
-                bool const better = is_better_collinear_for_union(
-                        op0, op1, edges.front().toi, edges.back().toi);
+                bool const better
+                    = is_better_collinear_for_union(op0, op1, edges.front().toi, edges.back().toi);
                 return better ? edges.front().toi : edges.back().toi;
             }
         }
@@ -299,7 +296,7 @@ public:
         return select_by_side(edges, p1, p2);
     }
 
-private:
+  private:
     Geometry1 const& m_geometry1;
     Geometry2 const& m_geometry2;
     Turns const& m_turns;
@@ -307,9 +304,11 @@ private:
     Strategy const& m_intersection_strategy;
 };
 
-}} // namespace detail::overlay
+} // namespace overlay
+} // namespace detail
 #endif // DOXYGEN_NO_DETAIL
 
-}} // namespace boost::geometry
+} // namespace geometry
+} // namespace boost
 
 #endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_SELECT_EDGE_HPP

--- a/include/boost/geometry/algorithms/detail/overlay/graph/select_toi_by_incoming.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/graph/select_toi_by_incoming.hpp
@@ -11,21 +11,27 @@
 
 #include <boost/geometry/algorithms/detail/overlay/turn_operation_id.hpp>
 
-
-namespace boost { namespace geometry
+namespace boost
+{
+namespace geometry
 {
 
 #ifndef DOXYGEN_NO_DETAIL
-namespace detail { namespace overlay
+namespace detail
+{
+namespace overlay
 {
 
 // For two operations from a cluster, having the same target, and having the same rank,
 // the outgoing side makes it unclear. This function inspects the target and uses the incoming
 // side, which should be more clear.
 template <typename Turns, typename Operation>
-bool select_toi_for_union(turn_operation_id& result, Operation const& op0, Operation const& op1, 
-        turn_operation_id const& toi0, turn_operation_id const& toi1,
-        Turns const& turns)
+bool select_toi_for_union(turn_operation_id& result,
+                          Operation const& op0,
+                          Operation const& op1,
+                          turn_operation_id const& toi0,
+                          turn_operation_id const& toi1,
+                          Turns const& turns)
 {
     if (op0.enriched.travels_to_ip_index != op1.enriched.travels_to_ip_index
         || op0.enriched.travels_to_ip_index < 0)
@@ -46,10 +52,9 @@ bool select_toi_for_union(turn_operation_id& result, Operation const& op0, Opera
     }
 
 #if defined(BOOST_GEOMETRY_DEBUG_TRAVERSE_GRAPH)
-    std::cout << "SELECT_BY_INCOMING " << toi0 << " vs " << toi1
-        << " " << operation_char(op0.operation) << operation_char(op1.operation)
-        << " traveling to " << op0.enriched.travels_to_ip_index
-        << std::endl;
+    std::cout << "SELECT_BY_INCOMING " << toi0 << " vs " << toi1 << " "
+              << operation_char(op0.operation) << operation_char(op1.operation) << " traveling to "
+              << op0.enriched.travels_to_ip_index << std::endl;
 #endif
 
     if (target_op0.seg_id.multi_index == target_op1.seg_id.multi_index)
@@ -88,9 +93,11 @@ bool select_toi_for_union(turn_operation_id& result, Operation const& op0, Opera
     return false;
 }
 
-}} // namespace detail::overlay
+} // namespace overlay
+} // namespace detail
 #endif // DOXYGEN_NO_DETAIL
 
-}} // namespace boost::geometry
+} // namespace geometry
+} // namespace boost
 
 #endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_SELECT_TOI_BY_INCOMING_HPP

--- a/include/boost/geometry/algorithms/detail/overlay/graph/traverse_graph.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/graph/traverse_graph.hpp
@@ -9,14 +9,14 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_TRAVERSE_GRAPH_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_TRAVERSE_GRAPH_HPP
 
-#include <boost/geometry/algorithms/detail/signed_size_type.hpp>
 #include <boost/geometry/algorithms/detail/overlay/copy_segments.hpp>
-#include <boost/geometry/algorithms/detail/overlay/overlay_type.hpp>
-#include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>
-#include <boost/geometry/algorithms/detail/overlay/graph/is_operation_included.hpp>
 #include <boost/geometry/algorithms/detail/overlay/graph/get_tois.hpp>
+#include <boost/geometry/algorithms/detail/overlay/graph/is_operation_included.hpp>
 #include <boost/geometry/algorithms/detail/overlay/graph/node_util.hpp>
 #include <boost/geometry/algorithms/detail/overlay/graph/select_edge.hpp>
+#include <boost/geometry/algorithms/detail/overlay/overlay_type.hpp>
+#include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>
+#include <boost/geometry/algorithms/detail/signed_size_type.hpp>
 #include <boost/geometry/algorithms/num_points.hpp>
 #include <boost/geometry/core/closure.hpp>
 
@@ -27,24 +27,25 @@
 #include <boost/geometry/io/wkt/wkt.hpp>
 #endif
 
-namespace boost { namespace geometry
+namespace boost
+{
+namespace geometry
 {
 
 #ifndef DOXYGEN_NO_DETAIL
-namespace detail { namespace overlay
+namespace detail
+{
+namespace overlay
 {
 
-template
-<
-    bool Reverse1,
-    bool Reverse2,
-    overlay_type OverlayType,
-    typename Geometry1,
-    typename Geometry2,
-    typename Turns,
-    typename Clusters,
-    typename Strategy
->
+template <bool Reverse1,
+          bool Reverse2,
+          overlay_type OverlayType,
+          typename Geometry1,
+          typename Geometry2,
+          typename Turns,
+          typename Clusters,
+          typename Strategy>
 struct traverse_graph
 {
     static constexpr operation_type target_operation = operation_from_overlay<OverlayType>::value;
@@ -56,15 +57,17 @@ struct traverse_graph
     using point_type = typename turn_type::point_type;
     using toi_set = std::set<turn_operation_id>;
 
-    inline traverse_graph(Geometry1 const& geometry1, Geometry2 const& geometry2,
-            Turns& turns, Clusters const& clusters,
-            Strategy const& strategy)
-        : m_edge_selector(geometry1, geometry2, turns, clusters, strategy)
-        , m_geometry1(geometry1)
-        , m_geometry2(geometry2)
-        , m_turns(turns)
-        , m_clusters(clusters)
-        , m_strategy(strategy)
+    inline traverse_graph(Geometry1 const& geometry1,
+                          Geometry2 const& geometry2,
+                          Turns& turns,
+                          Clusters const& clusters,
+                          Strategy const& strategy)
+        : m_edge_selector(geometry1, geometry2, turns, clusters, strategy),
+          m_geometry1(geometry1),
+          m_geometry2(geometry2),
+          m_turns(turns),
+          m_clusters(clusters),
+          m_strategy(strategy)
     {
     }
 
@@ -75,17 +78,14 @@ struct traverse_graph
         auto const to_vertex_index = op.enriched.travels_to_vertex_index;
         if (op.seg_id.source_index == 0)
         {
-            geometry::copy_segments<Reverse1>(m_geometry1,
-                    op.seg_id, to_vertex_index,
-                    m_strategy, ring);
+            geometry::copy_segments<Reverse1>(
+                m_geometry1, op.seg_id, to_vertex_index, m_strategy, ring);
         }
         else
         {
-            geometry::copy_segments<Reverse2>(m_geometry2,
-                    op.seg_id, to_vertex_index,
-                    m_strategy, ring);
+            geometry::copy_segments<Reverse2>(
+                m_geometry2, op.seg_id, to_vertex_index, m_strategy, ring);
         }
-
     }
 
     template <typename Ring>
@@ -102,7 +102,6 @@ struct traverse_graph
 #if defined(BOOST_GEOMETRY_DEBUG_TRAVERSE_GRAPH)
         std::cout << "At : " << toi << std::endl;
 #endif
-
 
         if (op.seg_id.segment_index == to_vertex_index && ! is_round_trip)
         {
@@ -176,31 +175,30 @@ struct traverse_graph
 
     template <typename Ring>
     bool continue_traverse(Ring& ring,
-            signed_size_type component_id,
-            signed_size_type start_node_id,
-            signed_size_type current_node_id)
+                           signed_size_type component_id,
+                           signed_size_type start_node_id,
+                           signed_size_type current_node_id)
     {
-        auto const current_turn_indices = get_turn_indices_by_node_id(m_turns, m_clusters,
-                current_node_id, allow_closed);
+        auto const current_turn_indices
+            = get_turn_indices_by_node_id(m_turns, m_clusters, current_node_id, allow_closed);
 
         // Any valid node should always deliver at least one turn
         BOOST_ASSERT(! current_turn_indices.empty());
 
-        auto const next_target_nodes = get_target_nodes<target_operation>(m_turns, m_clusters,
-                current_turn_indices, component_id);
+        auto const next_target_nodes = get_target_nodes<target_operation>(
+            m_turns, m_clusters, current_turn_indices, component_id);
 
         if (next_target_nodes.empty())
         {
 #if defined(BOOST_GEOMETRY_DEBUG_TRAVERSE_GRAPH)
-            std::cout << "Stuck, start: " << start_node_id
-                << " stuck: " << current_node_id
-                << " (no targets) " << std::endl;
+            std::cout << "Stuck, start: " << start_node_id << " stuck: " << current_node_id
+                      << " (no targets) " << std::endl;
 #endif
             return false;
         }
 
-        auto const tois = get_tois<target_operation>(m_turns, m_clusters,
-                current_node_id, next_target_nodes);
+        auto const tois
+            = get_tois<target_operation>(m_turns, m_clusters, current_node_id, next_target_nodes);
 
         if (tois.empty())
         {
@@ -221,9 +219,8 @@ struct traverse_graph
         if (m_visited_tois.count(toi) > 0 || m_finished_tois.count(toi) > 0)
         {
 #if defined(BOOST_GEOMETRY_DEBUG_TRAVERSE_GRAPH)
-            std::cout << "ALREADY visited, turn " << toi
-                << " in {" << current_node_id
-                << " -> size " << next_target_nodes.size() << "}" << std::endl;
+            std::cout << "ALREADY visited, turn " << toi << " in {" << current_node_id
+                      << " -> size " << next_target_nodes.size() << "}" << std::endl;
 #endif
             return false;
         }
@@ -234,8 +231,8 @@ struct traverse_graph
         use_vertices(ring, toi);
 
         auto const& selected_op = m_turns[toi.turn_index].operations[toi.operation_index];
-        auto const next_target_node_id = get_node_id(m_turns,
-            selected_op.enriched.travels_to_ip_index);
+        auto const next_target_node_id
+            = get_node_id(m_turns, selected_op.enriched.travels_to_ip_index);
         if (next_target_node_id == start_node_id)
         {
 #if defined(BOOST_GEOMETRY_DEBUG_TRAVERSE_GRAPH)
@@ -248,10 +245,11 @@ struct traverse_graph
     }
 
     template <typename Rings>
-    void start_traverse(Rings& rings, point_type const& start_point,
-            signed_size_type component_id,
-            signed_size_type start_node_id,
-            signed_size_type target_node_id)
+    void start_traverse(Rings& rings,
+                        point_type const& start_point,
+                        signed_size_type component_id,
+                        signed_size_type start_node_id,
+                        signed_size_type target_node_id)
     {
         // Select the first toi which is not yet visited and has the requested component.
         // If all tois are visited, not having the same component, it is not possible to continue,
@@ -276,27 +274,23 @@ struct traverse_graph
             return turn_operation_id{0, -1};
         };
 
-        auto const toi = select_first_toi(get_tois<target_operation>(m_turns, m_clusters,
-                start_node_id, target_node_id));
+        auto const toi = select_first_toi(
+            get_tois<target_operation>(m_turns, m_clusters, start_node_id, target_node_id));
         if (toi.operation_index < 0)
         {
             return;
         }
 
 #if defined(BOOST_GEOMETRY_DEBUG_TRAVERSE_GRAPH)
-        std::cout << "\n" << "-> Start traversing component " << component_id
-            << " at: " << toi
-            << " to " << target_node_id << std::endl;
+        std::cout << "\n"
+                  << "-> Start traversing component " << component_id << " at: " << toi << " to "
+                  << target_node_id << std::endl;
 #endif
-
 
         using ring_type = typename boost::range_value<Rings>::type;
 
         constexpr std::size_t min_size
-                = core_detail::closure::minimum_ring_size
-                        <
-                            geometry::closure<ring_type>::value
-                        >::value;
+            = core_detail::closure::minimum_ring_size<geometry::closure<ring_type>::value>::value;
 
         ring_type ring;
         detail::overlay::append_no_collinear(ring, start_point, m_strategy);
@@ -310,8 +304,8 @@ struct traverse_graph
         // Traverse the graph. If the target is at the start, it is a round trip,
         // and it is finished immediately.
         // The continuation could fail (no target nodes, or no target edges).
-        bool const is_finished = is_round_trip
-            || continue_traverse(ring, component_id, start_node_id, target_node_id);
+        bool const is_finished
+            = is_round_trip || continue_traverse(ring, component_id, start_node_id, target_node_id);
 
         if (! is_finished)
         {
@@ -324,9 +318,9 @@ struct traverse_graph
 
         if (geometry::num_points(ring) >= min_size)
         {
-        #if defined(BOOST_GEOMETRY_DEBUG_TRAVERSE_GRAPH)
+#if defined(BOOST_GEOMETRY_DEBUG_TRAVERSE_GRAPH)
             std::cout << "Add ring: " << geometry::wkt(ring) << std::endl;
-        #endif
+#endif
             rings.push_back(std::move(ring));
         }
         m_finished_tois.insert(m_visited_tois.begin(), m_visited_tois.end());
@@ -350,8 +344,8 @@ struct traverse_graph
             return;
         }
         auto const source_node_id = get_node_id(m_turns, turn_index);
-        auto const turn_indices = get_turn_indices_by_node_id(m_turns, m_clusters,
-                source_node_id, allow_closed);
+        auto const turn_indices
+            = get_turn_indices_by_node_id(m_turns, m_clusters, source_node_id, allow_closed);
 
         for (int j = 0; j < 2; j++)
         {
@@ -369,8 +363,8 @@ struct traverse_graph
             }
 
             auto const component_id = op.enriched.component_id;
-            auto const target_nodes = get_target_nodes<target_operation>(m_turns, m_clusters,
-                    turn_indices, component_id);
+            auto const target_nodes = get_target_nodes<target_operation>(
+                m_turns, m_clusters, turn_indices, component_id);
 
             for (auto const target_node_id : target_nodes)
             {
@@ -382,10 +376,11 @@ struct traverse_graph
                 }
                 m_starts.insert(start);
 
-    #if defined(BOOST_GEOMETRY_DEBUG_TRAVERSE_GRAPH)
-                std::cout << "\n" << "Traversing component " << component_id
-                    << " from " << source_node_id << " to " << target_node_id << std::endl;
-    #endif
+#if defined(BOOST_GEOMETRY_DEBUG_TRAVERSE_GRAPH)
+                std::cout << "\n"
+                          << "Traversing component " << component_id << " from " << source_node_id
+                          << " to " << target_node_id << std::endl;
+#endif
                 start_traverse(rings, turn.point, component_id, source_node_id, target_node_id);
             }
         }
@@ -402,15 +397,9 @@ struct traverse_graph
         update_administration();
     }
 
-private:
-
-    edge_selector
-        <
-            Reverse1, Reverse2, OverlayType,
-            Geometry1, Geometry2,
-            Turns, Clusters,
-            Strategy
-        > m_edge_selector;
+  private:
+    edge_selector<Reverse1, Reverse2, OverlayType, Geometry1, Geometry2, Turns, Clusters, Strategy>
+        m_edge_selector;
 
     Geometry1 const& m_geometry1;
     Geometry2 const& m_geometry2;
@@ -429,9 +418,11 @@ private:
     std::set<std::tuple<signed_size_type, signed_size_type, signed_size_type>> m_starts;
 };
 
-}} // namespace detail::overlay
+} // namespace overlay
+} // namespace detail
 #endif // DOXYGEN_NO_DETAIL
 
-}} // namespace boost::geometry
+} // namespace geometry
+} // namespace boost
 
 #endif // BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_TRAVERSE_GRAPH_HPP


### PR DESCRIPTION
This is experimental and verifies how `clang-format` could be used for our code base,
using a style that is most close to what we (in general) use.