### PR TITLE
fix: clamp content differences to prevent FMA-induced numerical instability

### DIFF
--- a/include/boost/geometry/index/detail/algorithms/content.hpp
+++ b/include/boost/geometry/index/detail/algorithms/content.hpp
@@ -112,6 +112,19 @@ typename default_content_result<Indexable>::type content(Indexable const& b)
             >::apply(b);
 }
 
+// Returns the content increase when expanding 'original' to 'expanded'.
+// Precondition: 'original' is covered by 'expanded'. Under this precondition
+// the result is mathematically non-negative, so clamping to 0 is valid and
+// guards against floating-point contraction artifacts (e.g. GCC FMA fusion
+// across function boundaries) that can make the difference negative or
+// spuriously non-zero for equal boxes. See GitHub issue #1452.
+template <typename Box>
+typename default_content_result<Box>::type content_diff(Box const& expanded, Box const& original)
+{
+    using content_type = typename default_content_result<Box>::type;
+    return (std::max)(content_type(0), content(expanded) - content(original));
+}
+
 #if defined(BOOST_GCC)
 #pragma GCC pop_options
 #endif

--- a/include/boost/geometry/index/detail/rtree/linear/redistribute_elements.hpp
+++ b/include/boost/geometry/index/detail/rtree/linear/redistribute_elements.hpp
@@ -16,6 +16,7 @@
 #ifndef BOOST_GEOMETRY_INDEX_DETAIL_RTREE_LINEAR_REDISTRIBUTE_ELEMENTS_HPP
 #define BOOST_GEOMETRY_INDEX_DETAIL_RTREE_LINEAR_REDISTRIBUTE_ELEMENTS_HPP
 
+#include <algorithm>
 #include <type_traits>
 
 #include <boost/core/ignore_unused.hpp>
@@ -432,8 +433,10 @@ struct redistribute_elements<MembersHolder, linear_tag>
                         content_type enlarged_content1 = index::detail::content(enlarged_box1);
                         content_type enlarged_content2 = index::detail::content(enlarged_box2);
 
