### PR TITLE
Fix Doxygen warnings

### DIFF
--- a/doc/doxy/Doxyfile
+++ b/doc/doxy/Doxyfile
@@ -1,4 +1,4 @@
-# Doxyfile 1.5.5
+# Doxyfile 1.14.0
 
 #---------------------------------------------------------------------------
 # Project related configuration options
@@ -6,8 +6,12 @@
 DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = "Boost.Geometry (aka GGL)"
 PROJECT_NUMBER         =
+PROJECT_BRIEF          =
+PROJECT_LOGO           =
 OUTPUT_DIRECTORY       = ./doxygen_output
 CREATE_SUBDIRS         = NO
+CREATE_SUBDIRS_LEVEL   = 8
+ALLOW_UNICODE_NAMES    = NO
 OUTPUT_LANGUAGE        = English
 BRIEF_MEMBER_DESC      = YES
 REPEAT_BRIEF           = YES
@@ -15,13 +19,15 @@ ABBREVIATE_BRIEF       =
 ALWAYS_DETAILED_SEC    = YES
 INLINE_INHERITED_MEMB  = NO
 FULL_PATH_NAMES        = YES
-STRIP_FROM_PATH        = c:/_svn/boost/trunk/boost/geometry  \
+STRIP_FROM_PATH        = c:/_svn/boost/trunk/boost/geometry \
                          c:/_svn/boost/trunk/libs/geometry/doc/doxygen_input/pages
 STRIP_FROM_INC_PATH    =
 SHORT_NAMES            = NO
 JAVADOC_AUTOBRIEF      = NO
+JAVADOC_BANNER         = NO
 QT_AUTOBRIEF           = NO
 MULTILINE_CPP_IS_BRIEF = NO
+PYTHON_DOCSTRING       = YES
 INHERIT_DOCS           = YES
 SEPARATE_MEMBER_PAGES  = NO
 TAB_SIZE               = 8
@@ -37,119 +43,133 @@ TAB_SIZE               = 8
 # \tparam* for various template parameters
 # \param* for various parameters
 # \return* for various return cases
