### PR TITLE
Move Boost::crc and Boost::program_options dependencies from library to unit and robustness tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,6 @@ target_link_libraries(boost_geometry
     Boost::mpl
     Boost::multiprecision
     Boost::numeric_conversion
-    Boost::program_options
     Boost::qvm
     Boost::range
     Boost::rational

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,7 +34,8 @@ function(boost_geometry_add_unit_test prefix item)
   # At least one unit test uses the crc library (but the Geometry library does not).
   target_link_libraries(${unit_test_name}
     PRIVATE
-      Boost::crc)
+      Boost::crc
+      Boost::program_options)
 
   # Include the main Geometry test folder and the current folder
   target_include_directories(${unit_test_name}

--- a/test/robustness/CMakeLists.txt
+++ b/test/robustness/CMakeLists.txt
@@ -15,6 +15,12 @@ function(boost_geometry_add_robustness_test item)
     PRIVATE
       Boost::geometry)
 
+  # Link to additional libraries required for testing.
+  target_link_libraries(${robustness_test_name}
+    PRIVATE
+      Boost::crc
+      Boost::program_options)
+
   # Include the main Geometry test folder and the current folder,
   # and the robustness test folder
   target_include_directories(${robustness_test_name}


### PR DESCRIPTION
Not an actual dependency of the library. Discovered when I tried to make Boost.Geometry a dependency of Boost.Graph, the CMake breaks.