### PR TITLE
Add regression test for non-overlapping polygon intersection (issue #1439)

### DIFF
--- a/test/algorithms/intersection/issue_1439.cpp
+++ b/test/algorithms/intersection/issue_1439.cpp
@@ -1,0 +1,39 @@
+#include <boost/geometry.hpp>
+#include <boost/geometry/geometries/point_xy.hpp>
+#include <boost/geometry/geometries/polygon.hpp>
+
+#include <vector>
+
+namespace bg = boost::geometry;
+
+using point = bg::model::d2::point_xy<double>;
+using polygon = bg::model::polygon<point>;
+
+int main()
+{
+    polygon p1, p2;
+
+    bg::read_wkt(
+        "POLYGON((-2.47089026 -86.03059246,"
+        "-1.161944873 146.3030596,"
+        "3.40221214 145.8628015,"
+        "3.024695769 141.949088,"
+        "2.420586453 111.9554564,"
+        "1.208013978 -86.04069936,"
+        "-2.47089026 -86.03059246))", p1);
+
+    bg::read_wkt(
+        "POLYGON((-6.213278056 -88.01851748,"
+        "-6.207382255 -86.51852906,"
+        "-6.20539951 -86.01408604,"
+        "-2.470873099 -86.02434575,"
+        "-2.472221358 -86.53315586,"
+        "-2.476196085 -88.03315059,"
+        "-6.213278056 -88.01851748))", p2);
+
+    std::vector<polygon> output;
+    bg::intersection(p1, p2, output);
+
+    // Expected: no intersection
+    return output.empty() ? 0 : 1;
+}


### PR DESCRIPTION
This PR adds a minimal regression test reproducing issue #1439.

The test shows that `boost::geometry::intersection` currently produces
a non-empty result for two polygons that do not overlap.

The test fails on Boost 1.89 (tested on Linux / Google Colab),
confirming that the reported behavior is still present.

Once the underlying issue is fixed, this test will help ensure
that the behavior does not regress in future changes.

<img width="1255" height="642" alt="Screenshot 2025-12-13 at 4 32 31 PM" src="https://github.com/user-attachments/assets/38afb46d-46bd-4be5-8b0a-50ecdd1d6fe1" />

Still reproducible on Boost 1.89 (Linux).
See attached output showing non-empty intersection for non-overlapping polygons.
