### PR TITLE
Fix/generalized randomized grid test and fixes

### DIFF
--- a/include/boost/geometry/algorithms/detail/buffer/piece_border.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/piece_border.hpp
@@ -231,7 +231,7 @@ struct piece_border
     template <typename TurnPoint, typename State>
     bool point_on_piece(TurnPoint const& point,
                         bool one_sided, bool is_linear_end_point,
-                        State& state) const
+                        State& state, bool is_exposed_start = false, bool is_exposed_end = false) const
     {
         if (ring_or_original_empty())
         {
@@ -253,12 +253,13 @@ struct piece_border
         geometry::strategy::buffer::place_on_ring_type const por_original
             = adapted_place_on_ring(geometry::strategy::buffer::place_on_ring_original,
                                     one_sided, is_linear_end_point);
+        // At flat ends and concave joins, helper segments also belong to the offsetted ring.
         geometry::strategy::buffer::place_on_ring_type const por_from_offsetted
             = adapted_place_on_ring(geometry::strategy::buffer::place_on_ring_from_offsetted,
-                                    one_sided, is_linear_end_point);
+                                    one_sided || is_exposed_end, is_linear_end_point);
         geometry::strategy::buffer::place_on_ring_type const por_to_offsetted
             = adapted_place_on_ring(geometry::strategy::buffer::place_on_ring_to_offsetted,
-                                    one_sided, is_linear_end_point);
+                                    one_sided || is_exposed_start, is_linear_end_point);
 
         bool continue_processing = true;
         if (m_original_size == 1)

--- a/include/boost/geometry/algorithms/detail/buffer/turn_in_piece_visitor.hpp
+++ b/include/boost/geometry/algorithms/detail/buffer/turn_in_piece_visitor.hpp
@@ -19,6 +19,7 @@
 
 #include <boost/geometry/algorithms/comparable_distance.hpp>
 #include <boost/geometry/algorithms/covered_by.hpp>
+#include <boost/geometry/algorithms/equals.hpp>
 #include <boost/geometry/algorithms/detail/disjoint/point_box.hpp>
 #include <boost/geometry/algorithms/detail/disjoint/box_box.hpp>
 #include <boost/geometry/algorithms/detail/dummy_geometries.hpp>
@@ -207,10 +208,21 @@ public:
         // Check if buffer is one-sided (at this point), because then a point
         // on the original border is not considered as within.
         bool const one_sided = has_zero_distance_at(turn.point);
+        // Another linestring's endpoint does not expose this piece's interior.
+        bool const is_linear_end_point = turn.is_linear_end_point
+            && border.m_original_size > 0
+            && ((piece.is_flat_start && geometry::equals(turn.point,
+                    border.m_originals[border.m_original_size - 1], m_umbrella_strategy))
+                || (piece.is_flat_end && geometry::equals(turn.point,
+                    border.m_originals[0], m_umbrella_strategy)));
 
         typename Border::state_type state;
         if (! border.point_on_piece(turn.point, one_sided,
-                                    turn.is_linear_end_point, state))
+                                    is_linear_end_point, state,
+                                    piece.is_flat_start
+                                        || m_pieces[piece.left_index].type == strategy::buffer::buffered_concave,
+                                    piece.is_flat_end
+                                        || m_pieces[piece.right_index].type == strategy::buffer::buffered_concave))
         {
             return true;
         }

--- a/include/boost/geometry/algorithms/detail/overlay/follow.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/follow.hpp
@@ -18,6 +18,7 @@
 
 #include <cstddef>
 #include <set>
+#include <memory>
 #include <type_traits>
 
 #include <boost/range/begin.hpp>
@@ -32,6 +33,7 @@
 #include <boost/geometry/algorithms/detail/overlay/debug_traverse.hpp>
 #include <boost/geometry/algorithms/detail/overlay/turn_info.hpp>
 #include <boost/geometry/algorithms/detail/point_on_border.hpp>
+#include <boost/geometry/algorithms/detail/relate/follow_helpers.hpp>
 #include <boost/geometry/algorithms/detail/relate/turns.hpp>
 #include <boost/geometry/algorithms/detail/tupled_output.hpp>
 #include <boost/geometry/core/static_assert.hpp>
@@ -248,7 +250,7 @@ struct action_selector<overlay_intersection, RemoveSpikes>
         typename Operation,
         typename Strategy
     >
-    static inline void leave(LineStringOut& current_piece,
+    static inline bool leave(LineStringOut& current_piece,
                 LineString const& linestring,
                 segment_identifier& segment_id,
                 signed_size_type index, Point const& point,
@@ -268,7 +270,9 @@ struct action_selector<overlay_intersection, RemoveSpikes>
             *out++ = current_piece;
         }
 
+        bool const isolated = ::boost::size(current_piece) == 1;
         geometry::clear(current_piece);
+        return isolated;
     }
 
     template
@@ -331,7 +335,7 @@ struct action_selector<overlay_difference, RemoveSpikes>
         typename Operation,
         typename Strategy
     >
