### PR TITLE
Fix degenerate linestring relation on boundary of areal

### DIFF
--- a/include/boost/geometry/algorithms/detail/relate/linear_areal.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/linear_areal.hpp
@@ -65,26 +65,26 @@ public:
         , m_result(res)
         , m_strategy(strategy)
         , m_boundary_checker(boundary_checker)
-        , m_interrupt_flags(0)
+        , m_interrupt_flags(0x00)
     {
         if ( ! may_update<interior, interior, '1', TransposeResult>(m_result) )
         {
-            m_interrupt_flags |= 1;
+            m_interrupt_flags |= 0x01;
         }
 
         if ( ! may_update<interior, exterior, '1', TransposeResult>(m_result) )
         {
-            m_interrupt_flags |= 2;
+            m_interrupt_flags |= 0x02;
         }
 
         if ( ! may_update<boundary, interior, '0', TransposeResult>(m_result) )
         {
-            m_interrupt_flags |= 4;
+            m_interrupt_flags |= 0x04;
         }
 
         if ( ! may_update<boundary, exterior, '0', TransposeResult>(m_result) )
         {
-            m_interrupt_flags |= 8;
+            m_interrupt_flags |= 0x08;
         }
 
         if ( ! may_update<interior, boundary, '1', TransposeResult>(m_result) )
@@ -119,7 +119,7 @@ public:
         if ( pig > 0 )
         {
             update<interior, interior, '1', TransposeResult>(m_result);
-            m_interrupt_flags |= 1;
+            m_interrupt_flags |= 0x01;
         }
         else if ( pig == 0 )
         {
@@ -132,7 +132,7 @@ public:
         else
         {
             update<interior, exterior, '1', TransposeResult>(m_result);
-            m_interrupt_flags |= 2;
+            m_interrupt_flags |= 0x02;
         }
 
         // check if there is a boundary
@@ -143,12 +143,12 @@ public:
             if ( pig > 0 )
             {
                 update<boundary, interior, '0', TransposeResult>(m_result);
-                m_interrupt_flags |= 4;
+                m_interrupt_flags |= 0x04;
             }
             else
             {
                 update<boundary, exterior, '0', TransposeResult>(m_result);
-                m_interrupt_flags |= 8;
+                m_interrupt_flags |= 0x08;
             }
         }
 

--- a/include/boost/geometry/algorithms/detail/relate/linear_areal.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/linear_areal.hpp
@@ -99,7 +99,7 @@ public:
         std::size_t const count = boost::size(linestring);
 
         // invalid input
-        if ( count < 2 )
+        if ( count < 1 )
         {
             // ignore
             // TODO: throw an exception?

--- a/include/boost/geometry/algorithms/detail/relate/linear_areal.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/linear_areal.hpp
@@ -86,6 +86,11 @@ public:
         {
             m_interrupt_flags |= 8;
         }
+
+        if ( ! may_update<interior, boundary, '1', TransposeResult>(m_result) )
+        {
+            m_interrupt_flags |= 0x10;
+        }
     }
 
     template <typename Linestring>
@@ -102,7 +107,7 @@ public:
         }
 
         // if those flags are set nothing will change
-        if ( m_interrupt_flags == 0xF )
+        if ( m_interrupt_flags == 0x1F )
         {
             return false;
         }
@@ -110,12 +115,19 @@ public:
         int const pig = detail::within::point_in_geometry(range::front(linestring),
                                                           m_geometry2,
                                                           m_strategy);
-        //BOOST_GEOMETRY_ASSERT_MSG(pig != 0, "There should be no IPs");
 
         if ( pig > 0 )
         {
             update<interior, interior, '1', TransposeResult>(m_result);
             m_interrupt_flags |= 1;
+        }
+        else if ( pig == 0 )
+        {
+            // no turns but still point on boundary can actually happen when the
+            // linestring is degenerate. so handle this case explicitly here.
+            // for consistency let's still report dimension 1 instead of 0
+            update<interior, boundary, '1', TransposeResult>(m_result);
+            m_interrupt_flags |= 0x10;
         }
         else
         {
@@ -140,7 +152,7 @@ public:
             }
         }
 
-        return m_interrupt_flags != 0xF
+        return m_interrupt_flags != 0x1F
             && ! m_result.interrupt;
     }
 

