### PR TITLE
Annotate facade header with IWYU export annotation

### DIFF
--- a/include/boost/geometry/geometry.hpp
+++ b/include/boost/geometry/geometry.hpp
@@ -20,6 +20,8 @@
 #ifndef BOOST_GEOMETRY_GEOMETRY_HPP
 #define BOOST_GEOMETRY_GEOMETRY_HPP
 
+// IWYU pragma: begin_exports
+
 #include <boost/config.hpp>
 
 #if defined(BOOST_NO_CXX14_CONSTEXPR)
@@ -133,5 +135,7 @@
 
 #include <boost/geometry/algorithms/is_convex.hpp>
 #include <boost/geometry/algorithms/point_on_surface.hpp>
+
+// IWYU pragma: end_exports
 
 #endif // BOOST_GEOMETRY_GEOMETRY_HPP


### PR DESCRIPTION
Without that annotation, tools such as `clang-tidy` or the `clangd` language server (as well as many other tools) will complain about headers not directly providing a symbol if users include `geometry.hpp`; With this annotation, they know.

Documentation IWYU
https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUPragmas.md#iwyu-pragma-begin_exportsend_exports

Documentation llvm include cleaner/clang-tidy/clangd https://clangd.llvm.org/design/include-cleaner#iwyu-pragmas