### PR TITLE
Fix windows runners in github actions

### DIFF
--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -245,18 +245,23 @@ jobs:
   ##############################################################################
   msvc:
     name: ${{ matrix.b2_toolset }}
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
         b2_toolset: [
-          msvc-14.3
+          msvc-14.3,
+          msvc-14.4
         ]
 
         include:
           - b2_toolset: msvc-14.3
             b2_cxxstd: 14,17,2a
+            os: windows-2022
+          #- b2_toolset: msvc-14.4 # b2 cannot find command for this MSVC toolset
+          #  b2_cxxstd: 14,17,2a
+          #  os: windows-2025
 
     steps:
       - name: Set up environment
@@ -298,73 +303,7 @@ jobs:
         shell: pwsh
         run: |
           cd $env:BOOST_ROOT
-          .\bootstrap.bat --with-toolset=msvc
-          .\b2 headers
-          .\b2 -v
-
-      - name: Build libs/geometry/test//minimal
-        shell: pwsh
-        run: |
-          cd $env:BOOST_ROOT
-          .\b2 toolset=${{ matrix.b2_toolset }} cxxstd=${{ matrix.b2_cxxstd }} variant=debug,release address-model=32,64 libs/geometry/test//minimal
-
-##############################################################################
-  msvc2:
-    name: ${{ matrix.b2_toolset }}
-    runs-on: windows-2019
-
-    strategy:
-      fail-fast: false
-      matrix:
-        b2_toolset: [
-          msvc-14.2
-        ]
-
-        include:
-          - b2_toolset: msvc-14.2
-            b2_cxxstd: 14,17,2a
-
-    steps:
-      - name: Set up environment
-        id: setenv
-        shell: pwsh
-        run: |
-          if ("$env:GITHUB_REF" -contains "master") {
-            echo "BOOST_BRANCH=master" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          } else {
-            echo "BOOST_BRANCH=develop" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          }
-          echo "BOOST_SELF=$((Get-Item $env:GITHUB_WORKSPACE).BaseName)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "BOOST_ROOT=$env:GITHUB_WORKSPACE\boost-root" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "boost_self=$((Get-Item $env:GITHUB_WORKSPACE).BaseName)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
-          echo "boost_root=$env:GITHUB_WORKSPACE\boost-root" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
-
-      - name: Clone boostorg/boost
-        shell: pwsh
-        run: |
-          git clone -b $env:BOOST_BRANCH --depth 1 https://github.com/boostorg/boost.git $env:BOOST_ROOT
-          cd $env:BOOST_ROOT
-          git submodule update -q --init libs/headers
-          git submodule update -q --init tools/boost_install
-          git submodule update -q --init tools/boostdep
-          git submodule update -q --init tools/build
-          New-Item -Path libs\$env:BOOST_SELF -ItemType Directory -ErrorAction SilentlyContinue
-
-      - uses: actions/checkout@v2
-        with:
-          path: ${{ steps.setenv.outputs.boost_root }}/libs/${{ steps.setenv.outputs.boost_self }}
-
-      - name: Run tools/boostdep/depinst/depinst.py
-        shell: pwsh
-        run: |
-          cd $env:BOOST_ROOT
-          python tools/boostdep/depinst/depinst.py --include benchmark --include example --include examples --include tools $env:BOOST_SELF
-
-      - name: Bootstrap boostorg/boost
-        shell: pwsh
-        run: |
-          cd $env:BOOST_ROOT
-          .\bootstrap.bat --with-toolset=msvc
+          .\bootstrap.bat --with-toolset=${{ matrix.b2_toolset }}
           .\b2 headers
           .\b2 -v
 

--- a/doc/release_notes.qbk
+++ b/doc/release_notes.qbk
@@ -20,29 +20,6 @@
 [section:release_notes Release Notes]
 
 [/=================]
-[heading Boost 1.89]
-[/=================]
-
-[*Major improvements]
-
-* [@https://github.com/boostorg/geometry/pull/1369 1369] Rewrite of traversal
-* [@https://github.com/boostorg/geometry/pull/1402 1402] Add geometry polyhedral surface
-
-[*Improvements]
-
-* [@https://github.com/boostorg/geometry/pull/1404 1404] Performance improvents in buffer
-* [@https://github.com/boostorg/geometry/pull/1405 1405] Avoid static variables and functions in header files
-
-[*Solved issues]
-
-* [@https://github.com/boostorg/geometry/issues/1221 1221] Difference with rectilinear multipolygon with integer coordinates produces invalid polygon with disconnected interior
-* [@https://github.com/boostorg/geometry/issues/1295 1295] Wrong result in intersection (result polygon is equal to the biggest of the input polygons)
-* [@https://github.com/boostorg/geometry/issues/1349 1349] Difference of polygons giving wrong result
-* [@https://github.com/boostorg/geometry/issues/1382 1382] Buffer operation creates self-intersection
-* Various fixes of errors and warnings
-
-
-[/=================]
 [heading Boost 1.88]
 [/=================]
 

--- a/doc/release_notes.qbk
+++ b/doc/release_notes.qbk
@@ -20,6 +20,29 @@
 [section:release_notes Release Notes]
 
 [/=================]
+[heading Boost 1.89]
+[/=================]
+
+[*Major improvements]
+
+* [@https://github.com/boostorg/geometry/pull/1369 1369] Rewrite of traversal
+* [@https://github.com/boostorg/geometry/pull/1402 1402] Add geometry polyhedral surface
+
+[*Improvements]
+
+* [@https://github.com/boostorg/geometry/pull/1404 1404] Performance improvents in buffer
+* [@https://github.com/boostorg/geometry/pull/1405 1405] Avoid static variables and functions in header files
+
+[*Solved issues]
+
+* [@https://github.com/boostorg/geometry/issues/1221 1221] Difference with rectilinear multipolygon with integer coordinates produces invalid polygon with disconnected interior
+* [@https://github.com/boostorg/geometry/issues/1295 1295] Wrong result in intersection (result polygon is equal to the biggest of the input polygons)
+* [@https://github.com/boostorg/geometry/issues/1349 1349] Difference of polygons giving wrong result
+* [@https://github.com/boostorg/geometry/issues/1382 1382] Buffer operation creates self-intersection
+* Various fixes of errors and warnings
+
+
+[/=================]
 [heading Boost 1.88]
 [/=================]
 


### PR DESCRIPTION
This PR removes the retired windows-2019 runner together with msvc-14.2 toolset. 

Also adds support for newer runner windows-2025 which gives access to  msvc-14.4 toolset but b2 returns an error so this case is commented out for now (needs more investigation). Related issue https://github.com/boostorg/boost/issues/914