--- a/test/algorithms/covered_by/covered_by.cpp
+++ b/test/algorithms/covered_by/covered_by.cpp
@@ -141,6 +141,24 @@ void test_all()
     test_geometry<box<P>, poly<P>>("BOX(1 1,2 2)", "POLYGON((0 0,0 3,3 1,1 0,0 0))", false);
     test_geometry<box<P>, mpoly<P>>("BOX(1 1,2 2)", "MULTIPOLYGON(((0 0,0 3,3 3,3 0,0 0)),((-1 -1,-3 -4,-7 -7,-4 -3,-1 -1)))", true);
     test_geometry<box<P>, mpoly<P>>("BOX(1 1,2 2)", "MULTIPOLYGON(((0 0,0 3,3 1,1 0,0 0)),((-1 -1,-3 -4,-7 -7,-4 -3,-1 -1)))", false);
+
+    // degenerate line segment - polygon
+    {
+        // on corner
+        test_geometry<ls<P>, poly<P>>("LINESTRING(0 0,0 0)", "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))", true);
+        // on edge
+        test_geometry<ls<P>, poly<P>>("LINESTRING(1 2,1 2)", "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))", true);
+        // inside
+        test_geometry<ls<P>, poly<P>>("LINESTRING(1 1,1 1)", "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))", true);
+        // outside
+        test_geometry<ls<P>, poly<P>>("LINESTRING(1 3,1 3)", "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))", false);
+        // inside hole
+        test_geometry<ls<P>, poly<P>>("LINESTRING(2 2,2 2)", "POLYGON((0 0, 0 4, 4 4, 4 0, 0 0),(1 1, 1 3, 3 3, 3 1, 1 1))", false);
+        // on corner of hole
+        test_geometry<ls<P>, poly<P>>("LINESTRING(3 3,3 3)", "POLYGON((0 0, 0 4, 4 4, 4 0, 0 0),(1 1, 1 3, 3 3, 3 1, 1 1))", true);
+        // on edge of hole
+        test_geometry<ls<P>, poly<P>>("LINESTRING(2 1,2 1)", "POLYGON((0 0, 0 4, 4 4, 4 0, 0 0),(1 1, 1 3, 3 3, 3 1, 1 1))", true);
+    }
 }
 
 

--- a/test/algorithms/covered_by/covered_by.cpp
+++ b/test/algorithms/covered_by/covered_by.cpp
@@ -146,18 +146,25 @@ void test_all()
     {
         // on corner
         test_geometry<ls<P>, poly<P>>("LINESTRING(0 0,0 0)", "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))", true);
+        test_geometry<ls<P>, poly<P>>("LINESTRING(0 0)", "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))", true);
         // on edge
         test_geometry<ls<P>, poly<P>>("LINESTRING(1 2,1 2)", "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))", true);
+        test_geometry<ls<P>, poly<P>>("LINESTRING(1 2)", "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))", true);
         // inside
         test_geometry<ls<P>, poly<P>>("LINESTRING(1 1,1 1)", "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))", true);
+        test_geometry<ls<P>, poly<P>>("LINESTRING(1 1)", "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))", true);
         // outside
         test_geometry<ls<P>, poly<P>>("LINESTRING(1 3,1 3)", "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))", false);
+        test_geometry<ls<P>, poly<P>>("LINESTRING(1 3)", "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))", false);
         // inside hole
         test_geometry<ls<P>, poly<P>>("LINESTRING(2 2,2 2)", "POLYGON((0 0, 0 4, 4 4, 4 0, 0 0),(1 1, 1 3, 3 3, 3 1, 1 1))", false);
+        test_geometry<ls<P>, poly<P>>("LINESTRING(2 2)", "POLYGON((0 0, 0 4, 4 4, 4 0, 0 0),(1 1, 1 3, 3 3, 3 1, 1 1))", false);
         // on corner of hole
         test_geometry<ls<P>, poly<P>>("LINESTRING(3 3,3 3)", "POLYGON((0 0, 0 4, 4 4, 4 0, 0 0),(1 1, 1 3, 3 3, 3 1, 1 1))", true);
+        test_geometry<ls<P>, poly<P>>("LINESTRING(3 3)", "POLYGON((0 0, 0 4, 4 4, 4 0, 0 0),(1 1, 1 3, 3 3, 3 1, 1 1))", true);
         // on edge of hole
         test_geometry<ls<P>, poly<P>>("LINESTRING(2 1,2 1)", "POLYGON((0 0, 0 4, 4 4, 4 0, 0 0),(1 1, 1 3, 3 3, 3 1, 1 1))", true);
+        test_geometry<ls<P>, poly<P>>("LINESTRING(2 1)", "POLYGON((0 0, 0 4, 4 4, 4 0, 0 0),(1 1, 1 3, 3 3, 3 1, 1 1))", true);
     }
 }
 