-    static inline void leave(LineStringOut& current_piece,
+    static inline bool leave(LineStringOut& current_piece,
                 LineString const& linestring,
                 segment_identifier& segment_id,
                 signed_size_type index, Point const& point,
@@ -341,6 +345,7 @@ struct action_selector<overlay_difference, RemoveSpikes>
     {
         normal_action::enter(current_piece, linestring, segment_id, index,
                     point, operation, strategy, out);
+        return false;
     }
 
     template
@@ -434,11 +439,22 @@ public :
         // Iterate through all intersection points (they are ordered along the line)
         bool entered = false;
         bool first = true;
+        typename boost::range_value<Turns>::type const* isolated_turn = nullptr;
         unsigned boundary_count = 0;
         std::set<signed_size_type> entered_polygons;
         for (auto const& turn : turns)
         {
             auto const& op = turn.operations[0];
+            if (isolated_turn != nullptr
+                && !relate::turn_on_the_same_ip<0>(*isolated_turn, turn, strategy))
+            {
+                if (!entered)
+                {
+                    action::template isolated_point<typename pointlike::type>
+                        (isolated_turn->point, pointlike::get(out));
+                }
+                isolated_turn = nullptr;
+            }
             // Touching another ring does not leave the boundary currently followed.
             if (op.operation == operation_continue)
             {
@@ -486,10 +502,15 @@ public :
                     debug_traverse(turn, op, "-> Leaving");
 
                     entered = false;
-                    action::leave(current_piece, linestring, current_segment_id,
+                    bool const isolated = action::leave(current_piece, linestring, current_segment_id,
                         op.seg_id.segment_index, turn.point, op,
                         strategy,
                         linear::get(out));
+                    if (BOOST_GEOMETRY_CONDITION(FollowIsolatedPoints) && isolated)
+                    {
+                        // Another turn at this position may enter a polygon.
+                        isolated_turn = std::addressof(turn);
+                    }
                 }
             }
             else if (BOOST_GEOMETRY_CONDITION(FollowIsolatedPoints)
@@ -504,6 +525,12 @@ public :
             }
 
             first = false;
+        }
+
+        if (isolated_turn != nullptr && !entered)
+        {
+            action::template isolated_point<typename pointlike::type>
+                (isolated_turn->point, pointlike::get(out));
         }
 
         if (action::is_entered(entered))

--- a/include/boost/geometry/algorithms/detail/overlay/follow.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/follow.hpp
@@ -17,6 +17,7 @@
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_OVERLAY_FOLLOW_HPP
 
 #include <cstddef>
+#include <set>
 #include <type_traits>
 
 #include <boost/range/begin.hpp>
@@ -90,10 +91,10 @@ inline bool is_leaving(Turn const& turn, Operation const& op,
     if (op.operation == operation_union)
     {
         return entered
-            || turn.method == method_crosses
             || (first
-                && op.position != position_front
-                && last_covered_by(turn, op, linestring, polygon, strategy))
+                && (turn.method == method_crosses
+                    || (op.position != position_front
+                        && last_covered_by(turn, op, linestring, polygon, strategy))))
             ;
     }
     return false;
@@ -113,15 +114,15 @@ inline bool is_staying_inside(Turn const& turn, Operation const& op,
                 LineString const& linestring, Polygon const& polygon,
                 Strategy const& strategy)
 {
-    if (turn.method == method_crosses)
+    if (turn.method == method_crosses && !first)
     {
-        // The normal case, this is completely covered with entering/leaving
-        // so stay out of this time consuming "covered_by"
-        return false;
+        // Entering another polygon need not end an already covered interval.
+        return entered && is_entering(turn, op);
     }
 
     if (is_entering(turn, op))
     {
+        // A first entry may coincide with an exit from another polygon.
         return entered || (first && last_covered_by(turn, op, linestring, polygon, strategy));
     }
 
@@ -433,14 +434,29 @@ public :
         // Iterate through all intersection points (they are ordered along the line)
         bool entered = false;
         bool first = true;
+        unsigned boundary_count = 0;
+        std::set<signed_size_type> entered_polygons;
         for (auto const& turn : turns)
         {
             auto const& op = turn.operations[0];
+            // Touching another ring does not leave the boundary currently followed.
+            if (op.operation == operation_continue)
+            {
+                if (first || !op.is_collinear)
+                {
+                    ++boundary_count;
+                }
+            }
+            else if (boundary_count > 0 && op.is_collinear)
+            {
+                --boundary_count;
+            }
 
             if (following::was_entered(turn, op, first, linestring, polygon, strategy))
             {
                 debug_traverse(turn, op, "-> Was entered");
                 entered = true;
+                entered_polygons.insert(turn.operations[1].seg_id.multi_index);
             }
 
             if (following::is_staying_inside(turn, op, entered, first, linestring, polygon, strategy))
@@ -448,12 +464,14 @@ public :
                 debug_traverse(turn, op, "-> Staying inside");
 
                 entered = true;
+                entered_polygons.insert(turn.operations[1].seg_id.multi_index);
             }
             else if (following::is_entering(turn, op))
             {
                 debug_traverse(turn, op, "-> Entering");
 
                 entered = true;
+                entered_polygons.insert(turn.operations[1].seg_id.multi_index);
                 action::enter(current_piece, linestring, current_segment_id,
                     op.seg_id.segment_index, turn.point, op,
                     strategy,
@@ -461,13 +479,18 @@ public :
             }
             else if (following::is_leaving(turn, op, entered, first, linestring, polygon, strategy))
             {
-                debug_traverse(turn, op, "-> Leaving");
+                // Coincident turns may enter another polygon before this one is left.
+                entered_polygons.erase(turn.operations[1].seg_id.multi_index);
+                if (boundary_count == 0 && entered_polygons.empty())
+                {
+                    debug_traverse(turn, op, "-> Leaving");
 
-                entered = false;
-                action::leave(current_piece, linestring, current_segment_id,
-                    op.seg_id.segment_index, turn.point, op,
-                    strategy,
-                    linear::get(out));
+                    entered = false;
+                    action::leave(current_piece, linestring, current_segment_id,
+                        op.seg_id.segment_index, turn.point, op,
+                        strategy,
+                        linear::get(out));
+                }
             }
             else if (BOOST_GEOMETRY_CONDITION(FollowIsolatedPoints)
                   && following::is_touching(turn, op, entered))

--- a/include/boost/geometry/algorithms/detail/overlay/graph/assign_clustered_counts.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/graph/assign_clustered_counts.hpp
@@ -530,7 +530,10 @@ struct clustered_count_handler
         }
 
         assign_turn_operations(cluster, connection_map);
-        change_reversed_operations(cluster_id, cluster, point_turn, point_origin);
+        if (OverlayType == overlay_buffer)
+        {
+            change_reversed_operations(cluster_id, cluster, point_turn, point_origin);
+        }
 
 #if defined(BOOST_GEOMETRY_DEBUG_TRAVERSE_GRAPH)
         // List the connections

--- a/include/boost/geometry/algorithms/detail/overlay/graph/detect_biconnected_components.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/graph/detect_biconnected_components.hpp
@@ -62,8 +62,8 @@ struct state_type
     // but there might be so called "extra" vertices, not associated with a node.
     std::map<signed_size_type, std::size_t> node_to_vertex_index;
 
-    // For each edge, store the segment identifier
-    std::map<std::pair<std::size_t, std::size_t>, segment_identifier> edge_to_seg_id;
+    // Several geometric arcs may connect the same graph vertices.
+    std::map<std::pair<std::size_t, std::size_t>, std::set<segment_identifier>> edge_to_seg_ids;
 
     // Keeps track of vertex index, which must, for Boost.Graph, be consecutive.
     // The turn index is not consecutive (because of discarded, and of clusters).
@@ -99,7 +99,7 @@ inline void add_edge(signed_size_type source_node_id, signed_size_type target_no
     // and store node and the segment id for this edge
     auto& vertex_info = state.vertex_map[it_source->second];
     vertex_info.node_id = source_node_id;
-    state.edge_to_seg_id[{it_source->second, it_target->second}] = seg_id;
+    state.edge_to_seg_ids[{it_source->second, it_target->second}].insert(seg_id);
 
     if (target_node_id != source_node_id)
     {
@@ -117,8 +117,8 @@ inline void add_edge(signed_size_type source_node_id, signed_size_type target_no
     // Store the segment id in both of these edges
     auto& extra_vertex_info = state.vertex_map[extra_vertex_index];
     extra_vertex_info.node_id = extra_node_id;
-    state.edge_to_seg_id[{it_source->second, extra_vertex_index}] = seg_id;
-    state.edge_to_seg_id[{extra_vertex_index, it_target->second}] = seg_id;
+    state.edge_to_seg_ids[{it_source->second, extra_vertex_index}].insert(seg_id);
+    state.edge_to_seg_ids[{extra_vertex_index, it_target->second}].insert(seg_id);
 
     extra_vertex_info.is_extra = true;
     extra_vertex_info.original_node_id = source_node_id;
@@ -184,7 +184,7 @@ void assign_biconnected_component_ids(Turns& turns, Clusters const& clusters, bo
 
         auto const source_node_id = node_id_from_it(it_source);
         auto const target_node_id = node_id_from_it(it_target);
-        auto const edge_seg_id = state.edge_to_seg_id.at({source(*ei, graph), target(*ei, graph)});
+        auto const& edge_seg_ids = state.edge_to_seg_ids.at({source(*ei, graph), target(*ei, graph)});
 
         auto const turn_indices = get_turn_indices_by_node_id(turns, clusters, source_node_id,
             allow_closed);
@@ -203,7 +203,7 @@ void assign_biconnected_component_ids(Turns& turns, Clusters const& clusters, bo
                 }
 
                 auto const travels_to_node_id = get_node_id(turns, op.enriched.travels_to_ip_index);
-                if (travels_to_node_id == target_node_id && op.seg_id == edge_seg_id)
+                if (travels_to_node_id == target_node_id && edge_seg_ids.count(op.seg_id) > 0)
                 {
                     op.enriched.component_id = static_cast<int>(component[*ei]);
                     if (turn.both(operation_continue))

--- a/include/boost/geometry/algorithms/detail/overlay/graph/select_edge.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/graph/select_edge.hpp
@@ -182,13 +182,16 @@ private:
 
         if (edges.front().side == 0)
         {
-            // Select for collinearity (it makes no sense to sort on mutual side)
-            auto compare = [&](edge_type const& a, edge_type const& b) -> bool
+            // This pairwise preference is not a strict weak ordering.
+            auto selected = edges.begin();
+            for (auto it = selected + 1; it != edges.end(); ++it)
             {
-                return select_collinear_target_edge(a, b);
-            };
-            std::sort(edges.begin(), edges.end(), compare);
-            return edges.front().toi;
+                if (select_collinear_target_edge(*it, *selected))
+                {
+                    selected = it;
+                }
+            }
+            return selected->toi;
         }
 
         // Phase 2, sort by mutual side, of the edges having the front edge's side.

--- a/include/boost/geometry/algorithms/detail/overlay/graph/traverse_graph.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/graph/traverse_graph.hpp
@@ -165,8 +165,10 @@ struct traverse_graph
             for (int j = 0; j < 2; j++)
             {
                 auto const& other_op = other_turn.operations[j];
-                if (other_op.enriched.travels_to_ip_index == op.enriched.travels_to_ip_index
-                    && other_op.seg_id == op.seg_id)
+                if (other_op.seg_id == op.seg_id
+                    && other_op.enriched.travels_to_ip_index >= 0
+                    && get_node_id(m_turns, other_op.enriched.travels_to_ip_index)
+                        == get_node_id(m_turns, op.enriched.travels_to_ip_index))
                 {
                     m_visited_tois.insert({turn_index, j});
                 }
@@ -276,7 +278,7 @@ struct traverse_graph
         {
             for (auto const& toi : tois)
             {
-                if (m_finished_tois.count(toi) > 0)
+                if (m_finished_tois.count(toi) > 0 || m_started_tois.count(toi) > 0)
                 {
                     // Visited in the meantime
                     continue;
@@ -298,6 +300,7 @@ struct traverse_graph
         {
             return;
         }
+        m_started_tois.insert(toi);
 
 #if defined(BOOST_GEOMETRY_DEBUG_TRAVERSE_GRAPH)
         std::cout << "\n" << "-> Start traversing component " << component_id
@@ -390,14 +393,6 @@ struct traverse_graph
 
             for (auto const target_node_id : target_nodes)
             {
-                auto const start = std::make_tuple(source_node_id, target_node_id, component_id);
-                if (m_starts.count(start) > 0)
-                {
-                    // Don't repeat earlier or finished trials. This speeds up some cases by 1.5x
-                    continue;
-                }
-                m_starts.insert(start);
-
     #if defined(BOOST_GEOMETRY_DEBUG_TRAVERSE_GRAPH)
                 std::cout << "\n" << "Traversing component " << component_id
                     << " from " << source_node_id << " to " << target_node_id << std::endl;
@@ -441,8 +436,8 @@ private:
     // Visited turn operations after a ring is added
     toi_set m_finished_tois;
 
-    // Keep track of started combinations (either finished, or stuck)
-    std::set<std::tuple<signed_size_type, signed_size_type, signed_size_type>> m_starts;
+    // Distinct ring paths may connect the same two nodes in one component.
+    toi_set m_started_tois;
 };
 
 }} // namespace detail::overlay

--- a/include/boost/geometry/algorithms/detail/overlay/intersection_insert.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/intersection_insert.hpp
@@ -324,7 +324,9 @@ struct intersection_of_linestring_with_areal
                      turns, policy);
 
         int inside_value = 0;
-        if (simple_turns_analysis(linestring, areal, strategy, turns, inside_value))
+        if (simple_turns_analysis(linestring, areal, strategy, turns, inside_value)
+            && !(FollowIsolatedPoints && OverlayType == overlay_intersection
+                 && inside_value < 0 && !turns.empty()))
         {
             // No crossing the boundary, it is either
             // inside (interior + borders)

--- a/include/boost/geometry/algorithms/detail/overlay/select_rings.hpp
+++ b/include/boost/geometry/algorithms/detail/overlay/select_rings.hpp
@@ -24,6 +24,7 @@
 #include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/algorithms/detail/covered_by/implementation.hpp>
+#include <boost/geometry/algorithms/detail/overlay/get_ring.hpp>
 #include <boost/geometry/algorithms/detail/overlay/range_in_geometry.hpp>
 #include <boost/geometry/algorithms/detail/overlay/ring_properties.hpp>
 #include <boost/geometry/algorithms/detail/overlay/overlay_type.hpp>
@@ -270,11 +271,13 @@ inline void update_ring_selection(Geometry1 const& geometry1,
             // within
             case 0 :
                 code = range_in_geometry(pair.second.point,
-                                         geometry1, geometry2, strategy);
+                                         get_ring<geometry::tag_t<Geometry1>>::apply(id, geometry1),
+                                         geometry2, strategy);
                 break;
             case 1 :
                 code = range_in_geometry(pair.second.point,
-                                         geometry2, geometry1, strategy);
+                                         get_ring<geometry::tag_t<Geometry2>>::apply(id, geometry2),
+                                         geometry1, strategy);
                 break;
         }
 

--- a/include/boost/geometry/algorithms/detail/relate/areal_areal.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/areal_areal.hpp
@@ -14,7 +14,10 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_RELATE_AREAL_AREAL_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_RELATE_AREAL_AREAL_HPP
 
+#include <map>
 #include <memory>
+#include <set>
+#include <utility>
 
 #include <boost/geometry/core/topological_dimension.hpp>
 
@@ -427,13 +430,10 @@ struct areal_areal
     public:
         turns_analyser()
             : m_previous_turn_ptr(0)
-            , m_previous_operation(overlay::operation_none)
-            , m_enter_detected(false)
-            , m_exit_detected(false)
         {}
 
         template <typename Result, typename TurnIt, typename EqPPStrategy>
-        void apply(Result & result, TurnIt it, EqPPStrategy const& strategy)
+        void apply(Result & result, TurnIt it, TurnIt last, EqPPStrategy const& strategy)
         {
             //BOOST_GEOMETRY_ASSERT( it != last );
 
@@ -451,99 +451,60 @@ struct areal_areal
             //segment_identifier const& other_id = it->operations[other_op_id].seg_id;
 
             const bool first_in_range = m_seg_watcher.update(seg_id);
-
-            if ( m_previous_turn_ptr )
+            if (m_previous_turn_ptr && (first_in_range
+                || !turn_on_the_same_ip<op_id>(*m_previous_turn_ptr, *it, strategy)))
             {
-                if ( m_exit_detected /*m_previous_operation == overlay::operation_union*/ )
+                apply(result);
+            }
+            if (first_in_range)
+            {
+                m_boundary_rings.clear();
+                // Rings are cyclic: the last turn of each other ring determines
+                // whether its boundary is already followed at the first turn.
+                for (TurnIt jt = it; jt != last
+                     && same_ring(seg_id)(jt->operations[op_id].seg_id); ++jt)
                 {
-                    // real exit point - may be multiple
-                    if ( first_in_range
-                      || ! turn_on_the_same_ip<op_id>(*m_previous_turn_ptr, *it, strategy) )
-                    {
-                        update_exit(result);
-                        m_exit_detected = false;
-                    }
-                    // fake exit point, reset state
-                    else if ( op != overlay::operation_union )
-                    {
-                        m_exit_detected = false;
-                    }
-                }
-                /*else*/
-                if ( m_enter_detected /*m_previous_operation == overlay::operation_intersection*/ )
-                {
-                    // real entry point
-                    if ( first_in_range
-                      || ! turn_on_the_same_ip<op_id>(*m_previous_turn_ptr, *it, strategy) )
-                    {
-                        update_enter(result);
-                        m_enter_detected = false;
-                    }
-                    // fake entry point, reset state
-                    else if ( op != overlay::operation_intersection )
-                    {
-                        m_enter_detected = false;
-                    }
+                    update_boundary(*jt);
                 }
             }
+            update_boundary(*it);
 
-            if ( op == overlay::operation_union )
-            {
-                // already set in interrupt policy
-                //update<boundary, boundary, '0', transpose_result>(m_result);
-
-                // ignore u/u
-                //if ( it->operations[other_op_id].operation != overlay::operation_union )
-                {
-                    m_exit_detected = true;
-                }
-            }
-            else if ( op == overlay::operation_intersection )
-            {
-                // ignore i/i
-                if ( it->operations[other_op_id].operation != overlay::operation_intersection )
-                {
-                    // this was set in the interrupt policy but it was wrong
-                    // also here it's wrong since it may be a fake entry point
-                    //update<interior, interior, '2', transpose_result>(result);
-
-                    // already set in interrupt policy
-                    //update<boundary, boundary, '0', transpose_result>(result);
-                    m_enter_detected = true;
-                }
-            }
-            else if ( op == overlay::operation_blocked )
-            {
-                // already set in interrupt policy
-            }
-            else // if ( op == overlay::operation_continue )
-            {
-                // already set in interrupt policy
-            }
+            auto const& other_id = it->operations[other_op_id].seg_id;
+            m_pending_operations[std::make_pair(other_id.multi_index, other_id.ring_index)]
+                = op;
 
             // store ref to previously analysed (valid) turn
             m_previous_turn_ptr = std::addressof(*it);
-            // and previously analysed (valid) operation
-            m_previous_operation = op;
         }
 
         // it == last
         template <typename Result>
         void apply(Result & result)
         {
-            //BOOST_GEOMETRY_ASSERT( first != last );
-
-            if ( m_exit_detected /*m_previous_operation == overlay::operation_union*/ )
+            // Classify the interval after all colocated turns. Leaving the shell
+            // or entering any hole puts it outside that polygon, but an entry
+            // into another polygon can still keep it inside the multigeometry.
+            bool inside = false, outside = false;
+            for (auto it = m_pending_operations.begin(); it != m_pending_operations.end();)
             {
-                update_exit(result);
-                m_exit_detected = false;
+                auto const multi_index = it->first.first;
+                bool enters = false, exits = false;
+                do
+                {
+                    enters = enters || it->second == overlay::operation_intersection;
+                    exits = exits || it->second == overlay::operation_union;
+                    ++it;
+                }
+                while (it != m_pending_operations.end() && it->first.first == multi_index);
+                inside = inside || (enters && !exits);
+                outside = outside || exits;
             }
-
-            if ( m_enter_detected /*m_previous_operation == overlay::operation_intersection*/ )
+            if (m_boundary_rings.empty())
             {
-                update_enter(result);
-                m_enter_detected = false;
+                if (inside) update_enter(result);
+                else if (outside) update_exit(result);
             }
+            m_pending_operations.clear();
         }
 
         template <typename Result>
@@ -562,11 +523,25 @@ struct areal_areal
         }
 
     private:
+        void update_boundary(TurnInfo const& turn)
+        {
+            auto const op = turn.operations[op_id].operation;
+            auto const& id = turn.operations[other_op_id].seg_id;
+            if (op == overlay::operation_continue || op == overlay::operation_blocked)
+            {
+                m_boundary_rings.emplace(id.multi_index, id.ring_index);
+            }
+            else if (op == overlay::operation_intersection || op == overlay::operation_union)
+            {
+                m_boundary_rings.erase(std::make_pair(id.multi_index, id.ring_index));
+            }
+        }
+
+        std::set<std::pair<signed_size_type, signed_size_type>> m_boundary_rings;
         segment_watcher<same_ring> m_seg_watcher;
         TurnInfo * m_previous_turn_ptr;
-        overlay::operation_type m_previous_operation;
-        bool m_enter_detected;
-        bool m_exit_detected;
+        std::map<std::pair<signed_size_type, signed_size_type>, overlay::operation_type>
+            m_pending_operations;
     };
 
     // call analyser.apply() for each turn in range
@@ -588,7 +563,7 @@ struct areal_areal
 
         for ( TurnIt it = first ; it != last ; ++it )
         {
-            analyser.apply(res, it, strategy);
+            analyser.apply(res, it, last, strategy);
 
             if ( BOOST_GEOMETRY_CONDITION(res.interrupt) )
                 return;
@@ -775,6 +750,7 @@ struct areal_areal
             //analyser.per_turn(*first);
 
             TurnIt prev = first;
+            TurnIt ring_first = first;
             for ( ++first ; first != last ; ++first, ++prev )
             {
                 // same multi
@@ -791,7 +767,8 @@ struct areal_areal
                     else
                     {
                         //analyser.end_ring(*prev);
-                        analyser.turns(prev, first);
+                        analyser.turns(ring_first, first);
+                        ring_first = first;
 
                         //if ( prev->operations[OpId].seg_id.ring_index + 1
                         //   < first->operations[OpId].seg_id.ring_index)
@@ -809,7 +786,8 @@ struct areal_areal
                 else
                 {
                     //analyser.end_ring(*prev);
-                    analyser.turns(prev, first);
+                    analyser.turns(ring_first, first);
+                    ring_first = first;
                     for_following_rings(analyser, *prev);
                     for_preceding_rings(analyser, *first);
                     //analyser.per_turn(*first);
@@ -822,7 +800,7 @@ struct areal_areal
             }
 
             //analyser.end_ring(*prev);
-            analyser.turns(prev, first); // first == last
+            analyser.turns(ring_first, first); // first == last
             for_following_rings(analyser, *prev);
         }
 

--- a/include/boost/geometry/algorithms/detail/relate/boundary_checker.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/boundary_checker.hpp
@@ -12,7 +12,6 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_RELATE_BOUNDARY_CHECKER_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_RELATE_BOUNDARY_CHECKER_HPP
 
-#include <boost/core/ignore_unused.hpp>
 #include <boost/range/size.hpp>
 
 #include <boost/geometry/algorithms/detail/equals/point_point.hpp>
@@ -54,23 +53,16 @@ public:
         : m_has_boundary(
             boost::size(g) >= 2
             && ! detail::equals::equals_point_point(range::front(g), range::back(g), s))
-#ifdef BOOST_GEOMETRY_DEBUG_RELATE_BOUNDARY_CHECKER
         , m_geometry(g)
-#endif
         , m_strategy(s)
     {}
 
     template <typename Point>
     bool is_endpoint_boundary(Point const& pt) const
     {
-        boost::ignore_unused(pt);
-#ifdef BOOST_GEOMETRY_DEBUG_RELATE_BOUNDARY_CHECKER
-        // may give false positives for INT
-        BOOST_GEOMETRY_ASSERT(
-            detail::equals::equals_point_point(pt, range::front(m_geometry), m_strategy)
-         || detail::equals::equals_point_point(pt, range::back(m_geometry), m_strategy));
-#endif
-        return m_has_boundary;
+        return m_has_boundary
+            && (detail::equals::equals_point_point(pt, range::front(m_geometry), m_strategy)
+             || detail::equals::equals_point_point(pt, range::back(m_geometry), m_strategy));
     }
 
     Strategy const& strategy() const
@@ -80,9 +72,7 @@ public:
 
 private:
     bool m_has_boundary;
-#ifdef BOOST_GEOMETRY_DEBUG_RELATE_BOUNDARY_CHECKER
     Geometry const& m_geometry;
-#endif
     Strategy const& m_strategy;
 };
 

--- a/include/boost/geometry/algorithms/detail/relate/follow_helpers.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/follow_helpers.hpp
@@ -32,6 +32,7 @@
 #include <boost/geometry/util/condition.hpp>
 #include <boost/geometry/util/range.hpp>
 #include <boost/geometry/util/type_traits.hpp>
+#include <boost/geometry/views/detail/closed_clockwise_view.hpp>
 
 #include <type_traits>
 
@@ -356,6 +357,21 @@ inline bool turn_on_the_same_ip(Turn const& prev_turn, Turn const& curr_turn,
     }
 
     return detail::equals::equals_point_point(prev_turn.point, curr_turn.point, strategy);
+}
+
+template <typename IntersectionPoint, typename OperationInfo, typename Geometry, typename Strategy>
+inline bool is_ip_on_segment(IntersectionPoint const& ip, OperationInfo const& operation,
+                             Geometry const& geometry, Strategy const& strategy)
+{
+    auto const& line = sub_range(geometry, operation.seg_id);
+    using range_type = typename std::remove_reference<decltype(line)>::type;
+    detail::closed_clockwise_view
+        <range_type, closure<range_type>::value, geometry::point_order<Geometry>::value> view(line);
+    auto const point_in_segment = strategy.relate(ip, line);
+    typename decltype(point_in_segment)::state_type state;
+    auto const index = operation.seg_id.segment_index;
+    point_in_segment.apply(ip, range::at(view, index), range::at(view, index + 1), state);
+    return point_in_segment.result(state) == 0;
 }
 
 template <typename IntersectionPoint, typename OperationInfo, typename BoundaryChecker>

--- a/include/boost/geometry/algorithms/detail/relate/linear_areal.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/linear_areal.hpp
@@ -1492,6 +1492,15 @@ struct linear_areal
         {
             overlay::operation_type op = it->operations[1].operation;
 
+            // A point-only contact cannot end an overlap with another line segment.
+            auto const& linear_op = it->operations[0];
+            if (op == overlay::operation_union
+                && linear_op.operation != overlay::operation_continue
+                && !linear_op.is_collinear)
+            {
+                return true;
+            }
+
             if ( it != last )
             {
                 if ( op != overlay::operation_union

--- a/include/boost/geometry/algorithms/detail/relate/linear_areal.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/linear_areal.hpp
@@ -1137,7 +1137,10 @@ struct linear_areal
                               /*&& ( op == overlay::operation_blocked
                                 || op == overlay::operation_union )*/ // if we're here it's u or x
                             {
-                                m_first_from_unknown = true;
+                                // Only the first intersection can leave the initial location unknown.
+                                m_first_from_unknown = first_point;
+                                if (!first_point)
+                                    update<interior, exterior, '1', TransposeResult>(res);
                             }
                             else
                             {
@@ -1338,8 +1341,19 @@ struct linear_areal
             return;
         }
 
+        TurnIt range_first = first;
         for ( TurnIt it = first ; it != last ; ++it )
         {
+            if (!same_single(range_first->operations[0].seg_id)(it->operations[0].seg_id))
+            {
+                analyser.apply(res, range_first, it, geometry, other_geometry, boundary_checker);
+                if (BOOST_GEOMETRY_CONDITION(res.interrupt))
+                {
+                    return;
+                }
+                range_first = it;
+            }
+
             analyser.apply(res, it,
                            geometry, other_geometry,
                            boundary_checker,
@@ -1351,7 +1365,7 @@ struct linear_areal
             }
         }
 
-        analyser.apply(res, first, last,
+        analyser.apply(res, range_first, last,
                        geometry, other_geometry,
                        boundary_checker);
     }

--- a/include/boost/geometry/algorithms/detail/relate/linear_areal.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/linear_areal.hpp
@@ -390,7 +390,8 @@ struct linear_areal
         using turn_type = typename turn_info_type<Geometry1, Geometry2, Strategy>::type;
         std::vector<turn_type> turns;
 
-        interrupt_policy_linear_areal<Geometry2, Result> interrupt_policy(geometry2, result);
+        interrupt_policy_linear_areal<Geometry2, BoundaryChecker1, Result>
+            interrupt_policy(geometry1, geometry2, boundary_checker1, result);
 
         turns::get_turns<Geometry1, Geometry2>::apply(turns, geometry1, geometry2, interrupt_policy, strategy);
         if ( BOOST_GEOMETRY_CONDITION( result.interrupt ) )
@@ -701,16 +702,32 @@ struct linear_areal
     }
 
 
+    template <typename Turn, typename BoundaryChecker>
+    static bool is_boundary_turn(Turn const& turn,
+                                 Geometry1 const& linear, Geometry2 const& areal,
+                                 BoundaryChecker const& checker)
+    {
+        return checker.is_endpoint_boundary(turn.point)
+            // An integer crossing may have been rounded onto an unrelated endpoint.
+            && (turn.method != overlay::method_crosses
+                || (is_ip_on_segment(turn.point, turn.operations[0], linear, checker.strategy())
+                    && is_ip_on_segment(turn.point, turn.operations[1], areal, checker.strategy())));
+    }
+
     // interrupt policy which may be passed to get_turns to interrupt the analysis
     // based on the info in the passed result/mask
-    template <typename Areal, typename Result>
+    template <typename Areal, typename BoundaryChecker, typename Result>
     class interrupt_policy_linear_areal
     {
     public:
         static bool const enabled = true;
 
-        interrupt_policy_linear_areal(Areal const& areal, Result & result)
+        interrupt_policy_linear_areal(Geometry1 const& linear, Areal const& areal,
+                                     BoundaryChecker const& boundary_checker,
+                                     Result & result)
             : m_result(result), m_areal(areal)
+            , m_linear(linear)
+            , m_boundary_checker(boundary_checker)
             , is_boundary_found(false)
         {}
 
@@ -739,7 +756,8 @@ struct linear_areal
                 }
                 else if ( ( it->operations[0].operation == overlay::operation_union
                          || it->operations[0].operation == overlay::operation_blocked )
-                       && it->operations[0].position == overlay::position_middle )
+                       && it->operations[0].position == overlay::position_middle
+                       && !is_boundary_turn(*it, m_linear, m_areal, m_boundary_checker) )
                 {
 // TODO: here we could also check the boundaries and set BB at this point
                     update<interior, boundary, '0', TransposeResult>(m_result);
@@ -752,6 +770,8 @@ struct linear_areal
     private:
         Result & m_result;
         Areal const& m_areal;
+        Geometry1 const& m_linear;
+        BoundaryChecker const& m_boundary_checker;
 
     public:
         bool is_boundary_found;
@@ -786,7 +806,7 @@ struct linear_areal
                   typename Strategy>
         void apply(Result & res, TurnIt it,
                    Geometry const& geometry,
-                   OtherGeometry const& /*other_geometry*/,
+                   OtherGeometry const& other_geometry,
                    BoundaryChecker const& boundary_checker,
                    Strategy const& strategy,
                    bool initially_inside)
@@ -1004,8 +1024,7 @@ struct linear_areal
                     update<interior, boundary, '1', TransposeResult>(res);
                 }
 
-                bool const this_b = is_ip_on_boundary(it->point, it->operations[op_id],
-                                                      boundary_checker);
+                bool const this_b = is_boundary_turn(*it, geometry, other_geometry, boundary_checker);
                 // going inside on boundary point
                 if ( this_b )
                 {
@@ -1015,35 +1034,35 @@ struct linear_areal
                 else
                 {
                     update<interior, boundary, '0', TransposeResult>(res);
+                }
 
-                    // if we didn't enter in the past, we were outside
-                    if ( no_enters_detected
-                      && ! fake_enter_detected
-                      && it->operations[op_id].position != overlay::position_front )
-                    {
+                // if we didn't enter in the past, we were outside
+                if ( no_enters_detected
+                  && ! fake_enter_detected
+                  && it->operations[op_id].position != overlay::position_front )
+                {
 // TODO: calculate_from_inside() is only needed if the current Linestring is not closed
-                        bool const from_inside =
-                            first_point && initially_inside;
+                    bool const from_inside =
+                        first_point && initially_inside;
 
-                        if ( from_inside )
-                            update<interior, interior, '1', TransposeResult>(res);
-                        else
-                            update<interior, exterior, '1', TransposeResult>(res);
+                    if ( from_inside )
+                        update<interior, interior, '1', TransposeResult>(res);
+                    else
+                        update<interior, exterior, '1', TransposeResult>(res);
 
-                        // if it's the first IP then the first point is outside
-                        if ( first_point )
+                    // if it's the first IP then the first point is outside
+                    if ( first_point )
+                    {
+                        bool const front_b = boundary_checker.is_endpoint_boundary(
+                                                range::front(sub_range(geometry, seg_id)));
+
+                        // if there is a boundary on the first point
+                        if ( front_b )
                         {
-                            bool const front_b = boundary_checker.is_endpoint_boundary(
-                                                    range::front(sub_range(geometry, seg_id)));
-
-                            // if there is a boundary on the first point
-                            if ( front_b )
-                            {
-                                if ( from_inside )
-                                    update<boundary, interior, '0', TransposeResult>(res);
-                                else
-                                    update<boundary, exterior, '0', TransposeResult>(res);
-                            }
+                            if ( from_inside )
+                                update<boundary, interior, '0', TransposeResult>(res);
+                            else
+                                update<boundary, exterior, '0', TransposeResult>(res);
                         }
                     }
                 }
@@ -1096,8 +1115,7 @@ struct linear_areal
                 // we're outside or inside and this is the first turn
                 else
                 {
-                    bool const this_b = is_ip_on_boundary(it->point, it->operations[op_id],
-                                                          boundary_checker);
+                    bool const this_b = is_boundary_turn(*it, geometry, other_geometry, boundary_checker);
                     // if current IP is on boundary of the geometry
                     if ( this_b )
                     {
@@ -1147,7 +1165,7 @@ struct linear_areal
                         }
 
                         // first IP on the last segment point - this means that the first point is outside or inside
-                        if ( first_point && ( !this_b || op_blocked ) )
+                        if ( first_point )
                         {
                             bool const front_b = boundary_checker.is_endpoint_boundary(
                                                     range::front(sub_range(geometry, seg_id)));

--- a/include/boost/geometry/algorithms/detail/relate/linear_areal.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/linear_areal.hpp
@@ -14,7 +14,10 @@
 #ifndef BOOST_GEOMETRY_ALGORITHMS_DETAIL_RELATE_LINEAR_AREAL_HPP
 #define BOOST_GEOMETRY_ALGORITHMS_DETAIL_RELATE_LINEAR_AREAL_HPP
 
+#include <algorithm>
+#include <map>
 #include <memory>
+#include <utility>
 
 #include <boost/core/ignore_unused.hpp>
 #include <boost/range/size.hpp>
@@ -783,9 +786,10 @@ struct linear_areal
                   typename Strategy>
         void apply(Result & res, TurnIt it,
                    Geometry const& geometry,
-                   OtherGeometry const& other_geometry,
+                   OtherGeometry const& /*other_geometry*/,
                    BoundaryChecker const& boundary_checker,
-                   Strategy const& strategy)
+                   Strategy const& strategy,
+                   bool initially_inside)
         {
             overlay::operation_type op = it->operations[op_id].operation;
 
@@ -1019,10 +1023,7 @@ struct linear_areal
                     {
 // TODO: calculate_from_inside() is only needed if the current Linestring is not closed
                         bool const from_inside =
-                            first_point && calculate_from_inside<op_id>(geometry,
-                                                                        other_geometry,
-                                                                        *it,
-                                                                        strategy);
+                            first_point && initially_inside;
 
                         if ( from_inside )
                             update<interior, interior, '1', TransposeResult>(res);
@@ -1117,10 +1118,7 @@ struct linear_areal
                         // the first checked Polygon may be the one which LS is outside for.
                         bool const first_point = first_in_range || m_first_from_unknown;
                         bool const first_from_inside =
-                            first_point && calculate_from_inside<op_id>(geometry,
-                                                                        other_geometry,
-                                                                        *it,
-                                                                        strategy);
+                            first_point && initially_inside;
                         if ( first_from_inside )
                         {
                             update<interior, interior, '1', TransposeResult>(res);
@@ -1341,23 +1339,54 @@ struct linear_areal
             return;
         }
 
-        TurnIt range_first = first;
+        TurnIt range_first = last;
+        bool initially_inside = false;
         for ( TurnIt it = first ; it != last ; ++it )
         {
-            if (!same_single(range_first->operations[0].seg_id)(it->operations[0].seg_id))
+            if (range_first == last
+                || !same_single(range_first->operations[0].seg_id)(it->operations[0].seg_id))
             {
-                analyser.apply(res, range_first, it, geometry, other_geometry, boundary_checker);
-                if (BOOST_GEOMETRY_CONDITION(res.interrupt))
+                if (range_first != last)
                 {
-                    return;
+                    analyser.apply(res, range_first, it, geometry, other_geometry, boundary_checker);
+                    if (BOOST_GEOMETRY_CONDITION(res.interrupt))
+                    {
+                        return;
+                    }
                 }
                 range_first = it;
+                std::map<signed_size_type, bool> polygons;
+                std::map<std::pair<signed_size_type, signed_size_type>, bool> rings;
+                // At a ring touch, arrival inside the polygon must satisfy every
+                // incident ring, not just the ring of the first processed turn.
+                for (TurnIt jt = it; jt != last && turn_on_the_same_ip<0>(*it, *jt, strategy); ++jt)
+                {
+                    auto const& id = jt->operations[1].seg_id;
+                    bool const inside = calculate_from_inside<0>(geometry, other_geometry, *jt, strategy);
+                    auto entry = rings.emplace(std::make_pair(id.multi_index, id.ring_index), inside);
+                    if (!entry.second)
+                    {
+                        entry.first->second = entry.first->second || inside;
+                    }
+                }
+                for (auto const& ring : rings)
+                {
+                    auto entry = polygons.emplace(ring.first.first, ring.second);
+                    if (!entry.second)
+                    {
+                        entry.first->second = entry.first->second && ring.second;
+                    }
+                }
+                // The incoming line is inside the multi-polygon if any of its
+                // polygons contains it, regardless of which turn is first.
+                initially_inside = std::any_of(polygons.begin(), polygons.end(),
+                    [](auto const& polygon) { return polygon.second; });
             }
-
             analyser.apply(res, it,
                            geometry, other_geometry,
                            boundary_checker,
-                           strategy);
+                           strategy,
+                           initially_inside);
 
             if ( BOOST_GEOMETRY_CONDITION( res.interrupt ) )
             {

--- a/include/boost/geometry/algorithms/detail/relate/linear_linear.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/linear_linear.hpp
@@ -147,7 +147,8 @@ struct linear_linear
             >::template turn_info_type<Strategy>::type;
         std::vector<turn_type> turns;
 
-        interrupt_policy_linear_linear<Result> interrupt_policy(result);
+        interrupt_policy_linear_linear<Result, BoundaryChecker1, BoundaryChecker2>
+            interrupt_policy(result, geometry1, geometry2, boundary_checker1, boundary_checker2);
 
         turns::get_turns
             <
@@ -213,14 +214,22 @@ struct linear_linear
         }
     }
 
-    template <typename Result>
+    template <typename Result, typename BoundaryChecker1, typename BoundaryChecker2>
     class interrupt_policy_linear_linear
     {
     public:
         static bool const enabled = true;
 
-        explicit interrupt_policy_linear_linear(Result & result)
+        interrupt_policy_linear_linear(Result & result,
+                                       Geometry1 const& geometry1,
+                                       Geometry2 const& geometry2,
+                                       BoundaryChecker1 const& boundary_checker1,
+                                       BoundaryChecker2 const& boundary_checker2)
             : m_result(result)
+            , m_geometry1(geometry1)
+            , m_geometry2(geometry2)
+            , m_boundary_checker1(boundary_checker1)
+            , m_boundary_checker2(boundary_checker2)
         {}
 
 // TODO: since we update result for some operations here, we may not do it in the analyser!
@@ -240,7 +249,14 @@ struct linear_linear
                          || it->operations[1].operation == overlay::operation_union
                          || it->operations[1].operation == overlay::operation_blocked )
                        && it->operations[0].position == overlay::position_middle
-                       && it->operations[1].position == overlay::position_middle )
+                       && it->operations[1].position == overlay::position_middle
+                       && ((!m_boundary_checker1.is_endpoint_boundary(it->point)
+                            && !m_boundary_checker2.is_endpoint_boundary(it->point))
+                           || (it->method == overlay::method_crosses
+                               && (!is_ip_on_segment(it->point, it->operations[0], m_geometry1,
+                                                     m_boundary_checker1.strategy())
+                                   || !is_ip_on_segment(it->point, it->operations[1], m_geometry2,
+                                                       m_boundary_checker2.strategy())))) )
                 {
 // TODO: here we could also check the boundaries and set IB,BI,BB at this point
                     update<interior, interior, '0'>(m_result);
@@ -252,6 +268,10 @@ struct linear_linear
 
     private:
         Result & m_result;
+        Geometry1 const& m_geometry1;
+        Geometry2 const& m_geometry2;
+        BoundaryChecker1 const& m_boundary_checker1;
+        BoundaryChecker2 const& m_boundary_checker2;
     };
 
     // This analyser should be used like Input or SinglePass Iterator
@@ -375,16 +395,14 @@ struct linear_linear
                 update<interior, interior, '1', transpose_result>(res);
 
                 bool const this_b = it->operations[op_id].position == overlay::position_front // ignore spikes!
-                                 && is_ip_on_boundary(it->point, it->operations[op_id],
-                                                      boundary_checker);
+                                 && boundary_checker.is_endpoint_boundary(it->point);
 
                 // going inside on boundary point
                 // may be front only
                 if ( this_b )
                 {
                     // may be front and back
-                    bool const other_b = is_ip_on_boundary(it->point, it->operations[other_op_id],
-                                                           other_boundary_checker);
+                    bool const other_b = other_boundary_checker.is_endpoint_boundary(it->point);
 
                     // it's also the boundary of the other geometry
                     if ( other_b )
@@ -460,9 +478,7 @@ struct linear_linear
                         if (boundary_checker.is_endpoint_boundary(it->point))
                         {
                             // may be front and back
-                            bool const other_b = is_ip_on_boundary(it->point,
-                                                                   it->operations[other_op_id],
-                                                                   other_boundary_checker);
+                            bool const other_b = other_boundary_checker.is_endpoint_boundary(it->point);
                             // it's also the boundary of the other geometry
                             if ( other_b )
                             {
@@ -487,8 +503,14 @@ struct linear_linear
                         update<interior, exterior, '1', transpose_result>(res);
                     }
 
-                    // boundaries don't overlap - just an optimization
-                    if ( it->method == overlay::method_crosses )
+                    // Do not mistake an integer-rounded crossing for an endpoint.
+                    if ( it->method == overlay::method_crosses
+                      && ((!boundary_checker.is_endpoint_boundary(it->point)
+                           && !other_boundary_checker.is_endpoint_boundary(it->point))
+                          || !is_ip_on_segment(it->point, it->operations[op_id], geometry,
+                                               boundary_checker.strategy())
+                          || !is_ip_on_segment(it->point, it->operations[other_op_id], other_geometry,
+                                               other_boundary_checker.strategy())) )
                     {
                         // the L1 is going from one side of the L2 to the other through the point
                         update<interior, interior, '0', transpose_result>(res);
@@ -509,13 +531,9 @@ struct linear_linear
                     // method other than crosses, check more conditions
                     else
                     {
-                        bool const this_b = is_ip_on_boundary(it->point,
-                                                              it->operations[op_id],
-                                                              boundary_checker);
-
-                        bool const other_b = is_ip_on_boundary(it->point,
-                                                               it->operations[other_op_id],
-                                                               other_boundary_checker);
+                        // A member's interior point may be a global boundary endpoint.
+                        bool const this_b = boundary_checker.is_endpoint_boundary(it->point);
+                        bool const other_b = other_boundary_checker.is_endpoint_boundary(it->point);
 
                         // if current IP is on boundary of the geometry
                         if ( this_b )
@@ -546,7 +564,6 @@ struct linear_linear
 
                         // first IP on the last segment point - this means that the first point is outside
                         if ( first_in_range
-                          && ( !this_b || op_blocked )
                           && was_outside
                           && it->operations[op_id].position != overlay::position_front
                           && ! m_collinear_spike_exit

--- a/include/boost/geometry/algorithms/detail/relate/linear_linear.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/linear_linear.hpp
@@ -186,7 +186,7 @@ struct linear_linear
             std::sort(turns.begin(), turns.end(), less_t());
 
             turns_analyser<turn_type, 0> analyser;
-            analyse_each_turn(result, analyser,
+            analyse_each_turn<0>(result, analyser,
                               turns.begin(), turns.end(),
                               geometry1, geometry2,
                               boundary_checker1, boundary_checker2);
@@ -206,7 +206,7 @@ struct linear_linear
             std::sort(turns.begin(), turns.end(), less_t());
 
             turns_analyser<turn_type, 1> analyser;
-            analyse_each_turn(result, analyser,
+            analyse_each_turn<1>(result, analyser,
                               turns.begin(), turns.end(),
                               geometry2, geometry1,
                               boundary_checker2, boundary_checker1);
@@ -755,7 +755,7 @@ struct linear_linear
         bool m_collinear_spike_exit;
     };
 
-    template <typename Result,
+    template <std::size_t OpId, typename Result,
               typename TurnIt,
               typename Analyser,
               typename Geometry,
@@ -773,8 +773,19 @@ struct linear_linear
         if ( first == last )
             return;
 
+        TurnIt range_first = first;
         for ( TurnIt it = first ; it != last ; ++it )
         {
+            if (!same_single(range_first->operations[OpId].seg_id)(it->operations[OpId].seg_id))
+            {
+                // Finish the previous linestring before its state can affect the next one.
+                analyser.apply(res, range_first, it,
+                               geometry, other_geometry,
+                               boundary_checker, other_boundary_checker);
+                if ( BOOST_GEOMETRY_CONDITION( res.interrupt ) )
+                    return;
+                range_first = it;
+            }
             analyser.apply(res, it,
                            geometry, other_geometry,
                            boundary_checker, other_boundary_checker);
@@ -783,7 +794,7 @@ struct linear_linear
                 return;
         }
 
-        analyser.apply(res, first, last,
+        analyser.apply(res, range_first, last,
                        geometry, other_geometry,
                        boundary_checker, other_boundary_checker);
     }

--- a/include/boost/geometry/algorithms/detail/relate/multi_point_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/multi_point_geometry.hpp
@@ -361,13 +361,10 @@ class multi_point_multi_geometry_ii_ib
 
                 int in_val = detail::within::point_in_geometry(point, single, m_strategy);
 
-                if (in_val > 0) // within
+                if (in_val >= 0)
                 {
-                    update<interior, interior, '0', Transpose>(m_result);
-                }
-                else if (in_val == 0)
-                {
-                    if (m_tc.check_boundary_point(point))
+                    if ((in_val == 0 || util::is_linear<MultiGeometry>::value)
+                        && m_tc.check_boundary_point(point))
                     {
                         update<interior, boundary, '0', Transpose>(m_result);
                     }
@@ -482,14 +479,10 @@ struct multi_point_multi_geometry_ii_ib_ie
 
                 int in_val = detail::within::point_in_geometry(point, single, strategy);
 
-                if (in_val > 0) // within
+                if (in_val >= 0)
                 {
-                    update<interior, interior, '0', Transpose>(result);
-                    found_ii_or_ib = true;
-                }
-                else if (in_val == 0) // on boundary of single
-                {
-                    if (tc.check_boundary_point(point))
+                    if ((in_val == 0 || util::is_linear<MultiGeometry>::value)
+                        && tc.check_boundary_point(point))
                     {
                         update<interior, boundary, '0', Transpose>(result);
                     }

--- a/include/boost/geometry/algorithms/detail/relate/multi_point_geometry.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/multi_point_geometry.hpp
@@ -26,6 +26,7 @@
 #include <boost/geometry/algorithms/detail/relate/topology_check.hpp>
 #include <boost/geometry/algorithms/detail/within/point_in_geometry.hpp>
 #include <boost/geometry/algorithms/envelope.hpp>
+#include <boost/geometry/algorithms/is_empty.hpp>
 
 #include <boost/geometry/core/point_type.hpp>
 
@@ -523,12 +524,19 @@ struct multi_point_multi_geometry
         using box_pair_type = std::pair<model::box<point_type_t<MultiGeometry>>, std::size_t>;
 
         std::size_t count2 = boost::size(multi_geometry);
-        std::vector<box_pair_type> boxes(count2);
+        std::vector<box_pair_type> boxes;
+        boxes.reserve(count2);
         for (std::size_t i = 0 ; i < count2 ; ++i)
         {
-            geometry::envelope(range::at(multi_geometry, i), boxes[i].first, strategy);
-            geometry::detail::expand_by_epsilon(boxes[i].first);
-            boxes[i].second = i;
+            auto const& single_geometry = range::at(multi_geometry, i);
+            if (geometry::is_empty(single_geometry))
+            {
+                continue;
+            }
+            boxes.emplace_back();
+            geometry::envelope(single_geometry, boxes.back().first, strategy);
+            geometry::detail::expand_by_epsilon(boxes.back().first);
+            boxes.back().second = i;
         }
 
         typedef detail::relate::topology_check<MultiGeometry, Strategy> tc_t;

--- a/include/boost/geometry/algorithms/detail/relate/point_point.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/point_point.hpp
@@ -103,6 +103,8 @@ struct point_multipoint
                              Result & result,
                              Strategy const& strategy)
     {
+        update<exterior, exterior, result_dimension<Point>::value, Transpose>(result);
+
         if ( boost::empty(multi_point) )
         {
             // TODO: throw on empty input?
@@ -126,8 +128,6 @@ struct point_multipoint
             update<interior, exterior, '0', Transpose>(result);
             update<exterior, interior, '0', Transpose>(result);
         }
-
-        update<exterior, exterior, result_dimension<Point>::value, Transpose>(result);
     }
 };
 
@@ -155,6 +155,12 @@ struct multipoint_multipoint
                              Result & result,
                              Strategy const& /*strategy*/)
     {
+        update<exterior, exterior, result_dimension<MultiPoint1>::value>(result);
+        if (result.interrupt)
+        {
+            return;
+        }
+
         {
             // TODO: throw on empty input?
             bool empty1 = boost::empty(multi_point1);
@@ -184,8 +190,6 @@ struct multipoint_multipoint
         {
             search_both<true, Strategy>(multi_point2, multi_point1, result);
         }
-
-        update<exterior, exterior, result_dimension<MultiPoint1>::value>(result);
     }
 
     template <bool Transpose, typename Strategy, typename MPt1, typename MPt2, typename Result>

--- a/include/boost/geometry/algorithms/detail/relate/topology_check.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/topology_check.hpp
@@ -15,6 +15,7 @@
 #include <boost/range/size.hpp>
 
 #include <boost/geometry/algorithms/detail/equals/point_point.hpp>
+#include <boost/geometry/algorithms/is_empty.hpp>
 #include <boost/geometry/algorithms/not_implemented.hpp>
 
 #include <boost/geometry/policies/compare.hpp>
@@ -315,29 +316,43 @@ struct topology_check_areal
     static const char interior = '2';
     static const char boundary = '1';
 
-    static bool has_interior() { return true; }
-    static bool has_boundary() { return true; }
+    template <typename Geometry>
+    explicit topology_check_areal(Geometry const& geometry)
+        : m_has_interior(!geometry::is_empty(geometry))
+    {}
+
+    bool has_interior() const { return m_has_interior; }
+    bool has_boundary() const { return m_has_interior; }
+
+private:
+    bool m_has_interior;
 };
 
 template <typename Ring, typename Strategy>
 struct topology_check<Ring, Strategy, ring_tag>
     : topology_check_areal
 {
-    topology_check(Ring const&, Strategy const&) {}
+    topology_check(Ring const& geometry, Strategy const&)
+        : topology_check_areal(geometry)
+    {}
 };
 
 template <typename Polygon, typename Strategy>
 struct topology_check<Polygon, Strategy, polygon_tag>
     : topology_check_areal
 {
-    topology_check(Polygon const&, Strategy const&) {}
+    topology_check(Polygon const& geometry, Strategy const&)
+        : topology_check_areal(geometry)
+    {}
 };
 
 template <typename MultiPolygon, typename Strategy>
 struct topology_check<MultiPolygon, Strategy, multi_polygon_tag>
     : topology_check_areal
 {
-    topology_check(MultiPolygon const&, Strategy const&) {}
+    topology_check(MultiPolygon const& geometry, Strategy const&)
+        : topology_check_areal(geometry)
+    {}
 
     template <typename Point>
     static bool check_boundary_point(Point const& ) { return true; }

--- a/include/boost/geometry/algorithms/detail/relate/turns.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/turns.hpp
@@ -188,7 +188,6 @@ struct less_op_areal_areal
     {
         static const std::size_t other_op_id = (OpId + 1) % 2;
         static op_to_int<0, 1, 2, 3, 4, 0> op_to_int_uixc;
-        static op_to_int<0, 2, 1, 3, 4, 0> op_to_int_iuxc;
 
         segment_identifier const& left_other_seg_id = left.operations[other_op_id].seg_id;
         segment_identifier const& right_other_seg_id = right.operations[other_op_id].seg_id;
@@ -205,27 +204,12 @@ struct less_op_areal_areal
             }
             else
             {
-                if ( left_other_seg_id.ring_index == -1 )
-                {
-                    if ( left_operation.operation == overlay::operation_union )
-                        return false;
-                    else if ( left_operation.operation == overlay::operation_intersection )
-                        return true;
-                }
-                else if ( right_other_seg_id.ring_index == -1 )
-                {
-                    if ( right_operation.operation == overlay::operation_union )
-                        return true;
-                    else if ( right_operation.operation == overlay::operation_intersection )
-                        return false;
-                }
-
-                return op_to_int_iuxc(left_operation) < op_to_int_iuxc(right_operation);
+                return left_other_seg_id.ring_index < right_other_seg_id.ring_index;
             }
         }
         else
         {
-            return op_to_int_uixc(left_operation) < op_to_int_uixc(right_operation);
+            return left_other_seg_id.multi_index < right_other_seg_id.multi_index;
         }
     }
 };

--- a/include/boost/geometry/algorithms/detail/relate/turns.hpp
+++ b/include/boost/geometry/algorithms/detail/relate/turns.hpp
@@ -161,7 +161,8 @@ struct less_op_linear_areal_single
         operation_type const& left_operation = left.operations[OpId];
         operation_type const& right_operation = right.operations[OpId];
 
-        if ( left_other_seg_id.ring_index == right_other_seg_id.ring_index )
+        if ( left_other_seg_id.multi_index == right_other_seg_id.multi_index
+          && left_other_seg_id.ring_index == right_other_seg_id.ring_index )
         {
             return op_to_int_xuic(left_operation)
                  < op_to_int_xuic(right_operation);

--- a/include/boost/geometry/strategies/cartesian/turn_in_ring_winding.hpp
+++ b/include/boost/geometry/strategies/cartesian/turn_in_ring_winding.hpp
@@ -80,7 +80,8 @@ public:
 
         inline bool is_inside() const
         {
-            return count < 0 || count_on_origin > 0;
+            // Internal helper edges are covered even when winding stopped at the first edge.
+            return count < 0 || count_on_origin > 0 || count_on_edge > 0;
         }
 
         inline bool is_on_boundary() const

--- a/include/boost/geometry/strategies/cartesian/turn_in_ring_winding.hpp
+++ b/include/boost/geometry/strategies/cartesian/turn_in_ring_winding.hpp
@@ -174,7 +174,7 @@ public:
 
         bool const vertical = s1x == s2x;
 
-        if (in_horizontal_range || (vertical && is_in_vertical_range(point, s1, s2)))
+        if (vertical ? is_in_vertical_range(point, s1, s2) : in_horizontal_range)
         {
             if (side == 0)
             {

--- a/test/algorithms/buffer/buffer_multi_linestring.cpp
+++ b/test/algorithms/buffer/buffer_multi_linestring.cpp
@@ -73,6 +73,23 @@ void test_all()
     bg::strategy::buffer::end_flat end_flat;
     bg::strategy::buffer::end_round end_round(100);
 
+    test_one<multi_linestring_type, polygon>("overlapping_flat_caps",
+        "MULTILINESTRING((0 0,20 0,20 15,0 15),(20 15,40 15,40 30,0 30))",
+        join_miter, end_flat, 45600.0, 120.0);
+    test_one<multi_linestring_type, polygon>("exposed_concave_helpers",
+        "MULTILINESTRING((40 0,40 15,0 15),(40 15,40 30,20 30),(20 105,40 105))",
+        join_miter, end_flat, 31800.0, 120.0);
+
+    test_one<multi_linestring_type, polygon>("internal_helper_edges",
+        "MULTILINESTRING((20 0,20 15),(60 15,40 15),"
+        "(80 15,60 15,60 30,80 30),(20 30,20 45),(0 60,20 60))",
+        join_miter, end_flat, 40800.0, 120.0);
+
+    test_one<multi_linestring_type, polygon>("unrelated_linear_endpoints",
+        "MULTILINESTRING((0 15,20 15,20 30,0 30),(40 0,40 15),"
+        "(40 30,20 30),(60 30,60 45,80 45))",
+        join_miter, end_flat, 48600.0, 120.0);
+
     bg::strategy::buffer::end_round end_round32(32);
     bg::strategy::buffer::join_round join_round32(32);
 

--- a/test/algorithms/buffer/buffer_multi_point.cpp
+++ b/test/algorithms/buffer/buffer_multi_point.cpp
@@ -25,6 +25,10 @@ static std::string const multipoint_b = "MULTIPOINT((5 56),(98 67),(20 7),(58 60
 // Grid, U-form, generates error for square point at 0.54 (top cells to control rescale)
 static std::string const grid_a = "MULTIPOINT(5 0,6 0,7 0,  5 1,7 1,  0 13,8 13)";
 
+// Multiple collinear outgoing edges caused an invalid comparison in traversal's sort.
+static std::string const grid_collinear
+    = "MULTIPOINT((20 15),(16 15),(12 15),(8 15),(4 15),(0 15),(0 9),(0 6),(0 3),(0 0))";
+
 static std::string const mysql_report_2015_02_25_1 = "MULTIPOINT(-9 19,9 -6,-4 4,16 -14,-3 16,14 9)";
 static std::string const mysql_report_2015_02_25_2 = "MULTIPOINT(-2 11,-15 3,6 4,-14 0,20 -7,-17 -1)";
 
@@ -76,6 +80,10 @@ void test_all()
         test_with_custom_strategies<multi_point_type, polygon>("grid_a54",
                 grid_a, join, end_flat,
                 distance_strategy(0.54), side_strategy, point_strategy, 7.819);
+
+        test_with_custom_strategies<multi_point_type, polygon>("grid_collinear",
+                grid_collinear, join, end_flat,
+                distance_strategy(12), side_strategy, point_strategy, 1416.0);
     }
 
     test_with_custom_strategies<multi_point_type, polygon>("mysql_report_2015_02_25_1_800",

--- a/test/algorithms/buffer/buffer_piece_border.cpp
+++ b/test/algorithms/buffer/buffer_piece_border.cpp
@@ -372,6 +372,24 @@ void test_diamond_point_on_piece_c()
     test_point<Point>("POINT(4.5 3.5)", false, false, true, false, border, mapper, "cyan");
 }
 
+template <typename Point>
+void test_segment_range()
+{
+    using strategy = bg::strategy::buffer::turn_in_ring_winding
+        <typename bg::coordinate_type<Point>::type>;
+    for (int direction : {-1, 1})
+    {
+        Point const s1(0, direction), s2(0, 3 * direction);
+        for (int y = 0; y <= 4; ++y)
+        {
+            typename strategy::state_type state;
+            strategy::apply(Point(0, y * direction), s1, s2,
+                bg::strategy::buffer::place_on_ring_original, false, state);
+            BOOST_CHECK_EQUAL(state.count_on_origin, y >= 1 && y <= 3 ? 1 : 0);
+        }
+    }
+}
+
 int test_main(int, char* [])
 {
     BoostGeometryWriteTestConfiguration();
@@ -385,6 +403,8 @@ int test_main(int, char* [])
 
     test_diamond_point_on_piece_a<point_type>();
     test_diamond_point_on_piece_c<point_type>();
+
+    test_segment_range<point_type>();
 
     return 0;
 }

--- a/test/algorithms/buffer/buffer_piece_border.cpp
+++ b/test/algorithms/buffer/buffer_piece_border.cpp
@@ -373,6 +373,26 @@ void test_diamond_point_on_piece_c()
 }
 
 template <typename Point>
+void test_exposed_helpers()
+{
+    using ring_type = bg::model::ring<Point>;
+    using border_type = bg::detail::buffer::piece_border<ring_type, Point>;
+    ring_type offsetted, original;
+    auto const border = setup_piece_border<border_type>(offsetted, original,
+        rectangle_offsetted, rectangle_original, 'a');
+    for (int x : {1, 2})
+    {
+        Point const point(x, 2.5);
+        typename border_type::state_type internal, exposed;
+        border.point_on_piece(point, false, false, internal);
+        border.point_on_piece(point, false, false, exposed, x == 1, x == 2);
+        BOOST_CHECK(internal.is_inside());
+        BOOST_CHECK(!internal.is_on_boundary());
+        BOOST_CHECK(exposed.is_on_boundary());
+    }
+}
+
+template <typename Point>
 void test_segment_range()
 {
     using strategy = bg::strategy::buffer::turn_in_ring_winding
@@ -405,6 +425,7 @@ int test_main(int, char* [])
     test_diamond_point_on_piece_c<point_type>();
 
     test_segment_range<point_type>();
+    test_exposed_helpers<point_type>();
 
     return 0;
 }

--- a/test/algorithms/crosses/crosses.cpp
+++ b/test/algorithms/crosses/crosses.cpp
@@ -58,8 +58,8 @@ void test_ll()
 
     test_geometry<mls, mls>("MULTILINESTRING((0 0,2 2,4 4),(3 0,3 4))", "MULTILINESTRING((0 1,4 1),(0 2,4 2))", true);
 
-    // spike - boundary and interior on the same point
-    test_geometry<ls, ls>("LINESTRING(3 7, 8 8, 2 6)", "LINESTRING(5 7, 10 7, 0 7)", true);
+    // The revisited endpoint is boundary, so neither contact is interior/interior.
+    test_geometry<ls, ls>("LINESTRING(3 7, 8 8, 2 6)", "LINESTRING(5 7, 10 7, 0 7)", false);
 }
 
 template <typename P>

--- a/test/algorithms/is_valid.cpp
+++ b/test/algorithms/is_valid.cpp
@@ -1746,7 +1746,7 @@ BOOST_AUTO_TEST_CASE(test_is_valid_polyhedral_surface)
         "POLYHEDRALSURFACE(((0 0 0,1 0 0,0 1 0,0 0 0)),((0.5 0.5 0,2 1 0,2 2 0,1 2 0,0.5 0.5 0)))",
         invalid_surface_invalid_intersection_vertex_edge);
     BOOST_CHECK(!bg::is_valid(invalid_surface_invalid_intersection_vertex_edge, failure));
-    BOOST_CHECK(failure == bg::failure_disconnected_surface);
+    BOOST_CHECK(failure == bg::failure_invalid_intersection);
 
     // Invalid polyhedral surface: invalid intersection (intersection vertex with vertex of another polygon)
     // Issue 1406

--- a/test/algorithms/overlay/get_turns_linear_areal.cpp
+++ b/test/algorithms/overlay/get_turns_linear_areal.cpp
@@ -18,6 +18,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #include "test_get_turns.hpp"
+#include <boost/geometry/algorithms/detail/relate/turns.hpp>
 #include <boost/geometry/geometries/geometries.hpp>
 
 
@@ -27,6 +28,24 @@ void test_all()
     typedef bg::model::point<T, 2, bg::cs::cartesian> pt;
     typedef bg::model::linestring<pt> ls;
     typedef bg::model::polygon<pt> poly;
+
+    // Different polygons' outer rings must not be treated as the same ring.
+    using turn = bg::detail::overlay::turn_info<pt>;
+    turn shell_exit, hole_entry, other_entry;
+    shell_exit.operations[0].operation = bg::detail::overlay::operation_union;
+    hole_entry.operations[0].operation = bg::detail::overlay::operation_intersection;
+    other_entry.operations[0].operation = bg::detail::overlay::operation_intersection;
+    shell_exit.operations[1].seg_id = bg::segment_identifier(1, 3, -1, 0);
+    hole_entry.operations[1].seg_id = bg::segment_identifier(1, 3, 0, 0);
+    other_entry.operations[1].seg_id = bg::segment_identifier(1, 2, -1, 0);
+    bg::detail::relate::turns::less_op_linear_areal_single<0> less;
+    BOOST_CHECK(less(hole_entry, shell_exit));
+    BOOST_CHECK(less(other_entry, shell_exit));
+    BOOST_CHECK(!less(shell_exit, other_entry));
+    BOOST_CHECK(!less(hole_entry, other_entry) && !less(other_entry, hole_entry));
+    other_entry.operations[1].seg_id.multi_index = 3;
+    BOOST_CHECK(less(shell_exit, other_entry));
+    BOOST_CHECK(!less(other_entry, shell_exit));
 
     test_geometry<ls, poly>("LINESTRING(15 5,24 5,20 2,19 0,13 -4,1 0,10 0,13 3,15 7,16 10,10 10,8 10,4 6,2 8,1 10)",
                             "POLYGON((0 0,5 5,0 10,20 10,20 2,19 0,0 0)(10 3,15 3,15 7,10 7,10 3))",

--- a/test/algorithms/relate/relate_areal_areal.cpp
+++ b/test/algorithms/relate/relate_areal_areal.cpp
@@ -396,6 +396,20 @@ void test_multi_polygon_multi_polygon()
     typedef bg::model::polygon<P> poly;
     typedef bg::model::multi_polygon<poly> mpoly;
 
+    using ccw_multi = bg::model::multi_polygon<bg::model::polygon<P, false>>;
+    test_geometry<ccw_multi, ccw_multi>(
+        "MULTIPOLYGON(((40 30,60 15,60 45,40 30)),"
+        "((40 30,20 45,0 30,0 0,40 0,60 15,40 15,40 30),(40 30,20 15,20 30,40 30)))",
+        "MULTIPOLYGON(((0 30,20 30,20 45,0 30)),((40 30,20 15,40 15,40 30)),"
+        "((40 30,60 45,40 45,40 30)),((20 15,0 15,0 0,20 15)),((20 15,20 0,40 0,20 15)))",
+        "212F11212");
+
+    test_geometry<ccw_multi, ccw_multi>(
+        "MULTIPOLYGON(((40 30,20 45,20 30,0 30,20 15,40 15,40 30)),"
+        "((40 30,60 45,40 45,40 30)))",
+        "MULTIPOLYGON(((60 45,20 45,0 30,20 15,60 15,60 45),"
+        "(40 30,20 15,20 30,40 30)))", "21211F212");
+
     test_geometry<mpoly, mpoly>("MULTIPOLYGON(((0 0,0 10,10 10,10 0,0 0)))",
                                 "MULTIPOLYGON(((5 5,5 10,6 10,6 5,5 5)),((0 20,0 30,10 30,10 20,0 20)))",
                                 "212F11212");
@@ -412,9 +426,53 @@ void test_multi_polygon_multi_polygon()
 }
 
 template <typename P>
+void test_areal_turn_order()
+{
+    using turn_type = bg::detail::overlay::turn_info<P>;
+    std::vector<turn_type> turns;
+    for (int multi = 0; multi < 2; ++multi)
+        for (int ring = -1; ring < 2; ++ring)
+            for (auto op : {bg::detail::overlay::operation_union,
+                            bg::detail::overlay::operation_intersection,
+                            bg::detail::overlay::operation_blocked,
+                            bg::detail::overlay::operation_continue})
+            {
+                turn_type turn;
+                turn.operations[0].operation = op;
+                turn.operations[1].seg_id.multi_index = multi;
+                turn.operations[1].seg_id.ring_index = ring;
+                turns.push_back(turn);
+            }
+    bg::detail::relate::turns::less_op_areal_areal<0> less;
+    for (auto const& a : turns)
+        for (auto const& b : turns)
+        {
+            BOOST_CHECK(!(less(a,b) && less(b,a)));
+            for (auto const& c : turns)
+            {
+                if (less(a,b) && less(b,c)) BOOST_CHECK(less(a,c));
+                if (!less(a,b) && !less(b,a) && !less(b,c) && !less(c,b))
+                    BOOST_CHECK(!less(a,c) && !less(c,a));
+            }
+        }
+}
+
+template <typename P>
 void test_all()
 {
+    using poly = bg::model::polygon<P>;
+    using mpoly = bg::model::multi_polygon<poly>;
+    test_geometry<mpoly, mpoly>(
+        "MULTIPOLYGON(((40 30,40 0,0 0,40 30)))",
+        "MULTIPOLYGON(((60 15,60 0,0 0,40 30,60 15)),"
+        "((0 30,20 15,0 15,0 30)))", "2FF11F212");
+    test_geometry<mpoly, mpoly>(
+        "MULTIPOLYGON(((16 12,40 30,40 0,0 0,16 12)))",
+        "MULTIPOLYGON(((60 15,60 0,0 0,40 30,60 15)),"
+        "((0 30,20 15,0 15,0 30)))", "2FF11F212");
+
     test_polygon_polygon<P>();
+    test_areal_turn_order<P>();
     test_polygon_multi_polygon<P>();
     test_multi_polygon_multi_polygon<P>();
 }

--- a/test/algorithms/relate/relate_linear_areal.cpp
+++ b/test/algorithms/relate/relate_linear_areal.cpp
@@ -574,6 +574,13 @@ void test_all()
         "MULTIPOLYGON(((0 0,1 -1,0 -2,-1 -1,0 0)),"
         "((2 2,2 0,0 0,-1 1,0 2,2 2),(1 1,0 1,0 0,1 1)))", "1010F0212");
 
+    std::string const area = "MULTIPOLYGON(((0 30,20 15,20 0,0 0,0 30)))";
+    test_geometry<mls, mpoly>(
+        "MULTILINESTRING((0 15,20 15,20 0,0 0,0 30),(20 15,0 30))",
+        area, "11FF0F2F2");
+    test_geometry<mls, mpoly>(
+        "MULTILINESTRING((0 15,20 15,20 0,0 0,0 30))",
+        area, "11FF0F212");
 
     std::string const triangle = "MULTIPOLYGON(((0 0,0 15,20 15,0 0)))";
     test_geometry<mls, mpoly>("MULTILINESTRING((20 0,20 15,20 30),(20 15,0 30))",

--- a/test/algorithms/relate/relate_linear_areal.cpp
+++ b/test/algorithms/relate/relate_linear_areal.cpp
@@ -551,10 +551,10 @@ void test_multi_linestring_multi_polygon()
                               "11F00F212");
     test_geometry<mls, mpoly>("MULTILINESTRING((5 5,0 0,5 -5),(0 0,9 1))",
                               "MULTIPOLYGON(((0 0,0 10,10 10,10 0,0 0)),((0 0,0 -10,-10 -10,-10 0,0 0)))",
-                              "101000212");
+                              "1F1000212");
     test_geometry<mls, mpoly>("MULTILINESTRING((5 -5,0 0,5 5),(0 0,5 -1))",
                               "MULTIPOLYGON(((0 0,0 10,10 10,10 0,0 0)),((0 0,0 -10,-10 -10,-10 0,0 0)))",
-                              "101000212");
+                              "1F1000212");
 }
 
 template <typename P>
@@ -562,7 +562,8 @@ void test_all()
 {
     using ls = bg::model::linestring<P>;
     using mls = bg::model::multi_linestring<ls>;
-    using mpoly = bg::model::multi_polygon<bg::model::polygon<P>>;
+    using poly = bg::model::polygon<P>;
+    using mpoly = bg::model::multi_polygon<poly>;
     std::string const touching =
         "MULTIPOLYGON(((2 2,2 0,0 0,-1 1,0 2,2 2),(1 1,0 1,0 0,1 1)),"
         "((0 0,1 -1,0 -2,-1 -1,0 0)))";
@@ -572,6 +573,21 @@ void test_all()
     test_geometry<ls, mpoly>("LINESTRING(0 -1,0 0,-1 0)",
         "MULTIPOLYGON(((0 0,1 -1,0 -2,-1 -1,0 0)),"
         "((2 2,2 0,0 0,-1 1,0 2,2 2),(1 1,0 1,0 0,1 1)))", "1010F0212");
+
+
+    std::string const triangle = "MULTIPOLYGON(((0 0,0 15,20 15,0 0)))";
+    test_geometry<mls, mpoly>("MULTILINESTRING((20 0,20 15,20 30),(20 15,0 30))",
+        triangle, "FF1F00212");
+    test_geometry<mls, mpoly>("MULTILINESTRING((20 15,0 30),(20 30,20 0))",
+        triangle, "FF1F00212");
+    test_geometry<ls, mpoly>("LINESTRING(20 0,20 30,40 30,20 15)",
+        triangle, "FF1F00212");
+    test_geometry<mls, mpoly>("MULTILINESTRING((20 0,20 30),(20 15,0 30),(20 15,40 15))",
+        triangle, "F01FF0212");
+    test_geometry<mls, mpoly>("MULTILINESTRING((0 0,4 4),(1 1,3 1))",
+        "MULTIPOLYGON(((0 2,0 4,4 4,4 0,2 0,0 2)))", "1F1000212");
+    test_geometry<ls, poly>("LINESTRING(0 0,1 1)",
+        "POLYGON((0 1,2 1,2 -1,0 1))", "101F00212");
 
     test_linestring_polygon<P>();
     test_linestring_multi_polygon<P>();

--- a/test/algorithms/relate/relate_linear_areal.cpp
+++ b/test/algorithms/relate/relate_linear_areal.cpp
@@ -492,6 +492,18 @@ void test_multi_linestring_multi_polygon()
                               "MULTIPOLYGON(((0 0,0 10,10 10,10 0,0 0)))",
                               "F11FFF2F2");
 
+    // Repeated turns at the last point must not reclassify the first point.
+    using ccw_mpoly = bg::model::multi_polygon<bg::model::polygon<P, false>>;
+    test_geometry<mls, ccw_mpoly>("MULTILINESTRING((0 120,0 135,20 135))",
+        "MULTIPOLYGON(((20 135,20 120,40 120,20 135)),((20 135,20 150,0 150,20 135)),((20 120,0 120,20 105,20 120)))",
+        "FF1F0F212");
+
+    // Finalize an exterior tail even when the next member follows a boundary.
+    test_geometry<mls, mpoly>("MULTILINESTRING((0 0,0 -2),(0 0,2 0))",
+        "MULTIPOLYGON(((0 0,0 2,2 0,0 0)))", "F11F00212");
+    test_geometry<mls, mpoly>("MULTILINESTRING((0 0,2 0),(0 0,0 -2))",
+        "MULTIPOLYGON(((0 0,0 2,2 0,0 0)))", "F11F00212");
+
     // disjoint
     test_geometry<mls, mpoly>("MULTILINESTRING((20 20,30 30),(30 30,40 40))",
                               "MULTIPOLYGON(((0 0,0 10,10 10,10 0,0 0)))",

--- a/test/algorithms/relate/relate_linear_areal.cpp
+++ b/test/algorithms/relate/relate_linear_areal.cpp
@@ -179,6 +179,12 @@ void test_linestring_polygon()
     {
         typedef bg::model::polygon<P, false> ccwpoly;
 
+        // The hole and exterior ring meet at the last point, approached from outside.
+        test_geometry<ls, ccwpoly>("LINESTRING(6 2,4 2)",
+            "POLYGON((0 0,4 0,4 4,0 4,0 0),(2 1,2 3,4 2,2 1))", "FF1F00212");
+        test_geometry<ls, ccwpoly>("LINESTRING(4 2,6 2)",
+            "POLYGON((0 0,4 0,4 4,0 4,0 0),(2 1,2 3,4 2,2 1))", "FF1F00212");
+
         // IE IB0 II
         test_geometry<ls, ccwpoly>("LINESTRING(11 1,10 5,5 5)", "POLYGON((0 0,10 0,10 10,0 10,0 0))", "1010F0212");
         // IE IB1 II
@@ -554,6 +560,19 @@ void test_multi_linestring_multi_polygon()
 template <typename P>
 void test_all()
 {
+    using ls = bg::model::linestring<P>;
+    using mls = bg::model::multi_linestring<ls>;
+    using mpoly = bg::model::multi_polygon<bg::model::polygon<P>>;
+    std::string const touching =
+        "MULTIPOLYGON(((2 2,2 0,0 0,-1 1,0 2,2 2),(1 1,0 1,0 0,1 1)),"
+        "((0 0,1 -1,0 -2,-1 -1,0 0)))";
+    test_geometry<ls, mpoly>("LINESTRING(0 -1,0 0,-1 0)", touching, "1010F0212");
+    test_geometry<ls, mpoly>("LINESTRING(-1 0,0 0,0 -1)", touching, "1010F0212");
+    test_geometry<mls, mpoly>("MULTILINESTRING((0 -1,0 0,-1 0))", touching, "1010F0212");
+    test_geometry<ls, mpoly>("LINESTRING(0 -1,0 0,-1 0)",
+        "MULTIPOLYGON(((0 0,1 -1,0 -2,-1 -1,0 0)),"
+        "((2 2,2 0,0 0,-1 1,0 2,2 2),(1 1,0 1,0 0,1 1)))", "1010F0212");
+
     test_linestring_polygon<P>();
     test_linestring_multi_polygon<P>();
     test_multi_linestring_polygon<P>();

--- a/test/algorithms/relate/relate_linear_areal_sph.cpp
+++ b/test/algorithms/relate/relate_linear_areal_sph.cpp
@@ -387,10 +387,10 @@ void test_multi_linestring_multi_polygon()
                               "11F00F212");
     test_geometry<mls, mpoly>("MULTILINESTRING((5 5,0 0,5 -5),(0 0,9 1))",
                               "MULTIPOLYGON(((0 0,0 10,10 10,10 0,0 0)),((0 0,0 -10,-10 -10,-10 0,0 0)))",
-                              "101000212");
+                              "1F1000212");
     test_geometry<mls, mpoly>("MULTILINESTRING((5 -5,0 0,5 5),(0 0,5 -1))",
                               "MULTIPOLYGON(((0 0,0 10,10 10,10 0,0 0)),((0 0,0 -10,-10 -10,-10 0,0 0)))",
-                              "101000212");
+                              "1F1000212");
 }
 
 template <typename P>

--- a/test/algorithms/relate/relate_linear_linear.cpp
+++ b/test/algorithms/relate/relate_linear_linear.cpp
@@ -403,6 +403,14 @@ void test_multi_linestring_multi_linestring()
     test_geometry<mls, mls>("MULTILINESTRING((0 0,0 0,18 0,18 0,19 0,19 0,19 0,30 0,30 0))",
                             "MULTILINESTRING((0 10,5 0,20 0,20 0,30 0))",
                             "1F1F00102");
+
+    // An exterior tail must be handled before moving to the common component.
+    test_geometry<mls, mls>("MULTILINESTRING((60 0,60 15),(20 60,20 75))",
+                            "MULTILINESTRING((40 0,60 0),(20 60,20 75))",
+                            "1F1F00102");
+    test_geometry<mls, mls>("MULTILINESTRING((20 60,20 75),(60 0,60 15))",
+                            "MULTILINESTRING((40 0,60 0),(20 60,20 75))",
+                            "1F1F00102");
     test_geometry<mls, mls>("MULTILINESTRING((0 0,0 0,18 0,18 0,19 0,19 0,19 0,30 0,30 0))",
                             //"MULTILINESTRING((0 10,5 0,20 0,20 0,30 0),(1 10,1 10,1 0,1 0,1 -10),(2 0,2 0),(3 0,3 0,3 0),(0 0,0 0,0 10,0 10),(30 0,30 0,31 0,31 0))",
                             "MULTILINESTRING((0 10,5 0,20 0,20 0,30 0),(1 10,1 10,1 0,1 0,1 -10),(0 0,0 0,0 10,0 10),(30 0,30 0,31 0,31 0))",

--- a/test/algorithms/relate/relate_linear_linear.cpp
+++ b/test/algorithms/relate/relate_linear_linear.cpp
@@ -230,8 +230,8 @@ void test_linestring_linestring()
         BOOST_CHECK_THROW(bg::relate(ls1, ls2, bg::de9im::mask("A")), bg::invalid_input_exception);
     }
 
-    // spike - boundary and interior on the same point
-    test_geometry<ls, ls>("LINESTRING(3 7, 8 8, 2 6)", "LINESTRING(5 7, 10 7, 0 7)", "0010F0102");
+    // A boundary endpoint is revisited inside the same linestring.
+    test_geometry<ls, ls>("LINESTRING(3 7, 8 8, 2 6)", "LINESTRING(5 7, 10 7, 0 7)", "F010F0102");
 
     // 22.01.2015
     test_geometry<ls, ls>("LINESTRING(5 5,10 10)", "LINESTRING(6 6,3 3)", "1010F0102");
@@ -327,15 +327,15 @@ void test_linestring_multi_linestring()
 
     test_geometry<ls, mls>("LINESTRING(0 0, 5 0)",                      //   |--------------|
                            "MULTILINESTRING((0 0, 5 0),(-1 0, 6 0))",   //   |--------------|
-                           "1FF00F102");                                // |------------------|
+                           "1FFF0F102");                                // |------------------|
 
     test_geometry<ls, mls>("LINESTRING(0 0, 5 0)",                      //   |--------------|
                            "MULTILINESTRING((0 0, 5 0),(-1 0, 2 0))",   //   |--------------|
-                           "10F00F102");                                // |-------|
+                           "10FF0F102");                                // |-------|
 
     test_geometry<ls, mls>("LINESTRING(0 0, 5 0)",                      //   |--------------|
                            "MULTILINESTRING((0 0, 5 0),(2 0, 6 0))",    //   |--------------|
-                           "10F00F102");                                //            |-------|
+                           "10FF0F102");                                //            |-------|
 
     test_geometry<ls, mls>("LINESTRING(0 0, 5 0)",                      //   |--------------|
                            "MULTILINESTRING((0 0, 5 0),(2 0, 2 2))",    //   |--------------|
@@ -399,6 +399,17 @@ void test_multi_linestring_multi_linestring()
     using coord_t = typename bg::coordinate_type<P>::type;
     using ls = bg::model::linestring<P>;
     using mls = bg::model::multi_linestring<ls>;
+
+    // The endpoint is revisited in the interior of the same linestring.
+    test_geometry<ls, ls>("LINESTRING(40 30,20 45)",
+        "LINESTRING(0 30,20 45,20 60,0 60,20 45)", "FF1F00102");
+    test_geometry<mls, mls>("MULTILINESTRING((40 30,20 45))",
+        "MULTILINESTRING((0 30,20 45,20 60,0 60,20 45))", "FF1F00102");
+    // A segment crossing can also lie on a global boundary endpoint.
+    test_geometry<mls, mls>("MULTILINESTRING((-20 15,20 15))",
+        "MULTILINESTRING((0 0,0 30),(0 15,20 30))", "F01FF0102");
+    test_geometry<ls, ls>("LINESTRING(-20 15,20 15)",
+        "LINESTRING(0 0,0 30,20 30,0 15)", "F01FF0102");
 
     test_geometry<mls, mls>("MULTILINESTRING((0 0,0 0,18 0,18 0,19 0,19 0,19 0,30 0,30 0))",
                             "MULTILINESTRING((0 10,5 0,20 0,20 0,30 0))",

--- a/test/algorithms/relate/relate_linear_linear_sph.cpp
+++ b/test/algorithms/relate/relate_linear_linear_sph.cpp
@@ -326,15 +326,15 @@ void test_linestring_multi_linestring()
 
     test_geometry<ls, mls>("LINESTRING(0 0, 5 0)",                      //   |--------------|
                            "MULTILINESTRING((0 0, 5 0),(-1 0, 6 0))",   //   |--------------|
-                           "1FF00F102");                                // |------------------|
+                           "1FFF0F102");                                // |------------------|
 
     test_geometry<ls, mls>("LINESTRING(0 0, 5 0)",                      //   |--------------|
                            "MULTILINESTRING((0 0, 5 0),(-1 0, 2 0))",   //   |--------------|
-                           "10F00F102");                                // |-------|
+                           "10FF0F102");                                // |-------|
 
     test_geometry<ls, mls>("LINESTRING(0 0, 5 0)",                      //   |--------------|
                            "MULTILINESTRING((0 0, 5 0),(2 0, 6 0))",    //   |--------------|
-                           "10F00F102");                                //            |-------|
+                           "10FF0F102");                                //            |-------|
 
     test_geometry<ls, mls>("LINESTRING(0 0, 5 0)",                      //   |--------------|
                            "MULTILINESTRING((0 0, 5 0),(2 0, 2 2))",    //   |--------------|

--- a/test/algorithms/relate/relate_pointlike_geometry.cpp
+++ b/test/algorithms/relate/relate_pointlike_geometry.cpp
@@ -28,6 +28,8 @@ void test_point_multipoint()
 {
     typedef bg::model::multi_point<P> mpt;
 
+    test_geometry<P, mpt>("POINT(0 0)", "MULTIPOINT EMPTY", "FF0FFFFF2");
+
     test_geometry<P, mpt>("POINT(0 0)", "MULTIPOINT(0 0)", "0FFFFFFF2");
     test_geometry<P, mpt>("POINT(1 0)", "MULTIPOINT(0 0)", "FF0FFF0F2");
     test_geometry<P, mpt>("POINT(0 0)", "MULTIPOINT(0 0, 1 0)", "0FFFFF0F2");
@@ -37,6 +39,9 @@ template <typename P>
 void test_multipoint_multipoint()
 {
     typedef bg::model::multi_point<P> mpt;
+
+    test_geometry<mpt, mpt>("MULTIPOINT EMPTY", "MULTIPOINT EMPTY", "FFFFFFFF2");
+    test_geometry<mpt, mpt>("MULTIPOINT(0 0)", "MULTIPOINT EMPTY", "FF0FFFFF2");
 
     test_geometry<mpt, mpt>("MULTIPOINT(0 0)", "MULTIPOINT(0 0)", "0FFFFFFF2");
     test_geometry<mpt, mpt>("MULTIPOINT(1 0)", "MULTIPOINT(0 0)", "FF0FFF0F2");

--- a/test/algorithms/relate/relate_pointlike_geometry.cpp
+++ b/test/algorithms/relate/relate_pointlike_geometry.cpp
@@ -238,6 +238,21 @@ void test_multipoint_multipolygon()
 template <typename P>
 void test_all()
 {
+    using ring = bg::model::ring<P>;
+    using poly = bg::model::polygon<P>;
+    using mpoly = bg::model::multi_polygon<poly>;
+    using mpt = bg::model::multi_point<P>;
+    test_geometry<P, ring>("POINT(0 0)", "POLYGON EMPTY", "FF0FFFFF2");
+    test_geometry<P, poly>("POINT(0 0)", "POLYGON EMPTY", "FF0FFFFF2");
+    test_geometry<P, mpoly>("POINT(0 0)", "MULTIPOLYGON EMPTY", "FF0FFFFF2");
+    test_geometry<mpt, ring>("MULTIPOINT(0 0)", "POLYGON EMPTY", "FF0FFFFF2");
+    test_geometry<mpt, poly>("MULTIPOINT(0 0)", "POLYGON EMPTY", "FF0FFFFF2");
+    test_geometry<mpt, mpoly>("MULTIPOINT(0 0)", "MULTIPOLYGON EMPTY", "FF0FFFFF2");
+    test_geometry<mpt, mpoly>("MULTIPOINT EMPTY", "MULTIPOLYGON EMPTY", "FFFFFFFF2");
+    test_geometry<mpt, mpoly>("MULTIPOINT EMPTY", "MULTIPOLYGON((()))", "FFFFFFFF2");
+    test_geometry<mpt, mpoly>("MULTIPOINT EMPTY",
+        "MULTIPOLYGON((()),((0 0,0 2,2 2,2 0,0 0)))", "FFFFFF212");
+
     test_point_point<P>();
     test_point_multipoint<P>();
     test_multipoint_multipoint<P>();

--- a/test/algorithms/relate/relate_pointlike_geometry.cpp
+++ b/test/algorithms/relate/relate_pointlike_geometry.cpp
@@ -144,6 +144,17 @@ void test_multipoint_multilinestring()
     typedef bg::model::multi_point<P> mpt;
     typedef bg::model::linestring<P> ls;
     typedef bg::model::multi_linestring<ls> mls;
+
+    // An interior point of one member is a boundary endpoint of another.
+    std::string const branched = "MULTILINESTRING((0 0,20 15,20 0),(20 15,20 30))";
+    test_geometry<mpt, mls>("MULTIPOINT(20 15)", branched, "F0FFFF102");
+    test_geometry<P, mls>("POINT(20 15)", branched, "F0FFFF102");
+    test_geometry<mpt, mls>("MULTIPOINT(20 15)", branched, "F0*******");
+    test_geometry<mpt, mls>("MULTIPOINT(20 15)",
+        "MULTILINESTRING((20 15,20 30),(0 0,20 15,20 0))", "F0FFFF102");
+    test_geometry<mpt, mls>("MULTIPOINT(20 15)",
+        "MULTILINESTRING((0 0,20 15,20 0),(20 15,20 30),(20 15,40 15))",
+        "0FFFFF102");
     
     test_geometry<mpt, mls>("MULTIPOINT(0 0)", "MULTILINESTRING((0 0, 2 2),(2 2, 3 2))", "F0FFFF102");
     test_geometry<mpt, mls>("MULTIPOINT(0 0, 1 1)", "MULTILINESTRING((0 0, 2 2),(2 2, 3 2))", "00FFFF102");

--- a/test/algorithms/relate/relate_pointlike_geometry.cpp
+++ b/test/algorithms/relate/relate_pointlike_geometry.cpp
@@ -252,6 +252,20 @@ void test_all()
     test_geometry<mpt, mpoly>("MULTIPOINT EMPTY", "MULTIPOLYGON((()))", "FFFFFFFF2");
     test_geometry<mpt, mpoly>("MULTIPOINT EMPTY",
         "MULTIPOLYGON((()),((0 0,0 2,2 2,2 0,0 0)))", "FFFFFF212");
+    // Empty members have no envelope to index; retain the other members' indices.
+    for (auto const& area : {
+        "MULTIPOLYGON((()),((0 0,0 2,2 2,2 0,0 0)),(()))",
+        "MULTIPOLYGON(((0 0,0 2,2 2,2 0,0 0)),(()))"})
+    {
+        test_geometry<mpt, mpoly>("MULTIPOINT(1 1,0 1,3 1)", area, "000FFF212");
+        test_geometry<mpt, mpoly>("MULTIPOINT(1 1,0 1,3 1)", area, "00*******");
+    }
+    test_geometry<mpt, mpoly>("MULTIPOINT(1 1)", "MULTIPOLYGON((()))", "FF0FFFFF2");
+    using mls = bg::model::multi_linestring<bg::model::linestring<P>>;
+    test_geometry<mpt, mls>("MULTIPOINT(1 0,0 0,3 0)",
+        "MULTILINESTRING((),(0 0,2 0),())", "000FFF102");
+    test_geometry<mpt, mls>("MULTIPOINT(1 0,0 0,3 0)",
+        "MULTILINESTRING((),(0 0,2 0),())", "00*******");
 
     test_point_point<P>();
     test_point_multipoint<P>();

--- a/test/algorithms/set_operations/difference/difference_multi.cpp
+++ b/test/algorithms/set_operations/difference/difference_multi.cpp
@@ -7,6 +7,7 @@
 // Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+#include <cstdint>
 #include <iostream>
 #include <string>
 
@@ -387,6 +388,17 @@ void test_all()
 template <typename Polygon, typename MultiPolygon>
 void test_specific_areal()
 {
+    test_one<Polygon, MultiPolygon, MultiPolygon>("issue_1490",
+        "MULTIPOLYGON(((0 0,20 0,20 20,0 20,0 0),(5 15,14 14,9 6,5 15)))",
+        "MULTIPOLYGON(((5 15,5 5,15 5,15 15,5 15)))",
+        1, -1, 300, 1, -1, 38.5, 2, -1, 338.5);
+
+    test_one<Polygon, MultiPolygon, MultiPolygon>("issue_1490_grid",
+        "MULTIPOLYGON(((60 75,20 75,20 60,0 60,0 0,80 0,80 60,60 60,60 75),"
+        "(60 45,40 30,40 45,60 45)))",
+        "MULTIPOLYGON(((40 60,20 45,20 15,60 15,60 45,40 60)))",
+        1, -1, 3900, 1, -1, 150, 2, -1, 4050);
+
     {
         // Spikes in a-b and b-a, causing invalidity
         ut_settings settings;
@@ -473,6 +485,7 @@ int test_main(int, char* [])
     test_all<bg::model::d2::point_xy<default_test_type> >();
 
     test_specific<bg::model::d2::point_xy<int>, false, false>();
+    test_specific<bg::model::d2::point_xy<std::int_least64_t>, true, true>();
 
 #if ! defined(BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE)
     test_all<bg::model::d2::point_xy<float> >();

--- a/test/algorithms/set_operations/difference/difference_multi.cpp
+++ b/test/algorithms/set_operations/difference/difference_multi.cpp
@@ -41,6 +41,14 @@
 template <typename Ring, typename Polygon, typename MultiPolygon>
 void test_areal()
 {
+    test_one<Polygon, MultiPolygon, MultiPolygon>("parallel_graph_arcs",
+        "MULTIPOLYGON(((140 60,160 60,140 75,140 60)),"
+        "((140 60,140 45,160 45,140 60)),((160 60,160 45,180 45,160 60)))",
+        "MULTIPOLYGON(((160 75,160 60,180 60,160 75)),"
+        "((160 75,180 75,160 90,160 75)),((160 45,160 60,140 60,160 45)),"
+        "((160 45,180 30,180 45,160 45)),((140 60,120 75,120 60,140 60)))",
+        3, -1, 450, 5, -1, 750, 4, -1, 1200);
+
     test_one<Polygon, MultiPolygon, MultiPolygon>("simplex_multi",
             case_multi_simplex[0], case_multi_simplex[1],
             5, 21, 5.58, 4, 17, 2.58);

--- a/test/algorithms/set_operations/difference/difference_multi_areal_linear.cpp
+++ b/test/algorithms/set_operations/difference/difference_multi_areal_linear.cpp
@@ -36,6 +36,48 @@ void test_areal_linear()
     typedef typename bg::point_type<polygon>::type point;
     typedef bg::model::ring<point> ring;
 
+    test_one_lp<linestring, MultiLineString, MultiPolygon>("first_crossing_between_polygons",
+        "MULTILINESTRING((180 30,180 60))",
+        "MULTIPOLYGON(((160 60,160 45,200 45,200 60,160 60)),"
+        "((160 30,200 0,200 30,180 45,160 30)))", 0, 0, 0.0);
+
+    test_one_lp<linestring, MultiLineString, MultiPolygon>("touching_hole_between_polygons",
+        "MULTILINESTRING((20 0,0 0,0 15),"
+        "(40 0,20 0,20 15,20 30,0 30,20 45,0 45,0 60,20 60,20 30,40 30,60 30,"
+        "60 15,40 15,40 30,20 45,40 60,60 60),(20 15,40 0,60 15),"
+        "(40 30,60 45,40 45),(60 30,60 45))",
+        "MULTIPOLYGON(((40 60,60 45,60 60,40 60)),((40 60,20 60,20 45,40 60)),"
+        "((60 45,40 45,40 30,60 15,60 30,60 45)),"
+        "((40 30,20 45,0 30,0 0,40 0,40 30),(40 30,20 15,20 30,40 30)))",
+        3, 8, 100.0);
+
+    test_one_lp<linestring, MultiLineString, MultiPolygon>("touch_while_inside_another_polygon",
+        "MULTILINESTRING((6 4,6 8))",
+        "MULTIPOLYGON(((0 0,8 0,8 8,0 8,0 0),(2 2,2 6,6 4,2 2)),"
+        "((3 3,6 4,3 5,3 3)))", 0, 0, 0.0);
+    // Leave a touching hole and shell while following another polygon's boundary.
+    for (auto const& area : {
+        "MULTIPOLYGON(((80 90,60 75,80 60,80 90)),"
+        "((60 75,40 90,0 60,40 30,60 45,60 75),(60 75,40 60,40 75,60 75)))",
+        "MULTIPOLYGON(((60 75,40 90,0 60,40 30,60 45,60 75),"
+        "(60 75,40 60,40 75,60 75)),((80 90,60 75,80 60,80 90)))"})
+    {
+        test_one_lp<linestring, MultiLineString, MultiPolygon>("leave_touching_boundaries",
+            "MULTILINESTRING((80 60,60 75,60 90))", area, 1, 2, 15.0);
+        test_one_lp<linestring, MultiLineString, MultiPolygon>("enter_touching_boundaries",
+            "MULTILINESTRING((60 90,60 75,80 60))", area, 1, 2, 15.0);
+    }
+
+    test_one_lp<linestring, MultiLineString, MultiPolygon>("cross_while_covered",
+        "MULTILINESTRING((4 4,4 8))",
+        "MULTIPOLYGON(((0 0,8 0,8 8,0 8,0 0),(2 2,2 6,6 6,6 2,2 2)),"
+        "((4 4,6 4,4 6,4 4)))", 0, 0, 0.0);
+
+    test_one_lp<linestring, MultiLineString, MultiPolygon>("touch_while_following_boundary",
+        "MULTILINESTRING((180 60,160 75,140 75,120 75))",
+        "MULTIPOLYGON(((160 75,120 75,140 60,160 60,160 75)),"
+        "((140 75,140 90,120 90,140 75)))", 1, 2, 25.0);
+
     test_one_lp<linestring, linestring, MultiPolygon>("case_mp_ls_1", "LINESTRING(2 0,2 5)", case_multi_simplex[0], 2, 4, 1.30);
     test_one_lp<linestring, MultiLineString, polygon>("case_p_mls_1", "MULTILINESTRING((2 0,2 5),(3 0,3 5))", case_single_simplex, 3, 6, 2.5);
     test_one_lp<linestring, MultiLineString, MultiPolygon>("case_mp_mls_1", "MULTILINESTRING((2 0,2 5),(3 0,3 5))", case_multi_simplex[0], 5, 10, 3.1666667);

--- a/test/algorithms/set_operations/intersection/intersection_tupled.cpp
+++ b/test/algorithms/set_operations/intersection/intersection_tupled.cpp
@@ -10,8 +10,10 @@
 #include <geometry_test_common.hpp>
 
 #include <boost/geometry/algorithms/correct.hpp>
+#include <boost/geometry/algorithms/difference.hpp>
 #include <boost/geometry/algorithms/equals.hpp>
 #include <boost/geometry/algorithms/intersection.hpp>
+#include <boost/geometry/algorithms/length.hpp>
 #include <boost/geometry/geometries/geometries.hpp>
 #include <boost/geometry/io/wkt/wkt.hpp>
 #include <boost/geometry/strategies/cartesian/intersection.hpp>
@@ -35,6 +37,40 @@ typedef bg::model::multi_linestring<Ls> MLs;
 typedef bg::model::multi_polygon<Po> MPo;
 
 #include <tuple>
+#include <cstdint>
+
+template <typename Coordinate, bool Clockwise, bool Closed>
+void test_coincident_exits()
+{
+    using point = bg::model::d2::point_xy<Coordinate>;
+    using line = bg::model::linestring<point>;
+    using lines = bg::model::multi_linestring<line>;
+    using polygon = bg::model::polygon<point, Clockwise, Closed>;
+    using polygons = bg::model::multi_polygon<polygon>;
+    using points = bg::model::multi_point<point>;
+
+    for (bool reverse_line : {false, true})
+    for (bool reverse_polygons : {false, true})
+    {
+        lines a;
+        polygons b;
+        bg::read_wkt("MULTILINESTRING((160 105,160 135))", a);
+        bg::read_wkt("MULTIPOLYGON(((180 135,160 120,200 120,180 135)),"
+            "((120 120,160 90,180 105,140 135,120 120)))", b);
+        bg::correct(b);
+        if (reverse_line) std::reverse(a.front().begin(), a.front().end());
+        if (reverse_polygons) std::reverse(b.begin(), b.end());
+
+        lines intersection, difference;
+        std::tuple<points, lines, polygons> tuple;
+        bg::intersection(a, b, intersection);
+        bg::intersection(a, b, tuple);
+        bg::difference(a, b, difference);
+        BOOST_CHECK_EQUAL(bg::length(intersection), 15);
+        BOOST_CHECK_EQUAL(bg::length(std::get<1>(tuple)), 15);
+        BOOST_CHECK_EQUAL(bg::length(difference), 15);
+    }
+}
 
 template <typename G>
 inline void check(std::string const& wkt1,
@@ -236,6 +272,37 @@ inline void test_ll()
 template <typename Tup>
 inline void test_la()
 {
+    test_one<MLs, MPo, Tup>("MULTILINESTRING((180 30,180 60))",
+        "MULTIPOLYGON(((160 60,160 45,200 45,200 60,160 60)),"
+        "((160 30,200 0,200 30,180 45,160 30)))",
+        "MULTIPOINT()", "MULTILINESTRING((180 30,180 60))");
+
+    for (auto const& area : {
+        "MULTIPOLYGON(((80 90,60 75,80 60,80 90)),"
+        "((60 75,40 90,0 60,40 30,60 45,60 75),(60 75,40 60,40 75,60 75)))",
+        "MULTIPOLYGON(((60 75,40 90,0 60,40 30,60 45,60 75),"
+        "(60 75,40 60,40 75,60 75)),((80 90,60 75,80 60,80 90)))"})
+    {
+        test_one<MLs, MPo, Tup>("MULTILINESTRING((80 60,60 75,60 90))", area,
+            "MULTIPOINT()", "MULTILINESTRING((80 60,60 75))");
+        test_one<MLs, MPo, Tup>("MULTILINESTRING((60 90,60 75,80 60))", area,
+            "MULTIPOINT()", "MULTILINESTRING((60 75,80 60))");
+    }
+
+    test_one<MLs, MPo, Tup>("MULTILINESTRING((4 4,4 8))",
+        "MULTIPOLYGON(((0 0,8 0,8 8,0 8,0 0),(2 2,2 6,6 6,6 2,2 2)),"
+        "((4 4,6 4,4 6,4 4)))", "MULTIPOINT()", "MULTILINESTRING((4 4,4 8))");
+
+    test_one<MLs, MPo, Tup>(
+        "MULTILINESTRING((180 60,160 75,140 75,120 75))",
+        "MULTIPOLYGON(((160 75,120 75,140 60,160 60,160 75)),"
+        "((140 75,140 90,120 90,140 75)))",
+        "MULTIPOINT()", "MULTILINESTRING((160 75,120 75))");
+
+    test_one<MLs, MPo, Tup>("MULTILINESTRING((6 4,6 8))",
+        "MULTIPOLYGON(((0 0,8 0,8 8,0 8,0 0),(2 2,2 6,6 4,2 2)),"
+        "((3 3,6 4,3 5,3 3)))", "MULTIPOINT()", "MULTILINESTRING((6 4,6 8))");
+
     test_one<Ls, R, Tup>(
         "LINESTRING(0 2, -4 1, 0 0, 5 0, 9 1, 5 2, 9 3, 5 5, 4 9, 4 5, 3 3, 2 5, 2 9, 0 5)",
         "POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))",
@@ -351,6 +418,11 @@ inline void test_tuple()
 
 int test_main(int, char* [])
 {
+    test_coincident_exits<std::int_least64_t, true, true>();
+    test_coincident_exits<std::int_least64_t, false, false>();
+    test_coincident_exits<double, true, true>();
+    test_coincident_exits<double, false, false>();
+
     test_pair<std::pair<MPt, MLs> >();
     test_tuple<boost::tuple<MPt, MLs, MPo> >();
     test_tuple<std::tuple<MPt, MLs, MPo> >();

--- a/test/algorithms/set_operations/intersection/intersection_tupled.cpp
+++ b/test/algorithms/set_operations/intersection/intersection_tupled.cpp
@@ -277,6 +277,9 @@ inline void test_la()
         "((160 30,200 0,200 30,180 45,160 30)))",
         "MULTIPOINT()", "MULTILINESTRING((180 30,180 60))");
 
+    test_one<MLs, MPo, Tup>("MULTILINESTRING((6 4,6 8))",
+        "MULTIPOLYGON(((0 0,8 0,8 8,0 8,0 0),(2 2,2 6,6 4,2 2)),"
+        "((3 3,6 4,3 5,3 3)))", "MULTIPOINT()", "MULTILINESTRING((6 4,6 8))");
     for (auto const& area : {
         "MULTIPOLYGON(((80 90,60 75,80 60,80 90)),"
         "((60 75,40 90,0 60,40 30,60 45,60 75),(60 75,40 60,40 75,60 75)))",
@@ -293,15 +296,16 @@ inline void test_la()
         "MULTIPOLYGON(((0 0,8 0,8 8,0 8,0 0),(2 2,2 6,6 6,6 2,2 2)),"
         "((4 4,6 4,4 6,4 4)))", "MULTIPOINT()", "MULTILINESTRING((4 4,4 8))");
 
+    test_one<Ls, Po, Tup>("LINESTRING(4 2,6 2)",
+        "POLYGON((0 0,4 0,4 4,0 4,0 0),(2 1,2 3,4 2,2 1))", "MULTIPOINT(4 2)");
+    test_one<Ls, Po, Tup>("LINESTRING(6 2,4 2)",
+        "POLYGON((0 0,4 0,4 4,0 4,0 0),(2 1,2 3,4 2,2 1))", "MULTIPOINT(4 2)");
+
     test_one<MLs, MPo, Tup>(
         "MULTILINESTRING((180 60,160 75,140 75,120 75))",
         "MULTIPOLYGON(((160 75,120 75,140 60,160 60,160 75)),"
         "((140 75,140 90,120 90,140 75)))",
         "MULTIPOINT()", "MULTILINESTRING((160 75,120 75))");
-
-    test_one<MLs, MPo, Tup>("MULTILINESTRING((6 4,6 8))",
-        "MULTIPOLYGON(((0 0,8 0,8 8,0 8,0 0),(2 2,2 6,6 4,2 2)),"
-        "((3 3,6 4,3 5,3 3)))", "MULTIPOINT()", "MULTILINESTRING((6 4,6 8))");
     test_one<Ls, Po, Tup>("LINESTRING(0 1,2 1)",
         "POLYGON((1 1,2 2,0 2,1 1))", "MULTIPOINT(1 1)");
     test_one<Ls, Po, Tup>("LINESTRING(1 1,2 0)",

--- a/test/algorithms/set_operations/intersection/intersection_tupled.cpp
+++ b/test/algorithms/set_operations/intersection/intersection_tupled.cpp
@@ -302,6 +302,12 @@ inline void test_la()
     test_one<MLs, MPo, Tup>("MULTILINESTRING((6 4,6 8))",
         "MULTIPOLYGON(((0 0,8 0,8 8,0 8,0 0),(2 2,2 6,6 4,2 2)),"
         "((3 3,6 4,3 5,3 3)))", "MULTIPOINT()", "MULTILINESTRING((6 4,6 8))");
+    test_one<Ls, Po, Tup>("LINESTRING(0 1,2 1)",
+        "POLYGON((1 1,2 2,0 2,1 1))", "MULTIPOINT(1 1)");
+    test_one<Ls, Po, Tup>("LINESTRING(1 1,2 0)",
+        "POLYGON((1 1,2 2,0 2,1 1))", "MULTIPOINT(1 1)");
+    test_one<Ls, Po, Tup>("LINESTRING(2 0,1 1)",
+        "POLYGON((1 1,2 2,0 2,1 1))", "MULTIPOINT(1 1)");
 
     test_one<Ls, R, Tup>(
         "LINESTRING(0 2, -4 1, 0 0, 5 0, 9 1, 5 2, 9 3, 5 5, 4 9, 4 5, 3 3, 2 5, 2 9, 0 5)",

--- a/test/algorithms/set_operations/union/union_multi.cpp
+++ b/test/algorithms/set_operations/union/union_multi.cpp
@@ -45,6 +45,11 @@ void test_areal()
 {
     using ct = typename bg::coordinate_type<Ring>::type;
 
+    test_one<Polygon, MultiPolygon, MultiPolygon>("clustered_distinct_round_trips",
+        "MULTIPOLYGON(((40 30,20 30,20 15,40 0,40 15,60 15,40 30)),((20 15,0 0,20 0,20 15)))",
+        "MULTIPOLYGON(((60 45,20 45,20 15,40 0,60 15,60 45),(40 30,40 15,20 15,40 30)))",
+        2, 0, 11, 1650);
+
     test_one<Polygon, MultiPolygon, MultiPolygon>("simplex_multi",
         case_multi_simplex[0], case_multi_simplex[1],
         1, 0, 20, 14.58);

--- a/test/algorithms/set_operations/union/union_multi.cpp
+++ b/test/algorithms/set_operations/union/union_multi.cpp
@@ -45,6 +45,13 @@ void test_areal()
 {
     using ct = typename bg::coordinate_type<Ring>::type;
 
+    test_one<Polygon, MultiPolygon, MultiPolygon>("parallel_ring_paths",
+        "MULTIPOLYGON(((20 75,0 60,20 45,20 60,40 60,20 75)),"
+        "((40 60,60 45,80 45,80 30,40 30,20 45,20 15,100 15,100 45,80 60,40 60)),"
+        "((20 45,40 45,40 60,20 45)))",
+        "MULTIPOLYGON(((40 60,60 75,40 75,40 60)))",
+        4, 0, 26, 3000);
+
     test_one<Polygon, MultiPolygon, MultiPolygon>("clustered_distinct_round_trips",
         "MULTIPOLYGON(((40 30,20 30,20 15,40 0,40 15,60 15,40 30)),((20 15,0 0,20 0,20 15)))",
         "MULTIPOLYGON(((60 45,20 45,20 15,40 0,60 15,60 45),(40 30,40 15,20 15,40 30)))",

--- a/test/robustness/overlay/CMakeLists.txt
+++ b/test/robustness/overlay/CMakeLists.txt
@@ -7,4 +7,5 @@
 
 add_subdirectory(areal_areal)
 add_subdirectory(buffer)
+add_subdirectory(grid)
 add_subdirectory(linear_areal)

--- a/test/robustness/overlay/grid/CMakeLists.txt
+++ b/test/robustness/overlay/grid/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Boost.Geometry
+#
+# Copyright (c) 2026 Tinko Bartels, Shenzhen, China.
+#
+# Use, modification and distribution is subject to the Boost Software License,
+# Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+boost_geometry_add_robustness_test(random_grid_buffer)
+boost_geometry_add_robustness_test(random_grid_relate)
+boost_geometry_add_robustness_test(random_grid_set_operations)

--- a/test/robustness/overlay/grid/Jamfile
+++ b/test/robustness/overlay/grid/Jamfile
@@ -1,0 +1,17 @@
+# Boost.Geometry (aka GGL, Generic Geometry Library)
+#
+# Copyright (c) 2026 Tinko Bartels, Shenzhen, China.
+#
+# Use, modification and distribution is subject to the Boost Software License,
+# Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+project boost-geometry-robustness-overlay-grid
+    : requirements
+        <include>.
+        <library>/boost/program_options//boost_program_options
+    ;
+
+exe random_grid_buffer : random_grid_buffer.cpp ;
+exe random_grid_relate : random_grid_relate.cpp ;
+exe random_grid_set_operations : random_grid_set_operations.cpp ;

--- a/test/robustness/overlay/grid/README.md
+++ b/test/robustness/overlay/grid/README.md
@@ -1,0 +1,130 @@
+# Random Grid Tests
+
+The four line families are `x = 20i`, `y = 15j`, `3x + 4y = 120k`
+and `3x - 4y = 120k`, for integer indices. Every intersection lies at
+`(20i, 15j)`. Each 20-by-15 rectangle has two triangles: a rising diagonal
+when `i+j` is even, a falling one otherwise. The pattern repeats every two
+columns and rows; `--width` and `--height` count rectangles, not pairs.
+Interior vertices alternate between degree eight and degree four.
+
+The diagonal spacing is twice that of the original three-direction grid.
+This avoids additional intersections at rectangle centres.
+Scaling the original grid by two embeds all of its lines in this grid, so its
+geometries remain representable as unions of the new cells and edges.
+The miter-buffer distance is fixed at 120: it shifts columns by 6, rows by 8,
+and diagonal supports by 5 line indices. There is no `--max-distance` option.
+
+## Buffer
+
+Buffer uses standard straight sides, miter joins (limit 5), flat linestring
+ends and square point buffers. The sharpest grid corner has miter length
+`sqrt(10)*distance`, below the limit. The grid margin accommodates coordinate
+displacements up to three times the maximum distance.
+
+The reference uses fixed cell-index helpers: rectangles for square point
+buffers and axis-aligned sides/corners, and seven row-mask tables for diagonal
+sides/corners. Translation and reflection use only index arithmetic. No points,
+normals, offsets or geometric predicates are constructed or evaluated by the
+reference. At distance 120 no cell sample lies on a helper's boundary, so their
+cell masks combine with ordinary bitset OR; sector coverage is unnecessary.
+
+Polygon boundary edges come from incident cell bits. Line and ring vertex paths
+are recorded during geometry assembly, before collinear vertices are removed.
+They preserve which edges actually join within a member, including where a hole
+touches an outer ring: miter buffering does not distribute over primitive unions.
+Ring closure follows the ring traits. Collinear joins contribute nothing, and
+closed linestrings retain their explicit end caps.
+
+The linear buffer's margin mask enables only horizontal and vertical edges,
+before geometry creation. Diagonal edges are disabled throughout each member,
+not just at its ends: exposed internal concave connectors could otherwise
+introduce perpendicular directions and noninteger intersections. Axis-aligned
+linear buffering stays on grid lines. Polygon buffering and the set-operation
+and relate tests retain both diagonal directions. No endpoint trimming is needed.
+As before, comparison checks only strict membership at cell test points,
+not output area or grid alignment. The algorithm under test retains its
+double-coordinate buffer model, despite the mathematically integer construction.
+
+Build from the Boost root:
+
+```sh
+./b2 -j3 libs/geometry/test/robustness/overlay/grid variant=release
+```
+
+All three executables accept `--svg DIRECTORY` to write SVGs on failure. The
+directory must already exist. For example, with the executable on `PATH`:
+
+```sh
+mkdir -p /tmp/grid-failures
+random_grid_relate --width 10 --height 10 --seed 2027090710 --count 4 \
+    --svg /tmp/grid-failures
+```
+
+`--svg-limit N` limits output to the first N failure reports (default 20);
+`--svg-limit 0` writes every failure. Without `--svg`, no SVGs are written.
+
+Each filename identifies the test, operation, input types, tile dimensions,
+seed and zero-based iteration. Buffer filenames also identify the fixed
+distance. Repeating the same case overwrites its SVG.
+
+Set-operation SVGs show inputs, expected output and raw actual output. Sample
+markers identify missing or unexpected membership; length, area and validity
+diagnostics appear underneath. Relate SVGs show inputs and both DE-9IM matrices,
+with differing entries highlighted. Buffer SVGs show expected cells directly,
+without another union operation. Construction failures are drawn too; invalid
+geometries are not queried for sample membership.
+
+The SVG includes replay options and input/output WKT in its descriptions.
+These are the original failures, not automatically reduced cases. Drawing uses
+floating-point screen coordinates only; test arithmetic is unchanged.
+
+## Exact inputs
+
+The set-operation and relate tests accept `--point1`, `--point2`, `--line1`,
+`--line2`, `--area1`, and `--area2`, using the printed `{decimal chunks}` format.
+Each chunk is an unsigned 64-bit integer; chunk zero contains bits 0 through 63,
+with bit zero least significant. Missing trailing chunks are zero. `{}` is empty.
+Too many chunks, nonzero padding bits, malformed input, and overflow are rejected.
+
+Supplying any pattern selects exact mode: unspecified inputs are empty and the
+default iteration count is one. `--count` can explicitly repeat the case. The
+seed does not affect exact inputs. Without any patterns, randomized behavior
+and seed sequences are unchanged.
+
+`--line-vertices1`, `--line-vertices2`, `--area-vertices1`, and `--area-vertices2`
+specify which collinear vertices to retain. They use the grid's vertex indices;
+an omitted pattern in exact mode removes all removable collinear vertices.
+Failures print a complete one-iteration replay including these patterns.
+Exact-input SVGs also store the supplied options in their description.
+
+## Issue 1490
+
+This is the regression for the nested, vertex-touching hole defect, fixed on
+this branch:
+
+```sh
+random_grid_set_operations --width 4 --height 5 \
+    --area1 '{261990907903}' --area2 '{339491840}' --verbose
+```
+
+A selects 35 cells; B selects 10. Cell 21 is A's triangular hole, with vertices
+`(40,30)`, `(40,45)`, `(60,45)`. B contains it and touches it only at `(60,45)`;
+B is strictly inside A's outer ring. Both inputs are valid.
+
+Difference now has area 3900 and valid output. Symmetric difference preserves
+the triangular island and has area 4050 in both operand orders. Before the
+ring-selection fix these areas were 3750 and 3900, respectively. Relate also
+passes. Retaining all collinear vertices covered the same defect.
+
+The patterns are minimal for this one-cell-hole, single-contact construction:
+the noncontact hole vertices require all their incident cells in B, and B's
+vertices require all their incident cells inside A's outer ring. These force
+10 and 36 cells respectively, with the hole removed from A. Enumerating these
+mandatory neighborhoods in every grid of at most 20 tiles finds no smaller
+grid, and four configurations at 4x5/5x4, two of which failed. This is not a claim
+of global minimality among arbitrary polygons or different failure topologies.
+
+Controls: replacing A by `{261992480767}` horizontally reflects the hole and
+passes; filling the hole (`--area1 '{261993005055}'`) also passes. A simpler
+rectangular-outer-ring version uses A `{1099509530623}` and B `{1010580480}` on
+the same grid; its difference now has the expected area 4200 (formerly 4050).

--- a/test/robustness/overlay/grid/buffer_cell_helpers.hpp
+++ b/test/robustness/overlay/grid/buffer_cell_helpers.hpp
@@ -1,0 +1,245 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+// Copyright (c) 2026 Tinko Bartels, Shenzhen, China.
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_TEST_BUFFER_CELL_HELPERS_HPP
+#define BOOST_GEOMETRY_TEST_BUFFER_CELL_HELPERS_HPP
+
+#include "random_grid.hpp"
+
+namespace random_grid
+{
+
+constexpr int buffer_distance = 24 * scale;
+
+namespace buffer_helper_data
+{
+
+// Fixed distance 120. Row bit 2*(di+4)+upper denotes cell (di,dj,upper)
+// relative to an even-parity vertex. Reflections cover the other orientations.
+// The six corner tables are N->NW, N->SW, NW->W, NE->W, NE->NW,
+// NW->SW, followed by the rising edge's right-side strip. None of their
+// boundaries contains a cell sample at this distance, so ordinary OR suffices.
+struct row
+{
+    int dj;
+    std::uint64_t cells;
+};
+
+static constexpr row rows[] = {
+    // Corner 1.
+    {0, 0xffd00ULL}, {1, 0xffc00ULL}, {2, 0xff800ULL},
+    {3, 0xff000ULL}, {4, 0x7d000ULL}, {5, 0x1c000ULL},
+    // Corner 2.
+    {0, 0xfff80ULL}, {1, 0xfffc0ULL}, {2, 0xfffd0ULL},
+    {3, 0xffff0ULL}, {4, 0xffff8ULL}, {5, 0xffffcULL},
+    {6, 0xffffdULL}, {7, 0xffff4ULL}, {8, 0xfffd0ULL},
+    {9, 0xfff40ULL}, {10, 0xffd00ULL}, {11, 0xff400ULL},
+    {12, 0xfd000ULL}, {13, 0xf4000ULL}, {14, 0xd0000ULL},
+    {15, 0x40000ULL},
+    // Corner 3.
+    {0, 0x200ULL}, {1, 0x300ULL}, {2, 0x700ULL},
+    {3, 0xf00ULL}, {4, 0x2f00ULL}, {5, 0x3f00ULL},
+    {6, 0x7f00ULL}, {7, 0x1f00ULL},
+    // Corner 4.
+    {-6, 0x2c000ULL}, {-5, 0xbe000ULL}, {-4, 0x2ff000ULL},
+    {-3, 0xbff400ULL}, {-2, 0x2fffc00ULL}, {-1, 0xbfffe00ULL},
+    {0, 0x2fffff00ULL}, {1, 0xbfffff00ULL}, {2, 0x2ffffff00ULL},
+    {3, 0xbffffff00ULL}, {4, 0x2fffffff00ULL}, {5, 0xbfffffff00ULL},
+    {6, 0x2ffffffff00ULL}, {7, 0xbffffffff00ULL},
+    // Corner 5.
+    {-6, 0x2c000ULL}, {-5, 0xbe000ULL}, {-4, 0x2ff000ULL},
+    {-3, 0xbff400ULL}, {-2, 0x2fffc00ULL}, {-1, 0xbfffe00ULL},
+    {0, 0x7fffd00ULL}, {1, 0x1fffc00ULL}, {2, 0x7ff800ULL},
+    {3, 0x1ff000ULL}, {4, 0x7d000ULL}, {5, 0x1c000ULL},
+    // Corner 6.
+    {0, 0x280ULL}, {1, 0x3c0ULL}, {2, 0x7d0ULL},
+    {3, 0xff0ULL}, {4, 0x2ff8ULL}, {5, 0x3ffcULL},
+    {6, 0x7ffdULL}, {7, 0x1ff4ULL}, {8, 0x7d0ULL},
+    {9, 0x140ULL},
+    // Diagonal side.
+    {-6, 0x2c000ULL}, {-5, 0xe000ULL}, {-4, 0x7000ULL},
+    {-3, 0x3400ULL}, {-2, 0x2c00ULL}, {-1, 0xe00ULL},
+    {0, 0x500ULL},
+};
+
+static constexpr int row_ranges[][2] = {
+    {0, 6}, {6, 22}, {22, 30}, {30, 44}, {44, 56}, {56, 66}, {66, 73}
+};
+
+// Directions: E, NE, N, NW, W, SW, S, SE. Each entry selects
+// 4*corner + reflections (bit 0: horizontal, bit 1: vertical).
+// Corner 0 is a 6-by-8 rectangle; corners 1..6 use the row tables.
+// Equal and opposite directions have no corner.
+static constexpr int corners[8][8] = {
+    {-1, 14, 2, 18, -1, 19, 3, 15},
+    {14, -1, 6, 22, 16, -1, 11, 27},
+    {2, 6, -1, 4, 0, 8, -1, 10},
+    {18, 22, 4, -1, 12, 25, 9, -1},
+    {-1, 16, 0, 12, -1, 13, 1, 17},
+    {19, -1, 8, 25, 13, -1, 5, 23},
+    {3, 11, -1, 9, 1, 5, -1, 7},
+    {15, 27, 10, -1, 17, 23, 7, -1},
+};
+
+} // namespace buffer_helper_data
+
+inline int grid_direction(grid const& g, int from, int to)
+{
+    int const di = to % (g.width + 1) - from % (g.width + 1);
+    int const dj = to / (g.width + 1) - from / (g.width + 1);
+    static constexpr int directions[3][3] = {{5, 6, 7}, {4, -1, 0}, {3, 2, 1}};
+    BOOST_GEOMETRY_ASSERT(di != 0 || dj != 0);
+    return directions[1 + (dj > 0) - (dj < 0)][1 + (di > 0) - (di < 0)];
+}
+
+struct buffer_cell_helpers
+{
+    grid const& g;
+    bits cells;
+
+    explicit buffer_cell_helpers(grid const& grid)
+        : g(grid), cells(make_bits(g.cell_count()))
+    {}
+
+    void rectangle(int min_i, int max_i, int min_j, int max_j)
+    {
+        for (int j = (std::max)(min_j, 0); j < (std::min)(max_j, g.height); ++j)
+            for (int i = (std::max)(min_i, 0); i < (std::min)(max_i, g.width); ++i)
+                for (int upper = 0; upper < 2; ++upper)
+                    random_grid::set(cells, g.cell_index(i, j, upper));
+    }
+
+    void set(int vertex, int helper, int reflections)
+    {
+        int const i = vertex % (g.width + 1), j = vertex / (g.width + 1);
+        BOOST_GEOMETRY_ASSERT(g.rising(i, j));
+        auto const& range = buffer_helper_data::row_ranges[helper];
+        for (int r = range[0]; r < range[1]; ++r)
+        {
+            auto mask = buffer_helper_data::rows[r].cells;
+            for (int bit = 0; mask != 0; ++bit, mask >>= 1)
+            {
+                if (!(mask & 1)) continue;
+                int di = bit / 2 - 4, dj = buffer_helper_data::rows[r].dj;
+                int upper = bit % 2;
+                if (reflections & 1) di = -di - 1;
+                if (reflections & 2) { dj = -dj - 1; upper = 1 - upper; }
+                if (g.valid_tile(i + di, j + dj))
+                    random_grid::set(cells, g.cell_index(i + di, j + dj, upper));
+            }
+        }
+    }
+
+    void side(int vertex, int direction)
+    {
+        int const i = vertex % (g.width + 1), j = vertex / (g.width + 1);
+        switch (direction)
+        {
+        case 0: rectangle(i, i + 1, j - 8, j); break;
+        case 2: rectangle(i, i + 6, j, j + 1); break;
+        case 4: rectangle(i - 1, i, j, j + 8); break;
+        case 6: rectangle(i - 6, i, j - 1, j); break;
+        case 1: set(vertex, 6, 0); break;
+        case 3: set(g.vertex_index(i - 1, j + 1), 6, 2); break;
+        case 5: set(vertex, 6, 3); break;
+        case 7: set(g.vertex_index(i + 1, j - 1), 6, 1); break;
+        default: BOOST_GEOMETRY_ASSERT(false);
+        }
+    }
+
+    void corner(int vertex, int incoming, int outgoing, bool linear)
+    {
+        int const turn = (outgoing - incoming + 8) % 8;
+        if (turn == 0 || turn == 4 || (!linear && turn > 4)) return;
+        if (turn > 4)
+        {
+            incoming = (incoming + 4) % 8;
+            outgoing = (outgoing + 4) % 8;
+        }
+        int const code = buffer_helper_data::corners[incoming][outgoing];
+        BOOST_GEOMETRY_ASSERT(code >= 0);
+        int const helper = code / 4, reflections = code % 4;
+        if (helper == 0)
+        {
+            int const i = vertex % (g.width + 1), j = vertex / (g.width + 1);
+            int const di = reflections & 1 ? -6 : 0;
+            int const dj = reflections & 2 ? -8 : 0;
+            rectangle(i + di, i + di + 6, j + dj, j + dj + 8);
+        }
+        else set(vertex, helper - 1, reflections);
+    }
+};
+
+inline bits buffer_cells(grid const& g, bits const& selected, bg::multi_point_tag,
+                         vertex_paths const& = vertex_paths())
+{
+    buffer_cell_helpers result(g);
+    for (int vertex = 0; vertex < g.vertex_count(); ++vertex)
+    {
+        if (!get(selected, vertex)) continue;
+        int const i = vertex % (g.width + 1), j = vertex / (g.width + 1);
+        result.rectangle(i - 6, i + 6, j - 8, j + 8);
+    }
+    return std::move(result.cells);
+}
+
+inline bits buffer_cells(grid const& g, bits const& selected,
+                         bg::multi_linestring_tag, vertex_paths const& paths)
+{
+    buffer_cell_helpers result(g);
+    for (int edge = 0; edge < g.edge_count(); ++edge)
+    {
+        if (!get(selected, edge)) continue;
+        BOOST_GEOMETRY_ASSERT(g.family(edge) != edge_family::diagonal);
+        auto const ends = g.edge_vertices(edge);
+        int const direction = grid_direction(g, ends.first, ends.second);
+        result.side(ends.first, direction);
+        result.side(ends.second, (direction + 4) % 8);
+    }
+    for (auto const& path : paths)
+        for (std::size_t k = 1; k + 1 < path.size(); ++k)
+            result.corner(path[k], grid_direction(g, path[k - 1], path[k]),
+                          grid_direction(g, path[k], path[k + 1]), true);
+    return std::move(result.cells);
+}
+
+inline bits buffer_cells(grid const& g, bits const& selected,
+                         bg::multi_polygon_tag, vertex_paths const& paths)
+{
+    buffer_cell_helpers result(g);
+    result.cells = selected;
+    for (int cell = 0; cell < g.cell_count(); ++cell)
+    {
+        if (!get(selected, cell)) continue;
+        auto const edges = g.cell_edges(cell);
+        auto const vertices = g.cell_vertices(cell);
+        for (int k = 0; k < 3; ++k)
+        {
+            bool boundary = true;
+            for (int neighbor : g.edge_cells(edges[k]))
+                if (neighbor != cell && get(selected, neighbor)) boundary = false;
+            if (!boundary) continue;
+            int const from = vertices[k], to = vertices[(k + 1) % 3];
+            int const direction = grid_direction(g, from, to);
+            result.side(from, direction);
+        }
+    }
+    for (auto const& path : paths)
+    {
+        for (std::size_t k = 0; k < path.size(); ++k)
+        {
+            int const previous = path[k == 0 ? path.size() - 1 : k - 1];
+            int const next = path[(k + 1) % path.size()];
+            result.corner(path[k], grid_direction(g, previous, path[k]),
+                          grid_direction(g, path[k], next), false);
+        }
+    }
+    return std::move(result.cells);
+}
+
+} // namespace random_grid
+
+#endif

--- a/test/robustness/overlay/grid/random_grid.hpp
+++ b/test/robustness/overlay/grid/random_grid.hpp
@@ -1,0 +1,1001 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+// Robustness Test
+
+// Copyright (c) 2026 Tinko Bartels, Shenzhen, China.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_TEST_ROBUSTNESS_OVERLAY_GRID_RANDOM_GRID_HPP
+#define BOOST_GEOMETRY_TEST_ROBUSTNESS_OVERLAY_GRID_RANDOM_GRID_HPP
+
+#include <boost/geometry/algorithms/area.hpp>
+#include <boost/geometry/algorithms/covered_by.hpp>
+#include <boost/geometry/algorithms/is_valid.hpp>
+#include <boost/geometry/algorithms/union.hpp>
+#include <boost/geometry/algorithms/within.hpp>
+#include <boost/geometry/core/assert.hpp>
+#include <boost/geometry/geometries/geometries.hpp>
+#include <boost/geometry/io/wkt/write.hpp>
+
+#include <boost/program_options.hpp>
+
+#include <algorithm>
+#include <bitset>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <initializer_list>
+#include <iostream>
+#include <map>
+#include <numeric>
+#include <random>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#define BOOST_GEOMETRY_TEST_ONLY_ONE_TYPE
+#ifndef BOOST_GEOMETRY_DEFAULT_TEST_TYPE
+#define BOOST_GEOMETRY_DEFAULT_TEST_TYPE std::int_least64_t
+#endif
+#include <geometry_test_common.hpp>
+
+namespace bg = boost::geometry;
+
+namespace random_grid
+{
+
+constexpr int chunk_size = 64;
+// H_j: y=15j, V_i: x=20i, D_k: 3x+4y=120k, E_k: 3x-4y=120k.
+// Even tiles (i+j) have a rising diagonal, odd tiles a falling one.
+constexpr int scale = 5;
+constexpr int cell_area = 150;
+using bits = std::vector<std::bitset<chunk_size>>;
+using generator_type = std::mt19937_64;
+
+using coordinate_type = BOOST_GEOMETRY_DEFAULT_TEST_TYPE;
+using point = bg::model::d2::point_xy<coordinate_type>;
+using linestring = bg::model::linestring<point>;
+using ring = bg::model::ring<point, false>;
+using polygon = bg::model::polygon<point, false>;
+using multi_point = bg::model::multi_point<point>;
+using multi_linestring = bg::model::multi_linestring<linestring>;
+using multi_polygon = bg::model::multi_polygon<polygon>;
+using output_tuple = std::tuple<multi_point, multi_linestring, multi_polygon>;
+using primitive_vectors = std::tuple<std::vector<point>,
+                                     std::vector<linestring>,
+                                     std::vector<ring>>;
+using test_point_vectors = std::tuple<std::vector<point>,
+                                      std::vector<point>,
+                                      std::vector<point>>;
+using vertex_paths = std::vector<std::vector<int>>;
+
+struct settings
+{
+    int width = 3;
+    int height = 3;
+    int count = 100;
+    generator_type::result_type seed = generator_type::default_seed;
+    bool verbose = false;
+    bool stop_on_failure = false;
+    std::string svg_directory;
+    int svg_limit = 20;
+    std::map<std::string, bits> bit_patterns;
+};
+
+inline bits make_bits(int size)
+{
+    return bits((size + chunk_size - 1) / chunk_size);
+}
+
+inline bool get(bits const& value, int index)
+{
+    return value[index / chunk_size][index % chunk_size];
+}
+
+inline void set(bits& value, int index, bool state = true)
+{
+    value[index / chunk_size].set(index % chunk_size, state);
+}
+
+inline void reset(bits& value, int index)
+{
+    value[index / chunk_size].reset(index % chunk_size);
+}
+
+inline int count(bits const& value)
+{
+    return std::accumulate(value.begin(), value.end(), 0,
+        [](int result, std::bitset<chunk_size> const& chunk)
+        {
+            return result + static_cast<int>(chunk.count());
+        });
+}
+
+inline bits random_bits(generator_type& generator, int size)
+{
+    bits result = make_bits(size);
+    std::generate(result.begin(), result.end(), std::ref(generator));
+    if (size % chunk_size != 0)
+    {
+        std::bitset<chunk_size> mask;
+        mask.set();
+        mask >>= chunk_size - size % chunk_size;
+        result.back() &= mask;
+    }
+    return result;
+}
+
+inline std::string bit_string(bits const& value)
+{
+    std::ostringstream out;
+    out << '{';
+    char const* separator = "";
+    for (auto const& chunk : value)
+    {
+        out << separator << chunk.to_ullong();
+        separator = " ";
+    }
+    out << '}';
+    return out.str();
+}
+
+inline void bit_pattern_error(std::string const& name, char const* reason)
+{
+    std::cerr << "--" << name << ": " << reason << '\n';
+    std::exit(EXIT_FAILURE);
+}
+
+inline bits parse_bit_pattern(std::string const& text, std::string const& name)
+{
+    auto const first = text.find_first_not_of(" \t\r\n");
+    auto const last = text.find_last_not_of(" \t\r\n");
+    if (first == std::string::npos || text[first] != '{' || text[last] != '}')
+        bit_pattern_error(name, "expected {decimal chunks}, least-significant chunk first");
+    std::istringstream input(text.substr(first + 1, last - first - 1));
+    bits result;
+    std::string token;
+    while (input >> token)
+    {
+        unsigned long long chunk;
+        std::istringstream number(token);
+        if (token.find_first_not_of("0123456789") != std::string::npos
+            || !(number >> chunk) || !number.eof())
+            bit_pattern_error(name, "each chunk must be an unsigned 64-bit decimal integer");
+        result.emplace_back(chunk);
+    }
+    return result;
+}
+
+inline void add_bit_options(settings& value,
+                            boost::program_options::options_description& description)
+{
+    for (char const* name : {"point1", "point2", "line1", "line2", "area1", "area2",
+                            "line-vertices1", "line-vertices2", "area-vertices1", "area-vertices2"})
+    {
+        description.add_options()(name,
+            boost::program_options::value<std::string>()->notifier(
+                [&value, name](std::string const& text)
+                {
+                    value.bit_patterns[name] = parse_bit_pattern(text, name);
+                }),
+            "Exact {decimal chunks}; unspecified patterns are empty, vertices are removable");
+    }
+}
+
+inline bits input_bits(generator_type& generator, int size,
+                        settings const& settings, char const* name)
+{
+    if (settings.bit_patterns.empty()) return random_bits(generator, size);
+    bits result = make_bits(size);
+    auto const found = settings.bit_patterns.find(name);
+    if (found == settings.bit_patterns.end()) return result;
+    auto const& pattern = found->second;
+    if (pattern.size() > result.size()
+        || (pattern.size() == result.size() && size % chunk_size != 0
+            && (pattern.back() >> (size % chunk_size)).any()))
+        bit_pattern_error(name, "pattern exceeds this grid's bit count");
+    std::copy(pattern.begin(), pattern.end(), result.begin());
+    return result;
+}
+
+inline void print_replay(settings const& settings,
+                         std::initializer_list<std::pair<char const*, bits const*>> patterns)
+{
+    std::cout << "replay: --width " << settings.width << " --height " << settings.height
+              << " --count 1";
+    for (auto const& pattern : patterns)
+        std::cout << " --" << pattern.first << " '" << bit_string(*pattern.second) << '\'';
+    std::cout << '\n';
+}
+
+inline int failure_count(std::map<std::string, int> const& failures)
+{
+    return std::accumulate(failures.begin(), failures.end(), 0,
+        [](int result, std::pair<std::string const, int> const& failure)
+        {
+            return result + failure.second;
+        });
+}
+
+inline bool parse_options(int argc, char** argv, char const* title, settings& value,
+                          boost::program_options::options_description const& additional
+                              = boost::program_options::options_description())
+{
+    namespace po = boost::program_options;
+    po::options_description description(title);
+    description.add_options()
+        ("help", "Help message")
+        ("seed", po::value<generator_type::result_type>(&value.seed)->default_value(value.seed),
+         "Initialization seed")
+        ("count", po::value<int>(&value.count)->default_value(value.count),
+         "Number of iterations (-1 for an infinite run)")
+        ("width", po::value<int>(&value.width)->default_value(value.width), "Tile columns")
+        ("height", po::value<int>(&value.height)->default_value(value.height), "Tile rows")
+        ("verbose", po::bool_switch(&value.verbose), "Print geometries on failure")
+        ("svg", po::value<std::string>(&value.svg_directory),
+         "Write failure SVGs to an existing directory")
+        ("svg-limit", po::value<int>(&value.svg_limit)->default_value(value.svg_limit),
+         "Maximum failure SVGs per run (0 for unlimited)")
+        ("stop-on-failure", po::bool_switch(&value.stop_on_failure),
+         "Stop after the first failing iteration");
+    description.add(additional);
+
+    po::variables_map variables;
+    po::store(po::parse_command_line(argc, argv, description), variables);
+    po::notify(variables);
+    if (variables.count("help"))
+    {
+        std::cout << description << '\n';
+        return false;
+    }
+    if (!value.bit_patterns.empty() && variables["count"].defaulted()) value.count = 1;
+    if (value.width < 1 || value.height < 1 || value.count < -1)
+    {
+        std::cerr << "width and height must be positive; count must be at least -1\n";
+        std::exit(EXIT_FAILURE);
+    }
+    if (value.svg_limit < 0)
+    {
+        std::cerr << "svg-limit must be nonnegative\n";
+        std::exit(EXIT_FAILURE);
+    }
+    return true;
+}
+
+inline std::string report(std::chrono::high_resolution_clock::time_point start,
+                          int iterations,
+                          std::map<std::string, int> const& failures)
+{
+    auto const elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::high_resolution_clock::now() - start).count();
+    std::ostringstream out;
+    out << iterations << " iterations in " << elapsed << " ms";
+    if (failures.empty())
+    {
+        out << ", no failures\n";
+    }
+    else
+    {
+        out << ", failures:";
+        for (auto const& failure : failures)
+        {
+            out << "\n  " << failure.first << ": " << failure.second;
+        }
+        out << '\n';
+    }
+    return out.str();
+}
+
+enum class edge_family { horizontal, vertical, diagonal };
+enum class location { interior = 0, boundary = 1, exterior = 2 };
+
+struct grid
+{
+    int width;
+    int height;
+
+    explicit grid(int w, int h)
+        : width(w), height(h)
+    {}
+
+    int vertex_count() const { return (width + 1) * (height + 1); }
+    int horizontal_count() const { return width * (height + 1); }
+    int vertical_count() const { return (width + 1) * height; }
+    int diagonal_count() const { return width * height; }
+    int edge_count() const { return horizontal_count() + vertical_count() + diagonal_count(); }
+    int cell_count() const { return 2 * width * height; }
+
+    int vertex_index(int i, int j) const { return j * (width + 1) + i; }
+    int vertex_index(point const& p) const
+    {
+        int const i = static_cast<int>(p.x() / (4 * scale));
+        int const j = static_cast<int>(p.y() / (3 * scale));
+        BOOST_GEOMETRY_ASSERT(p.x() == coordinate_type(4 * scale) * i);
+        BOOST_GEOMETRY_ASSERT(p.y() == coordinate_type(3 * scale) * j);
+        BOOST_GEOMETRY_ASSERT(0 <= i && i <= width && 0 <= j && j <= height);
+        return vertex_index(i, j);
+    }
+    int horizontal_index(int i, int j) const { return j * width + i; }
+    int vertical_index(int i, int j) const
+    {
+        return horizontal_count() + j * (width + 1) + i;
+    }
+    int diagonal_index(int i, int j) const
+    {
+        return horizontal_count() + vertical_count() + j * width + i;
+    }
+    int cell_index(int i, int j, int upper) const
+    {
+        return 2 * (j * width + i) + upper;
+    }
+
+    bool valid_tile(int i, int j) const
+    {
+        return 0 <= i && i < width && 0 <= j && j < height;
+    }
+
+    bool rising(int i, int j) const
+    {
+        return (i + j) % 2 == 0;
+    }
+
+    point vertex_point(int i, int j) const
+    {
+        return point(coordinate_type(4 * scale) * i,
+                     coordinate_type(3 * scale) * j);
+    }
+    point cell_sample(int i, int j, int upper) const
+    {
+        point const p = vertex_point(i, j);
+        int const x = (upper != rising(i, j) ? 3 : 1) * scale;
+        return point(p.x() + x, p.y() + (upper ? 2 : 1) * scale);
+    }
+
+    edge_family family(int edge) const
+    {
+        if (edge < horizontal_count()) return edge_family::horizontal;
+        if (edge < horizontal_count() + vertical_count()) return edge_family::vertical;
+        return edge_family::diagonal;
+    }
+
+    void edge_position(int edge, int& i, int& j) const
+    {
+        switch (family(edge))
+        {
+        case edge_family::horizontal:
+            i = edge % width;
+            j = edge / width;
+            break;
+        case edge_family::vertical:
+        {
+            int const local = edge - horizontal_count();
+            i = local % (width + 1);
+            j = local / (width + 1);
+            break;
+        }
+        case edge_family::diagonal:
+        {
+            int const local = edge - horizontal_count() - vertical_count();
+            i = local % width;
+            j = local / width;
+            break;
+        }
+        }
+    }
+
+    std::pair<int, int> edge_vertices(int edge) const
+    {
+        int i, j;
+        edge_position(edge, i, j);
+        switch (family(edge))
+        {
+        case edge_family::horizontal:
+            return {vertex_index(i, j), vertex_index(i + 1, j)};
+        case edge_family::vertical:
+            return {vertex_index(i, j), vertex_index(i, j + 1)};
+        case edge_family::diagonal:
+            if (rising(i, j))
+                return {vertex_index(i, j), vertex_index(i + 1, j + 1)};
+            return {vertex_index(i, j + 1), vertex_index(i + 1, j)};
+        }
+        BOOST_GEOMETRY_ASSERT(false);
+        return {};
+    }
+
+    std::vector<int> edge_cells(int edge) const
+    {
+        int i, j;
+        edge_position(edge, i, j);
+        std::vector<int> result;
+        switch (family(edge))
+        {
+        case edge_family::horizontal:
+            if (valid_tile(i, j - 1)) result.push_back(cell_index(i, j - 1, 1));
+            if (valid_tile(i, j)) result.push_back(cell_index(i, j, 0));
+            break;
+        case edge_family::vertical:
+            if (valid_tile(i - 1, j))
+                result.push_back(cell_index(i - 1, j, rising(i - 1, j) ? 0 : 1));
+            if (valid_tile(i, j))
+                result.push_back(cell_index(i, j, rising(i, j) ? 1 : 0));
+            break;
+        case edge_family::diagonal:
+            result.push_back(cell_index(i, j, 0));
+            result.push_back(cell_index(i, j, 1));
+            break;
+        }
+        return result;
+    }
+
+    std::vector<int> cell_vertices(int cell) const
+    {
+        int const upper = cell % 2;
+        int const tile = cell / 2;
+        int const i = tile % width;
+        int const j = tile / width;
+        if (rising(i, j))
+        {
+            if (upper)
+                return {vertex_index(i, j), vertex_index(i + 1, j + 1),
+                        vertex_index(i, j + 1)};
+            return {vertex_index(i, j), vertex_index(i + 1, j),
+                    vertex_index(i + 1, j + 1)};
+        }
+        if (upper)
+        {
+            return {vertex_index(i + 1, j), vertex_index(i + 1, j + 1),
+                    vertex_index(i, j + 1)};
+        }
+        return {vertex_index(i, j), vertex_index(i + 1, j), vertex_index(i, j + 1)};
+    }
+
+    std::vector<int> cell_edges(int cell) const
+    {
+        int const upper = cell % 2;
+        int const tile = cell / 2;
+        int const i = tile % width;
+        int const j = tile / width;
+        if (rising(i, j))
+        {
+            if (upper)
+                return {diagonal_index(i, j), horizontal_index(i, j + 1),
+                        vertical_index(i, j)};
+            return {horizontal_index(i, j), vertical_index(i + 1, j),
+                    diagonal_index(i, j)};
+        }
+        if (upper)
+        {
+            return {vertical_index(i + 1, j), horizontal_index(i, j + 1),
+                    diagonal_index(i, j)};
+        }
+        return {horizontal_index(i, j), diagonal_index(i, j), vertical_index(i, j)};
+    }
+
+    std::vector<int> vertex_edges(int vertex) const
+    {
+        int const i = vertex % (width + 1);
+        int const j = vertex / (width + 1);
+        std::vector<int> result;
+        if (i > 0) result.push_back(horizontal_index(i - 1, j));
+        if (i < width) result.push_back(horizontal_index(i, j));
+        if (j > 0) result.push_back(vertical_index(i, j - 1));
+        if (j < height) result.push_back(vertical_index(i, j));
+        if (rising(i, j))
+        {
+            for (int dj = -1; dj <= 0; ++dj)
+                for (int di = -1; di <= 0; ++di)
+                    if (valid_tile(i + di, j + dj))
+                        result.push_back(diagonal_index(i + di, j + dj));
+        }
+        return result;
+    }
+
+    std::vector<int> vertex_cells(int vertex) const
+    {
+        int const i = vertex % (width + 1);
+        int const j = vertex / (width + 1);
+        std::vector<int> result;
+        for (int dj = -1; dj <= 0; ++dj)
+        {
+            for (int di = -1; di <= 0; ++di)
+            {
+                if (! valid_tile(i + di, j + dj)) continue;
+                int const upper = dj == -1 ? 1 : 0;
+                result.push_back(cell_index(i + di, j + dj, upper));
+                if (rising(i, j))
+                    result.push_back(cell_index(i + di, j + dj, 1 - upper));
+            }
+        }
+        return result;
+    }
+};
+
+inline primitive_vectors make_primitives(grid const& g)
+{
+    std::vector<point> points;
+    points.reserve(g.vertex_count());
+    for (int vertex = 0; vertex < g.vertex_count(); ++vertex)
+    {
+        points.push_back(g.vertex_point(vertex % (g.width + 1),
+                                        vertex / (g.width + 1)));
+    }
+
+    std::vector<linestring> lines;
+    lines.reserve(g.edge_count());
+    for (int edge = 0; edge < g.edge_count(); ++edge)
+    {
+        auto const endpoints = g.edge_vertices(edge);
+        lines.push_back(linestring{
+            points[endpoints.first], points[endpoints.second]});
+    }
+
+    std::vector<ring> rings;
+    rings.reserve(g.cell_count());
+    for (int cell = 0; cell < g.cell_count(); ++cell)
+    {
+        ring primitive;
+        for (int vertex : g.cell_vertices(cell))
+            primitive.push_back(points[vertex]);
+        primitive.push_back(primitive.front());
+        rings.push_back(std::move(primitive));
+    }
+    return std::make_tuple(std::move(points), std::move(lines), std::move(rings));
+}
+
+inline test_point_vectors make_test_points(grid const& g,
+                                           primitive_vectors const& primitives)
+{
+    std::vector<point> edge_points;
+    edge_points.reserve(g.edge_count());
+    for (linestring const& edge : std::get<1>(primitives))
+    {
+        edge_points.emplace_back(
+            edge.front().x() + (edge.back().x() - edge.front().x()) / scale,
+            edge.front().y() + (edge.back().y() - edge.front().y()) / scale);
+    }
+
+    std::vector<point> cell_points;
+    cell_points.reserve(g.cell_count());
+    for (int cell = 0; cell < g.cell_count(); ++cell)
+    {
+        int const tile = cell / 2;
+        cell_points.push_back(g.cell_sample(tile % g.width, tile / g.width, cell % 2));
+    }
+
+    return std::make_tuple(std::get<0>(primitives),
+                           std::move(edge_points), std::move(cell_points));
+}
+
+template <typename MultiGeometry>
+inline void connect_members(grid const&, MultiGeometry&)
+{}
+
+inline void connect_members(grid const& g, multi_linestring& geometry)
+{
+    std::vector<std::vector<std::size_t>> incident(g.vertex_count());
+    for (std::size_t index = 0; index < geometry.size(); ++index)
+    {
+        BOOST_GEOMETRY_ASSERT(geometry[index].size() >= 2);
+        incident[g.vertex_index(geometry[index].front())].push_back(index);
+        incident[g.vertex_index(geometry[index].back())].push_back(index);
+    }
+
+    multi_linestring result;
+    std::vector<bool> used(geometry.size(), false);
+    auto follow = [&](int vertex)
+    {
+        linestring line;
+        while (! incident[vertex].empty())
+        {
+            std::size_t const index = incident[vertex].back();
+            incident[vertex].pop_back();
+            if (used[index]) continue;
+            used[index] = true;
+            linestring const& member = geometry[index];
+            if (g.vertex_index(member.front()) == vertex)
+            {
+                line.insert(line.end(), member.begin() + (line.empty() ? 0 : 1),
+                            member.end());
+                vertex = g.vertex_index(member.back());
+            }
+            else
+            {
+                line.insert(line.end(), member.rbegin() + (line.empty() ? 0 : 1),
+                            member.rend());
+                vertex = g.vertex_index(member.front());
+            }
+        }
+        if (! line.empty()) result.push_back(std::move(line));
+    };
+
+    // Start open trails at odd-degree vertices, then consume any remaining cycles.
+    std::vector<int> starts;
+    for (int vertex = 0; vertex < g.vertex_count(); ++vertex)
+    {
+        if (incident[vertex].size() % 2 != 0) starts.push_back(vertex);
+    }
+    for (int vertex : starts) follow(vertex);
+    for (int vertex = 0; vertex < g.vertex_count(); ++vertex) follow(vertex);
+    geometry = std::move(result);
+}
+
+inline bool removable_vertex(grid const& g, bits const& vertices,
+                             point const& previous, point const& current,
+                             point const& next)
+{
+    return ! get(vertices, g.vertex_index(current))
+        && bg::covered_by(current, bg::model::segment<point>(previous, next));
+}
+
+inline void remove_vertices(grid const& g, bits const& vertices,
+                            linestring& line)
+{
+    for (std::size_t index = 1; index + 1 < line.size();)
+    {
+        if (removable_vertex(g, vertices,
+                             line[index - 1], line[index], line[index + 1]))
+        {
+            line.erase(line.begin() + index);
+        }
+        else
+        {
+            ++index;
+        }
+    }
+}
+
+inline void remove_vertices(grid const& g, bits const& vertices,
+                            ring& boundary)
+{
+    bool const closed = bg::closure<ring>::value == bg::closed;
+    std::vector<point> points(boundary.begin(),
+        boundary.end() - (closed && ! boundary.empty() ? 1 : 0));
+    for (std::size_t index = 0; points.size() > 3 && index < points.size();)
+    {
+        std::size_t const previous = index == 0 ? points.size() - 1 : index - 1;
+        std::size_t const next = index + 1 == points.size() ? 0 : index + 1;
+        if (removable_vertex(g, vertices,
+                             points[previous], points[index], points[next]))
+        {
+            points.erase(points.begin() + index);
+            if (index == points.size()) index = 0;
+        }
+        else
+        {
+            ++index;
+        }
+    }
+
+    boundary.assign(points.begin(), points.end());
+    if (closed && ! boundary.empty()) boundary.push_back(boundary.front());
+}
+
+inline void remove_vertices(grid const&, bits const&, multi_point&)
+{}
+
+inline void remove_vertices(grid const& g, bits const& vertices,
+                            multi_linestring& geometry)
+{
+    for (linestring& line : geometry) remove_vertices(g, vertices, line);
+}
+
+inline void remove_vertices(grid const& g, bits const& vertices,
+                            multi_polygon& geometry)
+{
+    for (polygon& area : geometry)
+    {
+        remove_vertices(g, vertices, bg::exterior_ring(area));
+        for (ring& interior : bg::interior_rings(area))
+            remove_vertices(g, vertices, interior);
+    }
+}
+
+template <typename Range>
+inline void append_vertex_path(grid const& g, Range const& range,
+                               vertex_paths& paths, bool closed)
+{
+    paths.emplace_back();
+    std::size_t const size = range.size() - (closed && !range.empty() ? 1 : 0);
+    for (std::size_t index = 0; index < size; ++index)
+        paths.back().push_back(g.vertex_index(range[index]));
+}
+
+inline void record_vertex_paths(grid const&, multi_point const&, vertex_paths&)
+{}
+
+inline void record_vertex_paths(grid const& g, multi_linestring const& geometry,
+                                vertex_paths& paths)
+{
+    for (auto const& line : geometry) append_vertex_path(g, line, paths, false);
+}
+
+inline void record_vertex_paths(grid const& g, multi_polygon const& geometry,
+                                vertex_paths& paths)
+{
+    bool const closed = bg::closure<ring>::value == bg::closed;
+    for (auto const& area : geometry)
+    {
+        append_vertex_path(g, bg::exterior_ring(area), paths, closed);
+        for (auto const& hole : bg::interior_rings(area))
+            append_vertex_path(g, hole, paths, closed);
+    }
+}
+
+template <typename MultiGeometry, typename Primitive>
+inline MultiGeometry bits_to_geometry(bits const& selected,
+                                      bits const& vertices,
+                                      grid const& g,
+                                      std::vector<Primitive> const& primitives,
+                                      vertex_paths* paths = nullptr)
+{
+    MultiGeometry result;
+    for (std::size_t index = 0; index < primitives.size(); ++index)
+    {
+        if (! get(selected, static_cast<int>(index))) continue;
+        MultiGeometry next;
+        bg::union_(result, primitives[index], next);
+        result = std::move(next);
+    }
+    connect_members(g, result);
+    if (paths)
+    {
+        paths->clear();
+        record_vertex_paths(g, result, *paths);
+    }
+    remove_vertices(g, vertices, result);
+    return result;
+}
+
+enum class boolean_operation { union_, intersection, difference, sym_difference };
+
+inline bool apply_boolean(bool lhs, bool rhs, boolean_operation operation)
+{
+    switch (operation)
+    {
+    case boolean_operation::union_: return lhs || rhs;
+    case boolean_operation::intersection: return lhs && rhs;
+    case boolean_operation::difference: return lhs && ! rhs;
+    case boolean_operation::sym_difference: return lhs != rhs;
+    }
+    BOOST_GEOMETRY_ASSERT(false);
+    return false;
+}
+
+template <typename Geometry>
+inline bits geometry_to_bits(Geometry const& geometry,
+                             std::vector<point> const& test_points)
+{
+    bits result = make_bits(static_cast<int>(test_points.size()));
+    for (std::size_t index = 0; index < test_points.size(); ++index)
+    {
+        if (bg::within(test_points[index], geometry))
+            set(result, static_cast<int>(index));
+    }
+    return result;
+}
+
+template <typename Geometry>
+inline bool validate_geometry(bits const& expected, Geometry const& geometry,
+                              std::vector<point> const& test_points,
+                              std::string& error)
+{
+    std::string validity_error;
+    if (! bg::is_valid(geometry, validity_error))
+    {
+        error = "invalid=" + validity_error;
+        return false;
+    }
+
+    bits const detected = geometry_to_bits(geometry, test_points);
+    if (detected == expected) return true;
+
+    std::ostringstream out;
+    out << "expected=" << bit_string(expected)
+        << " detected=" << bit_string(detected);
+    error = out.str();
+    return false;
+}
+
+inline output_tuple canonical_output(grid const& g, primitive_vectors const& primitives,
+                                     test_point_vectors const& test_points,
+                                     output_tuple const& output)
+{
+    bits vertices = geometry_to_bits(std::get<0>(output), std::get<0>(test_points));
+    bits edges = geometry_to_bits(std::get<1>(output), std::get<1>(test_points));
+    bits const cells = geometry_to_bits(std::get<2>(output), std::get<2>(test_points));
+    bits covered_vertices = make_bits(g.vertex_count());
+    bits covered_edges = make_bits(g.edge_count());
+
+    for (int cell = 0; cell < g.cell_count(); ++cell)
+    {
+        if (! get(cells, cell)) continue;
+        for (int edge : g.cell_edges(cell)) set(covered_edges, edge);
+        for (int vertex : g.cell_vertices(cell)) set(covered_vertices, vertex);
+    }
+    for (int edge = 0; edge < g.edge_count(); ++edge)
+    {
+        if (! get(edges, edge)) continue;
+        if (get(covered_edges, edge))
+        {
+            reset(edges, edge);
+            continue;
+        }
+        auto const endpoints = g.edge_vertices(edge);
+        set(covered_vertices, endpoints.first);
+        set(covered_vertices, endpoints.second);
+    }
+    for (int vertex = 0; vertex < g.vertex_count(); ++vertex)
+    {
+        if (get(covered_vertices, vertex)) reset(vertices, vertex);
+    }
+
+    return std::make_tuple(bits_to_geometry<multi_point>(
+                               vertices, covered_vertices, g, std::get<0>(primitives)),
+                           bits_to_geometry<multi_linestring>(
+                               edges, covered_vertices, g, std::get<1>(primitives)),
+                           std::get<2>(output));
+}
+
+inline location point_location(grid const& g, bits const& selected, int vertex)
+{
+    (void) g;
+    return get(selected, vertex) ? location::interior : location::exterior;
+}
+
+inline location line_vertex_location(grid const& g, bits const& selected, int vertex)
+{
+    int degree = 0;
+    for (int edge : g.vertex_edges(vertex)) degree += get(selected, edge) ? 1 : 0;
+    if (degree == 0) return location::exterior;
+    return degree % 2 == 0 ? location::interior : location::boundary;
+}
+
+inline location area_edge_location(grid const& g, bits const& selected, int edge)
+{
+    int adjacent = 0;
+    for (int cell : g.edge_cells(edge)) adjacent += get(selected, cell) ? 1 : 0;
+    if (adjacent == 0) return location::exterior;
+    return adjacent == 2 ? location::interior : location::boundary;
+}
+
+inline location area_vertex_location(grid const& g, bits const& selected, int vertex)
+{
+    bool has_cell = false;
+    for (int cell : g.vertex_cells(vertex)) has_cell = has_cell || get(selected, cell);
+    if (! has_cell) return location::exterior;
+    for (int edge : g.vertex_edges(vertex))
+    {
+        if (area_edge_location(g, selected, edge) == location::boundary)
+            return location::boundary;
+    }
+    return location::interior;
+}
+
+inline location element_location(grid const& g, bits const& selected,
+                                  int dimension, int index, bg::pointlike_tag)
+{
+    return dimension == 0 ? point_location(g, selected, index) : location::exterior;
+}
+
+inline location element_location(grid const& g, bits const& selected,
+                                  int dimension, int index, bg::linear_tag)
+{
+    if (dimension == 1)
+        return get(selected, index) ? location::interior : location::exterior;
+    if (dimension == 0) return line_vertex_location(g, selected, index);
+    return location::exterior;
+}
+
+inline location element_location(grid const& g, bits const& selected,
+                                  int dimension, int index, bg::areal_tag)
+{
+    if (dimension == 2)
+        return get(selected, index) ? location::interior : location::exterior;
+    if (dimension == 1) return area_edge_location(g, selected, index);
+    return area_vertex_location(g, selected, index);
+}
+
+template <typename Tag>
+inline location element_location(grid const& g, bits const& selected,
+                                  int dimension, int index)
+{
+    return element_location(g, selected, dimension, index, Tag{});
+}
+
+template <typename LhsTag, typename RhsTag>
+inline output_tuple expected_operation(grid const& g, bits const& lhs, bits const& rhs,
+                                       primitive_vectors const& primitives,
+                                       boolean_operation operation)
+{
+    bits vertices = make_bits(g.vertex_count());
+    bits edges = make_bits(g.edge_count());
+    bits cells = make_bits(g.cell_count());
+    bits covered_vertices = make_bits(g.vertex_count());
+    bits covered_edges = make_bits(g.edge_count());
+
+    for (int cell = 0; cell < g.cell_count(); ++cell)
+    {
+        bool const lhs_member
+            = element_location<LhsTag>(g, lhs, 2, cell) != location::exterior;
+        bool const rhs_member
+            = element_location<RhsTag>(g, rhs, 2, cell) != location::exterior;
+        if (! apply_boolean(lhs_member, rhs_member, operation)) continue;
+        set(cells, cell);
+        for (int edge : g.cell_edges(cell)) set(covered_edges, edge);
+        for (int vertex : g.cell_vertices(cell)) set(covered_vertices, vertex);
+    }
+    for (int edge = 0; edge < g.edge_count(); ++edge)
+    {
+        bool const lhs_member
+            = element_location<LhsTag>(g, lhs, 1, edge) != location::exterior;
+        bool const rhs_member
+            = element_location<RhsTag>(g, rhs, 1, edge) != location::exterior;
+        if (! apply_boolean(lhs_member, rhs_member, operation)
+            || get(covered_edges, edge))
+        {
+            continue;
+        }
+        set(edges, edge);
+        auto const endpoints = g.edge_vertices(edge);
+        set(covered_vertices, endpoints.first);
+        set(covered_vertices, endpoints.second);
+    }
+    for (int vertex = 0; vertex < g.vertex_count(); ++vertex)
+    {
+        bool const lhs_member
+            = element_location<LhsTag>(g, lhs, 0, vertex) != location::exterior;
+        bool const rhs_member
+            = element_location<RhsTag>(g, rhs, 0, vertex) != location::exterior;
+        if (apply_boolean(lhs_member, rhs_member, operation)
+            && ! get(covered_vertices, vertex))
+        {
+            set(vertices, vertex);
+        }
+    }
+
+    return std::make_tuple(bits_to_geometry<multi_point>(
+                               vertices, covered_vertices, g, std::get<0>(primitives)),
+                           bits_to_geometry<multi_linestring>(
+                               edges, covered_vertices, g, std::get<1>(primitives)),
+                           bits_to_geometry<multi_polygon>(
+                               cells, covered_vertices, g, std::get<2>(primitives)));
+}
+
+inline char dimension_char(int dimension)
+{
+    return dimension < 0 ? 'F' : static_cast<char>('0' + dimension);
+}
+
+template <typename LhsTag, typename RhsTag>
+inline std::string expected_relation(grid const& g, bits const& lhs, bits const& rhs)
+{
+    int matrix[3][3] = {{-1, -1, -1}, {-1, -1, -1}, {-1, -1, -1}};
+    auto update = [&](location l, location r, int dimension)
+    {
+        int& value = matrix[static_cast<int>(l)][static_cast<int>(r)];
+        value = (std::max)(value, dimension);
+    };
+    update(location::exterior, location::exterior, 2);
+    for (int cell = 0; cell < g.cell_count(); ++cell)
+        update(element_location<LhsTag>(g, lhs, 2, cell),
+               element_location<RhsTag>(g, rhs, 2, cell), 2);
+    for (int edge = 0; edge < g.edge_count(); ++edge)
+        update(element_location<LhsTag>(g, lhs, 1, edge),
+               element_location<RhsTag>(g, rhs, 1, edge), 1);
+    for (int vertex = 0; vertex < g.vertex_count(); ++vertex)
+        update(element_location<LhsTag>(g, lhs, 0, vertex),
+               element_location<RhsTag>(g, rhs, 0, vertex), 0);
+
+    std::string result;
+    for (auto const& row : matrix)
+        for (int value : row) result.push_back(dimension_char(value));
+    return result;
+}
+
+} // namespace random_grid
+
+#endif

--- a/test/robustness/overlay/grid/random_grid_buffer.cpp
+++ b/test/robustness/overlay/grid/random_grid_buffer.cpp
@@ -1,0 +1,262 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+// Robustness Test
+
+// Copyright (c) 2026 Tinko Bartels, Shenzhen, China.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_GEOMETRY_NO_BOOST_TEST
+
+#include "random_grid.hpp"
+#include "random_grid_svg.hpp"
+#include "buffer_cell_helpers.hpp"
+
+#include <boost/geometry/algorithms/buffer.hpp>
+#include <boost/geometry/algorithms/convert.hpp>
+
+#include <boost/geometry/strategies/agnostic/buffer_distance_symmetric.hpp>
+#include <boost/geometry/strategies/cartesian/buffer_point_square.hpp>
+#include <boost/geometry/strategies/cartesian/buffer_side_straight.hpp>
+#include <boost/geometry/strategies/cartesian/buffer_join_miter.hpp>
+#include <boost/geometry/strategies/cartesian/buffer_end_flat.hpp>
+
+using namespace random_grid;
+
+using buffer_point = bg::model::d2::point_xy<double>;
+using buffer_linestring = bg::model::linestring<buffer_point>;
+using buffer_polygon = bg::model::polygon<buffer_point, false>;
+using buffer_multi_point = bg::model::multi_point<buffer_point>;
+using buffer_multi_linestring = bg::model::multi_linestring<buffer_linestring>;
+using buffer_multi_polygon = bg::model::multi_polygon<buffer_polygon>;
+using margin_masks = std::tuple<bits, bits, bits>;
+
+margin_masks make_margin_masks(grid const& g, int grid_margin)
+{
+    margin_masks result{make_bits(g.vertex_count()),
+                        make_bits(g.edge_count()),
+                        make_bits(g.cell_count())};
+    bits& vertices = std::get<0>(result);
+    bits& edges = std::get<1>(result);
+    bits& cells = std::get<2>(result);
+    int const max_i = g.width - grid_margin;
+    int const max_j = g.height - grid_margin;
+
+    for (int j = grid_margin; j <= max_j; ++j)
+        for (int i = grid_margin; i <= max_i; ++i)
+            set(vertices, g.vertex_index(i, j));
+
+    // Linear buffers use only axis-aligned edges; diagonal bits remain clear.
+    for (int j = grid_margin; j <= max_j; ++j)
+        for (int i = grid_margin; i < max_i; ++i)
+            set(edges, g.horizontal_index(i, j));
+    for (int j = grid_margin; j < max_j; ++j)
+        for (int i = grid_margin; i <= max_i; ++i)
+            set(edges, g.vertical_index(i, j));
+    for (int j = grid_margin; j < max_j; ++j)
+    {
+        for (int i = grid_margin; i < max_i; ++i)
+        {
+            set(cells, g.cell_index(i, j, 0));
+            set(cells, g.cell_index(i, j, 1));
+        }
+    }
+    return result;
+}
+
+bits random_masked_bits(generator_type& generator, int size, bits const& mask)
+{
+    bits result = random_bits(generator, size);
+    BOOST_GEOMETRY_ASSERT(result.size() == mask.size());
+    for (std::size_t chunk = 0; chunk < result.size(); ++chunk)
+        result[chunk] &= mask[chunk];
+    return result;
+}
+
+template <typename Geometry>
+buffer_multi_polygon apply_buffer(Geometry const& geometry)
+{
+    bg::strategy::buffer::distance_symmetric<double> distance(buffer_distance);
+    bg::strategy::buffer::side_straight side;
+    bg::strategy::buffer::join_miter join(5.0);
+    bg::strategy::buffer::end_flat end;
+    bg::strategy::buffer::point_square point_strategy;
+    buffer_multi_polygon result;
+    bg::buffer(geometry, result, distance, side, join, end, point_strategy);
+    return result;
+}
+
+template <typename BufferGeometry, typename Geometry>
+bool check_buffer(char const* label, Geometry const& input,
+                  bits const& input_bits, vertex_paths const& paths,
+                  std::vector<point> const& input_test_points,
+                  std::vector<point> const& cell_test_points,
+                  grid const& g, settings const& settings, int iteration,
+                  std::map<std::string, int>& failures)
+{
+    std::string input_error;
+    if (! validate_geometry(input_bits, input, input_test_points, input_error))
+    {
+        std::cout << label << " construction mismatch input=" << bit_string(input_bits)
+                  << ": " << input_error << '\n';
+        if (settings.verbose) std::cout << "  input geometry: " << bg::wkt(input) << '\n';
+        if (svg_enabled(settings, failures))
+            write_construction_svg(settings, iteration,
+                std::string("buffer ") + label + " construction",
+                g, input_bits, input, input_test_points, input_error);
+        ++failures[std::string(label) + " construction"];
+        return false;
+    }
+
+    BufferGeometry buffer_input;
+    bg::convert(input, buffer_input);
+    bits const expected = buffer_cells(g, input_bits, bg::tag_t<Geometry>{}, paths);
+    buffer_multi_polygon const output = apply_buffer(buffer_input);
+    bits const detected = geometry_to_bits(output, cell_test_points);
+    if (detected == expected) return true;
+
+    std::cout << label << " buffer mismatch distance=" << buffer_distance
+              << " input=" << bit_string(input_bits) << '\n'
+              << "  expected=" << bit_string(expected)
+              << " detected=" << bit_string(detected) << '\n';
+    if (settings.verbose)
+    {
+        std::cout << "  input geometry: " << bg::wkt(input) << '\n'
+                  << "  output geometry: " << bg::wkt(output) << '\n';
+    }
+    if (svg_enabled(settings, failures))
+    {
+        write_failure_svg(settings, iteration,
+            std::string("buffer ") + label + " distance " + std::to_string(buffer_distance),
+            g, [&](failure_svg& svg)
+        {
+            svg.add(input);
+            svg.add(output);
+            svg.record("Input", input);
+            svg.record("Actual buffer", output);
+            svg.panel(0, "Input", [&] { svg.map(input); });
+            svg.panel(1, "Expected cells", [&] { svg.cells(expected); });
+            svg.panel(2, "Actual buffer", [&]
+            {
+                svg.map(output);
+                svg.samples(expected, detected, cell_test_points);
+            });
+            svg.text(20, 585, "Miter buffer, flat ends, square points; distance = "
+                + std::to_string(buffer_distance)
+                + ". Comparison uses cell sample membership only.");
+        });
+    }
+    ++failures[std::string(label) + " buffer"];
+    return false;
+}
+
+bool test_multipoint(grid const& g,
+                     bits const& margin_mask,
+                     std::vector<point> const& primitives,
+                     std::vector<point> const& test_points,
+                     std::vector<point> const& cell_test_points,
+                     settings const& settings, int iteration,
+                     generator_type& generator,
+                     std::map<std::string, int>& failures)
+{
+    bits const point_bits
+        = random_masked_bits(generator, g.vertex_count(), margin_mask);
+    multi_point const points
+        = bits_to_geometry<multi_point>(point_bits, point_bits, g, primitives);
+    return check_buffer<buffer_multi_point>("point", points, point_bits, {},
+        test_points, cell_test_points, g, settings, iteration, failures);
+}
+
+bool test_multilinestring(grid const& g,
+                          bits const& margin_mask,
+                          std::vector<linestring> const& primitives,
+                          std::vector<point> const& test_points,
+                          std::vector<point> const& cell_test_points,
+                          settings const& settings, int iteration,
+                          generator_type& generator,
+                          std::map<std::string, int>& failures)
+{
+    bits const line_bits
+        = random_masked_bits(generator, g.edge_count(), margin_mask);
+    bits const vertices = random_bits(generator, g.vertex_count());
+    vertex_paths paths;
+    multi_linestring const lines
+        = bits_to_geometry<multi_linestring>(line_bits, vertices, g, primitives, &paths);
+    return check_buffer<buffer_multi_linestring>("line", lines, line_bits, paths,
+        test_points, cell_test_points, g, settings, iteration, failures);
+}
+
+bool test_multipolygon(grid const& g,
+                       bits const& margin_mask,
+                       std::vector<ring> const& primitives,
+                       std::vector<point> const& cell_test_points,
+                       settings const& settings, int iteration,
+                       generator_type& generator,
+                       std::map<std::string, int>& failures)
+{
+    bits const area_bits
+        = random_masked_bits(generator, g.cell_count(), margin_mask);
+    bits const vertices = random_bits(generator, g.vertex_count());
+    vertex_paths paths;
+    multi_polygon const areas
+        = bits_to_geometry<multi_polygon>(area_bits, vertices, g, primitives, &paths);
+    return check_buffer<buffer_multi_polygon>("area", areas, area_bits, paths,
+        cell_test_points, cell_test_points, g, settings, iteration, failures);
+}
+
+int main(int argc, char** argv)
+{
+    BoostGeometryWriteTestConfiguration();
+    try
+    {
+        settings settings;
+        if (! parse_options(argc, argv, "=== random_grid_buffer ===", settings))
+            return 0;
+        // Miter coordinate displacements are at most 3d, or 24 tile rows.
+        int const grid_margin = 24;
+        grid const g(settings.width + 2 * grid_margin,
+                     settings.height + 2 * grid_margin);
+        primitive_vectors const primitives = make_primitives(g);
+        margin_masks const masks = make_margin_masks(g, grid_margin);
+        test_point_vectors const test_points = make_test_points(g, primitives);
+        generator_type generator(settings.seed);
+        std::map<std::string, int> failures;
+        auto const start = std::chrono::high_resolution_clock::now();
+        int iterations = 0;
+        for (; iterations < settings.count || settings.count == -1; ++iterations)
+        {
+            bool ok = test_multipoint(
+                g, std::get<0>(masks), std::get<0>(primitives),
+                std::get<0>(test_points),
+                std::get<2>(test_points), settings, iterations, generator, failures);
+            if (ok || ! settings.stop_on_failure)
+            {
+                bool const linear_ok = test_multilinestring(
+                    g, std::get<1>(masks), std::get<1>(primitives),
+                    std::get<1>(test_points),
+                    std::get<2>(test_points), settings, iterations, generator, failures);
+                ok = linear_ok && ok;
+            }
+            if (ok || ! settings.stop_on_failure)
+            {
+                bool const areal_ok = test_multipolygon(
+                    g, std::get<2>(masks), std::get<2>(primitives),
+                    std::get<2>(test_points),
+                    settings, iterations, generator, failures);
+                ok = areal_ok && ok;
+            }
+            if (! ok)
+                std::cout << "replay: --width " << settings.width << " --height " << settings.height
+                          << " --seed " << settings.seed << " (iteration " << iterations << ")\n";
+            if (! ok && settings.stop_on_failure) { ++iterations; break; }
+        }
+        std::cout << report(start, iterations, failures);
+        return failure_count(failures) == 0 ? 0 : 1;
+    }
+    catch (std::exception const& error)
+    {
+        std::cout << "Exception: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/test/robustness/overlay/grid/random_grid_relate.cpp
+++ b/test/robustness/overlay/grid/random_grid_relate.cpp
@@ -1,0 +1,199 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+// Robustness Test
+
+// Copyright (c) 2026 Tinko Bartels, Shenzhen, China.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_GEOMETRY_NO_BOOST_TEST
+
+#include "random_grid.hpp"
+#include "random_grid_svg.hpp"
+
+#include <boost/geometry/algorithms/detail/relation/interface.hpp>
+#include <boost/geometry/algorithms/relate.hpp>
+
+using namespace random_grid;
+
+template <typename Geometry>
+bool check_construction(char const* label, bits const& expected, Geometry const& geometry,
+                        std::vector<point> const& test_points,
+                        grid const& grid, settings const& settings, int iteration,
+                        std::map<std::string, int>& failures)
+{
+    std::string error;
+    bool const ok = validate_geometry(expected, geometry, test_points, error);
+    if (! ok)
+    {
+        std::cout << label << " construction mismatch: " << error << '\n';
+        if (settings.verbose) std::cout << bg::wkt(geometry) << '\n';
+        if (svg_enabled(settings, failures))
+            write_construction_svg(settings, iteration,
+                std::string("relate ") + label + " construction", grid,
+                expected, geometry, test_points, error);
+        ++failures[std::string(label) + " construction"];
+    }
+    return ok;
+}
+
+template <typename Tag1, typename Tag2, typename Geometry1, typename Geometry2>
+bool check_relation(char const* label,
+                    Geometry1 const& geometry1, Geometry2 const& geometry2,
+                    bits const& bits1, bits const& bits2,
+                    grid const& grid, settings const& settings, int iteration,
+                    std::map<std::string, int>& failures)
+{
+    std::string const expected = expected_relation<Tag1, Tag2>(grid, bits1, bits2);
+    std::string const detected = bg::relation(geometry1, geometry2).str();
+    bool const matrix_ok = expected == detected;
+    bool const mask_ok = bg::relate(geometry1, geometry2, bg::de9im::mask(expected));
+    if (! matrix_ok || ! mask_ok)
+    {
+        std::cout << label << " mismatch expected=" << expected << " detected=" << detected
+                  << " mask=" << mask_ok << '\n'
+                  << "  input bits: " << bit_string(bits1) << " and "
+                  << bit_string(bits2) << '\n';
+        if (settings.verbose)
+        {
+            std::cout << "  geometry1: " << bg::wkt(geometry1) << '\n'
+                      << "  geometry2: " << bg::wkt(geometry2) << '\n';
+        }
+        if (svg_enabled(settings, failures))
+        {
+            write_failure_svg(settings, iteration, std::string("relate ") + label,
+                grid, [&](failure_svg& svg)
+            {
+                svg.add(geometry1);
+                svg.add(geometry2);
+                svg.record("A", geometry1);
+                svg.record("B", geometry2);
+                svg.panel(0, "Inputs", [&] { svg.inputs(geometry1, geometry2); });
+                svg.matrix(1, "Expected DE-9IM", expected, detected);
+                svg.matrix(2, "Actual DE-9IM", detected, expected);
+                svg.text(20, 585, "I = interior; B = boundary; E = exterior. F = empty; 0 = points; 1 = curves; 2 = area.");
+                svg.text(20, 615, std::string("relate(expected mask) = ") + (mask_ok ? "true" : "false"));
+            });
+        }
+        ++failures[label];
+    }
+    return matrix_ok && mask_ok;
+}
+
+bool test_iteration(grid const& grid, primitive_vectors const& primitives,
+                    test_point_vectors const& test_points,
+                    settings const& settings, int iteration,
+                    generator_type& generator, std::map<std::string, int>& failures)
+{
+    bits const points1 = input_bits(generator, grid.vertex_count(), settings, "point1");
+    bits const points2 = input_bits(generator, grid.vertex_count(), settings, "point2");
+    bits const lines1 = input_bits(generator, grid.edge_count(), settings, "line1");
+    bits const lines2 = input_bits(generator, grid.edge_count(), settings, "line2");
+    bits const areas1 = input_bits(generator, grid.cell_count(), settings, "area1");
+    bits const areas2 = input_bits(generator, grid.cell_count(), settings, "area2");
+    bits const line_vertices1 = input_bits(generator, grid.vertex_count(), settings, "line-vertices1");
+    bits const line_vertices2 = input_bits(generator, grid.vertex_count(), settings, "line-vertices2");
+    bits const area_vertices1 = input_bits(generator, grid.vertex_count(), settings, "area-vertices1");
+    bits const area_vertices2 = input_bits(generator, grid.vertex_count(), settings, "area-vertices2");
+    auto finish = [&](bool ok)
+    {
+        if (!ok) print_replay(settings, {
+            {"point1", &points1}, {"point2", &points2}, {"line1", &lines1}, {"line2", &lines2},
+            {"area1", &areas1}, {"area2", &areas2},
+            {"line-vertices1", &line_vertices1}, {"line-vertices2", &line_vertices2},
+            {"area-vertices1", &area_vertices1}, {"area-vertices2", &area_vertices2}});
+        return ok;
+    };
+
+    multi_point const gp1
+        = bits_to_geometry<multi_point>(points1, points1, grid, std::get<0>(primitives));
+    multi_point const gp2
+        = bits_to_geometry<multi_point>(points2, points2, grid, std::get<0>(primitives));
+    multi_linestring const gl1
+        = bits_to_geometry<multi_linestring>(lines1, line_vertices1, grid,
+                                             std::get<1>(primitives));
+    multi_linestring const gl2
+        = bits_to_geometry<multi_linestring>(lines2, line_vertices2, grid,
+                                             std::get<1>(primitives));
+    multi_polygon const ga1
+        = bits_to_geometry<multi_polygon>(areas1, area_vertices1, grid,
+                                          std::get<2>(primitives));
+    multi_polygon const ga2
+        = bits_to_geometry<multi_polygon>(areas2, area_vertices2, grid,
+                                          std::get<2>(primitives));
+
+    bool const inputs_ok
+        = check_construction("point1", points1, gp1, std::get<0>(test_points),
+                             grid, settings, iteration, failures)
+       && check_construction("point2", points2, gp2, std::get<0>(test_points),
+                             grid, settings, iteration, failures)
+       && check_construction("line1", lines1, gl1, std::get<1>(test_points),
+                             grid, settings, iteration, failures)
+       && check_construction("line2", lines2, gl2, std::get<1>(test_points),
+                             grid, settings, iteration, failures)
+       && check_construction("area1", areas1, ga1, std::get<2>(test_points),
+                             grid, settings, iteration, failures)
+       && check_construction("area2", areas2, ga2, std::get<2>(test_points),
+                             grid, settings, iteration, failures);
+    if (! inputs_ok) return finish(false);
+
+    bool ok = true;
+#define CHECK_RELATION(label, g1, g2, tag1, b1, tag2, b2) \
+    do { bool const relation_ok = check_relation<tag1, tag2>(label, g1, g2, b1, b2, \
+             grid, settings, iteration, failures); ok = ok && relation_ok; \
+         if (! relation_ok && settings.stop_on_failure) return finish(false); } while (false)
+
+    CHECK_RELATION("point/point", gp1, gp2,
+                   bg::pointlike_tag, points1, bg::pointlike_tag, points2);
+    CHECK_RELATION("point/line", gp1, gl2,
+                   bg::pointlike_tag, points1, bg::linear_tag, lines2);
+    CHECK_RELATION("point/area", gp1, ga2,
+                   bg::pointlike_tag, points1, bg::areal_tag, areas2);
+    CHECK_RELATION("line/point", gl1, gp2,
+                   bg::linear_tag, lines1, bg::pointlike_tag, points2);
+    CHECK_RELATION("line/line", gl1, gl2,
+                   bg::linear_tag, lines1, bg::linear_tag, lines2);
+    CHECK_RELATION("line/area", gl1, ga2,
+                   bg::linear_tag, lines1, bg::areal_tag, areas2);
+    CHECK_RELATION("area/point", ga1, gp2,
+                   bg::areal_tag, areas1, bg::pointlike_tag, points2);
+    CHECK_RELATION("area/line", ga1, gl2,
+                   bg::areal_tag, areas1, bg::linear_tag, lines2);
+    CHECK_RELATION("area/area", ga1, ga2,
+                   bg::areal_tag, areas1, bg::areal_tag, areas2);
+#undef CHECK_RELATION
+    return finish(ok);
+}
+
+int main(int argc, char** argv)
+{
+    BoostGeometryWriteTestConfiguration();
+    try
+    {
+        settings settings;
+        boost::program_options::options_description bit_options("Exact inputs");
+        add_bit_options(settings, bit_options);
+        if (! parse_options(argc, argv, "=== random_grid_relate ===", settings, bit_options)) return 0;
+        grid const grid(settings.width, settings.height);
+        primitive_vectors const primitives = make_primitives(grid);
+        test_point_vectors const test_points = make_test_points(grid, primitives);
+        generator_type generator(settings.seed);
+        std::map<std::string, int> failures;
+        auto const start = std::chrono::high_resolution_clock::now();
+        int iterations = 0;
+        for (; iterations < settings.count || settings.count == -1; ++iterations)
+        {
+            bool const ok = test_iteration(grid, primitives, test_points,
+                                           settings, iterations, generator, failures);
+            if (! ok && settings.stop_on_failure) { ++iterations; break; }
+        }
+        std::cout << report(start, iterations, failures);
+        return failure_count(failures) == 0 ? 0 : 1;
+    }
+    catch (std::exception const& error)
+    {
+        std::cout << "Exception: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/test/robustness/overlay/grid/random_grid_set_operations.cpp
+++ b/test/robustness/overlay/grid/random_grid_set_operations.cpp
@@ -1,0 +1,307 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+// Robustness Test
+
+// Copyright (c) 2026 Tinko Bartels, Shenzhen, China.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_GEOMETRY_NO_BOOST_TEST
+
+#include "random_grid.hpp"
+#include "random_grid_svg.hpp"
+
+#include <boost/geometry/algorithms/difference.hpp>
+#include <boost/geometry/algorithms/intersection.hpp>
+#include <boost/geometry/algorithms/length.hpp>
+#include <boost/geometry/algorithms/sym_difference.hpp>
+#include <boost/geometry/algorithms/union.hpp>
+
+using namespace random_grid;
+
+template <typename Tag1, typename Tag2,
+          typename Geometry1, typename Geometry2, typename Operation>
+bool check_operation(char const* label, boolean_operation operation,
+                     Geometry1 const& geometry1, Geometry2 const& geometry2,
+                     grid const& grid, primitive_vectors const& primitives,
+                     test_point_vectors const& test_points,
+                     settings const& settings, int iteration,
+                     bits const& bits1, bits const& bits2,
+                     Operation const& apply,
+                     std::map<std::string, int>& failures)
+{
+    output_tuple output;
+    apply(geometry1, geometry2, output);
+    output_tuple const expected
+        = expected_operation<Tag1, Tag2>(grid, bits1, bits2, primitives, operation);
+
+    bits const expected_points
+        = geometry_to_bits(std::get<0>(expected), std::get<0>(test_points));
+    bits const expected_lines
+        = geometry_to_bits(std::get<1>(expected), std::get<1>(test_points));
+    bits const expected_areas
+        = geometry_to_bits(std::get<2>(expected), std::get<2>(test_points));
+
+    output_tuple const detected = canonical_output(grid, primitives, test_points, output);
+    bits const detected_points
+        = geometry_to_bits(std::get<0>(detected), std::get<0>(test_points));
+    bits const detected_lines
+        = geometry_to_bits(std::get<1>(detected), std::get<1>(test_points));
+    bits const detected_areas
+        = geometry_to_bits(std::get<2>(detected), std::get<2>(test_points));
+    bool ok = detected_points == expected_points
+           && detected_lines == expected_lines
+           && detected_areas == expected_areas;
+
+    std::string reason;
+    bool const area_valid = bg::is_valid(std::get<2>(output), reason);
+    coordinate_type const expected_area = cell_area * count(expected_areas);
+    auto const detected_area = bg::area(std::get<2>(output));
+    int expected_length = 0;
+    for (int edge = 0; edge < grid.edge_count(); ++edge)
+    {
+        if (! get(expected_lines, edge)) continue;
+        switch (grid.family(edge))
+        {
+        case edge_family::horizontal: expected_length += 4 * scale; break;
+        case edge_family::vertical: expected_length += 3 * scale; break;
+        case edge_family::diagonal: expected_length += 5 * scale; break;
+        }
+    }
+    auto const detected_length = bg::length(std::get<1>(output));
+    ok = ok && area_valid && detected_area == expected_area
+            && detected_length == expected_length;
+    if (! ok)
+    {
+        std::cout << label << " mismatch\n"
+                  << "  input bits: " << bit_string(bits1) << " and "
+                  << bit_string(bits2) << '\n'
+                  << "  expected: points=" << bit_string(expected_points)
+                  << " lines=" << bit_string(expected_lines)
+                  << " areas=" << bit_string(expected_areas) << '\n'
+                  << "  detected: points=" << bit_string(detected_points)
+                  << " lines=" << bit_string(detected_lines)
+                  << " areas=" << bit_string(detected_areas) << '\n';
+        if (! area_valid) std::cout << "  invalid area: " << reason << '\n';
+        if (detected_area != expected_area)
+            std::cout << "  area: expected=" << expected_area << " detected=" << detected_area << '\n';
+        if (detected_length != expected_length)
+            std::cout << "  length: expected=" << expected_length
+                      << " detected=" << detected_length << '\n';
+        if (settings.verbose)
+        {
+            std::cout << "  expected point: " << bg::wkt(std::get<0>(expected)) << '\n'
+                      << "  expected line: " << bg::wkt(std::get<1>(expected)) << '\n'
+                      << "  expected area: " << bg::wkt(std::get<2>(expected)) << '\n'
+                      << "  point output: " << bg::wkt(std::get<0>(output)) << '\n'
+                      << "  line output: " << bg::wkt(std::get<1>(output)) << '\n'
+                      << "  area output: " << bg::wkt(std::get<2>(output)) << '\n';
+        }
+        if (svg_enabled(settings, failures))
+        {
+            write_failure_svg(settings, iteration, std::string("set_operations ") + label,
+                grid, [&](failure_svg& svg)
+            {
+                svg.add(geometry1);
+                svg.add(geometry2);
+                svg.add(expected);
+                svg.add(output);
+                svg.record("A", geometry1);
+                svg.record("B", geometry2);
+                svg.record("Expected", expected);
+                svg.record("Actual (raw)", output);
+                svg.panel(0, "Inputs", [&] { svg.inputs(geometry1, geometry2); });
+                svg.panel(1, "Expected result", [&] { svg.map(expected); });
+                svg.panel(2, "Actual result (raw)", [&]
+                {
+                    svg.map(output);
+                    svg.samples(expected_points, detected_points, std::get<0>(test_points));
+                    svg.samples(expected_lines, detected_lines, std::get<1>(test_points));
+                    svg.samples(expected_areas, detected_areas, std::get<2>(test_points));
+                });
+                std::ostringstream measures;
+                measures << "Length: expected " << expected_length << ", actual " << detected_length
+                         << "; area: expected " << expected_area << ", actual " << detected_area;
+                svg.text(20, 585, measures.str());
+                if (!area_valid) svg.text(20, 615, "Invalid area: " + reason, "#c32f4b");
+            });
+        }
+        ++failures[label];
+    }
+    return ok;
+}
+
+template <typename Tag1, typename Tag2, typename Geometry1, typename Geometry2>
+bool check_pair(char const* pair_label,
+                Geometry1 const& geometry1, Geometry2 const& geometry2,
+                grid const& grid, primitive_vectors const& primitives,
+                test_point_vectors const& test_points,
+                settings const& settings, int iteration,
+                bits const& bits1, bits const& bits2,
+                std::map<std::string, int>& failures)
+{
+    bool ok = true;
+    auto check = [&](char const* operation_label, boolean_operation operation,
+                     auto const& apply)
+    {
+        std::string const label = std::string(operation_label) + " " + pair_label;
+        bool const operation_ok = check_operation<Tag1, Tag2>(label.c_str(), operation,
+            geometry1, geometry2, grid, primitives, test_points,
+            settings, iteration, bits1, bits2, apply, failures);
+        ok = ok && operation_ok;
+        return operation_ok || ! settings.stop_on_failure;
+    };
+    return check("union", boolean_operation::union_,
+                 [](auto const& a, auto const& b, auto& out) { bg::union_(a, b, out); })
+        && check("intersection", boolean_operation::intersection,
+                 [](auto const& a, auto const& b, auto& out) { bg::intersection(a, b, out); })
+        && check("difference", boolean_operation::difference,
+                 [](auto const& a, auto const& b, auto& out) { bg::difference(a, b, out); })
+        && check("sym_difference", boolean_operation::sym_difference,
+                 [](auto const& a, auto const& b, auto& out) { bg::sym_difference(a, b, out); })
+        && ok;
+}
+
+template <typename Geometry>
+bool check_conversion(char const* label, bits const& expected, Geometry const& geometry,
+                      std::vector<point> const& test_points,
+                      grid const& grid, settings const& settings, int iteration,
+                      std::map<std::string, int>& failures)
+{
+    std::string error;
+    bool const ok = validate_geometry(expected, geometry, test_points, error);
+    if (! ok)
+    {
+        std::cout << label << " construction mismatch: " << error << '\n';
+        if (settings.verbose) std::cout << bg::wkt(geometry) << '\n';
+        if (svg_enabled(settings, failures))
+            write_construction_svg(settings, iteration,
+                std::string("set_operations ") + label + " construction", grid,
+                expected, geometry, test_points, error);
+        ++failures[std::string(label) + " construction"];
+    }
+    return ok;
+}
+
+bool test_iteration(grid const& grid, primitive_vectors const& primitives,
+                    test_point_vectors const& test_points,
+                    settings const& settings, int iteration,
+                    generator_type& generator, std::map<std::string, int>& failures)
+{
+    bits const p1 = input_bits(generator, grid.vertex_count(), settings, "point1");
+    bits const p2 = input_bits(generator, grid.vertex_count(), settings, "point2");
+    bits const l1 = input_bits(generator, grid.edge_count(), settings, "line1");
+    bits const l2 = input_bits(generator, grid.edge_count(), settings, "line2");
+    bits const a1 = input_bits(generator, grid.cell_count(), settings, "area1");
+    bits const a2 = input_bits(generator, grid.cell_count(), settings, "area2");
+    bits const line_vertices1 = input_bits(generator, grid.vertex_count(), settings, "line-vertices1");
+    bits const line_vertices2 = input_bits(generator, grid.vertex_count(), settings, "line-vertices2");
+    bits const area_vertices1 = input_bits(generator, grid.vertex_count(), settings, "area-vertices1");
+    bits const area_vertices2 = input_bits(generator, grid.vertex_count(), settings, "area-vertices2");
+    auto finish = [&](bool ok)
+    {
+        if (!ok) print_replay(settings, {
+            {"point1", &p1}, {"point2", &p2}, {"line1", &l1}, {"line2", &l2},
+            {"area1", &a1}, {"area2", &a2},
+            {"line-vertices1", &line_vertices1}, {"line-vertices2", &line_vertices2},
+            {"area-vertices1", &area_vertices1}, {"area-vertices2", &area_vertices2}});
+        return ok;
+    };
+
+    multi_point const gp1
+        = bits_to_geometry<multi_point>(p1, p1, grid, std::get<0>(primitives));
+    multi_point const gp2
+        = bits_to_geometry<multi_point>(p2, p2, grid, std::get<0>(primitives));
+    multi_linestring const gl1
+        = bits_to_geometry<multi_linestring>(
+            l1, line_vertices1, grid, std::get<1>(primitives));
+    multi_linestring const gl2
+        = bits_to_geometry<multi_linestring>(
+            l2, line_vertices2, grid, std::get<1>(primitives));
+    multi_polygon const ga1
+        = bits_to_geometry<multi_polygon>(
+            a1, area_vertices1, grid, std::get<2>(primitives));
+    multi_polygon const ga2
+        = bits_to_geometry<multi_polygon>(
+            a2, area_vertices2, grid, std::get<2>(primitives));
+
+    bool ok = check_conversion("point1", p1, gp1, std::get<0>(test_points),
+                               grid, settings, iteration, failures)
+           && check_conversion("point2", p2, gp2, std::get<0>(test_points),
+                               grid, settings, iteration, failures)
+           && check_conversion("line1", l1, gl1, std::get<1>(test_points),
+                               grid, settings, iteration, failures)
+           && check_conversion("line2", l2, gl2, std::get<1>(test_points),
+                               grid, settings, iteration, failures)
+           && check_conversion("area1", a1, ga1, std::get<2>(test_points),
+                               grid, settings, iteration, failures)
+           && check_conversion("area2", a2, ga2, std::get<2>(test_points),
+                               grid, settings, iteration, failures);
+    if (! ok) return finish(false);
+
+#define CHECK_PAIR(label, g1, g2, tag1, tag2, b1, b2) \
+    do { bool const pair_ok = check_pair<tag1, tag2>(label, g1, g2, grid, primitives, \
+             test_points, settings, iteration, b1, b2, failures); \
+         ok = ok && pair_ok; if (!pair_ok && settings.stop_on_failure) return finish(false); } while (false)
+
+    CHECK_PAIR("point/point", gp1, gp2,
+               bg::pointlike_tag, bg::pointlike_tag, p1, p2);
+    CHECK_PAIR("point/point reversed", gp2, gp1,
+               bg::pointlike_tag, bg::pointlike_tag, p2, p1);
+    CHECK_PAIR("point/line", gp1, gl2,
+               bg::pointlike_tag, bg::linear_tag, p1, l2);
+    CHECK_PAIR("line/point", gl1, gp2,
+               bg::linear_tag, bg::pointlike_tag, l1, p2);
+    CHECK_PAIR("point/area", gp1, ga2,
+               bg::pointlike_tag, bg::areal_tag, p1, a2);
+    CHECK_PAIR("area/point", ga1, gp2,
+               bg::areal_tag, bg::pointlike_tag, a1, p2);
+    CHECK_PAIR("line/line", gl1, gl2,
+               bg::linear_tag, bg::linear_tag, l1, l2);
+    CHECK_PAIR("line/line reversed", gl2, gl1,
+               bg::linear_tag, bg::linear_tag, l2, l1);
+    CHECK_PAIR("line/area", gl1, ga2,
+               bg::linear_tag, bg::areal_tag, l1, a2);
+    CHECK_PAIR("area/line", ga1, gl2,
+               bg::areal_tag, bg::linear_tag, a1, l2);
+    CHECK_PAIR("area/area", ga1, ga2,
+               bg::areal_tag, bg::areal_tag, a1, a2);
+    CHECK_PAIR("area/area reversed", ga2, ga1,
+               bg::areal_tag, bg::areal_tag, a2, a1);
+#undef CHECK_PAIR
+    return finish(ok);
+}
+
+int main(int argc, char** argv)
+{
+    BoostGeometryWriteTestConfiguration();
+    try
+    {
+        settings settings;
+        boost::program_options::options_description bit_options("Exact inputs");
+        add_bit_options(settings, bit_options);
+        if (! parse_options(argc, argv, "=== random_grid_set_operations ===", settings, bit_options))
+            return 0;
+        grid const grid(settings.width, settings.height);
+        primitive_vectors const primitives = make_primitives(grid);
+        test_point_vectors const test_points = make_test_points(grid, primitives);
+        generator_type generator(settings.seed);
+        std::map<std::string, int> failures;
+        auto const start = std::chrono::high_resolution_clock::now();
+        int iterations = 0;
+        for (; iterations < settings.count || settings.count == -1; ++iterations)
+        {
+            bool const ok = test_iteration(grid, primitives, test_points,
+                                           settings, iterations, generator, failures);
+            if (! ok && settings.stop_on_failure) { ++iterations; break; }
+        }
+        std::cout << report(start, iterations, failures);
+        return failure_count(failures) == 0 ? 0 : 1;
+    }
+    catch (std::exception const& error)
+    {
+        std::cout << "Exception: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/test/robustness/overlay/grid/random_grid_svg.hpp
+++ b/test/robustness/overlay/grid/random_grid_svg.hpp
@@ -1,0 +1,270 @@
+// Boost.Geometry (aka GGL, Generic Geometry Library)
+// Robustness Test
+
+// Copyright (c) 2026 Tinko Bartels, Shenzhen, China.
+
+// Use, modification and distribution is subject to the Boost Software License,
+// Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_GEOMETRY_TEST_ROBUSTNESS_OVERLAY_GRID_RANDOM_GRID_SVG_HPP
+#define BOOST_GEOMETRY_TEST_ROBUSTNESS_OVERLAY_GRID_RANDOM_GRID_SVG_HPP
+
+#include "random_grid.hpp"
+#include <boost/geometry/core/topological_dimension.hpp>
+#include <boost/geometry/io/svg/svg_mapper.hpp>
+
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <type_traits>
+
+namespace random_grid
+{
+
+inline bool svg_enabled(settings const& settings,
+                        std::map<std::string, int> const& failures)
+{
+    return !settings.svg_directory.empty()
+        && (settings.svg_limit == 0 || failure_count(failures) < settings.svg_limit);
+}
+
+inline std::string svg_escape(std::string const& text)
+{
+    std::string result;
+    for (char c : text)
+    {
+        switch (c)
+        {
+        case '&': result += "&amp;"; break;
+        case '<': result += "&lt;"; break;
+        case '>': result += "&gt;"; break;
+        default: result += c;
+        }
+    }
+    return result;
+}
+
+struct failure_svg
+{
+    using svg_point = bg::model::d2::point_xy<double>;
+    std::ostream& out;
+    bg::svg_mapper<svg_point>& mapper;
+    grid const& g;
+
+    void text(int x, int y, std::string const& value, char const* color = "#243540",
+              int size = 15)
+    {
+        out << "<text x=\"" << x << "\" y=\"" << y << "\" fill=\"" << color
+            << "\" font-family=\"sans-serif\" font-size=\"" << size << "\">"
+            << svg_escape(value) << "</text>\n";
+    }
+
+    template <typename Geometry>
+    void add(Geometry const& geometry) { mapper.add(geometry); }
+
+    void add(output_tuple const& geometry)
+    {
+        add(std::get<0>(geometry));
+        add(std::get<1>(geometry));
+        add(std::get<2>(geometry));
+    }
+
+    template <typename Geometry>
+    void map(Geometry const& geometry, char const* color = "#2868b2")
+    {
+        using tag = bg::tag_cast_t<bg::tag_t<Geometry>, bg::areal_tag, bg::linear_tag>;
+        std::string const fill = std::is_same<tag, bg::linear_tag>::value ? "none" : color;
+        mapper.map(geometry, "fill:" + fill + ";fill-opacity:0.25;stroke:" + color
+                            + ";stroke-width:2", 3);
+    }
+
+    void map(output_tuple const& geometry, char const* color = "#2868b2")
+    {
+        map(std::get<2>(geometry), color);
+        map(std::get<1>(geometry), color);
+        map(std::get<0>(geometry), color);
+    }
+
+    template <typename Geometry1, typename Geometry2>
+    void inputs(Geometry1 const& a, Geometry2 const& b)
+    {
+        // Draw lower-dimensional inputs last so polygon fills cannot hide them.
+        if (bg::topological_dimension<Geometry1>::value >= bg::topological_dimension<Geometry2>::value)
+        {
+            map(a);
+            map(b, "#13836c");
+        }
+        else
+        {
+            map(b, "#13836c");
+            map(a);
+        }
+    }
+
+    template <typename Geometry>
+    void record(char const* label, Geometry const& geometry)
+    {
+        std::ostringstream wkt;
+        wkt << std::setprecision(std::numeric_limits<double>::max_digits10) << bg::wkt(geometry);
+        out << "<desc>" << svg_escape(label) << ": " << svg_escape(wkt.str()) << "</desc>\n";
+    }
+
+    void record(char const* label, output_tuple const& geometry)
+    {
+        record(label, std::get<0>(geometry));
+        record(label, std::get<1>(geometry));
+        record(label, std::get<2>(geometry));
+    }
+
+    template <typename Draw>
+    void panel(int index, char const* title, Draw const& draw)
+    {
+        text(20 + 440 * index, 115, title, "#243540", 18);
+        out << "<g transform=\"translate(" << 20 + 440 * index << ",135)\">\n";
+        for (int edge = 0; edge < g.edge_count(); ++edge)
+        {
+            auto const v = g.edge_vertices(edge);
+            linestring const segment{
+                g.vertex_point(v.first % (g.width + 1), v.first / (g.width + 1)),
+                g.vertex_point(v.second % (g.width + 1), v.second / (g.width + 1))};
+            mapper.map(segment, "fill:none;stroke:#e5eaee;stroke-width:0.6");
+        }
+        draw();
+        out << "</g>\n";
+    }
+
+    void samples(bits const& expected, bits const& detected,
+                 std::vector<point> const& points)
+    {
+        for (std::size_t i = 0; i < points.size(); ++i)
+        {
+            if (get(expected, static_cast<int>(i)) == get(detected, static_cast<int>(i))) continue;
+            char const* color = get(expected, static_cast<int>(i)) ? "#d47a00" : "#c32f4b";
+            out << "<g><title>Sample " << i << ": " << bg::wkt(points[i]) << "</title>\n";
+            mapper.map(points[i], std::string("fill:white;stroke:") + color + ";stroke-width:2", 4);
+            out << "</g>\n";
+        }
+    }
+
+    void cells(bits const& selected)
+    {
+        for (int cell = 0; cell < g.cell_count(); ++cell)
+        {
+            if (!get(selected, cell)) continue;
+            ring triangle;
+            for (int v : g.cell_vertices(cell))
+                triangle.push_back(g.vertex_point(v % (g.width + 1), v / (g.width + 1)));
+            triangle.push_back(triangle.front());
+            map(triangle);
+        }
+    }
+
+    void matrix(int index, char const* title, std::string const& value,
+                std::string const& other)
+    {
+        int const x = 20 + 440 * index;
+        text(x, 115, title, "#243540", 18);
+        char const* row[] = {"I(A)", "B(A)", "E(A)"};
+        char const* col[] = {"I(B)", "B(B)", "E(B)"};
+        for (int i = 0; i < 3; ++i)
+        {
+            text(x + 105 + 85 * i, 180, col[i]);
+            text(x + 20, 234 + 75 * i, row[i]);
+            for (int j = 0; j < 3; ++j)
+            {
+                bool const different = value[3 * i + j] != other[3 * i + j];
+                out << "<rect x=\"" << x + 85 + j * 85 << "\" y=\"" << 195 + i * 75
+                    << "\" width=\"80\" height=\"70\" fill=\""
+                    << (different ? "#ffe9ee" : "#f3f6f8") << "\"/>\n";
+                text(x + 113 + j * 85, 240 + i * 75, value.substr(3 * i + j, 1),
+                     different ? "#c32f4b" : "#243540", 28);
+            }
+        }
+        text(x + 85, 465, value, "#243540", 20);
+    }
+};
+
+template <typename Draw>
+void write_failure_svg(settings const& settings, int iteration,
+                       std::string const& label, grid const& g, Draw const& draw,
+                       std::string const& extra_options = "")
+{
+    std::string name = label;
+    for (char& c : name)
+        if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+            || (c >= '0' && c <= '9'))) c = '_';
+    std::string const filename = settings.svg_directory + '/' + name + '_'
+        + std::to_string(settings.width) + 'x' + std::to_string(settings.height)
+        + "_seed" + std::to_string(settings.seed) + "_iteration" + std::to_string(iteration) + ".svg";
+    std::ofstream out(filename);
+    if (!out)
+    {
+        std::cerr << "Cannot write SVG: " << filename << '\n';
+        std::exit(EXIT_FAILURE);
+    }
+    {
+        bg::svg_mapper<failure_svg::svg_point> mapper(out, 400, 400, 0.95,
+            "width=\"1320\" height=\"660\" viewBox=\"0 0 1320 660\"");
+        failure_svg svg{out, mapper, g};
+        out << "<title>" << svg_escape(label) << "</title>\n";
+        if (!settings.bit_patterns.empty())
+        {
+            out << "<desc>Exact replay: --width " << settings.width
+                << " --height " << settings.height << " --count 1";
+            for (auto const& pattern : settings.bit_patterns)
+                out << " --" << pattern.first << " '" << bit_string(pattern.second) << '\'';
+            out << "</desc>\n";
+        }
+        // A nondegenerate frame also covers empty, point and horizontal/vertical inputs.
+        mapper.add(g.vertex_point(0, 0));
+        mapper.add(g.vertex_point(g.width, g.height));
+        out << "<rect width=\"1320\" height=\"660\" fill=\"white\"/>\n";
+        svg.text(20, 30, label, "#243540", 22);
+        svg.text(20, 58, "--width " + std::to_string(settings.width) + " --height "
+            + std::to_string(settings.height) + " --seed " + std::to_string(settings.seed)
+            + extra_options + " --count " + std::to_string(static_cast<long long>(iteration) + 1)
+            + " (iteration " + std::to_string(iteration) + ", zero-based)"
+            + (settings.bit_patterns.empty() ? "" : " [exact inputs in SVG description]"));
+        svg.text(20, 82, "Inputs: A blue, B green. Sample markers: orange missing, red unexpected.");
+        draw(svg);
+    }
+    out.close();
+    if (!out)
+    {
+        std::cerr << "Failed writing SVG: " << filename << '\n';
+        std::exit(EXIT_FAILURE);
+    }
+    std::cout << "  SVG: " << filename << '\n';
+}
+
+template <typename Geometry>
+void write_construction_svg(settings const& settings, int iteration,
+                            std::string const& label, grid const& g, bits const& expected,
+                            Geometry const& geometry, std::vector<point> const& points,
+                            std::string const& error, std::string const& extra_options = "")
+{
+    write_failure_svg(settings, iteration, label, g, [&](failure_svg& svg)
+    {
+        svg.add(geometry);
+        svg.record("Constructed", geometry);
+        svg.panel(0, "Expected selected samples", [&]
+        {
+            for (std::size_t i = 0; i < points.size(); ++i)
+                if (get(expected, static_cast<int>(i))) svg.map(points[i]);
+        });
+        svg.panel(1, "Constructed geometry", [&] { svg.map(geometry); });
+        svg.panel(2, "Sampling discrepancies", [&]
+        {
+            svg.map(geometry);
+            if (bg::is_valid(geometry))
+                svg.samples(expected, geometry_to_bits(geometry, points), points);
+        });
+        svg.out << "<desc>Construction mismatch: " << svg_escape(error) << "</desc>\n";
+        svg.text(20, 590, error.size() <= 140 ? error : error.substr(0, 137) + "...");
+    }, extra_options);
+}
+
+} // namespace random_grid
+
+#endif


### PR DESCRIPTION
This PR draft is vibe-coded and not as clean as I would like it to be but I share it early to avoid duplication of efforts. 

The main idea is to generalize random_bitset_grids (#1361) and use it as a test harness for LLMs to figure out the remaining algorithmic bugs in Boost.Geometry, as far as the generalisation of the mentioned older test permits.

<details>
<summary>reminder of what #1361 was</summary>
As a reminder, the original test considers an integer grid with horizontal and vertical uniformly spaced lines, associates each cell, associates it with a bitset, such that each cell corresponds to one bit’s index in the bitset, and then generates two bitsets, the corresponding multipolygons and checks if a set operation (union, intersection, sym_diff, …) produces a geometry that maps to the bitset produced by the corresponding bit operation (OR, AND, XOR, …). The idea is to autogenerate many problems automatically for which we can easily predict the correct result, do so in a way that can represent many topological situations in principle and then just let it run a long time. This also produces relatively simple test cases. Another important part of this test was, to separate this test entirely from the concern for floating-point issues, so all intermediate results must be integers.
</details>

We generalize this in the following ways:
1. We add two more line families 3x+4y=const and 3x-4y=const. This requires spacing the lines out more to keep all intersections at integer points. It increases the maximum degree of vertices in the grid, allowing more topological situations to be represented (e.g. 4 non-overlapping rings meeting in one point). For illustration, the following is a 2x2 grid with the added directions. It has 8 cells, 9 vertices, and 16 edges. v_0 is at (0 0), v_8 is at (8 6). All intersections are at numbered vertices at integer coordinates. By repeating this pattern, we get larger grids:

<img width="518" height="390"  alt="image" src="https://github.com/user-attachments/assets/83f3313e-19f7-4927-b501-839a5fcca9fb" />

2. In addition to multipolygons (unions of some choice of the cells as in the picture above). We also consider multipoints (same for the vertices as in the picture above) and multilinestrings (unions of some choice of the edges as in the picture above) across the grid-lines. This is a rather natural generalisation.

3. We add testing of the relate methods. We can determine the expected DE9IM matrix from the bitsets because the adjacency and incidents relationships of the vertices, edges, and cells follow regular patterns.

4. We add testing for the buffer method with miter joins. For that it is important that all directions follow pythagorean triplets, so that there is a rational (not involving square roots) common distance such that for every line segment, the buffered line is again on the grid. Unfortunately buffer doesn’t fully do integer coordinates, but since our test points are comfortably within each cell, this shouldn’t affect results.

In principle this could be further generalised by adding more directions (there are infinite integer pythagorean triplets) but it gets very ugly very quickly and I think with 4 directions, allowing 8 nonoverlapping segments to meet in one point and having many such points, we can already represent a lot.

Running this at small sizes, generated a variety of failures for all three operations. which I used Codex GPT 5.6/6 to solve until running out of tokens. There are still some failures in buffer left. It also seems to fix some open issues:
59787a382 fixes #1238
a10fc80b4 fixes #1420, #1421
bbb1acdc9 fixes #1406
eb4427739 fixes #1490
The other commits fix bugs uncovered by the new tests that have no associated issues.

The individual fixes are intentionally kept in separate commits to allow for git bisection.

The changes create one failure in a buffer test (specifically here: https://github.com/tinko92/geometry/actions/runs/34663822728/job/103471604820#step:10:129 ), that I believe to be spurious. I think the test has numerical robustness issues that get unmasked by changed behaviour from unrelated buffer fixes.

I hope to understand every fix before marking it not a draft and possibly clean up the test code more. The test code already went through several iterations to be more reasonable than the original LLM output (except for the SVG drawing which I'm not so worried about) but miter buffer cells computation for example remains quite ugly. This may be acceptable for test-only code that is not intended to become part of the CI. I left the README.md that the agent tends to write in for now, for reviewability.