-ALIASES                = qbk{1}="\xmlonly <qbk>\1</qbk> \endxmlonly" \
-                         qbk{2}="\xmlonly <qbk.\1>\2</qbk.\1> \endxmlonly" \
-                         wkt="WKT" \
-                         well_known_text="Well-Known Text" \
-                         brief_calc{1}="Calculates the \1 of a geometry" \
-                         brief_calc2{1}="Calculate the \1 of two geometries" \
-                         brief_calc2{2}="Calculate the \1 \2 two geometries" \
-                         brief_check{1}="Checks if a geometry \1" \
-                         brief_check2{1}="Checks if two geometries \1" \
-                         brief_check12{1}="Checks if the first geometry \1 the second geometry" \
-                         brief_strategy="using the specified strategy" \
-                         brief_macro{1}="Macro to register a \1" \
-                         brief_macro_const=" (const version)" \
-                         brief_macro_getset=" (having separate get/set methods)" \
-                         brief_meta{3}="Metafunction defining [*\1] as the \2 of the \3" \
-                         tparam_allocator="container-allocator-type" \
-                         tparam_box="Any type fulfilling a Box Concept" \
-                         tparam_box_or_segment="Any type fulfilling a Box Concept or a Segment Concept" \
-                         tparam_calculation="numeric type for calculation (e.g. high precision); if [*void] then it is extracted automatically from the coordinate type and (if necessary) promoted to floating point" \
-                         tparam_radius="numeric type for radius (of sphere, earth)" \
-                         tparam_radius_or_sphere="numeric type for radius (of sphere, earth) or sphere model" \
-                         tparam_container="container type, for example std::vector, std::deque" \
-                         tparam_dimension_required="Dimension, this template parameter is required. Should contain \\[0 .. n-1\\] for an n-dimensional geometry" \
-                         tparam_functor="Function or class with operator()" \
-                         tparam_output_collection="output collection, either a multi-geometry, or a std::vector<Geometry> / std::deque<Geometry> etc" \
-                         tparam_geometry="Any type fulfilling a Geometry Concept" \
-                         tparam_geometry{1}="A type fulfilling the \1 Concept" \
-                         tparam_index_required="Index, this template parameter is required. For a Box: either min_corner or max_corner. For a Segment: either 0 or 1 for first or last point." \
-                         tparam_numeric="numerical type (int, double, ttmath, ...)" \
-                         tparam_out{1}="A valid output iterator type, accepting geometries of \1 Concept" \
-                         tparam_point="Any type fulfilling a Point Concept" \
-                         tparam_range_point="Any type fulfilling a Range Concept where it range_value type fulfills the Point Concept" \
-                         tparam_first_point="first point type" \
-                         tparam_first_box="first box type" \
-                         tparam_second_point="second point type" \
-                         tparam_second_box="second box type" \
-                         tparam_segment_point="segment point type" \
-                         tparam_strategy{1}="Any type fulfilling a \1 Strategy Concept" \
-                         tparam_strategy_overlay="Compound strategy for segment intersection" \
-                         param_box="A model of the specified Box Concept" \
-                         param_box_or_segment="A box modelling the specified Box Concept or segment modelling the specified Segment Concept" \
-                         param_geometry="A model of the specified concept" \
-                         param_out{1}="The output iterator, to which \1 geometries are feeded" \
-                         param_point="A model of the specified Point Concept" \
-                         param_set{1}="which is set to the \1" \
-                         param_strategy{1}="The strategy which will be used for \1 calculations" \
-                         param_macro_type{1}="\1 type to be registered" \
-                         param_macro_coortype{1}="Type of the coordinates of the \1 (e.g. double)" \
-                         param_macro_coorsystem="Coordinate system (e.g. cs::cartesian)" \
-                         param_macro_member{1}="Member containing \1 coordinate" \
-                         param_macro_getset{2}="Method to \1 the \2 coordinate" \
-                         param_range_point="A range containing points fulfilling range and point concepts" \
-                         param_x="First coordinate (usually x-coordinate)" \
-                         param_y="Second coordinate (usually y-coordinate)" \
-                         param_z="Third coordinate (usually z-coordinate)" \
-                         constructor_default_no_init="Default constructor, no initialization" \
-                         constructor_default{1}="Default constructor, creating an empty \1" \
-                         constructor_begin_end{1}="Constructor with begin and end,  filling the \1" \
-                         constructor_initializer_list{1}="Constructor taking std::initializer_list, filling the \1" \
-                         assignment_initializer_list{1}="Assignment operator taking std::initializer_list, assigning values to the \1" \
-                         details_calc{2}="The free function \1 calculates the \2 of a geometry" \
-                         details_calc{1}="The free function \1 calculates the \1 of a geometry" \
-                         details_calc2{2}="The free function \1 calculates the \2 of two geometries" \
-                         details_calc2{1}="The free function \1 calculates the \1 of two geometries" \
-                         details_free_function{3}="The free function [^\1] calculates the \2 \3 two geometries" \
-                         details_check12{2}="The free function \1 checks if the first geometry \2 the second geometry" \
-                         details_macro{2}="The macro \1 registers a \2 such that it is recognized by Boost.Geometry and that Boost.Geometry functionality can be used with the specified type." \
-                         details_macro_const="The const version registers only read access to the fields, the point type is therefore read-only." \
-                         details_macro_getset="The get/set version registers get and set methods separately and can be used for classes with protected member variables and get/set methods to change coordinates." \
-                         details_macro_templated{2}="The type must have one template parameter, which should be a \2 type, and should not be specified. Boost.Geometry takes care of inserting the template parameter. Hence all types of this templated \1 are registered, regardless of their point type." \
-                         details_macro_lola="For geographic coordinate systems, be sure to specify first longitude and then latitude, to be able to use the strategies included in the library." \
-                         details_default_strategy="It uses the default strategy, based on the coordinate system of the geometry." \
-                         details_strategy_reasons="Reasons to specify a strategy include: use another coordinate system for calculations; construct the strategy beforehand (e.g. with the radius of the Earth); select a strategy when there are more than one available for a calculation." \
-                         details_return{1}="This version with the return_ prefix returns the \1, and a template parameter must therefore be specified in the call." \
-                         details_insert{1}="This version with the _insert suffix outputs the \1 to an output iterator, and a template parameter must therefore be specified in the call." \
-                         details_get_set="The free functions [*get] and [*set] are two of the most important functions of Boost.Geometry, both within the library, as also for the library user. With these two functions you normally get and set coordinate values from and for a point, box, segment or sphere." \
-                         details_make="Boost.Geometry uses concepts for all its geometries. It does not rely on constructors. The "make" functions are object generators creating geometries. There are overloads, currently with two or three coordinate values or ranges, to construct geometry instances" \
-                         return_calc{1}="The calculated \1" \
-                         return_check{1}="Returns true if the geometry \1" \
-                         return_check2{1}="Returns true if two geometries \1" \
-                         return_out="The output iterator" \
-                         meta_geometry_type="specified geometry type" \
-                         meta_point_type="point type making up the specified geometry type" \
-                         brf_for_each{1}="Applies function [*f] to each \1" \
-                         det_envelope="envelope (also known as axis aligned bounding box, aabb, or minimum bounding rectangle, mbr)" \
-                         det_buffer="buffer (a polygon being the spatial point set collection within a specified maximum distance from a geometry)" \
-                         det_for_each{1}="Applies a function [*f] (functor, having operator() defined) to each \1 making up the geometry" \
-                         par_for_each_f{1}="Unary function, taking a \1 as argument" \
-                         macro_x="first (usually x)" \
-                         macro_y="second (usually y)" \
-                         macro_z="third (usually z)" \
-                         macro_x_lon="first (usually x, or longitude)" \
-                         macro_y_lat="second (usually y, or latitude)" \
-                         p_l_or_c="Point, LineString or Polygon"
+ALIASES                = "qbk{1}=\xmlonly <qbk>\1</qbk> \endxmlonly" \
+                         "qbk{2}=\xmlonly <qbk.\1>\2</qbk.\1> \endxmlonly" \
+                         "wkt=WKT" \
+                         "well_known_text=Well-Known Text" \
+                         "brief_calc{1}=Calculates the \1 of a geometry" \
+                         "brief_calc2{1}=Calculate the \1 of two geometries" \
+                         "brief_calc2{2}=Calculate the \1 \2 two geometries" \
+                         "brief_check{1}=Checks if a geometry \1" \
+                         "brief_check2{1}=Checks if two geometries \1" \
+                         "brief_check12{1}=Checks if the first geometry \1 the second geometry" \
+                         "brief_strategy=using the specified strategy" \
+                         "brief_macro{1}=Macro to register a \1" \
+                         "brief_macro_const= (const version)" \
+                         "brief_macro_getset= (having separate get/set methods)" \
+                         "brief_meta{3}=Metafunction defining [*\1] as the \2 of the \3" \
+                         "tparam_allocator=container-allocator-type" \
+                         "tparam_box=Any type fulfilling a Box Concept" \
+                         "tparam_box_or_segment=Any type fulfilling a Box Concept or a Segment Concept" \
+                         "tparam_calculation=numeric type for calculation (e.g. high precision); if [*void] then it is extracted automatically from the coordinate type and (if necessary) promoted to floating point" \
+                         "tparam_radius_or_sphere=numeric type for radius (of sphere, earth) or sphere model" \
+                         "tparam_container=container type, for example std::vector, std::deque" \
+                         "tparam_dimension_required=Dimension, this template parameter is required. Should contain \\[0 .. n-1\\] for an n-dimensional geometry" \
+                         "tparam_functor=Function or class with operator()" \
+                         "tparam_output_collection=output collection, either a multi-geometry, or a std::vector<Geometry> / std::deque<Geometry> etc" \
+                         "tparam_geometry=Any type fulfilling a Geometry Concept" \
+                         "tparam_geometry{1}=A type fulfilling the \1 Concept" \
+                         "tparam_index_required=Index, this template parameter is required. For a Box: either min_corner or max_corner. For a Segment: either 0 or 1 for first or last point." \
+                         "tparam_numeric=numerical type (int, double, ttmath, ...)" \
+                         "tparam_out{1}=A valid output iterator type, accepting geometries of \1 Concept" \
+                         "tparam_point=Any type fulfilling a Point Concept" \
+                         "tparam_range_point=Any type fulfilling a Range Concept where it range_value type fulfills the Point Concept" \
+                         "tparam_first_point=first point type" \
+                         "tparam_first_box=first box type" \
+                         "tparam_second_point=second point type" \
+                         "tparam_second_box=second box type" \
+                         "tparam_segment_point=segment point type" \
+                         "tparam_strategy{1}=Any type fulfilling a \1 Strategy Concept" \
+                         "tparam_strategy_overlay=Compound strategy for segment intersection" \
+                         "param_box=A model of the specified Box Concept" \
+                         "param_box_or_segment=A box modelling the specified Box Concept or segment modelling the specified Segment Concept" \
+                         "param_geometry=A model of the specified concept" \
+                         "param_out{1}=The output iterator, to which \1 geometries are fed" \
+                         "param_point=A model of the specified Point Concept" \
+                         "param_set{1}=which is set to the \1" \
+                         "param_strategy{1}=The strategy which will be used for \1 calculations" \
+                         "param_macro_type{1}=\1 type to be registered" \
+                         "param_macro_coortype{1}=Type of the coordinates of the \1 (e.g. double)" \
+                         "param_macro_coorsystem=Coordinate system (e.g. cs::cartesian)" \
+                         "param_macro_member{1}=Member containing \1 coordinate" \
+                         "param_macro_getset{2}=Method to \1 the \2 coordinate" \
+                         "param_range_point=A range containing points fulfilling range and point concepts" \
+                         "param_x=First coordinate (usually x-coordinate)" \
+                         "param_y=Second coordinate (usually y-coordinate)" \
+                         "param_z=Third coordinate (usually z-coordinate)" \
+                         "constructor_default_no_init=Default constructor, no initialization" \
+                         "constructor_default{1}=Default constructor, creating an empty \1" \
+                         "constructor_begin_end{1}=Constructor with begin and end,  filling the \1" \
+                         "constructor_initializer_list{1}=Constructor taking std::initializer_list, filling the \1" \
+                         "assignment_initializer_list{1}=Assignment operator taking std::initializer_list, assigning values to the \1" \
+                         "details_calc{2}=The free function \1 calculates the \2 of a geometry" \
+                         "details_calc{1}=The free function \1 calculates the \1 of a geometry" \
+                         "details_calc2{2}=The free function \1 calculates the \2 of two geometries" \
+                         "details_calc2{1}=The free function \1 calculates the \1 of two geometries" \
+                         "details_free_function{3}=The free function [^\1] calculates the \2 \3 two geometries" \
+                         "details_check12{2}=The free function \1 checks if the first geometry \2 the second geometry" \
+                         "details_macro{2}=The macro \1 registers a \2 such that it is recognized by Boost.Geometry and that Boost.Geometry functionality can be used with the specified type." \
+                         "details_macro_const=The const version registers only read access to the fields, the point type is therefore read-only." \
+                         "details_macro_getset=The get/set version registers get and set methods separately and can be used for classes with protected member variables and get/set methods to change coordinates." \
+                         "details_macro_templated{2}=The type must have one template parameter, which should be a \2 type, and should not be specified. Boost.Geometry takes care of inserting the template parameter. Hence all types of this templated \1 are registered, regardless of their point type." \
+                         "details_macro_lola=For geographic coordinate systems, be sure to specify first longitude and then latitude, to be able to use the strategies included in the library." \
+                         "details_default_strategy=It uses the default strategy, based on the coordinate system of the geometry." \
+                         "details_strategy_reasons=Reasons to specify a strategy include: use another coordinate system for calculations; construct the strategy beforehand (e.g. with the radius of the Earth); select a strategy when there are more than one available for a calculation." \
+                         "details_return{1}=This version with the return_ prefix returns the \1, and a template parameter must therefore be specified in the call." \
+                         "details_insert{1}=This version with the _insert suffix outputs the \1 to an output iterator, and a template parameter must therefore be specified in the call." \
+                         "details_get_set=The free functions [*get] and [*set] are two of the most important functions of Boost.Geometry, both within the library, as also for the library user. With these two functions you normally get and set coordinate values from and for a point, box, segment or sphere." \
+                         "return_calc{1}=The calculated \1" \
+                         "return_check{1}=Returns true if the geometry \1" \
+                         "return_check2{1}=Returns true if two geometries \1" \
+                         "return_out=The output iterator" \
+                         "meta_geometry_type=specified geometry type" \
+                         "meta_point_type=point type making up the specified geometry type" \
+                         "brf_for_each{1}=Applies function [*f] to each \1" \
+                         "det_envelope=envelope (also known as axis aligned bounding box, aabb, or minimum bounding rectangle, mbr)" \
+                         "det_buffer=buffer (a polygon being the spatial point set collection within a specified maximum distance from a geometry)" \
+                         "det_for_each{1}=Applies a function [*f] (functor, having operator() defined) to each \1 making up the geometry" \
+                         "par_for_each_f{1}=Unary function, taking a \1 as argument" \
+                         "macro_x=first (usually x)" \
+                         "macro_y=second (usually y)" \
+                         "macro_z=third (usually z)" \
+                         "macro_x_lon=first (usually x, or longitude)" \
+                         "macro_y_lat=second (usually y, or latitude)" \
+                         "p_l_or_c=Point, LineString or Polygon"
 OPTIMIZE_OUTPUT_FOR_C  = NO
 OPTIMIZE_OUTPUT_JAVA   = NO
 OPTIMIZE_FOR_FORTRAN   = NO
 OPTIMIZE_OUTPUT_VHDL   = NO
