### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,6 @@ target_link_libraries(boost_geometry
     Boost::qvm
     Boost::range
     Boost::rational
-    Boost::static_assert
     Boost::throw_exception
     Boost::tokenizer
     Boost::tuple

--- a/build.jam
+++ b/build.jam
@@ -34,7 +34,6 @@ constant boost_dependencies :
     /boost/range//boost_range
     /boost/rational//boost_rational
     /boost/serialization//boost_serialization
-    /boost/static_assert//boost_static_assert
     /boost/thread//boost_thread
     /boost/throw_exception//boost_throw_exception
     /boost/tokenizer//boost_tokenizer


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.