### PR TITLE
Narrow the condition for the parent assignment optimisation to union …

### DIFF
--- a/include/boost/geometry/algorithms/detail/overlay/assign_parents.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/assign_parents.hpp
@@ -249,7 +249,6 @@ inline void assign_parents(Geometry1 const& geometry1,
             RingMap& ring_map,
             Strategy const& strategy)
 {
-    static bool const is_difference = OverlayType == overlay_difference;
     static bool const is_buffer = OverlayType == overlay_buffer;
     static bool const is_dissolve = OverlayType == overlay_dissolve;
     static bool const check_for_orientation = is_buffer || is_dissolve;
@@ -316,7 +315,7 @@ inline void assign_parents(Geometry1 const& geometry1,
                 return;
             }
 
-            if (count_positive == 1 && ! is_difference && ! is_dissolve)
+            if (count_positive == 1 && OverlayType == overlay_union)
             {
                 // Optimization for one outer ring
                 // -> assign this as parent to all others (all interior rings)

--- a/test/algorithms/set_operations/set_ops_areal_areal.cpp
+++ b/test/algorithms/set_operations/set_ops_areal_areal.cpp
@@ -298,10 +298,7 @@ int test_main(int, char* [])
 
     TEST_CASE(case_bitset_1);
     TEST_CASE(case_bitset_2);
-#if defined(BOOST_GEOMETRY_TEST_FAILURES)
-    // Needs a fix in assign_parents
     TEST_CASE(case_bitset_3);
-#endif
 
     TEST_CASE(case_recursive_boxes_89);
     TEST_CASE(case_recursive_boxes_90);


### PR DESCRIPTION
This PR fixes case_bitset_3 which fails for intersection due to the optimisation for one outer ring, which seems only safe for union (that seems to be consistent with the comment). The local is_difference variable was removed because it is now unused and no new variable was created because this  condition is checked only on one line and is readable. The test case was enabled.