+OPTIMIZE_OUTPUT_SLICE  = NO
+EXTENSION_MAPPING      =
+MARKDOWN_SUPPORT       = YES
+TOC_INCLUDE_HEADINGS   = 6
+MARKDOWN_ID_STYLE      = DOXYGEN
+AUTOLINK_SUPPORT       = YES
 BUILTIN_STL_SUPPORT    = YES
 CPP_CLI_SUPPORT        = NO
 SIP_SUPPORT            = NO
+IDL_PROPERTY_SUPPORT   = YES
 DISTRIBUTE_GROUP_DOC   = NO
+GROUP_NESTED_COMPOUNDS = NO
 SUBGROUPING            = YES
+INLINE_GROUPED_CLASSES = NO
+INLINE_SIMPLE_STRUCTS  = NO
 TYPEDEF_HIDES_STRUCT   = NO
+LOOKUP_CACHE_SIZE      = 0
+NUM_PROC_THREADS       = 1
+TIMESTAMP              = NO
 #---------------------------------------------------------------------------
 # Build related configuration options
 #---------------------------------------------------------------------------
 EXTRACT_ALL            = YES
 EXTRACT_PRIVATE        = NO
+EXTRACT_PRIV_VIRTUAL   = NO
+EXTRACT_PACKAGE        = NO
 EXTRACT_STATIC         = YES
 EXTRACT_LOCAL_CLASSES  = NO
 EXTRACT_LOCAL_METHODS  = NO
 EXTRACT_ANON_NSPACES   = NO
+RESOLVE_UNNAMED_PARAMS = YES
 HIDE_UNDOC_MEMBERS     = NO
 HIDE_UNDOC_CLASSES     = NO
 HIDE_FRIEND_COMPOUNDS  = NO
@@ -157,12 +177,18 @@ HIDE_IN_BODY_DOCS      = NO
 INTERNAL_DOCS          = NO
 CASE_SENSE_NAMES       = NO
 HIDE_SCOPE_NAMES       = NO
+HIDE_COMPOUND_REFERENCE= NO
+SHOW_HEADERFILE        = YES
 SHOW_INCLUDE_FILES     = NO
+SHOW_GROUPED_MEMB_INC  = NO
+FORCE_LOCAL_INCLUDES   = NO
 INLINE_INFO            = NO
 SORT_MEMBER_DOCS       = NO
 SORT_BRIEF_DOCS        = YES
+SORT_MEMBERS_CTORS_1ST = NO
 SORT_GROUP_NAMES       = YES
 SORT_BY_SCOPE_NAME     = YES
+STRICT_PROTO_MATCHING  = NO
 GENERATE_TODOLIST      = NO
 GENERATE_TESTLIST      = YES
 GENERATE_BUGLIST       = YES
@@ -170,21 +196,31 @@ GENERATE_DEPRECATEDLIST= YES
 ENABLED_SECTIONS       =
 MAX_INITIALIZER_LINES  = 30
 SHOW_USED_FILES        = NO
+SHOW_FILES             = YES
+SHOW_NAMESPACES        = YES
 FILE_VERSION_FILTER    =
