### PR TITLE
Adding explanation about BG examples in README and quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Boost.Geometry, part of collection of the [Boost C++ Libraries](http://github.co
 
 ### Directories
 
-* **doc** - QuickBook documentation sources
-* **example** - Boost.Geometry examples
+* **doc** - QuickBook documentation sources, containing embedded examples located in `doc/src/examples/`
+* **example** - Boost.Geometry standalone examples
 * **_extensions_** - examples and tests for the extensions - _develop branch_
 * **include** - the sourcecode of Boost.Geometry
 * **index** - examples and tests for the Spatial Index

--- a/doc/quickstart.qbk
+++ b/doc/quickstart.qbk
@@ -15,6 +15,10 @@
 This Quick Start section shows some of the features of __boost_geometry__
 in the form of annotated, relatively simple, code snippets.
 
+For longer standalone tutorial-style programs, see the repository's `example/` directory;
+for smaller reference-oriented snippets used throughout the manual,
+see `doc/src/examples/`.
+
 The code below assumes that `boost/geometry.hpp` is included, and that `namespace 
 boost::geometry` is used. __boost_geometry__ is header only, so including 
 headerfiles is enough. There is no linking with any library necessary.


### PR DESCRIPTION
This pull request updates documentation to clarify the organization and location of code examples within the Boost.Geometry project as identified in the relevant JOSS review ([comment1](https://github.com/openjournals/joss-reviews/issues/10328#issuecomment-4322783598), [comment2](https://github.com/openjournals/joss-reviews/issues/10328#issuecomment-4305002945)).
The changes help users distinguish between standalone tutorial programs and smaller reference snippets, making it easier to find relevant example code.

Documentation improvements:

* Updated the `README.md` to specify that the `doc` directory contains QuickBook documentation sources with embedded examples in `doc/src/examples/`, and clarified that the `example` directory contains standalone examples.
* Added guidance in `doc/quickstart.qbk` directing users to the `example/` directory for longer tutorial-style programs and to `doc/src/examples/` for smaller reference-oriented snippets.

