### PR TITLE
Avoid static variables and functions in header files.

### DIFF
--- a/include/boost/geometry/algorithms/detail/overlay/assign_parents.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/assign_parents.hpp
@@ -50,7 +50,7 @@ template
     typename RingCollection,
     typename Strategy
 >
-static inline bool within_selected_input(Item const& item2,
+inline bool within_selected_input(Item const& item2,
         InnerGeometry const& inner_geometry,
         ring_identifier const& outer_id,
         Geometry1 const& geometry1, Geometry2 const& geometry2,
@@ -86,7 +86,7 @@ template
     typename RingCollection,
     typename Strategy
 >
-static inline bool within_selected_input(Item const& item2,
+inline bool within_selected_input(Item const& item2,
         ring_identifier const& inner_id, ring_identifier const& outer_id,
         Geometry1 const& geometry1, Geometry2 const& geometry2,
         RingCollection const& collection,

--- a/include/boost/geometry/algorithms/detail/overlay/follow_linear_linear.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/follow_linear_linear.hpp
@@ -60,7 +60,7 @@ namespace following { namespace linear
 // follower for linear/linear geometries set operations
 
 template <typename Turn, typename Operation>
-static inline bool is_entering(Turn const& turn,
+inline bool is_entering(Turn const& turn,
                                Operation const& operation)
 {
     if ( turn.method != method_touch && turn.method != method_touch_interior )
@@ -73,7 +73,7 @@ static inline bool is_entering(Turn const& turn,
 
 
 template <typename Turn, typename Operation>
-static inline bool is_staying_inside(Turn const& turn,
+inline bool is_staying_inside(Turn const& turn,
                                      Operation const& operation,
                                      bool entered)
 {
@@ -92,7 +92,7 @@ static inline bool is_staying_inside(Turn const& turn,
 
 
 template <typename Turn, typename Operation>
-static inline bool is_leaving(Turn const& turn,
+inline bool is_leaving(Turn const& turn,
                               Operation const& operation,
                               bool entered)
 {
@@ -125,7 +125,7 @@ static inline bool is_leaving(Turn const& turn,
 
 
 template <typename Turn, typename Operation>
-static inline bool is_isolated_point(Turn const& turn,
+inline bool is_isolated_point(Turn const& turn,
                                      Operation const& operation,
                                      bool entered)
 {

--- a/include/boost/geometry/algorithms/detail/overlay/range_in_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/range_in_geometry.hpp
@@ -106,7 +106,7 @@ struct point_in_geometry_helper<Box, box_tag>
 // This function returns
 // when it finds a point of geometry1 inside or outside geometry2
 template <typename Geometry1, typename Geometry2, typename Strategy>
-static inline int range_in_geometry(Geometry1 const& geometry1,
+inline int range_in_geometry(Geometry1 const& geometry1,
                                     Geometry2 const& geometry2,
                                     Strategy const& strategy,
                                     bool skip_first = false)

--- a/include/boost/geometry/algorithms/detail/relate/follow_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/follow_helpers.hpp
@@ -358,7 +358,7 @@ inline bool turn_on_the_same_ip(Turn const& prev_turn, Turn const& curr_turn,
 }
 
 template <typename IntersectionPoint, typename OperationInfo, typename BoundaryChecker>
-static inline bool is_ip_on_boundary(IntersectionPoint const& ip,
+inline bool is_ip_on_boundary(IntersectionPoint const& ip,
                                      OperationInfo const& operation_info,
                                      BoundaryChecker const& boundary_checker)
 {

--- a/include/boost/geometry/core/access.hpp
+++ b/include/boost/geometry/core/access.hpp
@@ -33,10 +33,10 @@ namespace boost { namespace geometry
 {
 
 /// Index of minimum corner of the box.
-int const min_corner = 0;
+BOOST_INLINE_CONSTEXPR int min_corner = 0;
 
 /// Index of maximum corner of the box.
-int const max_corner = 1;
+BOOST_INLINE_CONSTEXPR int max_corner = 1;
 
 namespace traits
 {

--- a/include/boost/geometry/formulas/spherical.hpp
+++ b/include/boost/geometry/formulas/spherical.hpp
@@ -45,7 +45,7 @@ struct result_spherical
 };
 
 template <typename T>
-static inline void sph_to_cart3d(T const& lon, T const& lat, T & x, T & y, T & z)
+inline void sph_to_cart3d(T const& lon, T const& lat, T & x, T & y, T & z)
 {
     T const cos_lat = cos(lat);
     x = cos_lat * cos(lon);
@@ -54,7 +54,7 @@ static inline void sph_to_cart3d(T const& lon, T const& lat, T & x, T & y, T & z
 }
 
 template <typename Point3d, typename PointSph>
-static inline Point3d sph_to_cart3d(PointSph const& point_sph)
+inline Point3d sph_to_cart3d(PointSph const& point_sph)
 {
     using calc_t = coordinate_type_t<Point3d>;
 
@@ -72,14 +72,14 @@ static inline Point3d sph_to_cart3d(PointSph const& point_sph)
 }
 
 template <typename T>
-static inline void cart3d_to_sph(T const& x, T const& y, T const& z, T & lon, T & lat)
+inline void cart3d_to_sph(T const& x, T const& y, T const& z, T & lon, T & lat)
 {
     lon = atan2(y, x);
     lat = asin(z);
 }
 
 template <typename PointSph, typename Point3d>
-static inline PointSph cart3d_to_sph(Point3d const& point_3d)
+inline PointSph cart3d_to_sph(Point3d const& point_3d)
 {
     using coord_t = coordinate_type_t<PointSph>;
     using calc_t = coordinate_type_t<Point3d>;
@@ -113,7 +113,7 @@ static inline PointSph cart3d_to_sph(Point3d const& point_3d)
 // 1 left
 // 0 on
 template <typename Point3d1, typename Point3d2>
-static inline int sph_side_value(Point3d1 const& norm, Point3d2 const& pt)
+inline int sph_side_value(Point3d1 const& norm, Point3d2 const& pt)
 {
     typedef typename select_coordinate_type<Point3d1, Point3d2>::type calc_t;
     calc_t c0 = 0;
@@ -124,7 +124,7 @@ static inline int sph_side_value(Point3d1 const& norm, Point3d2 const& pt)
 }
 
 template <typename CT, bool ReverseAzimuth, typename T1, typename T2>
-static inline result_spherical<CT> spherical_azimuth(T1 const& lon1,
+inline result_spherical<CT> spherical_azimuth(T1 const& lon1,
                                                      T1 const& lat1,
                                                      T2 const& lon2,
                                                      T2 const& lat2)

--- a/include/boost/geometry/index/detail/utilities.hpp
+++ b/include/boost/geometry/index/detail/utilities.hpp
@@ -20,22 +20,22 @@
 namespace boost { namespace geometry { namespace index { namespace detail {
 
 template<class T>
-static inline void assign_cond(T & l, T const& r, std::true_type)
+inline void assign_cond(T & l, T const& r, std::true_type)
 {
     l = r;
 }
 
 template<class T>
-static inline void assign_cond(T &, T const&, std::false_type) {}
+inline void assign_cond(T &, T const&, std::false_type) {}
 
 template<class T>
-static inline void move_cond(T & l, T & r, std::true_type)
+inline void move_cond(T & l, T & r, std::true_type)
 {
     l = std::move(r);
 }
 
 template<class T>
-static inline void move_cond(T &, T &, std::false_type) {}
+inline void move_cond(T &, T &, std::false_type) {}
 
 template <typename T> inline
 void swap_cond(T & l, T & r, std::true_type)


### PR DESCRIPTION
I am working on converting a large scientific library (https://www.dealii.org) that builds on BOOST to C++20 modules, see https://github.com/dealii/dealii/issues/18071. As part of this effort, I have to find ways to "wrap" BOOST into a module partition, something that will look like this file: https://github.com/bangerth/dealii/blob/cxx-modules/cxx20-modules/interface_module_partitions/boost.ccm 

Wrapping works by "exporting" certain BOOST names via `using` declarations, but the targets of these `using` declarations can only be names that have "external linkage". This excludes `static` variables and functions because they have "internal linkage". GCC 15 also requires that all names *referenced* by entities I want to export *also* have external linkage, and this turns up quite a large number of `static` variables and functions in BOOST header files.

There are good reasons to avoid internal linkage variables and functions in header files beyond my desire to use C++20 modules. In particular, they should be avoided because they are replicated in each translation unit that `#include`s a header file; if the object had external linkage, the linker would unify these copies into one, reducing code size.

This patch addresses a number of places where this BOOST sub-library uses names with internal linkage in header files, by removing the `static` keyword and, where applicable, marking variables as `inline`. (Variables marked as `const` or `constexpr` implicitly have internal linkage unless marked with `inline`.)