+LAYOUT_FILE            =
+CITE_BIB_FILES         =
 #---------------------------------------------------------------------------
-# configuration options related to warning and progress messages
+# Configuration options related to warning and progress messages
 #---------------------------------------------------------------------------
 QUIET                  = YES
 WARNINGS               = YES
 WARN_IF_UNDOCUMENTED   = YES
 WARN_IF_DOC_ERROR      = YES
+WARN_IF_INCOMPLETE_DOC = YES
 WARN_NO_PARAMDOC       = NO
+WARN_IF_UNDOC_ENUM_VAL = NO
+WARN_AS_ERROR          = NO
 WARN_FORMAT            = "$file:$line: $text"
+WARN_LINE_FORMAT       = "at line $line of file $file"
 WARN_LOGFILE           =
 #---------------------------------------------------------------------------
-# configuration options related to the input files
+# Configuration options related to the input files
 #---------------------------------------------------------------------------
-INPUT                  = . .. ../../../../boost/geometry/core \
+INPUT                  = . \
+                         .. \
+                         ../../../../boost/geometry/core \
                          ../../../../boost/geometry/algorithms \
                          ../../../../boost/geometry/algorithms/detail \
                          ../../../../boost/geometry/algorithms/detail/buffer \
@@ -235,6 +271,7 @@ INPUT                  = . .. ../../../../boost/geometry/core \
                          ../../../../boost/geometry/views \
                          ./doxygen_input/groups
 INPUT_ENCODING         = UTF-8
+INPUT_FILE_ENCODING    =
 FILE_PATTERNS          = *.hpp
 RECURSIVE              = NO
 EXCLUDE                = ../../../../boost/geometry/util/builder.hpp \
@@ -246,7 +283,10 @@ EXCLUDE                = ../../../../boost/geometry/util/builder.hpp \
 EXCLUDE_SYMLINKS       = NO
 EXCLUDE_PATTERNS       =
 EXCLUDE_SYMBOLS        =
-EXAMPLE_PATH           = . .. ../../example ../../example/with_external_libs \
+EXAMPLE_PATH           = . \
+                         .. \
+                         ../../example \
+                         ../../example/with_external_libs \
                          doxygen_input/sourcecode \
                          ../../../../boost/geometry/geometries \
                          ../../../../boost/geometry/strategies \
@@ -258,8 +298,11 @@ IMAGE_PATH             = doxygen_input/images
 INPUT_FILTER           =
 FILTER_PATTERNS        =
 FILTER_SOURCE_FILES    = NO
+FILTER_SOURCE_PATTERNS =
+USE_MDFILE_AS_MAINPAGE =
+FORTRAN_COMMENT_AFTER  = 72
 #---------------------------------------------------------------------------
-# configuration options related to source browsing
+# Configuration options related to source browsing
 #---------------------------------------------------------------------------
 SOURCE_BROWSER         = NO
 INLINE_SOURCES         = NO
@@ -267,15 +310,20 @@ STRIP_CODE_COMMENTS    = YES
 REFERENCED_BY_RELATION = NO
 REFERENCES_RELATION    = NO
 REFERENCES_LINK_SOURCE = NO
+SOURCE_TOOLTIPS        = YES
 USE_HTAGS              = NO
 VERBATIM_HEADERS       = NO
+CLANG_ASSISTED_PARSING = NO
+CLANG_ADD_INC_PATHS    = YES
+CLANG_OPTIONS          =
+CLANG_DATABASE_PATH    =
 #---------------------------------------------------------------------------
-# configuration options related to the alphabetical class index
+# Configuration options related to the alphabetical class index
 #---------------------------------------------------------------------------
-COLS_IN_ALPHA_INDEX    = 3
+ALPHABETICAL_INDEX     = YES
 IGNORE_PREFIX          =
 #---------------------------------------------------------------------------
-# configuration options related to the HTML output
+# Configuration options related to the HTML output
 # This is only for debug purposes. For the final documentation, XML output is
 # converted to QuickBook and then to BoostBook and DocBook and html
 #---------------------------------------------------------------------------
@@ -285,38 +333,60 @@ HTML_FILE_EXTENSION    = .html
 HTML_HEADER            = doxygen_input/ggl_doxygen_header.html
 HTML_FOOTER            = doxygen_input/ggl_doxygen_footer.html
 HTML_STYLESHEET        =
-GENERATE_HTMLHELP      = NO
-GENERATE_DOCSET        = NO
-DOCSET_FEEDNAME        = "Generated documentation, by Doxygen"
-DOCSET_BUNDLE_ID       = org.doxygen.Project
+HTML_EXTRA_STYLESHEET  =
+HTML_EXTRA_FILES       =
+HTML_COLORSTYLE        = AUTO_LIGHT
+HTML_COLORSTYLE_HUE    = 220
+HTML_COLORSTYLE_SAT    = 100
+HTML_COLORSTYLE_GAMMA  = 80
+HTML_DYNAMIC_MENUS     = YES
 HTML_DYNAMIC_SECTIONS  = NO
+HTML_CODE_FOLDING      = YES
+HTML_INDEX_NUM_ENTRIES = 100
+GENERATE_DOCSET        = NO
+GENERATE_HTMLHELP      = NO
 CHM_FILE               =
 HHC_LOCATION           =
 GENERATE_CHI           = NO
+CHM_INDEX_ENCODING     =
 BINARY_TOC             = NO
 TOC_EXPAND             = NO
+SITEMAP_URL            =
+GENERATE_QHP           = NO
+GENERATE_ECLIPSEHELP   = NO
 DISABLE_INDEX          = NO
-ENUM_VALUES_PER_LINE   = 4
 GENERATE_TREEVIEW      = NO
+FULL_SIDEBAR           = NO
+ENUM_VALUES_PER_LINE   = 4
 TREEVIEW_WIDTH         = 250
-
+EXT_LINKS_IN_WINDOW    = NO
+OBFUSCATE_EMAILS       = YES
+HTML_FORMULA_FORMAT    = png
+FORMULA_FONTSIZE       = 10
+FORMULA_MACROFILE      =
+USE_MATHJAX            = NO
+SEARCHENGINE           = NO
+SERVER_BASED_SEARCH    = NO
+EXTERNAL_SEARCH        = NO
+SEARCHENGINE_URL       =
+SEARCHDATA_FILE        = searchdata.xml
+EXTERNAL_SEARCH_ID     =
+EXTRA_SEARCH_MAPPINGS  =
+GENERATE_LATEX         = NO
+GENERATE_RTF           = NO
+GENERATE_MAN           = NO
 #---------------------------------------------------------------------------
-# configuration options related to the XML output
+# Configuration options related to the XML output
 #---------------------------------------------------------------------------
 GENERATE_XML           = YES
 XML_OUTPUT             = xml
 XML_PROGRAMLISTING     = NO
+XML_NS_MEMB_FILE_SCOPE = NO
 
