### PR TITLE
Prevent FP contractions to FMA in index/.../content.hpp to avoid numerical instability in rtree

### DIFF
--- a/include/boost/geometry/index/detail/algorithms/content.hpp
+++ b/include/boost/geometry/index/detail/algorithms/content.hpp
@@ -16,6 +16,8 @@
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_ALGORITHMS_CONTENT_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_ALGORITHMS_CONTENT_HPP
 
+#include <boost/config.hpp>
+
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_dimension.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
@@ -25,6 +27,18 @@
 #include <boost/geometry/util/select_most_precise.hpp>
 
 namespace boost { namespace geometry { namespace index { namespace detail {
+
+#if defined(BOOST_GCC)
+// The following pragmas set fp-contract=off for GCC, to prevent surprising and
+// subtle numerical behaviour changes as a result of cross-statement/function
+// FMA contractions which can result in e.g. content(b1) - content(b2) != 0 
+// (or < 0) for content(b1) == content(b2) (or >=), due to the fp-contract=fast
+// default from at least GCC 4.4 to present GCC 15.2. This avoids Github issue
+// #1452. Safe to remove after numerically robust handling of degenerate cases
+// is ensured at all index::detail::content(box) call sites.
+#pragma GCC push_options
+#pragma GCC optimize ("fp-contract=off")
+#endif
 
 template <typename Indexable>
 struct default_content_result
@@ -97,6 +111,10 @@ typename default_content_result<Indexable>::type content(Indexable const& b)
                 tag_t<Indexable>
             >::apply(b);
 }
+
+#if defined(BOOST_GCC)
+#pragma GCC pop_options
+#endif
 
 }}}} // namespace boost::geometry::index::detail
 


### PR DESCRIPTION
This PR addresses #1452 . The issue shows a performance regression on GCC with -march=x86-64-v3 over -march=x86-64-v2  and presumably optimizations enabled, the compilation flags are not fully specified. After instrumenting the code further, I noticed many more calls to distance_cross_track and a different tree structure in v3 vs. v2 with less efficient querying (~twice as many geographic distance computations). The issue no longer replicates after doing any change out of a) disabling inlining, b) disabling FMA, c) removing the points with duplicate coordinates from the data.csv in the issue.

This points to a numerical instability in tree insertion due to some fusing of multiply and add/sub (b) across function boundaries (a), in some expression where cancellation to == 0.0 would occur without FMA but not with (from c). After disallowing this as in the commit with fp-contract=off for the content algorithm, the issue disappears. The content algorithm ends in a multiply, so when this small method is inlined, this multiply may be fused into the next addition/subtraction, so it fits the findings.

Multiple call sites of content seem to be affected by this (changing call sites individually yielded different tree structures), so I think, disallowing the fusing at the level of content.hpp is the cleanest solution. I consider this a conservative change because it keeps the behavior similar to how it would have been at x86-64-v2 and before (probably the most tested settings), where no FMA would be available, and also similar to Clang and MSVC which do not default to fp-contract=fast like GCC when optimizations are enabled.

It is guarded behind the BOOST_GCC macro to avoid warnings for compilers that do not support this pragma and because GCC is the only compiler I am aware of that defaults to fp-contract=fast at common optimization levels without enabling it specifically or setting something well-known to be unsafe like -ffast-math.

Edit: Added explanatory comment. No test-case added because the behaviour changes are compiler- and machine-dependent and I see no guarantees wrt to CPU architectures for the Github CI).