-                        content_type content_increase1 = enlarged_content1 - content1;
-                        content_type content_increase2 = enlarged_content2 - content2;
+                        content_type const content_increase1
+                            = (std::max)(content_type(0), enlarged_content1 - content1);
+                        content_type const content_increase2
+                            = (std::max)(content_type(0), enlarged_content2 - content2);
 
                         // choose group which box content have to be enlarged least or has smaller content or has fewer elements
                         if ( content_increase1 < content_increase2 ||

--- a/include/boost/geometry/index/detail/rtree/quadratic/redistribute_elements.hpp
+++ b/include/boost/geometry/index/detail/rtree/quadratic/redistribute_elements.hpp
@@ -74,9 +74,10 @@ inline void pick_seeds(Elements const& elements,
 
             bounded_indexable_view bounded_ind1(ind1, strategy);
             bounded_indexable_view bounded_ind2(ind2, strategy);
-            content_type free_content = ( index::detail::content(enlarged_box)
-                                            - index::detail::content(bounded_ind1) )
-                                                - index::detail::content(bounded_ind2);
+            content_type free_content = (std::max)(content_type(0),
+                ( index::detail::content(enlarged_box)
+                    - index::detail::content(bounded_ind1) )
+                        - index::detail::content(bounded_ind2));
 
             if ( greatest_free_content < free_content )
             {
@@ -273,7 +274,7 @@ struct redistribute_elements<MembersHolder, quadratic_tag>
         typedef typename boost::iterator_value<It>::type element_type;
         typedef typename rtree::element_indexable_type<element_type, translator_type>::type indexable_type;
 
-        content_type greatest_content_incrase_diff = 0;
+        content_type greatest_content_increase_diff = 0;
         It out_it = first;
         out_content_increase1 = 0;
         out_content_increase2 = 0;
@@ -291,18 +292,20 @@ struct redistribute_elements<MembersHolder, quadratic_tag>
             content_type enlarged_content1 = index::detail::content(enlarged_box1);
             content_type enlarged_content2 = index::detail::content(enlarged_box2);
 
-            content_type content_incrase1 = (enlarged_content1 - content1);
-            content_type content_incrase2 = (enlarged_content2 - content2);
+            content_type const content_increase1
+                = (std::max)(content_type(0), enlarged_content1 - content1);
+            content_type const content_increase2
+                = (std::max)(content_type(0), enlarged_content2 - content2);
 
-            content_type content_incrase_diff = content_incrase1 < content_incrase2 ?
-                content_incrase2 - content_incrase1 : content_incrase1 - content_incrase2;
+            content_type content_increase_diff = content_increase1 < content_increase2 ?
+                content_increase2 - content_increase1 : content_increase1 - content_increase2;
 
-            if ( greatest_content_incrase_diff < content_incrase_diff )
+            if ( greatest_content_increase_diff < content_increase_diff )
             {
-                greatest_content_incrase_diff = content_incrase_diff;
+                greatest_content_increase_diff = content_increase_diff;
                 out_it = el_it;
-                out_content_increase1 = content_incrase1;
-                out_content_increase2 = content_incrase2;
+                out_content_increase1 = content_increase1;
+                out_content_increase2 = content_increase2;
             }
         }
 

--- a/include/boost/geometry/index/detail/rtree/rstar/choose_next_node.hpp
+++ b/include/boost/geometry/index/detail/rtree/rstar/choose_next_node.hpp
@@ -117,7 +117,7 @@ private:
 
             // areas difference
             content_type content = index::detail::content(box_exp);
-            content_type content_diff = content - index::detail::content(ch_i.first);
+            content_type content_diff = index::detail::content_diff(box_exp, ch_i.first);
 
             children_contents[i].set(i, content, content_diff);
 
@@ -246,7 +246,7 @@ private:
 
             // areas difference
             content_type content = index::detail::content(box_exp);
-            content_type content_diff = content - index::detail::content(ch_i.first);
+            content_type content_diff = index::detail::content_diff(box_exp, ch_i.first);
 
             // update the result
             if ( content_diff < smallest_content_diff ||

--- a/include/boost/geometry/index/detail/rtree/visitors/insert.hpp
+++ b/include/boost/geometry/index/detail/rtree/visitors/insert.hpp
@@ -89,7 +89,7 @@ public:
 
             // areas difference
             content_type content = index::detail::content(box_exp);
-            content_type content_diff = content - index::detail::content(ch_i.first);
+            content_type content_diff = index::detail::content_diff(box_exp, ch_i.first);
 
             // update the result
             if ( content_diff < smallest_content_diff ||


### PR DESCRIPTION
Might fix #1452

@tinko92 could you verify if this helps the problem?

The fix is by Claude Code (reviewed/directed by me), it argues:

```
 Analysis

  The core invariant being violated

  When box_exp is expanded from box_orig to include an indexable, we have box_exp ⊇ box_orig, so mathematically content(box_exp) >=
  content(box_orig) and content_diff >= 0. With FMA fusion, this invariant breaks: the multiply inside content() fuses with the
  subsequent subtraction differently for the two calls, yielding negative or spuriously non-zero results.

  The dangerous patterns

  Every call site follows one of two shapes:

  Shape 1 — "enlargement cost" (5 sites): content(expanded) - content(original)
  - insert.hpp:92
  - rstar/choose_next_node.hpp:120, 249
  - quadratic/redistribute_elements.hpp:294-295
  - linear/redistribute_elements.hpp:435-436

  Shape 2 — "free content" (1 site): content(union) - content(a) - content(b)
  - quadratic/redistribute_elements.hpp:77-79

  In all cases the result is mathematically guaranteed >= 0, but FMA can make it negative or spuriously non-zero.

  Why negative matters more than "slightly different positive"

  When content_diff becomes negative for a box that didn't actually expand, that box appears to shrink when receiving the new element —
  making it the "best" choice by a wide margin. This cascades: wrong node selections lead to a suboptimal tree structure (6685 nodes
  instead of 6763 in the reported case), which means far less effective pruning during queries.

  The fix: clamp to the known invariant

  Since we know these differences are >= 0, clamping them is mathematically sound and eliminates the FMA issue without suppressing any  compiler optimizations globally:

  content_type content_diff = (std::max)(content_type(0),
      content - index::detail::content(ch_i.first));

  This fixes both failure modes:
  - Negative values become exactly 0 (correct: the box didn't enlarge)
  - "Should be zero but is epsilon" — while (std::max) doesn't fix this, it doesn't need to. Two boxes that both don't enlarge will both   clamp to exactly 0, so equality comparisons work. Two boxes that both enlarge by a tiny positive amount are just heuristic  tie-breakers where sub-ULP differences are irrelevant.

  Interesting existing precedent

  The code at rstar/choose_next_node.hpp:135 already does epsilon-aware comparison:
  if ( min_content_diff < -std::numeric_limits<content_type>::epsilon()
    || std::numeric_limits<content_type>::epsilon() < min_content_diff )
  This shows the codebase already anticipated near-zero issues, just not systematically.

  What about the == comparisons?

  Lines like content_diff == smallest_content_diff and content1 == content2 are used as tie-breakers. After clamping, the most important
   case — two equal boxes both showing zero enlargement — will compare as exactly 0 == 0. For two genuinely different enlargements,
  sub-ULP differences in tie-breaking are harmless for the heuristic.

  Concrete changes needed:

  │ insert.hpp                          │ 92      │ Clamp content_diff                 │
  │ rstar/choose_next_node.hpp          │ 120     │ Clamp content_diff                 │
  │ rstar/choose_next_node.hpp          │ 249     │ Clamp content_diff                 │
  │ quadratic/redistribute_elements.hpp │ 77-79   │ Clamp free_content                 │
  │ quadratic/redistribute_elements.hpp │ 294-295 │ Clamp both content_increase values │
  │ linear/redistribute_elements.hpp    │ 435-436 │ Clamp both content_increase values │
 ```

I think this makes sense, looks good - and locally it did not break any unit tests (the RST always failed for me - on the fly that is fixed now as well, see other PR)