-#---------------------------------------------------------------------------
-# Configuration options turned off
-#---------------------------------------------------------------------------
-GENERATE_LATEX         = NO
-GENERATE_MAN           = NO
-GENERATE_RTF           = NO
+GENERATE_DOCBOOK       = NO
 GENERATE_AUTOGEN_DEF   = NO
+GENERATE_SQLITE3       = NO
 GENERATE_PERLMOD       = NO
-
-
 #---------------------------------------------------------------------------
 # Configuration options related to the preprocessor
 #---------------------------------------------------------------------------
@@ -339,11 +409,14 @@ PREDEFINED             = BOOST_CONCEPT_REQUIRES(x) \
                          DOXYGEN_INVOKED
 EXPAND_AS_DEFINED      =
 SKIP_FUNCTION_MACROS   = YES
-
-
 #---------------------------------------------------------------------------
-# Configuration::additions related to the search engine
+# Configuration options related to external references
 #---------------------------------------------------------------------------
-SEARCHENGINE           = NO
+TAGFILES               =
+GENERATE_TAGFILE       =
+ALLEXTERNALS           = NO
+EXTERNAL_GROUPS        = YES
+EXTERNAL_PAGES         = YES
 
+HIDE_UNDOC_RELATIONS   = YES
 HAVE_DOT               = NO

--- a/doc/doxy/doxygen_input/groups/groups.hpp
+++ b/doc/doxy/doxygen_input/groups/groups.hpp
@@ -25,15 +25,19 @@
 \defgroup centroid centroid: calculate centroid (center of gravity) of a geometry
 \defgroup clear clear: clear geometries
 \defgroup closest_points closest points: compute closest points between two geometries
+\defgroup collect_vectors collect vectors
 \defgroup compare compare: define compare functors for points
 \defgroup concepts geometry concepts: defines and checks concepts for geometries
+\defgroup const_concepts constant geometry concepts
 \defgroup convert convert: convert geometries from one type to another
 \defgroup convex_hull convex hull: calculate the convex hull of a geometry
 \defgroup core core: meta-functions for geometry types
 \defgroup correct correct: correct geometries
+\defgroup correct_closure correct closure
 \defgroup covered_by covered_by: detect if a geometry is inside or on the border of another geometry, a.o. point-in-polygon (border included)
 \defgroup crosses crosses: detect if two geometries crosses each other
 \defgroup cs coordinate systems
+\defgroup de9im DE-9IM
 \defgroup densify densify: add points to geometry, keeping shape
 \defgroup difference difference: difference of two geometries
 \defgroup discrete_frechet_distance discrete_frechet_distance : calculate discrete frechet distance between two geometries
@@ -59,10 +63,12 @@
 \defgroup length length: calculate length of a linear geometry
 \defgroup line_interpolate line_interpolate: interpolates points on a linestring
 \defgroup make make: construct geometries
+\defgroup mutable_range mutable ranges
 \defgroup num_geometries number of geometries: calculate the number of geometries in a multi-geometry
 \defgroup num_interior_rings number of interior rings: calculate the number of interior rings
 \defgroup num_points number of points: calculate number of points of a geometry
 \defgroup num_segments number of segments: calculate number of segments of a geometry
+\defgroup overlay overlay implementation
 \defgroup overlaps overlaps: detect overlap between two geometries
 \defgroup perimeter perimeter: calculate perimeter of a geometry
 \defgroup projection projection: Projection struct's, classes
@@ -71,12 +77,16 @@
 \defgroup register register: Macros for registration
 \defgroup relate relate: check spatial relation between two geometries
 \defgroup relation relation: calculate spatial relation between two geometries
+\defgroup remove_spikes remove spikes
 \defgroup reverse reverse: reverse a geometry
+\defgroup sectionalize sectionalize geometries
 \defgroup selected selection: check if a geometry is "selected" by a point
+\defgroup segment_intersection segment intersection strategies
 \defgroup set set: set geometries
 \defgroup simplify simplify: remove points from a geometry, keeping shape (simplification or generalization)
 \defgroup srs srs: Spatial Reference System definition
 \defgroup strategies strategies: strategies
+\defgroup strategy_concepts strategy concepts
 \defgroup svg svg: Stream SVG (Scalable Vector Graphics)
 \defgroup sym_difference sym_difference: sym_difference of two geometries
 \defgroup touches touches: detect if a geometry self-touches or if two geometries touch
@@ -84,6 +94,9 @@
 \defgroup transform transform: apply transformations on geometries
 \defgroup union union: calculate new geometry containing geometries A or B
 \defgroup unique unique: make a geometry unique w.r.t. points,
+\defgroup util strategy utilities
+\defgroup utility utility meta-functions and functions
+\defgroup views geometry views
 \defgroup within within: detect if a geometry is inside another geometry, a.o. point-in-polygon
 \defgroup wkt wkt: parse and stream WKT (Well-Known Text)
 */

--- a/doc/index/Doxyfile
+++ b/doc/index/Doxyfile
@@ -1,14 +1,17 @@
-# Doxyfile 1.8.1.2
+# Doxyfile 1.14.0
+
 #---------------------------------------------------------------------------
 # Project related configuration options
 #---------------------------------------------------------------------------
 DOXYFILE_ENCODING      = UTF-8
-PROJECT_NAME           = "Boost.Geometry.Index"
-PROJECT_NUMBER         = 
-PROJECT_BRIEF          = 
-PROJECT_LOGO           = 
+PROJECT_NAME           = Boost.Geometry.Index
+PROJECT_NUMBER         =
+PROJECT_BRIEF          =
+PROJECT_LOGO           =
 OUTPUT_DIRECTORY       =
 CREATE_SUBDIRS         = NO
+CREATE_SUBDIRS_LEVEL   = 8
+ALLOW_UNICODE_NAMES    = NO
 OUTPUT_LANGUAGE        = English
 BRIEF_MEMBER_DESC      = YES
 REPEAT_BRIEF           = YES
@@ -26,43 +29,53 @@ ABBREVIATE_BRIEF       = "The $name class" \
 ALWAYS_DETAILED_SEC    = NO
 INLINE_INHERITED_MEMB  = NO
 FULL_PATH_NAMES        = YES
-STRIP_FROM_PATH        = 
-STRIP_FROM_INC_PATH    = 
+STRIP_FROM_PATH        =
+STRIP_FROM_INC_PATH    =
 SHORT_NAMES            = NO
 JAVADOC_AUTOBRIEF      = NO
+JAVADOC_BANNER         = NO
 QT_AUTOBRIEF           = NO
 MULTILINE_CPP_IS_BRIEF = NO
+PYTHON_DOCSTRING       = YES
 INHERIT_DOCS           = YES
 SEPARATE_MEMBER_PAGES  = NO
 TAB_SIZE               = 8
-ALIASES                = 
-TCL_SUBST              = 
+ALIASES                =
 OPTIMIZE_OUTPUT_FOR_C  = NO
 OPTIMIZE_OUTPUT_JAVA   = NO
 OPTIMIZE_FOR_FORTRAN   = NO
 OPTIMIZE_OUTPUT_VHDL   = NO
