### PR TITLE
Clarify polygon orientation requirement for buffer algorithm

### DIFF
--- a/doc/reference/algorithms/buffer_with_strategies.qbk
+++ b/doc/reference/algorithms/buffer_with_strategies.qbk
@@ -18,6 +18,17 @@ The 5 strategies give the user control to the generated buffer
 * distance can be symmetric or asymmetric, and positive or negative
 * around points the shape can be circular or square
 * the sides can be controlled (currently there is only one option provided)
+[NOTE]
+The buffer algorithm expects polygons to be counter-clockwise. 
+If your polygon is clockwise, you may need to reverse the vertex order:
+
+[source,c++]
+----
+boost::geometry::reverse(poly);
+----
+
+For more details, see the Polygon Concept:
+[link geometry.reference.concepts.concept_polygon.html Polygon Concept].
 
 By specifying a negative distance for the distance_strategy, for the (multi) polygon case, the polygon will be smaller (also known as deflate). The distance cannot be 0.
 


### PR DESCRIPTION
This PR adds a note in the buffer documentation (under [heading Strategies])
to clarify that the buffer algorithm expects polygons to be counter-clockwise.
If a polygon is clockwise, it should be reversed using:

    boost::geometry::reverse(poly);

A link to the Polygon Concept is also provided for more details.

This helps users avoid confusion when using buffer with custom polygons.
Related issue: #1375
