### PR TITLE
fix: node invariant at exception

### DIFF
--- a/include/boost/geometry/index/detail/rtree/rstar/insert.hpp
+++ b/include/boost/geometry/index/detail/rtree/rstar/insert.hpp
@@ -122,35 +122,59 @@ public:
         >::type sorted_elements_type;
 
         sorted_elements_type sorted_elements;
-        // If constructor is used instead of resize() MS implementation leaks here
-        sorted_elements.reserve(elements_count);                                                         // MAY THROW, STRONG (V, E: alloc, copy)
 
-        for ( typename elements_type::const_iterator it = elements.begin() ;
-              it != elements.end() ; ++it )
+        BOOST_TRY
         {
-            point_type element_center;
-            geometry::centroid(rtree::element_indexable(*it, translator), element_center,
-                               strategy);
-            sorted_elements.push_back(std::make_pair(
-                comparable_distance_pp::call(node_center, element_center, strategy),
-                *it));                                                                                  // MAY THROW (V, E: copy)
+            // If constructor is used instead of resize() MS implementation leaks here
+            sorted_elements.reserve(elements_count);                                                     // MAY THROW, STRONG (alloc)
+
+            for ( typename elements_type::const_iterator it = elements.begin() ;
+                  it != elements.end() ; ++it )
+            {
+                point_type element_center;
+                geometry::centroid(rtree::element_indexable(*it, translator), element_center,
+                                   strategy);
+                sorted_elements.push_back(std::make_pair(
+                    comparable_distance_pp::call(node_center, element_center, strategy),
+                    *it));                                                                              // MAY THROW (V, E: copy)
+            }
+
+            // sort elements by distances from center
+            std::partial_sort(
+                sorted_elements.begin(),
+                sorted_elements.begin() + reinserted_elements_count,
+                sorted_elements.end(),
+                distances_dsc<comparable_distance_type, element_type>);                                            // MAY THROW, BASIC (V, E: copy)
+
+            // copy elements which will be reinserted
+            result_elements.clear();
+            result_elements.reserve(reinserted_elements_count);                                         // MAY THROW, STRONG (V, E: alloc, copy)
+            for ( typename sorted_elements_type::const_iterator it = sorted_elements.begin() ;
+                  it != sorted_elements.begin() + reinserted_elements_count ; ++it )
+            {
+                result_elements.push_back(it->second);                                                  // MAY THROW (V, E: copy)
+            }
         }
-
-        // sort elements by distances from center
-        std::partial_sort(
-            sorted_elements.begin(),
-            sorted_elements.begin() + reinserted_elements_count,
-            sorted_elements.end(),
-            distances_dsc<comparable_distance_type, element_type>);                                                // MAY THROW, BASIC (V, E: copy)
-
-        // copy elements which will be reinserted
-        result_elements.clear();
-        result_elements.reserve(reinserted_elements_count);                                             // MAY THROW, STRONG (V, E: alloc, copy)
-        for ( typename sorted_elements_type::const_iterator it = sorted_elements.begin() ;
-              it != sorted_elements.begin() + reinserted_elements_count ; ++it )
+        BOOST_CATCH(...)
         {
-            result_elements.push_back(it->second);                                                      // MAY THROW (V, E: copy)
+            // NOTE: This code is here to prevent leaving the node in overflow state
+            //  (with more than max elements) after an exception is thrown during the
+            //  preparation of elements for reinsertion (#1399). At this point the node
+            //  has not been modified yet and still contains exactly max+1 elements
+            //  (one push_back triggered the overflow handling).
+            //  Remove the overflow element to restore the node invariant, matching
+            //  the behavior of the split exception handler.
+            result_elements.clear();
+
+            if (elements.size() > parameters.get_max_elements())
+            {
+                destroy_element<MembersHolder>::apply(elements.back(), allocators);
+                elements.pop_back();
+            }
+
+            BOOST_RETHROW
         }
+        BOOST_CATCH_END
 
         BOOST_TRY
         {


### PR DESCRIPTION
Fixes: #1399

# Description

This fixes the errors in `boost_geometry_index_rtree_exceptions_rst` that I encountered before.

Now with help of Claude Code, reporting:

```
This is a genuine exception-safety bug in the R-tree insert*, and the reason it only fails on your machine is that the exact number of
   value copies differs between compilers/standard libraries, which determines where in the insert algorithm the exception fires.

  Root cause

  The R*-tree has a reinsert mechanism (unique to R*-tree, not used by linear/quadratic). When a node overflows, instead of immediately
  splitting, it first tries to remove some elements and reinsert them. The function remove_elements_to_reinsert at
  index/detail/rtree/rstar/insert.hpp:82-181 does this:

  1. Copies all elements from the node into a sorted_elements temporary (line 128-137 -- copies here)
  2. Copies elements-to-reinsert into result_elements (line 149-153 -- copies here)
  3. Clears the original node (line 158)
  4. Copies remaining elements back into the node (line 160-164 -- copies here, MAY THROW)

  If an exception fires at step 4, the catch handler (line 166-178) clears the node entirely and destroys all sorted_elements, then
  rethrows. The node is now empty, and the exception propagates up.
```

# Solution

By Claude Code: 
```
The fix

  The problem was in remove_elements_to_reinsert (rstar/insert.hpp). The first phase — copying elements into sorted_elements and
  result_elements — involves value copies that can throw. But at that point the node still has max+1 elements (overflow state). If any
  copy threw, the exception propagated with the node left in overflow, and nobody cleaned it up.

  The fix wraps that first phase in a try-catch that:
  1. Clears result_elements (partial copies)
  2. Pops the overflow element from the node (matching the established pattern in the split exception handler)
  3. Rethrows

  This ensures the node never has more than max_elements after an exception, regardless of where the throw occurs.
```

I reviewed it myself and it looks completely right, and it solves the problem.

@awulkiew can you verify this as well?