-EXTENSION_MAPPING      = 
+OPTIMIZE_OUTPUT_SLICE  = NO
+EXTENSION_MAPPING      =
 MARKDOWN_SUPPORT       = YES
+TOC_INCLUDE_HEADINGS   = 6
+MARKDOWN_ID_STYLE      = DOXYGEN
+AUTOLINK_SUPPORT       = YES
 BUILTIN_STL_SUPPORT    = YES
 CPP_CLI_SUPPORT        = NO
 SIP_SUPPORT            = NO
 IDL_PROPERTY_SUPPORT   = YES
 DISTRIBUTE_GROUP_DOC   = NO
+GROUP_NESTED_COMPOUNDS = NO
 SUBGROUPING            = YES
 INLINE_GROUPED_CLASSES = NO
 INLINE_SIMPLE_STRUCTS  = NO
 TYPEDEF_HIDES_STRUCT   = NO
 LOOKUP_CACHE_SIZE      = 0
+NUM_PROC_THREADS       = 1
+TIMESTAMP              = YES
 #---------------------------------------------------------------------------
 # Build related configuration options
 #---------------------------------------------------------------------------
 EXTRACT_ALL            = NO
 EXTRACT_PRIVATE        = NO
+EXTRACT_PRIV_VIRTUAL   = NO
 EXTRACT_PACKAGE        = NO
 EXTRACT_STATIC         = NO
 EXTRACT_LOCAL_CLASSES  = YES
 EXTRACT_LOCAL_METHODS  = NO
 EXTRACT_ANON_NSPACES   = NO
+RESOLVE_UNNAMED_PARAMS = YES
 HIDE_UNDOC_MEMBERS     = YES
 HIDE_UNDOC_CLASSES     = YES
 HIDE_FRIEND_COMPOUNDS  = NO
@@ -70,7 +83,10 @@ HIDE_IN_BODY_DOCS      = NO
 INTERNAL_DOCS          = NO
 CASE_SENSE_NAMES       = NO
 HIDE_SCOPE_NAMES       = NO
+HIDE_COMPOUND_REFERENCE= NO
+SHOW_HEADERFILE        = YES
 SHOW_INCLUDE_FILES     = YES
+SHOW_GROUPED_MEMB_INC  = NO
 FORCE_LOCAL_INCLUDES   = NO
 INLINE_INFO            = YES
 SORT_MEMBER_DOCS       = YES
@@ -83,30 +99,35 @@ GENERATE_TODOLIST      = YES
 GENERATE_TESTLIST      = YES
 GENERATE_BUGLIST       = YES
 GENERATE_DEPRECATEDLIST= YES
-ENABLED_SECTIONS       = 
+ENABLED_SECTIONS       =
 MAX_INITIALIZER_LINES  = 30
 SHOW_USED_FILES        = YES
 SHOW_FILES             = YES
 SHOW_NAMESPACES        = YES
-FILE_VERSION_FILTER    = 
-LAYOUT_FILE            = 
-CITE_BIB_FILES         = 
+FILE_VERSION_FILTER    =
+LAYOUT_FILE            =
+CITE_BIB_FILES         =
 #---------------------------------------------------------------------------
-# configuration options related to warning and progress messages
+# Configuration options related to warning and progress messages
 #---------------------------------------------------------------------------
 QUIET                  = YES
 WARNINGS               = YES
 WARN_IF_UNDOCUMENTED   = YES
 WARN_IF_DOC_ERROR      = YES
+WARN_IF_INCOMPLETE_DOC = YES
 WARN_NO_PARAMDOC       = NO
+WARN_IF_UNDOC_ENUM_VAL = NO
+WARN_AS_ERROR          = NO
 WARN_FORMAT            = "$file:$line: $text"
-WARN_LOGFILE           = 
+WARN_LINE_FORMAT       = "at line $line of file $file"
+WARN_LOGFILE           =
 #---------------------------------------------------------------------------
-# configuration options related to the input files
+# Configuration options related to the input files
 #---------------------------------------------------------------------------
 INPUT                  = ../../../../boost/geometry/index/ \
                          ../../../../boost/geometry/index/adaptors
 INPUT_ENCODING         = UTF-8
+INPUT_FILE_ENCODING    =
 FILE_PATTERNS          = *.c \
                          *.cc \
                          *.cxx \
@@ -142,20 +163,22 @@ FILE_PATTERNS          = *.c \
                          *.vhd \
                          *.vhdl
 RECURSIVE              = NO
-EXCLUDE                = 
+EXCLUDE                =
 EXCLUDE_SYMLINKS       = NO
-EXCLUDE_PATTERNS       = 
-EXCLUDE_SYMBOLS        = 
-EXAMPLE_PATH           = 
+EXCLUDE_PATTERNS       =
+EXCLUDE_SYMBOLS        =
+EXAMPLE_PATH           =
 EXAMPLE_PATTERNS       = *
 EXAMPLE_RECURSIVE      = NO
-IMAGE_PATH             = 
-INPUT_FILTER           = 
-FILTER_PATTERNS        = 
+IMAGE_PATH             =
+INPUT_FILTER           =
+FILTER_PATTERNS        =
 FILTER_SOURCE_FILES    = NO
-FILTER_SOURCE_PATTERNS = 
+FILTER_SOURCE_PATTERNS =
+USE_MDFILE_AS_MAINPAGE =
+FORTRAN_COMMENT_AFTER  = 72
 #---------------------------------------------------------------------------
-# configuration options related to source browsing
+# Configuration options related to source browsing
 #---------------------------------------------------------------------------
 SOURCE_BROWSER         = NO
 INLINE_SOURCES         = NO
@@ -163,117 +186,153 @@ STRIP_CODE_COMMENTS    = YES
 REFERENCED_BY_RELATION = NO
 REFERENCES_RELATION    = NO
 REFERENCES_LINK_SOURCE = YES
+SOURCE_TOOLTIPS        = YES
 USE_HTAGS              = NO
 VERBATIM_HEADERS       = YES
+CLANG_ASSISTED_PARSING = NO
+CLANG_ADD_INC_PATHS    = YES
+CLANG_OPTIONS          =
+CLANG_DATABASE_PATH    =
 #---------------------------------------------------------------------------
-# configuration options related to the alphabetical class index
+# Configuration options related to the alphabetical class index
 #---------------------------------------------------------------------------
 ALPHABETICAL_INDEX     = YES
-COLS_IN_ALPHA_INDEX    = 5
-IGNORE_PREFIX          = 
+IGNORE_PREFIX          =
 #---------------------------------------------------------------------------
-# configuration options related to the HTML output
+# Configuration options related to the HTML output
 # This is only for debug purposes. For the final documentation, XML output is
 # converted to QuickBook and then to BoostBook and DocBook and html
 #---------------------------------------------------------------------------
 GENERATE_HTML          = YES
 HTML_OUTPUT            = html_by_doxygen
 HTML_FILE_EXTENSION    = .html
