### PR TITLE
Use the dynamic type while calling epsilon().

### DIFF
--- a/include/boost/geometry/index/detail/rtree/rstar/choose_next_node.hpp
+++ b/include/boost/geometry/index/detail/rtree/rstar/choose_next_node.hpp
@@ -132,7 +132,7 @@ private:
 
         // is this assumption ok? if min_content_diff == 0 there is no overlap increase?
 
-        if ( min_content_diff < -std::numeric_limits<double>::epsilon() || std::numeric_limits<double>::epsilon() < min_content_diff )
+        if ( min_content_diff < -std::numeric_limits<content_type>::epsilon() || std::numeric_limits<content_type>::epsilon() < min_content_diff )
         {
             size_t first_n_children_count = children_count;
             if ( 0 < overlap_cost_threshold && overlap_cost_threshold < children.size() )


### PR DESCRIPTION
Current call to epsilon is made with the assumption that the dynamic type `content_type` is compatible with double. This does not hold true for numeric types that are bigger than double, e.g: `absl::uint128`. This CL fixes it by binding the call to `content_type`'s type.

This fixes #1430.