### PR TITLE
Skip unnecessary longitude normalization on antimeridian-crossing box

### DIFF
--- a/include/boost/geometry/util/normalize_spheroidal_box_coordinates.hpp
+++ b/include/boost/geometry/util/normalize_spheroidal_box_coordinates.hpp
@@ -48,8 +48,13 @@ public:
                              CoordinateType& latitude2,
                              bool band)
     {
+        bool const allow_antimeridian_crossing =
+               longitude1 >= constants::min_longitude()
+            && longitude1 <= constants::max_longitude()
+            && longitude2 > constants::max_longitude()
+            && longitude2 - constants::period() < longitude1;
         normalize::apply(longitude1, latitude1, false);
-        normalize::apply(longitude2, latitude2, false);
+        normalize::apply(longitude2, latitude2, false, true, allow_antimeridian_crossing);
 
         latitude_convert_if_polar<Units, IsEquatorial>::apply(latitude1);
         latitude_convert_if_polar<Units, IsEquatorial>::apply(latitude2);

--- a/include/boost/geometry/util/normalize_spheroidal_coordinates.hpp
+++ b/include/boost/geometry/util/normalize_spheroidal_coordinates.hpp
@@ -223,7 +223,8 @@ protected:
     }
 
 public:
-    static inline void apply(CoordinateType& longitude, bool exact = true)
+    static inline void apply(CoordinateType& longitude, bool exact = true,
+                             bool allow_antimeridian_crossing = false)
     {
         // normalize longitude
         CoordinateType const epsilon = std::numeric_limits<float>::epsilon();
@@ -234,7 +235,7 @@ public:
         {
             longitude = constants::half_period();
         }
-        else if (longitude > constants::half_period())
+        else if ( ! allow_antimeridian_crossing && longitude > constants::half_period())
         {
             longitude = normalize_up(longitude);
             if (exact || is_integer ? math::equals(longitude, -constants::half_period())
@@ -252,7 +253,8 @@ public:
     static inline void apply(CoordinateType& longitude,
                              CoordinateType& latitude,
                              bool normalize_poles = true,
-                             bool exact = true)
+                             bool exact = true,
+                             bool allow_antimeridian_crossing = false)
     {
         latitude_convert_if_polar<Units, IsEquatorial>::apply(latitude);
 
@@ -281,7 +283,7 @@ public:
 #endif // BOOST_GEOMETRY_NORMALIZE_LATITUDE
 
         // normalize longitude
-        apply(longitude, exact);
+        apply(longitude, exact, allow_antimeridian_crossing);
 
         // finally normalize poles
         if (normalize_poles)
@@ -302,7 +304,8 @@ public:
 #endif // BOOST_GEOMETRY_NORMALIZE_LATITUDE
 
         BOOST_GEOMETRY_ASSERT(! math::larger_or_equals(constants::min_longitude(), longitude));
-        BOOST_GEOMETRY_ASSERT(! math::larger(longitude, constants::max_longitude()));
+        BOOST_GEOMETRY_ASSERT(! math::larger(longitude, constants::max_longitude())
+                              || allow_antimeridian_crossing);
     }
 };
 

--- a/test/algorithms/envelope_expand/expand_on_spheroid.cpp
+++ b/test/algorithms/envelope_expand/expand_on_spheroid.cpp
@@ -591,6 +591,13 @@ void test_expand_point()
                   from_wkt<B>("BOX(10 -90,100 90)"),
                   from_wkt<G>("POINT(-95 -90)"),
                   10, -90, 100, 90);
+
+    // box crosses anti-meridian and contains point so it should not be changed
+    tester::apply("p21",
+                  from_wkt<B>("BOX(170 0,190.4 2)"),
+                  from_wkt<G>("POINT(175 1)"),
+                  170, 0, 190.4, 2,
+                  0.0);
 }
 
 BOOST_AUTO_TEST_CASE( expand_point )

--- a/test/algorithms/envelope_expand/test_envelope_expand_on_spheroid.hpp
+++ b/test/algorithms/envelope_expand/test_envelope_expand_on_spheroid.hpp
@@ -246,7 +246,7 @@ struct box_check_equals
             && (bg::get<0, 1>(box) < 0
                 ? equals(bg::get<0, 1>(box), lat_min)
                 : equals_with_eps(bg::get<0, 1>(box), lat_min))
-            && equals_with_eps(bg::get<1, 0>(box), lon_max)
+            && equals(bg::get<1, 0>(box), lon_max)
             && (bg::get<1, 1>(box) > 0
                 ? equals(bg::get<1, 1>(box), lat_max)
                 : equals_with_eps(bg::get<1, 1>(box), lat_max));


### PR DESCRIPTION
The program in issue #1452 triggers some cases in which a box shrinks when being expanded with a point that is already within it, due to rounding errors introduced unnecessarily in coordinate normalization. When a box crosses the antimeridian, the longitude of its max point is first normalized to be within [-180, 180], then increased by half_period() again, which can introduce rounding error, including shrinking the box. the shrinking then seems to produce unstable behaviour in the rtree when the computed area difference between a boxes expansion and itself is negative. This is only a small part of the tree instability in #1452 and does not resolve most of the issue but isolated enough from the other issues to be treated in a separated PR.

This PR contains the following changes:
1. Adds a flag that detects when a box crosses the antimeridian and has otherwise valid max longitude, and passes this flag down to coordinate normalization, so that this longitude is then not normalized down.
2. Add a test case with tolerance=0.0, in which the box would shrink without this change.
3. Update the box_equal code to respect the passed tolerance in longitude comparison rather than using the (more lenient) bg::math::equals unconditionally.