-HTML_HEADER            = 
-HTML_FOOTER            = 
-HTML_STYLESHEET        = 
-HTML_EXTRA_FILES       = 
+HTML_HEADER            =
+HTML_FOOTER            =
+HTML_STYLESHEET        =
+HTML_EXTRA_STYLESHEET  =
+HTML_EXTRA_FILES       =
+HTML_COLORSTYLE        = AUTO_LIGHT
 HTML_COLORSTYLE_HUE    = 220
 HTML_COLORSTYLE_SAT    = 100
 HTML_COLORSTYLE_GAMMA  = 80
-HTML_TIMESTAMP         = YES
+HTML_DYNAMIC_MENUS     = YES
 HTML_DYNAMIC_SECTIONS  = NO
+HTML_CODE_FOLDING      = YES
 HTML_INDEX_NUM_ENTRIES = 100
 GENERATE_DOCSET        = NO
 DOCSET_FEEDNAME        = "Doxygen generated docs"
+DOCSET_FEEDURL         =
 DOCSET_BUNDLE_ID       = org.doxygen.Project
 DOCSET_PUBLISHER_ID    = org.doxygen.Publisher
 DOCSET_PUBLISHER_NAME  = Publisher
 GENERATE_HTMLHELP      = NO
-CHM_FILE               = 
-HHC_LOCATION           = 
+CHM_FILE               =
+HHC_LOCATION           =
 GENERATE_CHI           = NO
-CHM_INDEX_ENCODING     = 
+CHM_INDEX_ENCODING     =
 BINARY_TOC             = NO
 TOC_EXPAND             = NO
+SITEMAP_URL            =
 GENERATE_QHP           = NO
-QCH_FILE               = 
+QCH_FILE               =
 QHP_NAMESPACE          = org.doxygen.Project
 QHP_VIRTUAL_FOLDER     = doc
-QHP_CUST_FILTER_NAME   = 
-QHP_CUST_FILTER_ATTRS  = 
-QHP_SECT_FILTER_ATTRS  = 
-QHG_LOCATION           = 
+QHP_CUST_FILTER_NAME   =
+QHP_CUST_FILTER_ATTRS  =
+QHP_SECT_FILTER_ATTRS  =
+QHG_LOCATION           =
 GENERATE_ECLIPSEHELP   = NO
 ECLIPSE_DOC_ID         = org.doxygen.Project
 DISABLE_INDEX          = NO
 GENERATE_TREEVIEW      = NO
+FULL_SIDEBAR           = NO
 ENUM_VALUES_PER_LINE   = 4
 TREEVIEW_WIDTH         = 250
 EXT_LINKS_IN_WINDOW    = NO
+OBFUSCATE_EMAILS       = YES
+HTML_FORMULA_FORMAT    = png
 FORMULA_FONTSIZE       = 10
-FORMULA_TRANSPARENT    = YES
+FORMULA_MACROFILE      =
 USE_MATHJAX            = NO
+MATHJAX_VERSION        = MathJax_2
+MATHJAX_FORMAT         = HTML-CSS
 MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
-MATHJAX_EXTENSIONS     = 
+MATHJAX_EXTENSIONS     =
+MATHJAX_CODEFILE       =
 SEARCHENGINE           = YES
 SERVER_BASED_SEARCH    = NO
+EXTERNAL_SEARCH        = NO
+SEARCHENGINE_URL       =
+SEARCHDATA_FILE        = searchdata.xml
+EXTERNAL_SEARCH_ID     =
+EXTRA_SEARCH_MAPPINGS  =
 #---------------------------------------------------------------------------
-# configuration options related to the LaTeX output
+# Configuration options related to the LaTeX output
 #---------------------------------------------------------------------------
 GENERATE_LATEX         = NO
 LATEX_OUTPUT           = latex
 LATEX_CMD_NAME         = latex
 MAKEINDEX_CMD_NAME     = makeindex
+LATEX_MAKEINDEX_CMD    = makeindex
 COMPACT_LATEX          = NO
 PAPER_TYPE             = a4
-EXTRA_PACKAGES         = 
-LATEX_HEADER           = 
-LATEX_FOOTER           = 
+EXTRA_PACKAGES         =
+LATEX_HEADER           =
+LATEX_FOOTER           =
+LATEX_EXTRA_STYLESHEET =
+LATEX_EXTRA_FILES      =
 PDF_HYPERLINKS         = YES
 USE_PDFLATEX           = YES
 LATEX_BATCHMODE        = NO
 LATEX_HIDE_INDICES     = NO
-LATEX_SOURCE_CODE      = NO
 LATEX_BIB_STYLE        = plain
+LATEX_EMOJI_DIRECTORY  =
 #---------------------------------------------------------------------------
-# configuration options related to the RTF output
+# Configuration options related to the RTF output
 #---------------------------------------------------------------------------
 GENERATE_RTF           = NO
 RTF_OUTPUT             = rtf
 COMPACT_RTF            = NO
 RTF_HYPERLINKS         = NO
-RTF_STYLESHEET_FILE    = 
-RTF_EXTENSIONS_FILE    = 
+RTF_STYLESHEET_FILE    =
+RTF_EXTENSIONS_FILE    =
 #---------------------------------------------------------------------------
-# configuration options related to the man page output
+# Configuration options related to the man page output
 #---------------------------------------------------------------------------
 GENERATE_MAN           = NO
 MAN_OUTPUT             = man
 MAN_EXTENSION          = .3
+MAN_SUBDIR             =
 MAN_LINKS              = NO
 #---------------------------------------------------------------------------
-# configuration options related to the XML output
+# Configuration options related to the XML output
 #---------------------------------------------------------------------------
 GENERATE_XML           = YES
 XML_OUTPUT             = xml
 XML_PROGRAMLISTING     = NO
+XML_NS_MEMB_FILE_SCOPE = NO
 #---------------------------------------------------------------------------
-# configuration options for the AutoGen Definitions output
+# Configuration options related to the DOCBOOK output
+#---------------------------------------------------------------------------
+GENERATE_DOCBOOK       = NO
+DOCBOOK_OUTPUT         = docbook
+#---------------------------------------------------------------------------
+# Configuration options for the AutoGen Definitions output
 #---------------------------------------------------------------------------
 GENERATE_AUTOGEN_DEF   = NO
 #---------------------------------------------------------------------------
-# configuration options related to the Perl module output
+# Configuration options related to Sqlite3 output
+#---------------------------------------------------------------------------
+GENERATE_SQLITE3       = NO
+SQLITE3_OUTPUT         = sqlite3
+SQLITE3_RECREATE_DB    = YES
+#---------------------------------------------------------------------------
+# Configuration options related to the Perl module output
 #---------------------------------------------------------------------------
 GENERATE_PERLMOD       = NO
 PERLMOD_LATEX          = NO
 PERLMOD_PRETTY         = YES
-PERLMOD_MAKEVAR_PREFIX = 
+PERLMOD_MAKEVAR_PREFIX =
 #---------------------------------------------------------------------------
 # Configuration options related to the preprocessor
 #---------------------------------------------------------------------------