--- a/test/algorithms/relate/relate_linear_areal.cpp
+++ b/test/algorithms/relate/relate_linear_areal.cpp
@@ -282,18 +282,25 @@ void test_linestring_polygon()
     {
         // on corner
         test_geometry<ls, poly>("LINESTRING(0 0,0 0)", "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))", "F1FFFF212");
+        test_geometry<ls, poly>("LINESTRING(0 0)", "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))", "F1FFFF212");
         // on edge
         test_geometry<ls, poly>("LINESTRING(1 2,1 2)", "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))", "F1FFFF212");
+        test_geometry<ls, poly>("LINESTRING(1 2)", "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))", "F1FFFF212");
         // inside
         test_geometry<ls, poly>("LINESTRING(1 1,1 1)", "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))", "1FFFFF212");
+        test_geometry<ls, poly>("LINESTRING(1 1)", "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))", "1FFFFF212");
         // outside
         test_geometry<ls, poly>("LINESTRING(1 3,1 3)", "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))", "FF1FFF212");
+        test_geometry<ls, poly>("LINESTRING(1 3)", "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))", "FF1FFF212");
         // inside hole
         test_geometry<ls, poly>("LINESTRING(2 2,2 2)", "POLYGON((0 0, 0 4, 4 4, 4 0, 0 0),(1 1, 1 3, 3 3, 3 1, 1 1))", "FF1FFF212");
+        test_geometry<ls, poly>("LINESTRING(2 2)", "POLYGON((0 0, 0 4, 4 4, 4 0, 0 0),(1 1, 1 3, 3 3, 3 1, 1 1))", "FF1FFF212");
         // on corner of hole
         test_geometry<ls, poly>("LINESTRING(3 3,3 3)", "POLYGON((0 0, 0 4, 4 4, 4 0, 0 0),(1 1, 1 3, 3 3, 3 1, 1 1))", "F1FFFF212");
+        test_geometry<ls, poly>("LINESTRING(3 3)", "POLYGON((0 0, 0 4, 4 4, 4 0, 0 0),(1 1, 1 3, 3 3, 3 1, 1 1))", "F1FFFF212");
         // on edge of hole
         test_geometry<ls, poly>("LINESTRING(2 1,2 1)", "POLYGON((0 0, 0 4, 4 4, 4 0, 0 0),(1 1, 1 3, 3 3, 3 1, 1 1))", "F1FFFF212");
+        test_geometry<ls, poly>("LINESTRING(2 1)", "POLYGON((0 0, 0 4, 4 4, 4 0, 0 0),(1 1, 1 3, 3 3, 3 1, 1 1))", "F1FFFF212");
     }
 }
 

--- a/test/algorithms/relate/relate_linear_areal.cpp
+++ b/test/algorithms/relate/relate_linear_areal.cpp
@@ -277,6 +277,24 @@ void test_linestring_polygon()
     test_geometry<ls, poly>("LINESTRING(2 9, 1 1, 10 1, 10 10, 1 10, 0 6, 5 6)",
                             "POLYGON((0 0,0 10,10 10,10 0,0 0),(4 4,4 6,6 6,6 4,4 4))",
                             "11F00F212");
+
+    // degenerate line segment
+    {
+        // on corner
+        test_geometry<ls, poly>("LINESTRING(0 0,0 0)", "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))", "F1FFFF212");
+        // on edge
+        test_geometry<ls, poly>("LINESTRING(1 2,1 2)", "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))", "F1FFFF212");
+        // inside
+        test_geometry<ls, poly>("LINESTRING(1 1,1 1)", "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))", "1FFFFF212");
+        // outside
+        test_geometry<ls, poly>("LINESTRING(1 3,1 3)", "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))", "FF1FFF212");
+        // inside hole
+        test_geometry<ls, poly>("LINESTRING(2 2,2 2)", "POLYGON((0 0, 0 4, 4 4, 4 0, 0 0),(1 1, 1 3, 3 3, 3 1, 1 1))", "FF1FFF212");
+        // on corner of hole
+        test_geometry<ls, poly>("LINESTRING(3 3,3 3)", "POLYGON((0 0, 0 4, 4 4, 4 0, 0 0),(1 1, 1 3, 3 3, 3 1, 1 1))", "F1FFFF212");
+        // on edge of hole
+        test_geometry<ls, poly>("LINESTRING(2 1,2 1)", "POLYGON((0 0, 0 4, 4 4, 4 0, 0 0),(1 1, 1 3, 3 3, 3 1, 1 1))", "F1FFFF212");
+    }
 }
 
 template <typename P>


### PR DESCRIPTION
Basically makes it so `covered_by` returns `true` for `LINESTRING(0 0,0 0)` and `POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))` instead of `false` as it did previously, which could be quite surprising.

Fixes #1473

The bit flags for interrupt aren't exactly pretty, but it follows the present implementation.