### PR TITLE
Fix/bjam leaking cxx14

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -5,9 +5,6 @@
 
 require-b2 5.2 ;
 
-import-search /boost/config/checks ;
-import config : requires ;
-
 constant boost_dependencies :
     /boost/algorithm//boost_algorithm
     /boost/any//boost_any
@@ -41,22 +38,12 @@ constant boost_dependencies :
     /boost/variant//boost_variant
     /boost/variant2//boost_variant2 ;
 
-project /boost/geometry
-    : common-requirements
-        <include>include
-    : requirements
-        [ requires
-            cxx14_constexpr
-            cxx14_return_type_deduction
-        ]
-        <toolset>msvc:<asynch-exceptions>on
-    ;
+project /boost/geometry ;
 
 explicit
-    [ alias boost_geometry : : : : <library>$(boost_dependencies) ]
+    [ alias boost_geometry : : : : <include>include <library>$(boost_dependencies) ]
     [ alias all : boost_geometry test example doc/src/examples index extensions ]
     ;
 
 call-if : boost-library geometry
     ;
-

--- a/doc/src/examples/Jamfile
+++ b/doc/src/examples/Jamfile
@@ -9,9 +9,17 @@
 # http://www.boost.org/LICENSE_1_0.txt)
 
 
+import-search /boost/config/checks ;
+import config : requires ;
+
 project boost-geometry-doc-src-example
     : requirements
         <library>/boost/geometry//boost_geometry
+        <cxxstd>14
+        [ requires
+            cxx14_constexpr
+            cxx14_return_type_deduction
+        ]
     ;
 
 exe quick_start : quick_start.cpp ;

--- a/example/Jamfile
+++ b/example/Jamfile
@@ -10,10 +10,18 @@
 # http://www.boost.org/LICENSE_1_0.txt)
 
 
+import-search /boost/config/checks ;
+import config : requires ;
+
 project boost-geometry-example
     : requirements
         <library>/boost/geometry//boost_geometry
         <library>/boost/foreach//boost_foreach
+        <cxxstd>14
+        [ requires
+            cxx14_constexpr
+            cxx14_return_type_deduction
+        ]
     ;
 
 exe 01_point_example : 01_point_example.cpp ;

--- a/extensions/Jamfile
+++ b/extensions/Jamfile
@@ -8,12 +8,20 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+import-search /boost/config/checks ;
+import config : requires ;
+
 project boost-geometry-extensions
     :
     requirements
         <toolset>msvc:<asynch-exceptions>on
         <library>/boost/geometry//boost_geometry
         <library>/boost/test//included
+        <cxxstd>14
+        [ requires
+            cxx14_constexpr
+            cxx14_return_type_deduction
+        ]
     ;
 
 build-project test ;

--- a/include/boost/geometry/srs/projections/code.hpp
+++ b/include/boost/geometry/srs/projections/code.hpp
@@ -11,6 +11,7 @@
 #define BOOST_GEOMETRY_PROJECTIONS_CODE_HPP
 
 
+#include <array>
 #include <cmath>
 
 #include <boost/geometry/srs/projections/dpar.hpp>

--- a/index/Jamfile
+++ b/index/Jamfile
@@ -8,10 +8,18 @@
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+import-search /boost/config/checks ;
+import config : requires ;
+
 project boost-geometry-index
     :
     requirements
         <library>/boost/geometry//boost_geometry
+        <cxxstd>14
+        [ requires
+            cxx14_constexpr
+            cxx14_return_type_deduction
+        ]
         <toolset>msvc:<asynch-exceptions>on
     ;
 

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -14,11 +14,18 @@
 
 import os ;
 import testing ;
+import-search /boost/config/checks ;
+import config : requires ;
 
 project boost-geometry-test
     :
     requirements
         <library>/boost/geometry//boost_geometry
+        <cxxstd>14
+        [ requires
+            cxx14_constexpr
+            cxx14_return_type_deduction
+        ]
         <include>.
         <toolset>msvc:<asynch-exceptions>on
         <toolset>msvc:<cxxflags>/bigobj
@@ -55,4 +62,3 @@ build-project util ;
 build-project views ;
 
 }
-


### PR DESCRIPTION
This PR aims to solve #1460 . The cxx14 requirements are moved from build.jam to the respective buildable targets. Because I lack deeper insight into the B2 conventions in boost, I copied this pattern from boostorg/gil. In addition this PR also sets the target C++ version via <cxxstd>14 for all buildable targets. This fixes the tests not building on my machine without adding a cxx version, probably due to https://github.com/boostorg/boost/blob/2813c94a3eefd1adbf623703f9c4d8e818f5398f/Jamroot#L256 . It's two commits to separate out the change to extensions for release picking.

The added include of array in code.hpp is due to this breaking the CI header target, I suspect because GCC otherwise defaults to a higher C++ version where the include from <array> comes indirectly through some other include chain but of course it should be explicit where it's used anyway so this was an oversight in my original work.