@@ -281,36 +340,37 @@ ENABLE_PREPROCESSING   = YES
 MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = YES
 SEARCH_INCLUDES        = YES
-INCLUDE_PATH           = 
-INCLUDE_FILE_PATTERNS  = 
+INCLUDE_PATH           =
+INCLUDE_FILE_PATTERNS  =
 PREDEFINED             = "BOOST_RV_REF(T)=T &&" \
                          "BOOST_COPY_ASSIGN_REF(T)=T const &"
-EXPAND_AS_DEFINED      = 
+EXPAND_AS_DEFINED      =
 SKIP_FUNCTION_MACROS   = YES
 #---------------------------------------------------------------------------
-# Configuration::additions related to external references
+# Configuration options related to external references
 #---------------------------------------------------------------------------
-TAGFILES               = 
-GENERATE_TAGFILE       = 
+TAGFILES               =
+GENERATE_TAGFILE       =
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES
-PERL_PATH              = /usr/bin/perl
+EXTERNAL_PAGES         = YES
 #---------------------------------------------------------------------------
-# Configuration options related to the dot tool
+# Configuration options related to diagram generator tools
 #---------------------------------------------------------------------------
-CLASS_DIAGRAMS         = YES
-MSCGEN_PATH            = 
 HIDE_UNDOC_RELATIONS   = YES
 HAVE_DOT               = NO
 DOT_NUM_THREADS        = 0
-DOT_FONTNAME           = Helvetica
-DOT_FONTSIZE           = 10
-DOT_FONTPATH           = 
+DOT_COMMON_ATTR        = "fontname=Helvetica,fontsize=10"
+DOT_EDGE_ATTR          = "labelfontname=Helvetica,labelfontsize=10"
+DOT_NODE_ATTR          = "shape=box,height=0.2,width=0.4"
+DOT_FONTPATH           =
 CLASS_GRAPH            = YES
 COLLABORATION_GRAPH    = YES
 GROUP_GRAPHS           = YES
 UML_LOOK               = NO
 UML_LIMIT_NUM_FIELDS   = 10
+DOT_UML_DETAILS        = NO
+DOT_WRAP_THRESHOLD     = 17
 TEMPLATE_RELATIONS     = NO
 INCLUDE_GRAPH          = YES
 INCLUDED_BY_GRAPH      = YES
@@ -318,14 +378,20 @@ CALL_GRAPH             = NO
 CALLER_GRAPH           = NO
 GRAPHICAL_HIERARCHY    = YES
 DIRECTORY_GRAPH        = YES
+DIR_GRAPH_MAX_DEPTH    = 1
 DOT_IMAGE_FORMAT       = png
 INTERACTIVE_SVG        = NO
-DOT_PATH               = 
-DOTFILE_DIRS           = 
-MSCFILE_DIRS           = 
+DOT_PATH               =
+DOTFILE_DIRS           =
+DIA_PATH               =
+DIAFILE_DIRS           =
+PLANTUML_JAR_PATH      =
+PLANTUML_CFG_FILE      =
+PLANTUML_INCLUDE_PATH  =
 DOT_GRAPH_MAX_NODES    = 50
 MAX_DOT_GRAPH_DEPTH    = 0
-DOT_TRANSPARENT        = NO
 DOT_MULTI_TARGETS      = NO
 GENERATE_LEGEND        = YES
 DOT_CLEANUP            = YES
+MSCGEN_TOOL            =
+MSCFILE_DIRS           =

--- a/include/boost/geometry/geometries/polyhedral_surface.hpp
+++ b/include/boost/geometry/geometries/polyhedral_surface.hpp
@@ -64,7 +64,7 @@ public :
         : polygon_container()
     {}
 
-    /// \constructor_initialized_list{polyhedron}
+    /// \constructor_initializer_list{polyhedron}
     inline polyhedral_surface(std::initializer_list<Polygon> l)
         : polygon_container(l.begin(), l.end())
     {}

--- a/include/boost/geometry/io/wkt/write.hpp
+++ b/include/boost/geometry/io/wkt/write.hpp
@@ -544,12 +544,6 @@ private:
 \brief Generic geometry template manipulator class, takes corresponding output class from traits class
 \ingroup wkt
 \details Stream manipulator, streams geometry classes as \wkt streams
-\par Example:
-Small example showing how to use the wkt class
-\dontinclude doxygen_1.cpp
-\skip example_as_wkt_point
-\line {
-\until }
 */
 template <typename Geometry>
 class wkt_manipulator

--- a/include/boost/geometry/util/normalize_spheroidal_coordinates.hpp
+++ b/include/boost/geometry/util/normalize_spheroidal_coordinates.hpp
@@ -341,10 +341,11 @@ inline void normalize_angle_cond(CoordinateType& angle)
 
 /*!
 \brief Short utility to normalize the coordinates on a spheroid
-\tparam Units The units of the coordindate system in the spheroid
+\tparam Units The units of the coordinate system in the spheroid
 \tparam CoordinateType The type of the coordinates
 \param longitude Longitude
 \param latitude Latitude
+\param exact Whether to use exact antimeridian checks; if false, a relaxed tolerance is used
 \ingroup utility
 */
 template <typename Units, typename CoordinateType>
@@ -376,6 +377,7 @@ inline void normalize_spheroidal_coordinates(CoordinateType& longitude,
 \tparam Units The units of the coordindate system in the spheroid
 \tparam CoordinateType The type of the coordinates
 \param longitude Longitude
+\param exact Whether to use exact antimeridian checks; if false, a relaxed tolerance is used
 \ingroup utility
 */
 template <typename Units, typename CoordinateType>


### PR DESCRIPTION
This PR fixes warnings currently produced by doxygen when building the BG doc. 

Some warnings were related to deprecated options. This is fixed with doxygen -u -s Doxyfile, which updates it to the newest version. I used Doxygen 1.14 for that, which seems to be used by the Boost release container. Unfortunately this is (imho) needlessly verbose and adds every available option with its default values. Where it added entire sections, I removed those. For the comments that looked manually written (e.g. explaining the role of HTML output for BG within Boost), I put them manually back in since doxygen removes all comments. Our CI uses Doxygen 1.9.8 from Ubuntu 24.04, so I removed the options added by 1.14 that produced warnings in doxygen 1.9.8.

One warning was about a syntax error in Alias for an unused alias. I removed all unused aliases.

Some warnings were related to missing groups (added) and missing parameter documentation (from an earlier PR of mine, also added).

PR is split into two commits because the first one should be neutral (not change the documentation output at all besides timestamps). To allow verifying that in review, I kept it in a separate commit.

Doxygen has an option to produce a non-zero exit code. My original intent was to fix the warnings, then enable that so the CI can warn about future drift. But since our documentation CI job does not necessarily use the same doxygen version as the Boost release image, I decided against it to avoid this causing problems in the future (e.g. Boost release updating to a future Doxygen version, then erroring on some obsolete option). We could consider adding some script to our documentation CI job that looks at the output and errors on warnings to avoid overlooking e.g. undocumented parameters like in my earlier PR.